### PR TITLE
Mark vendored MATPOWER cases as linguist-vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Vendored MATPOWER cases (BSD-3, verbatim from github.com/MATPOWER/matpower).
+# They're MATLAB syntax, so GitHub Linguist counts them as MATLAB and drowns
+# out the Rust source in the language bar. Mark them vendored to drop them from
+# the language stats and collapse them in diffs. The files stay in the repo so
+# the test suite stays hermetic.
+tests/data/*.m linguist-vendored


### PR DESCRIPTION
The `tests/data/*.m` MATPOWER fixtures are MATLAB syntax, so GitHub Linguist counts them as MATLAB. With `case2869pegase.m` (454 KB) added in #11, the vendored data outweighs the Rust/Python source and the repo's language bar flipped to MATLAB.

This adds a one-line `.gitattributes` marking them `linguist-vendored`, which drops them from the language stats and collapses them in diffs. The files stay in the repo, so the test suite stays hermetic — no submodule, no network fetch.

No code or test impact; GitHub recomputes the language bar on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)