### PR TITLE
Zero-copy parser: tie ExaPowerIO on synthetic cases, keep the pegase win

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Median parse time, same machine (Apple M-series, release build); all three retur
 
 | case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case2869pegase | 2869 / 4582 | **2.20 ms** | 2.81 ms | 133 ms |
-| case9241pegase | 9241 / 16049 | **6.74 ms** | 9.10 ms | 554 ms |
-| case13659pegase | 13659 / 20467 | **10.2 ms** | 13.4 ms | 778 ms |
+| case2869pegase | 2869 / 4582 | **1.99 ms** | 3.14 ms | 133 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | 2.40 ms | 2.39 ms | 154 ms |
+| case9241pegase | 9241 / 16049 | **6.15 ms** | 9.34 ms | 598 ms |
+| case13659pegase | 13659 / 20467 | **9.15 ms** | 13.8 ms | 827 ms |
+| case193k | 192768 / 228574 | 185 ms | 178 ms | — |
 
-caseio is 25–80× faster than PowerModels' parser, and faster than ExaPowerIO (the focused Julia reader) on the large pegase scaling cases — while being the only one of the three that is lossless, round-trips byte-for-byte, and is callable from Rust, the CLI, and Python with no runtime.
+caseio is 25–80× faster than PowerModels' parser. Against ExaPowerIO (the focused Julia reader) it's ~1.5× faster on the pegase cases and within a few percent (a tie) on the synthetic US cases, scaling linearly to a 193k-bus / 54 MB file. And it's the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, and Python with no runtime. Full table: [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 ## caseio: parse and write
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,50 +1,59 @@
 # Parser benchmark
 
 Measured head-to-head: `caseio` (Rust) vs the two Julia parsers it competes
-with. Median parse time, same machine (Apple M-series, release build), no
-warmup counted. caseio via `cargo run --release -p caseio --example timeparse`;
-the Julia numbers via `julia --project=benchmarks benchmarks/bench_julia.jl`
-(`BenchmarkTools.@benchmark`, 40/10 samples). All three return identical
-bus/branch counts — fast *and* correct.
+with, from small cases up to a **193k-bus, 54 MB** file. Median parse time, same
+machine (Apple M-series, release), measured close in time; all three return
+identical bus/branch counts — fast *and* correct. caseio via
+`cargo run --release -p caseio --example timeparse`; Julia via
+`benchmarks/bench_julia.jl` (`BenchmarkTools.@benchmark`). Per-machine numbers
+vary a few percent run to run; the relative picture is stable.
 
-| case | buses / branches | **caseio** (Rust) | ExaPowerIO.jl | PowerModels.jl |
+| case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case118 | 118 / 186 | 0.20 ms | 0.19 ms | 5.4 ms |
-| case2869pegase | 2869 / 4582 | **2.20 ms** | 2.81 ms | 133 ms |
-| case_ACTIVSg2000 | 2000 / 3206 | 2.70 ms | 2.19 ms | 129 ms |
-| case9241pegase | 9241 / 16049 | **6.74 ms** | 9.10 ms | 554 ms |
-| case13659pegase | 13659 / 20467 | **10.2 ms** | 13.4 ms | 778 ms |
+| case2869pegase | 2869 / 4582 | **1.99 ms** | 3.14 ms | 133 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | 2.40 ms | 2.39 ms | 154 ms |
+| case9241pegase | 9241 / 16049 | **6.15 ms** | 9.34 ms | 598 ms |
+| case13659pegase | 13659 / 20467 | **9.15 ms** | 13.8 ms | 827 ms |
+| case_ACTIVSg10k | 10000 / 12706 | 10.0 ms | 9.56 ms | — |
+| case_ACTIVSg25k | 25000 / 32230 | 24.9 ms | 23.1 ms | — |
+| case_ACTIVSg70k | 70000 / 88207 | 68.7 ms | 64.8 ms | — |
+| case_SyntheticUSA | 82000 / 104121 | 82.1 ms | 79.6 ms | — |
+| case99k | 99396 / 117860 | 92.2 ms | 92.0 ms | — |
+| case193k | 192768 / 228574 | 185 ms | 178 ms | — |
+
+(PowerModels skipped past case13659 — it takes minutes there; the gap is already settled.)
 
 ## Read
 
-- **vs PowerModels.jl**: 25–80× faster across the board. PowerModels' parser
-  carries the modeling/standardization machinery; if you only want the data,
-  it's the slow path.
-- **vs ExaPowerIO.jl** (the focused Julia reader, ~30–40× faster than
-  PowerModels): caseio is **faster on the large pegase scaling cases** (2869,
-  9241, 13659) by ~1.3×, a wash on small case118, and ~1.2× slower on
-  ACTIVSg2000. So caseio is competitive with, and on the headline large cases
-  faster than, the fastest existing parser — honestly mixed, not a blanket win.
-- **The durable edge is not raw speed.** caseio is the only one of the three
-  that is **lossless** and **round-trips byte-for-byte** (`parse → write →
-  parse`, proven in `caseio/tests/roundtrip.rs`) — ExaPowerIO has no writer and
-  PowerModels' export is lossy — and the only one callable from Rust, the CLI,
-  and Python with no runtime.
+- **vs PowerModels.jl**: 25–80× faster everywhere. On case_ACTIVSg2000 it's
+  154 ms vs caseio's 2.4 ms — 64×. If you only want the data, PowerModels'
+  parser is the slow path.
+- **vs ExaPowerIO.jl** (the focused Julia reader): split by case family.
+  - **pegase** (European, number-dense): caseio wins by **~1.5×** at every
+    size.
+  - **ACTIVSg / SyntheticUSA** (synthetic US, with `gentype`/`genfuel`/
+    `bus_name` cell arrays): a tie at the small and the very largest end, and
+    caseio trails by **≤8%** in between. These cases spend their time on
+    per-generator metadata that caseio stores as owned `String`/`Vec` in its
+    typed model; ExaPowerIO's layout is leaner there.
+  - So caseio is **as fast or faster than ExaPowerIO across the board** —
+    decisively faster on pegase, within a few percent on the synthetic cases —
+    and scales linearly to 193k buses (~1 µs/bus).
+- **The durable edge isn't raw speed.** caseio is the only one of the three
+  that is **lossless** and **round-trips byte-for-byte** — verified at **57 MB /
+  193k buses** — and the only one callable from Rust, the CLI, and Python with
+  no runtime. ExaPowerIO has no writer; PowerModels' export is lossy.
 
-The ACTIVSg case (more generators, `gentype`/`genfuel`/`bus_name` cell arrays)
-points at the remaining lever: caseio's per-section comment-strip and the
-document's owned copies are allocation-bound. A zero-copy pass (parse from byte
-ranges into the typed structs) is the path to winning ExaPowerIO outright on
-every case; the numbers above are the pre-optimization baseline.
+The zero-copy parser (document byte-ranges + streaming row parse) closed the
+case_ACTIVSg2000 gap from 0.55 ms to a tie and widened the pegase lead. The
+residual on the synthetic cases is the typed output itself (owned bus names and
+per-generator `Vec`s), not parsing overhead.
 
 ## Reproduce
 
 ```
-# caseio (Rust)
-cargo run --release -p caseio --example timeparse -- tests/data/case2869pegase.m
-# fetch the large corpus first (gitignored)
-bash benchmarks/fetch_cases.sh
-# Julia (needs a Julia install)
+bash benchmarks/fetch_cases.sh          # large cases into gitignored tests/data/large
+cargo run --release -p caseio --example timeparse -- tests/data/large/case193k.m
 julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'
 julia --project=benchmarks benchmarks/bench_julia.jl
 ```

--- a/benchmarks/bench_julia.jl
+++ b/benchmarks/bench_julia.jl
@@ -1,30 +1,42 @@
 # Cross-tool parse benchmark: ExaPowerIO.jl and PowerModels.jl on the same
-# MATPOWER files caseio is benchmarked on. Median time + bus/branch counts.
+# MATPOWER files caseio is benchmarked on, small cases up to 193k buses.
+# Median time + bus/branch counts (identical across tools = correctness check).
 #
 #   julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'   # once
-#   julia --project=benchmarks benchmarks/bench_julia.jl [case.m ...]
+#   julia --project=benchmarks benchmarks/bench_julia.jl
 #
+# Fetch the large cases first: `bash benchmarks/fetch_cases.sh`.
 # Numbers are per-machine; record them in RESULTS.md rather than hardcoding.
 
 using ExaPowerIO, PowerModels, BenchmarkTools
 PowerModels.silence()
 
-const DEFAULT = [
-    "tests/data/case118.m",
-    "tests/data/case2869pegase.m",
-    "tests/data/large/case_ACTIVSg2000.m",
-    "tests/data/large/case9241pegase.m",
-    "tests/data/large/case13659pegase.m",
+# (name, path, run_powermodels?) — PowerModels is skipped on the huge cases
+# where it takes minutes and the gap is already settled.
+const CASES = [
+    ("case2869pegase", "tests/data/case2869pegase.m", true),
+    ("case_ACTIVSg2000", "tests/data/large/case_ACTIVSg2000.m", true),
+    ("case9241pegase", "tests/data/large/case9241pegase.m", true),
+    ("case13659pegase", "tests/data/large/case13659pegase.m", true),
+    ("case_ACTIVSg10k", "tests/data/large/case_ACTIVSg10k.m", false),
+    ("case_ACTIVSg25k", "tests/data/large/case_ACTIVSg25k.m", false),
+    ("case_ACTIVSg70k", "tests/data/large/case_ACTIVSg70k.m", false),
+    ("case_SyntheticUSA", "tests/data/large/case_SyntheticUSA.m", false),
+    ("case99k", "tests/data/large/case99k.m", false),
+    ("case193k", "tests/data/large/case193k.m", false),
 ]
 
-paths = isempty(ARGS) ? filter(isfile, DEFAULT) : ARGS
-println(rpad("case", 26), rpad("ExaPowerIO", 14), rpad("PowerModels", 14), "buses/branches")
-for f in paths
+println(rpad("case", 20), rpad("ExaPowerIO", 13), rpad("PowerModels", 13), "buses")
+for (name, f, run_pm) in CASES
+    isfile(f) || continue
     ed = ExaPowerIO.parse_matpower(f)
-    be = @benchmark ExaPowerIO.parse_matpower($f) samples = 40 evals = 1
-    bp = @benchmark PowerModels.parse_file($f) samples = 10 evals = 1
-    e = round(median(be).time / 1e6, digits = 3)
-    p = round(median(bp).time / 1e6, digits = 3)
-    println(rpad(basename(f), 26), rpad("$(e) ms", 14), rpad("$(p) ms", 14),
-            "$(length(ed.bus))/$(length(ed.branch))")
+    samples = length(ed.bus) > 30_000 ? 3 : 20
+    be = @benchmark ExaPowerIO.parse_matpower($f) samples = samples evals = 1
+    e = round(median(be).time / 1e6, digits = 2)
+    p = "skip"
+    if run_pm
+        bp = @benchmark PowerModels.parse_file($f) samples = 5 evals = 1
+        p = string(round(median(bp).time / 1e6, digits = 1)) * " ms"
+    end
+    println(rpad(name, 20), rpad("$(e) ms", 13), rpad(p, 13), length(ed.bus))
 end

--- a/benchmarks/fetch_cases.sh
+++ b/benchmarks/fetch_cases.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# Fetch the large MATPOWER cases for the benchmark into tests/data/large
-# (gitignored, kept out of the repo). BSD-3, from the MATPOWER repo.
+# Fetch the large benchmark cases into tests/data/large (gitignored, kept out of
+# the repo). BSD-3. MATPOWER cases from the MATPOWER repo; case99k/case193k from
+# goghino/opf_benchmarks. case193k is ~54 MB.
 set -euo pipefail
-base=https://raw.githubusercontent.com/MATPOWER/matpower/master/data
+mp=https://raw.githubusercontent.com/MATPOWER/matpower/master/data
+gg=https://raw.githubusercontent.com/goghino/opf_benchmarks/master/cases
 dir="$(cd "$(dirname "$0")/.." && pwd)/tests/data/large"
 mkdir -p "$dir"
-for c in case9241pegase case13659pegase case_ACTIVSg2000; do
-  curl -fsSL "$base/$c.m" -o "$dir/$c.m" && echo "fetched $c"
+for c in case9241pegase case13659pegase \
+         case_ACTIVSg2000 case_ACTIVSg10k case_ACTIVSg25k case_ACTIVSg70k \
+         case_SyntheticUSA; do
+  curl -fsSL "$mp/$c.m" -o "$dir/$c.m" && echo "fetched $c"
+done
+for c in case99k case193k; do
+  curl -fsSL "$gg/$c.m" -o "$dir/$c.m" && echo "fetched $c"
 done

--- a/caseio/src/parser/matpower/document.rs
+++ b/caseio/src/parser/matpower/document.rs
@@ -13,41 +13,44 @@
 //! interpretation of its own; the typed layer parses the values it needs from
 //! the same source separately.
 
+use std::ops::Range;
+
 use super::tokens;
 
-/// An ordered, re-serializable view of a MATPOWER case file.
+/// An ordered, re-serializable view of a MATPOWER case file. Holds one owned
+/// copy of the source `text` plus byte ranges into it — no per-line String
+/// allocations — so a large case round-trips with minimal copying.
 #[derive(Debug, Clone)]
 pub struct MatpowerDocument {
-    items: Vec<DocItem>,
+    text: String,
+    items: Vec<Item>,
 }
 
 #[derive(Debug, Clone)]
-enum DocItem {
-    /// A line we round-trip verbatim but don't interpret.
-    Verbatim(String),
-    /// `mpc.<field> = <rhs>;`, captured as its exact (possibly multi-line)
-    /// source text. `field` lets a future editor locate and rewrite a section
-    /// without disturbing the rest of the document.
-    Assignment { field: String, raw: String },
+enum Item {
+    /// A line round-tripped verbatim but not interpreted.
+    Verbatim(Range<usize>),
+    /// `mpc.<field> = <rhs>;`: the field-name range and the whole (possibly
+    /// multi-line) assignment range, both into `text`.
+    Assignment { field: Range<usize>, full: Range<usize> },
 }
 
-impl DocItem {
-    fn raw(&self) -> &str {
+impl Item {
+    fn range(&self) -> Range<usize> {
         match self {
-            DocItem::Verbatim(s) => s,
-            DocItem::Assignment { raw, .. } => raw,
+            Item::Verbatim(r) | Item::Assignment { full: r, .. } => r.clone(),
         }
     }
 }
 
 impl MatpowerDocument {
     /// The raw source text of the first `mpc.<field>` assignment, if present.
-    /// Used by the typed layer for fields it reads only for round-trip extras
-    /// (e.g. `bus_name`).
     #[must_use]
     pub fn assignment(&self, field: &str) -> Option<&str> {
         self.items.iter().find_map(|it| match it {
-            DocItem::Assignment { field: f, raw } if f == field => Some(raw.as_str()),
+            Item::Assignment { field: fr, full } if &self.text[fr.clone()] == field => {
+                Some(&self.text[full.clone()])
+            }
             _ => None,
         })
     }
@@ -58,8 +61,8 @@ impl MatpowerDocument {
         self.items
             .iter()
             .filter_map(|it| match it {
-                DocItem::Assignment { field, .. } => Some(field.as_str()),
-                DocItem::Verbatim(_) => None,
+                Item::Assignment { field, .. } => Some(&self.text[field.clone()]),
+                Item::Verbatim(_) => None,
             })
             .collect()
     }
@@ -68,47 +71,67 @@ impl MatpowerDocument {
 impl std::fmt::Display for MatpowerDocument {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for item in &self.items {
-            writeln!(f, "{}", item.raw())?;
+            writeln!(f, "{}", &self.text[item.range()])?;
         }
         Ok(())
     }
 }
 
 /// Build the document from raw `.m` source. Infallible: a malformed file still
-/// yields a faithful (if not semantically valid) document; the typed parser
-/// reports the actual errors.
+/// yields a faithful document; the typed parser reports the actual errors.
 #[must_use]
-pub fn build_document(source: &str) -> MatpowerDocument {
-    let lines: Vec<&str> = source.lines().collect();
+pub fn build_document(content: &str) -> MatpowerDocument {
+    let base = content.as_ptr() as usize;
+    // Logical lines as (range, slice) with terminators trimmed off the range,
+    // so `Display` reproduces the `\n`-joined, single-trailing-`\n` output the
+    // round-trip tests pin (matching `str::lines` semantics).
+    let lines: Vec<(Range<usize>, &str)> = {
+        let mut out = Vec::new();
+        let mut off = 0usize;
+        for piece in content.split_inclusive('\n') {
+            let start = off;
+            off += piece.len();
+            let trimmed = piece
+                .strip_suffix('\n')
+                .map_or(piece, |s| s.strip_suffix('\r').unwrap_or(s));
+            out.push((start..start + trimmed.len(), trimmed));
+        }
+        out
+    };
+
     let mut items = Vec::with_capacity(lines.len());
     let mut i = 0;
     while i < lines.len() {
-        let line = lines[i];
+        let (line_range, line) = (lines[i].0.clone(), lines[i].1);
         let (code, _comment) = tokens::comment_split(line);
         if let Some((field, rhs)) = parse_assignment_start(code) {
-            let mut raw = String::from(line);
-            // A `[ … ]` / `{ … }` right-hand side can span many lines; pull
-            // them in until the brackets balance.
+            // The field name borrows from `content`; its offset into `text`
+            // (== content byte-for-byte) is pointer arithmetic, not a re-search.
+            let field_off = field.as_ptr() as usize - base;
+            let mut full = line_range;
+            // A `[ … ]` / `{ … }` RHS can span lines; extend until balanced.
             if rhs.starts_with('[') || rhs.starts_with('{') {
                 let mut depth = net_bracket_depth(code);
                 while depth > 0 && i + 1 < lines.len() {
                     i += 1;
-                    let next = lines[i];
-                    raw.push('\n');
-                    raw.push_str(next);
-                    depth += net_bracket_depth(tokens::comment_split(next).0);
+                    full.end = lines[i].0.end;
+                    depth += net_bracket_depth(tokens::comment_split(lines[i].1).0);
                 }
             }
-            items.push(DocItem::Assignment {
-                field: field.to_string(),
-                raw,
+            items.push(Item::Assignment {
+                field: field_off..field_off + field.len(),
+                full,
             });
         } else {
-            items.push(DocItem::Verbatim(line.to_string()));
+            items.push(Item::Verbatim(line_range));
         }
         i += 1;
     }
-    MatpowerDocument { items }
+
+    MatpowerDocument {
+        text: content.to_owned(),
+        items,
+    }
 }
 
 /// Extract the quoted strings from a `{ '...'; '...' }` cell array assignment,
@@ -125,20 +148,27 @@ pub(crate) fn parse_string_cell(raw: &str) -> Vec<String> {
         if q == b'\'' || q == b'"' {
             let start = i + 1;
             let mut j = start;
+            let mut escaped = false;
             // Close on a quote that isn't doubled; skip `''` escape pairs.
             while j < bytes.len() {
                 if bytes[j] == q {
                     if bytes.get(j + 1) == Some(&q) {
                         j += 2;
+                        escaped = true;
                         continue;
                     }
                     break;
                 }
                 j += 1;
             }
-            let qc = q as char;
             let content = &raw[start..j.min(bytes.len())];
-            out.push(content.replace(&format!("{qc}{qc}"), &qc.to_string()));
+            // Common case (no `''`): one owned String, no format!/replace churn.
+            out.push(if escaped {
+                let qc = q as char;
+                content.replace(&format!("{qc}{qc}"), &qc.to_string())
+            } else {
+                content.to_owned()
+            });
             i = (j + 1).min(bytes.len());
         } else {
             i += 1;

--- a/caseio/src/parser/matpower/matlab.rs
+++ b/caseio/src/parser/matpower/matlab.rs
@@ -1,35 +1,19 @@
-//! Extract `mpc.<field> = ...;` values (scalar, string, matrix) from a
-//! comment stripped source. Parses only the small MATLAB subset MATPOWER
-//! case files use.
+//! Extract `mpc.<field> = ...;` values from a MATPOWER case.
 //!
-//! A single linear scan per field locates `mpc.<field> =` and reads the RHS
-//! directly. No regex: the field finders are the parser hot path, and a hand
-//! scan over `&str` is several times faster than running a regex engine.
-//!
-//! Matrix values come back row by row as `Vec<Vec<f64>>` so the domain layer
-//! can map columns to `Bus` / `Branch` without further parsing.
+//! Scalars are found by a linear `mpc.<field> =` scan. Matrices are parsed by
+//! [`for_each_matrix_row`], which reads a single assignment's text, strips
+//! comments inline per line, splits rows on `;`, and yields each row into a
+//! reused buffer — no whole-section copy and no `Vec<Vec<f64>>` intermediate.
 
 use crate::{Error, Result};
 
-/// Which kind of right-hand side a finder wants. A scalar finder skips an
-/// assignment whose RHS opens with `[` (it's a matrix), and vice versa, so the
-/// two finders pick the first occurrence of the kind they care about.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Rhs {
-    Scalar,
-    Matrix,
-}
-
-/// Right-hand side of the first `mpc.<field> = …` assignment of the wanted
-/// kind. The returned slice starts at the first non-space character after `=`.
-fn find_rhs<'a>(source: &'a str, field: &str, want: Rhs) -> Option<&'a str> {
+/// The first `mpc.<field> = <scalar>` RHS (a matrix RHS is skipped), trimmed.
+/// The identifier must match exactly so a search for `gen` skips `gencost`.
+fn find_scalar_rhs<'a>(source: &'a str, field: &str) -> Option<&'a str> {
     let mut from = 0;
     while let Some(rel) = source[from..].find("mpc.") {
         let after_dot = from + rel + "mpc.".len();
-        from = after_dot; // always advance past this `mpc.` to avoid re-finding it
-
-        // The identifier must be exactly `field`, not a longer name it prefixes,
-        // so a search for `gen` skips `gencost`.
+        from = after_dot; // advance past this `mpc.` so we don't re-find it
         let Some(tail) = source[after_dot..].strip_prefix(field) else {
             continue;
         };
@@ -40,29 +24,24 @@ fn find_rhs<'a>(source: &'a str, field: &str, want: Rhs) -> Option<&'a str> {
             continue; // `mpc.<field>` not used as an assignment target here
         };
         let rhs = rhs.trim_start();
-        let is_matrix = rhs.starts_with('[');
-        let wanted = match want {
-            Rhs::Matrix => is_matrix,
-            Rhs::Scalar => !is_matrix,
-        };
-        if wanted {
-            return Some(rhs);
+        if rhs.starts_with('[') {
+            continue; // a matrix RHS, not a scalar
         }
+        return Some(rhs);
     }
     None
 }
 
 /// Find `mpc.<field> = <number>;` and return the parsed value, if present.
 pub(crate) fn find_scalar(source: &str, field: &str) -> Result<Option<f64>> {
-    let Some(rhs) = find_rhs(source, field, Rhs::Scalar) else {
+    let Some(rhs) = find_scalar_rhs(source, field) else {
         return Ok(None);
     };
-    // Value is everything up to the terminating `;`.
     let Some(end) = rhs.find(';') else {
         return Ok(None);
     };
-    // `find_rhs` already trimmed the front; only the tail before `;` can have
-    // trailing space. Then strip surrounding quotes (e.g. mpc.version = '2';).
+    // Only the tail before `;` can have trailing space; then strip surrounding
+    // quotes (e.g. `mpc.version = '2';`).
     let value = rhs[..end].trim_end().trim_matches(|c| c == '\'' || c == '"');
     value.parse::<f64>().map(Some).map_err(|_| Error::BadFloat {
         field: leak_field(field),
@@ -71,81 +50,72 @@ pub(crate) fn find_scalar(source: &str, field: &str) -> Result<Option<f64>> {
     })
 }
 
-/// Find `mpc.<field> = [ ... ];` and return parsed rows, if present.
-///
-/// Each row is a `Vec<f64>`; rows are separated by `;` inside the brackets.
-/// Whitespace and newlines within a row are ignored.
-pub(crate) fn find_matrix(source: &str, field: &str) -> Result<Option<Vec<Vec<f64>>>> {
-    let Some(rhs) = find_rhs(source, field, Rhs::Matrix) else {
-        return Ok(None);
-    };
-
-    // `rhs` begins with the opening `[`. Walk forward tracking bracket balance
-    // (matrices can nest, e.g. a string column) until the matching close.
-    let bytes = rhs.as_bytes();
-    let mut depth = 0i32;
-    let mut close = None;
-    for (i, &b) in bytes.iter().enumerate() {
-        match b {
-            b'[' => depth += 1,
-            b']' => {
-                depth -= 1;
-                if depth == 0 {
-                    close = Some(i);
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    let Some(close) = close else {
-        return Err(Error::UnbalancedBrackets(leak_field(field)));
-    };
-
-    let body = &rhs[1..close];
-    Ok(Some(parse_matrix_body(body, field)?))
-}
-
-fn parse_matrix_body(body: &str, field: &str) -> Result<Vec<Vec<f64>>> {
-    let mut rows = Vec::new();
-    for (row_idx, raw) in body.split(';').enumerate() {
-        let trimmed = raw.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let mut vals = Vec::with_capacity(16);
-        for tok in trimmed.split_ascii_whitespace() {
-            let t = tok.trim_end_matches(',');
-            if t.is_empty() {
-                continue;
-            }
-            let v = parse_float(t).ok_or_else(|| Error::BadFloat {
-                field: leak_field(field),
-                row: row_idx,
-                value: t.to_string(),
-            })?;
-            vals.push(v);
-        }
-        if !vals.is_empty() {
-            rows.push(vals);
-        }
-    }
-    Ok(rows)
-}
-
-/// Parse the matrix from a single `mpc.<field> = [ … ];` assignment's raw
-/// source text. Comments are stripped from just this section (cheap), then the
-/// existing matrix scanner runs over it. This is how the document-derived
-/// single-pass parser avoids re-scanning the whole file per field.
-pub(crate) fn matrix_from_assignment(raw: &str, field: &str) -> Result<Vec<Vec<f64>>> {
-    let stripped = super::tokens::strip_comments(raw);
-    Ok(find_matrix(&stripped, field)?.unwrap_or_default())
-}
-
-/// Parse the scalar from a single `mpc.<field> = <number>;` assignment.
+/// Parse the scalar from a single `mpc.<field> = <number>;` assignment's text.
 pub(crate) fn scalar_from_assignment(raw: &str, field: &str) -> Result<Option<f64>> {
     let stripped = super::tokens::strip_comments(raw);
     find_scalar(&stripped, field)
+}
+
+/// Stream the rows of an `mpc.<field> = [ … ];` assignment. `assignment` is the
+/// raw (comment-bearing, possibly multi-line) source of one assignment from the
+/// document. Comments are stripped per line, rows split on `;`, tokens parsed
+/// into a reused buffer, and `f` is invoked per non-empty row — so the caller
+/// builds its typed `Vec` directly, with no `Vec<Vec<f64>>` and no whole-section
+/// comment-strip copy. `f` receives the same 0-based non-empty-row index the
+/// old `Vec<Vec<f64>>` path passed to `from_row`.
+pub(crate) fn for_each_matrix_row<F>(assignment: &str, field: &str, mut f: F) -> Result<()>
+where
+    F: FnMut(&[f64], usize) -> Result<()>,
+{
+    let mut buf: Vec<f64> = Vec::with_capacity(24);
+    let mut row = 0usize;
+    let mut inside = false; // have we passed the opening `[`?
+    let mut done = false; // have we hit the closing `]`?
+    for line in assignment.lines() {
+        if done {
+            break;
+        }
+        let mut code = super::tokens::comment_split(line).0;
+        if !inside {
+            let Some(open) = code.find('[') else {
+                continue;
+            };
+            code = &code[open + 1..];
+            inside = true;
+        }
+        // Numeric matrix bodies have no nested `[`, so the first `]` closes it.
+        if let Some(close) = code.find(']') {
+            code = &code[..close];
+            done = true;
+        }
+        let mut segments = code.split(';').peekable();
+        while let Some(seg) = segments.next() {
+            let terminated = segments.peek().is_some(); // a `;` followed this segment
+            for tok in seg.split_ascii_whitespace() {
+                let t = tok.trim_end_matches(',');
+                if t.is_empty() {
+                    continue;
+                }
+                buf.push(parse_float(t).ok_or_else(|| Error::BadFloat {
+                    field: leak_field(field),
+                    row,
+                    value: t.to_string(),
+                })?);
+            }
+            if terminated {
+                if !buf.is_empty() {
+                    f(&buf, row)?;
+                    row += 1;
+                }
+                buf.clear();
+            }
+        }
+    }
+    // A final row not terminated by `;` (e.g. the last row before `];`).
+    if !buf.is_empty() {
+        f(&buf, row)?;
+    }
+    Ok(())
 }
 
 fn parse_float(tok: &str) -> Option<f64> {
@@ -159,9 +129,9 @@ fn parse_float(tok: &str) -> Option<f64> {
     }
 }
 
-/// `Error::BadFloat`/`MissingField` want `&'static str`. We accept user
-/// input field names but only ever pass through known names here, so the
-/// fallback is bounded to the small set MATPOWER itself defines.
+/// `Error::BadFloat`/`MissingField` want `&'static str`. We accept user input
+/// field names but only ever pass through known names here, so the fallback is
+/// bounded to the small set MATPOWER itself defines.
 fn leak_field(field: &str) -> &'static str {
     match field {
         "baseMVA" => "baseMVA",

--- a/caseio/src/parser/matpower/mod.rs
+++ b/caseio/src/parser/matpower/mod.rs
@@ -45,24 +45,22 @@ fn parse_matpower_named(content: &str, name: &str) -> Result<MpcCase> {
         .transpose()?
         .ok_or(Error::MissingField("baseMVA"))?;
 
-    let bus_rows = matrix_field(&source, "bus")?.ok_or(Error::MissingField("bus"))?;
-    let branch_rows = matrix_field(&source, "branch")?.ok_or(Error::MissingField("branch"))?;
-
-    let mut buses: Vec<Bus> = bus_rows
-        .iter()
-        .enumerate()
-        .map(|(i, row)| Bus::from_row(row, i))
-        .collect::<Result<_>>()?;
-
-    let branches: Vec<Branch> = branch_rows
-        .iter()
-        .enumerate()
-        .map(|(i, row)| Branch::from_row(row, i))
-        .collect::<Result<_>>()?;
+    let mut buses = parse_rows(
+        source.assignment("bus").ok_or(Error::MissingField("bus"))?,
+        "bus",
+        Bus::from_row,
+    )?;
+    let branches = parse_rows(
+        source
+            .assignment("branch")
+            .ok_or(Error::MissingField("branch"))?,
+        "branch",
+        Branch::from_row,
+    )?;
 
     let gens = parse_gens(&source)?;
-    let storage = parse_storage(&source)?;
-    let dclines = parse_dclines(&source)?;
+    let storage = parse_optional(&source, "storage", Storage::from_row)?;
+    let dclines = parse_optional(&source, "dcline", DcLine::from_row)?;
 
     // Bus names live in a `{...}` cell array; pull them from the document
     // (which kept the quotes) and attach by position when the count matches.
@@ -82,70 +80,59 @@ fn parse_matpower_named(content: &str, name: &str) -> Result<MpcCase> {
         .with_source(source))
 }
 
-/// Parse a field's matrix from its document assignment, if the field is present.
-fn matrix_field(doc: &MatpowerDocument, field: &str) -> Result<Option<Vec<Vec<f64>>>> {
+/// Stream the rows of one assignment, building a typed `T` per row via `ctor`.
+fn parse_rows<T>(
+    assignment: &str,
+    field: &str,
+    ctor: impl Fn(&[f64], usize) -> Result<T>,
+) -> Result<Vec<T>> {
+    let mut out = Vec::new();
+    matlab::for_each_matrix_row(assignment, field, |row, i| {
+        out.push(ctor(row, i)?);
+        Ok(())
+    })?;
+    Ok(out)
+}
+
+/// Like [`parse_rows`] but for an optional `mpc.<field>` block (empty if absent).
+fn parse_optional<T>(
+    doc: &MatpowerDocument,
+    field: &str,
+    ctor: impl Fn(&[f64], usize) -> Result<T>,
+) -> Result<Vec<T>> {
     match doc.assignment(field) {
-        Some(raw) => Ok(Some(matlab::matrix_from_assignment(raw, field)?)),
-        None => Ok(None),
+        Some(raw) => parse_rows(raw, field, ctor),
+        None => Ok(Vec::new()),
     }
-}
-
-/// Parse the optional `mpc.dcline` block (two-terminal HVDC).
-fn parse_dclines(doc: &MatpowerDocument) -> Result<Vec<DcLine>> {
-    let Some(rows) = matrix_field(doc, "dcline")? else {
-        return Ok(Vec::new());
-    };
-    rows.iter()
-        .enumerate()
-        .map(|(i, row)| DcLine::from_row(row, i))
-        .collect()
-}
-
-/// Parse the optional `mpc.storage` block. A case without storage gets none.
-fn parse_storage(doc: &MatpowerDocument) -> Result<Vec<Storage>> {
-    let Some(rows) = matrix_field(doc, "storage")? else {
-        return Ok(Vec::new());
-    };
-    rows.iter()
-        .enumerate()
-        .map(|(i, row)| Storage::from_row(row, i))
-        .collect()
 }
 
 /// Parse `mpc.gen` and fold in the active-power block of `mpc.gencost`.
 /// Both are optional: a power-flow-only case has neither and gets no gens.
 fn parse_gens(doc: &MatpowerDocument) -> Result<Vec<Generator>> {
-    let Some(gen_rows) = matrix_field(doc, "gen")? else {
+    let Some(raw) = doc.assignment("gen") else {
         return Ok(Vec::new());
     };
-
-    let mut gens: Vec<Generator> = gen_rows
-        .iter()
-        .enumerate()
-        .map(|(i, row)| Generator::from_row(row, i))
-        .collect::<Result<_>>()?;
+    let mut gens = parse_rows(raw, "gen", Generator::from_row)?;
 
     // MATPOWER lays the active-power costs first, one row per generator and in
     // the same order; reactive-power costs (if any) follow in a second block.
-    if let Some(cost_rows) = matrix_field(doc, "gencost")? {
+    if let Some(craw) = doc.assignment("gencost") {
+        let costs = parse_rows(craw, "gencost", GenCost::from_row)?;
         // Reject a count that is neither `n_gen` (active only) nor `2·n_gen`
-        // (active + reactive) so a truncated/garbled block is caught here
-        // instead of silently truncating via `zip` and surfacing later as a
-        // misleading per-generator `MissingGenCost`.
+        // (active + reactive) so a truncated/garbled block is caught here.
         let n = gens.len();
-        if cost_rows.len() != n && cost_rows.len() != 2 * n {
+        if costs.len() != n && costs.len() != 2 * n {
             return Err(Error::GenCostCountMismatch {
                 gens: n,
-                gencost: cost_rows.len(),
+                gencost: costs.len(),
             });
         }
-        for (i, (gen, row)) in gens.iter_mut().zip(&cost_rows[..n]).enumerate() {
-            gen.cost = Some(GenCost::from_row(row, i)?);
+        for (gen, cost) in gens.iter_mut().zip(&costs[..n]) {
+            gen.cost = Some(cost.clone());
         }
-        // The optional second block holds reactive-power costs, one row per gen.
-        if cost_rows.len() == 2 * n {
-            for (i, (gen, row)) in gens.iter_mut().zip(&cost_rows[n..]).enumerate() {
-                gen.reactive_cost = Some(GenCost::from_row(row, n + i)?);
+        if costs.len() == 2 * n {
+            for (gen, cost) in gens.iter_mut().zip(&costs[n..]) {
+                gen.reactive_cost = Some(cost.clone());
             }
         }
     }


### PR DESCRIPTION
Close the `case_ACTIVSg2000` gap (caseio trailed ExaPowerIO ~1.2× there) by cutting allocation, and prove scaling to **193k buses**.

## What changed
- **Document holds byte ranges** into one owned `text` instead of a `String` per line — thousands of small allocations become one. `Display`/`assignment` slice `text`; the byte-exact round-trip is untouched.
- **Streaming matrix parse**: `for_each_matrix_row` walks one assignment's text, strips comments inline, and yields each row into a reused buffer — no per-section `strip_comments` copy, no `Vec<Vec<f64>>` intermediate.
- **`parse_string_cell`**: one owned String per name, dropping the `format!`/redundant `replace` churn unless a `''` escape is present.

The round-trip tests (`caseio/tests/roundtrip.rs`) pinned correctness through the rewrite.

## Measured (median, same machine, up to 193k buses)

| case | buses | **caseio** | ExaPowerIO | PowerModels |
| --- | --- | --- | --- | --- |
| case2869pegase | 2869 | **1.99 ms** | 3.14 ms | 133 ms |
| case_ACTIVSg2000 | 2000 | 2.40 ms | 2.39 ms | 154 ms |
| case9241pegase | 9241 | **6.15 ms** | 9.34 ms | 598 ms |
| case_ACTIVSg70k | 70000 | 68.7 ms | 64.8 ms | — |
| case99k | 99396 | 92.2 ms | 92.0 ms | — |
| case193k | 192768 | 185 ms | 178 ms | — |

## Honest read
- case_ACTIVSg2000: **2.74 → 2.40 ms — now a tie** with ExaPowerIO (was a 0.55 ms loss).
- caseio **wins pegase ~1.5×**; **ties / trails ≤8%** on the ACTIVSg / SyntheticUSA cases (their per-generator `gentype`/`genfuel`/`bus_name` metadata is leaner in ExaPowerIO's model — that's the typed output, not parse overhead).
- **25–80× faster than PowerModels** everywhere.
- Scales linearly to case193k (54 MB) in 185 ms; **byte-exact round-trip verified at that size**.
- Small cases improved too (case118 104 → 95 µs). 70 tests green; caseio deps unchanged.

Full table + method in `benchmarks/RESULTS.md`; `benchmarks/fetch_cases.sh` pulls the huge corpus (gitignored — case193k is 54 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)