### PR TITLE
Phase 1a: IndexedNetwork view — matrix layer consumes a derived view, not MpcCase

### DIFF
--- a/caseio/src/case.rs
+++ b/caseio/src/case.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use petgraph::graph::UnGraph;
 
+use crate::indexed::ConnectivityReport;
+
 /// Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -538,21 +540,6 @@ impl MpcCase {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct ConnectivityReport {
-    pub n_buses: usize,
-    pub n_branches_in_service: usize,
-    pub n_components: usize,
-    /// Dense bus indices that have no incident in-service branches.
-    pub isolated_buses: Vec<usize>,
-}
-
-impl ConnectivityReport {
-    #[inline]
-    pub fn is_single_island(&self) -> bool {
-        self.n_components == 1 && self.isolated_buses.is_empty()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/caseio/src/indexed.rs
+++ b/caseio/src/indexed.rs
@@ -1,0 +1,242 @@
+//! [`IndexedNetwork`]: the dense-indexed analysis view over a [`Network`].
+//!
+//! [`Network`] is the canonical data record — format-neutral tables with no
+//! analysis behavior. The matrix builders, connectivity diagnostics, and the
+//! DC-OPF instance need things a plain table doesn't carry: a dense `[0, n)`
+//! bus index, demand and shunts aggregated per bus, the in-service subsets, and
+//! the reference bus. `IndexedNetwork` computes those once from a borrowed
+//! `&Network` and hands them to the numerics. Keeping this on a separate view
+//! (rather than on `Network`) is what stops `Network` from turning into a god
+//! type: data on one side, derived analysis on the other.
+//!
+//! It is cheap — one `HashMap` and four `Vec<f64>` — and built lazily, only
+//! when a matrix or a connectivity query is asked for, so the parse path never
+//! pays for it.
+
+use std::collections::HashMap;
+
+use petgraph::graph::UnGraph;
+
+use crate::case::BusType;
+use crate::network::{Branch, Generator, Network};
+use crate::{Error, Result};
+
+/// A `Network` plus the dense bus index and per-bus aggregates the numerics
+/// need. Borrows the network; build with [`IndexedNetwork::new`].
+#[derive(Debug)]
+pub struct IndexedNetwork<'n> {
+    net: &'n Network,
+    /// Stable bus id → dense index in `[0, n)`.
+    bus_id_to_idx: HashMap<usize, usize>,
+    /// Active demand summed per bus (dense index order, MW).
+    pd: Vec<f64>,
+    /// Reactive demand summed per bus (MVAr).
+    qd: Vec<f64>,
+    /// Shunt conductance summed per bus (MW at V = 1 p.u.).
+    gs: Vec<f64>,
+    /// Shunt susceptance summed per bus (MVAr at V = 1 p.u.).
+    bs: Vec<f64>,
+}
+
+impl<'n> IndexedNetwork<'n> {
+    /// Index `net`: map bus ids to dense indices and fold every load/shunt onto
+    /// its bus. Loads and shunts are summed regardless of their `in_service`
+    /// flag, matching the folded `pd/qd/gs/bs` the MATPOWER-shaped model carried
+    /// on the bus row (the matrices key off topology and these aggregates, not
+    /// per-element service status).
+    #[must_use]
+    pub fn new(net: &'n Network) -> Self {
+        let n = net.buses.len();
+        let mut bus_id_to_idx = HashMap::with_capacity(n);
+        for (idx, b) in net.buses.iter().enumerate() {
+            bus_id_to_idx.insert(b.id, idx);
+        }
+        // A duplicate bus id would collapse two buses onto one dense index and
+        // silently corrupt every aggregate. Readers run `check_references`, but
+        // an in-memory `Network` might not, so guard it in debug builds.
+        debug_assert_eq!(
+            bus_id_to_idx.len(),
+            n,
+            "duplicate bus id in network (run Network::check_references first)"
+        );
+        let mut pd = vec![0.0; n];
+        let mut qd = vec![0.0; n];
+        for l in &net.loads {
+            if let Some(&idx) = bus_id_to_idx.get(&l.bus) {
+                pd[idx] += l.p;
+                qd[idx] += l.q;
+            }
+        }
+        let mut gs = vec![0.0; n];
+        let mut bs = vec![0.0; n];
+        for s in &net.shunts {
+            if let Some(&idx) = bus_id_to_idx.get(&s.bus) {
+                gs[idx] += s.g;
+                bs[idx] += s.b;
+            }
+        }
+        Self { net, bus_id_to_idx, pd, qd, gs, bs }
+    }
+
+    /// The underlying network.
+    #[inline]
+    pub fn network(&self) -> &Network {
+        self.net
+    }
+
+    #[inline]
+    pub fn n(&self) -> usize {
+        self.net.buses.len()
+    }
+
+    #[inline]
+    pub fn base_mva(&self) -> f64 {
+        self.net.base_mva
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.net.name
+    }
+
+    /// All branches, in source order (column order for incidence-based builds).
+    #[inline]
+    pub fn branches(&self) -> &[Branch] {
+        &self.net.branches
+    }
+
+    /// All generators, in source order.
+    #[inline]
+    pub fn generators(&self) -> &[Generator] {
+        &self.net.generators
+    }
+
+    /// Resolve a bus id to its dense `[0, n)` index.
+    #[inline]
+    pub fn bus_index(&self, bus_id: usize) -> Option<usize> {
+        self.bus_id_to_idx.get(&bus_id).copied()
+    }
+
+    /// The bus id at dense index `idx` — the inverse of
+    /// [`bus_index`](Self::bus_index).
+    ///
+    /// # Panics
+    /// Panics if `idx >= n`. Pass a dense index (e.g. from [`bus_index`] or a
+    /// matrix row), not a raw bus id.
+    #[inline]
+    pub fn bus_id(&self, idx: usize) -> usize {
+        self.net.buses[idx].id
+    }
+
+    /// Nodal active demand, length `n`.
+    #[inline]
+    pub fn pd(&self) -> &[f64] {
+        &self.pd
+    }
+
+    /// Nodal reactive demand, length `n`.
+    #[inline]
+    pub fn qd(&self) -> &[f64] {
+        &self.qd
+    }
+
+    /// Nodal shunt conductance, length `n`.
+    #[inline]
+    pub fn gs(&self) -> &[f64] {
+        &self.gs
+    }
+
+    /// Nodal shunt susceptance, length `n`.
+    #[inline]
+    pub fn bs(&self) -> &[f64] {
+        &self.bs
+    }
+
+    /// In-service branches with their index into [`branches`](Self::branches).
+    pub fn in_service_branches(&self) -> impl Iterator<Item = (usize, &Branch)> {
+        self.net.branches.iter().enumerate().filter(|(_, b)| b.in_service)
+    }
+
+    /// In-service generators with their index into [`generators`](Self::generators).
+    pub fn in_service_gens(&self) -> impl Iterator<Item = (usize, &Generator)> {
+        self.net.generators.iter().enumerate().filter(|(_, g)| g.in_service)
+    }
+
+    /// Dense index of the single reference (slack) bus. Errors unless exactly
+    /// one [`BusType::Ref`] exists.
+    pub fn reference_bus_index(&self) -> Result<usize> {
+        let refs: Vec<usize> = self
+            .net
+            .buses
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| b.kind == BusType::Ref)
+            .map(|(i, _)| i)
+            .collect();
+        match refs.as_slice() {
+            [r] => Ok(*r),
+            other => Err(Error::ReferenceBusCount { found: other.len() }),
+        }
+    }
+
+    /// Undirected graph view: node weight = dense bus index, edge weight =
+    /// index into [`branches`](Self::branches). Out-of-service branches are
+    /// skipped; parallel branches are kept as separate edges.
+    pub fn to_petgraph(&self) -> UnGraph<usize, usize> {
+        let mut g = UnGraph::with_capacity(self.n(), self.net.branches.len());
+        let nodes: Vec<_> = (0..self.n()).map(|i| g.add_node(i)).collect();
+        for (idx, br) in self.in_service_branches() {
+            if let (Some(i), Some(j)) = (self.bus_index(br.from), self.bus_index(br.to)) {
+                g.add_edge(nodes[i], nodes[j], idx);
+            }
+        }
+        g
+    }
+
+    /// Number of connected components in the in-service topology.
+    pub fn n_connected_components(&self) -> usize {
+        petgraph::algo::connected_components(&self.to_petgraph())
+    }
+
+    /// True iff the in-service topology is a forest (`|E| = |V| - components`).
+    pub fn is_radial(&self) -> bool {
+        let g = self.to_petgraph();
+        let n_components = petgraph::algo::connected_components(&g);
+        g.edge_count() == g.node_count().saturating_sub(n_components)
+    }
+
+    /// One-shot topological diagnostic.
+    pub fn connectivity_report(&self) -> ConnectivityReport {
+        let g = self.to_petgraph();
+        let n_components = petgraph::algo::connected_components(&g);
+        let isolated: Vec<usize> = g
+            .node_indices()
+            .filter(|n| g.neighbors(*n).next().is_none())
+            .map(|n| g[n])
+            .collect();
+        ConnectivityReport {
+            n_buses: self.n(),
+            n_branches_in_service: self.net.branches.iter().filter(|b| b.in_service).count(),
+            n_components,
+            isolated_buses: isolated,
+        }
+    }
+}
+
+/// Topological invariants the TUI Inspect screen and downstream solvers care
+/// about.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ConnectivityReport {
+    pub n_buses: usize,
+    pub n_branches_in_service: usize,
+    pub n_components: usize,
+    /// Dense bus indices with no incident in-service branch.
+    pub isolated_buses: Vec<usize>,
+}
+
+impl ConnectivityReport {
+    #[inline]
+    pub fn is_single_island(&self) -> bool {
+        self.n_components == 1 && self.isolated_buses.is_empty()
+    }
+}

--- a/caseio/src/lib.rs
+++ b/caseio/src/lib.rs
@@ -10,14 +10,16 @@
 pub mod case;
 pub mod error;
 pub mod format;
+pub mod indexed;
 pub mod network;
 pub mod parser;
 
-pub use case::{Branch, Bus, ConnectivityReport, DcLine, GenCost, Generator, MpcCase, Storage};
+pub use case::{Branch, Bus, DcLine, GenCost, Generator, MpcCase, Storage};
 pub use error::{Error, Result};
 pub use format::{
     parse_powermodels_json, parse_powerworld, parse_psse, write_as, write_egret_json,
     write_powermodels_json, write_powerworld, write_psse, Conversion, TargetFormat,
 };
+pub use indexed::{ConnectivityReport, IndexedNetwork};
 pub use network::{Network, SourceFormat};
 pub use parser::{parse_matpower, parse_matpower_file, write_matpower};

--- a/casemat-ext/src/lib.rs
+++ b/casemat-ext/src/lib.rs
@@ -27,7 +27,7 @@ use casemat::matrix::{
     build_ptdf, build_weighted_laplacian, build_ybus, BuildOptions, DcConvention, Scheme, Units,
 };
 use casemat::opf_pipeline::{write_dcopf_bundle as write_bundle, DcOpfOptions};
-use casemat::MpcCase;
+use casemat::{IndexedNetwork, MpcCase};
 
 pyo3::create_exception!(
     _casemat,
@@ -283,7 +283,9 @@ impl PyCase {
             scheme: parse_scheme(scheme.unwrap_or("bx"))?,
             ..BuildOptions::default()
         };
-        let m = build_bprime(&self.inner, &opts).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_bprime(&view, &opts).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
@@ -299,7 +301,9 @@ impl PyCase {
             scheme: parse_scheme(scheme.unwrap_or("bx"))?,
             ..BuildOptions::default()
         };
-        let m = build_bdoubleprime(&self.inner, &opts).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_bdoubleprime(&view, &opts).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
@@ -311,12 +315,16 @@ impl PyCase {
         include_shifts: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_options(Scheme::Bx, include_taps, include_shifts);
-        let m = build_lacpf(&self.inner, &opts).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_lacpf(&view, &opts).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
     fn adjacency<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let m = build_adjacency(&self.inner).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_adjacency(&view).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
@@ -329,7 +337,9 @@ impl PyCase {
         include_shifts: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_options(Scheme::Bx, include_taps, include_shifts);
-        let yb = build_ybus(&self.inner, &opts).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let yb = build_ybus(&view, &opts).map_err(to_pyerr)?;
         let g = coo_triplets(py, &yb.g)?;
         let b = coo_triplets(py, &yb.b)?;
         Ok((g, b).into_pyobject(py)?.into_any())
@@ -338,14 +348,18 @@ impl PyCase {
     #[pyo3(signature = (convention=None))]
     fn ptdf<'py>(&self, py: Python<'py>, convention: Option<&str>) -> PyResult<Bound<'py, PyAny>> {
         let conv = parse_convention(convention.unwrap_or("paper"))?;
-        let m = build_ptdf(&self.inner, conv).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_ptdf(&view, conv).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
     #[pyo3(signature = (convention=None))]
     fn lodf<'py>(&self, py: Python<'py>, convention: Option<&str>) -> PyResult<Bound<'py, PyAny>> {
         let conv = parse_convention(convention.unwrap_or("paper"))?;
-        let m = build_lodf(&self.inner, conv).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let m = build_lodf(&view, conv).map_err(to_pyerr)?;
         coo_triplets(py, &m)
     }
 
@@ -359,7 +373,9 @@ impl PyCase {
         convention: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let conv = parse_convention(convention.unwrap_or("paper"))?;
-        let parts = build_incidence(&self.inner, conv).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let parts = build_incidence(&view, conv).map_err(to_pyerr)?;
         let a = coo_triplets(py, &parts.a)?;
         let b = parts.b.into_pyarray(py);
         let p_shift = parts.p_shift.into_pyarray(py);
@@ -376,7 +392,9 @@ impl PyCase {
         convention: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let conv = parse_convention(convention.unwrap_or("paper"))?;
-        let parts = build_incidence(&self.inner, conv).map_err(to_pyerr)?;
+        let net = self.inner.to_network();
+        let view = IndexedNetwork::new(&net);
+        let parts = build_incidence(&view, conv).map_err(to_pyerr)?;
         let l = build_weighted_laplacian(&parts.a, &parts.b);
         coo_triplets(py, &l)
     }

--- a/casemat/src/lib.rs
+++ b/casemat/src/lib.rs
@@ -9,11 +9,11 @@
 // the matrix modules' `crate::case` / `crate::Error` / `crate::parser` paths
 // resolve unchanged after the split.
 pub use caseio::{
-    case, error, format, network, parser, parse_matpower, parse_matpower_file,
+    case, error, format, indexed, network, parser, parse_matpower, parse_matpower_file,
     parse_powermodels_json, parse_powerworld, parse_psse, write_as, write_egret_json, write_matpower,
     write_powermodels_json, write_powerworld, write_psse, Branch, Bus,
-    ConnectivityReport, Conversion, DcLine, Error, GenCost, Generator, MpcCase, Network, Result,
-    SourceFormat, Storage, TargetFormat,
+    ConnectivityReport, Conversion, DcLine, Error, GenCost, Generator, IndexedNetwork, MpcCase,
+    Network, Result, SourceFormat, Storage, TargetFormat,
 };
 
 pub mod io;

--- a/casemat/src/main.rs
+++ b/casemat/src/main.rs
@@ -399,16 +399,18 @@ fn run_sensitivities(
     let mpc = casemat::parse_matpower_file(&input)
         .with_context(|| format!("parse {}", input.display()))?;
     std::fs::create_dir_all(&output)?;
-    let ptdf = casemat::build_ptdf(&mpc, convention)
+    let net = mpc.to_network();
+    let view = casemat::IndexedNetwork::new(&net);
+    let ptdf = casemat::build_ptdf(&view, convention)
         .with_context(|| format!("PTDF for {}", input.display()))?;
-    let lodf = casemat::build_lodf(&mpc, convention)
+    let lodf = casemat::build_lodf(&view, convention)
         .with_context(|| format!("LODF for {}", input.display()))?;
-    let ptdf_path = output.join(format!("{}_ptdf.mtx", mpc.name));
-    let lodf_path = output.join(format!("{}_lodf.mtx", mpc.name));
+    let ptdf_path = output.join(format!("{}_ptdf.mtx", view.name()));
+    let lodf_path = output.join(format!("{}_lodf.mtx", view.name()));
     casemat::io::mtx::write_mtx(&ptdf, &ptdf_path)?;
     casemat::io::mtx::write_mtx(&lodf, &lodf_path)?;
     tracing::info!(
-        case = %mpc.name,
+        case = %view.name(),
         ptdf = %ptdf_path.display(),
         lodf = %lodf_path.display(),
         "wrote DC sensitivities"
@@ -442,19 +444,21 @@ fn run_verify(input: PathBuf, kind: MatrixKind, scheme: Scheme) -> anyhow::Resul
         scheme,
         ..Default::default()
     };
+    let net = mpc.to_network();
+    let view = casemat::IndexedNetwork::new(&net);
     let matrix = match kind {
-        MatrixKind::BPrime => casemat::build_bprime(&mpc, &opts)?,
-        MatrixKind::BDoublePrime => casemat::build_bdoubleprime(&mpc, &opts)?,
-        MatrixKind::YbusG => casemat::build_ybus(&mpc, &opts)?.g,
+        MatrixKind::BPrime => casemat::build_bprime(&view, &opts)?,
+        MatrixKind::BDoublePrime => casemat::build_bdoubleprime(&view, &opts)?,
+        MatrixKind::YbusG => casemat::build_ybus(&view, &opts)?.g,
         MatrixKind::YbusB => {
-            let mut b = casemat::build_ybus(&mpc, &opts)?.b;
+            let mut b = casemat::build_ybus(&view, &opts)?.b;
             for v in b.data_mut() {
                 *v = -*v;
             }
             b
         }
-        MatrixKind::Lacpf => casemat::build_lacpf(&mpc, &opts)?,
-        MatrixKind::Adjacency => casemat::build_adjacency(&mpc)?,
+        MatrixKind::Lacpf => casemat::build_lacpf(&view, &opts)?,
+        MatrixKind::Adjacency => casemat::build_adjacency(&view)?,
     };
     let stats = casemat::matrix::MatrixStats::from_csr(&matrix);
     let sddm = sddm_check(&matrix);

--- a/casemat/src/matrix/adjacency.rs
+++ b/casemat/src/matrix/adjacency.rs
@@ -6,21 +6,21 @@ use std::collections::HashSet;
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::matrix::triplet::CooBuilder;
 use crate::{Error, Result};
 
 /// Build the `n × n` 0/1 adjacency matrix.
-pub fn build_adjacency(case: &MpcCase) -> Result<CsMat<f64>> {
+pub fn build_adjacency(case: &IndexedNetwork) -> Result<CsMat<f64>> {
     let n = case.n();
     let mut edges: HashSet<(usize, usize)> = HashSet::new();
     for (idx, br) in case.in_service_branches() {
         let i = case
-            .bus_index(br.from_id)
-            .ok_or(Error::UnknownBus { bus_id: br.from_id, row: idx })?;
+            .bus_index(br.from)
+            .ok_or(Error::UnknownBus { bus_id: br.from, row: idx })?;
         let j = case
-            .bus_index(br.to_id)
-            .ok_or(Error::UnknownBus { bus_id: br.to_id, row: idx })?;
+            .bus_index(br.to)
+            .ok_or(Error::UnknownBus { bus_id: br.to, row: idx })?;
         if i != j {
             edges.insert(if i < j { (i, j) } else { (j, i) });
         }

--- a/casemat/src/matrix/bdoubleprime.rs
+++ b/casemat/src/matrix/bdoubleprime.rs
@@ -10,13 +10,13 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::Result;
 
 use super::ybus::{YbusFlags, build_ybus_with_flags};
 use super::{BuildOptions, Scheme};
 
-pub fn build_bdoubleprime(case: &MpcCase, opts: &BuildOptions) -> Result<CsMat<f64>> {
+pub fn build_bdoubleprime(case: &IndexedNetwork, opts: &BuildOptions) -> Result<CsMat<f64>> {
     let flags = YbusFlags {
         zero_resistance: matches!(opts.scheme, Scheme::Bx),
         zero_charging: false,

--- a/casemat/src/matrix/bprime.rs
+++ b/casemat/src/matrix/bprime.rs
@@ -12,22 +12,22 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::{Error, Result};
 
 use super::{BuildOptions, Scheme, triplet::CooBuilder};
 
-pub fn build_bprime(case: &MpcCase, opts: &BuildOptions) -> Result<CsMat<f64>> {
+pub fn build_bprime(case: &IndexedNetwork, opts: &BuildOptions) -> Result<CsMat<f64>> {
     let n = case.n();
-    let mut coo = CooBuilder::with_capacity(n, 4 * case.branches.len() + n);
+    let mut coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);
 
     for (row_idx, br) in case.in_service_branches() {
-        let i = case.bus_index(br.from_id).ok_or(Error::UnknownBus {
-            bus_id: br.from_id,
+        let i = case.bus_index(br.from).ok_or(Error::UnknownBus {
+            bus_id: br.from,
             row: row_idx,
         })?;
-        let j = case.bus_index(br.to_id).ok_or(Error::UnknownBus {
-            bus_id: br.to_id,
+        let j = case.bus_index(br.to).ok_or(Error::UnknownBus {
+            bus_id: br.to,
             row: row_idx,
         })?;
 

--- a/casemat/src/matrix/incidence.rs
+++ b/casemat/src/matrix/incidence.rs
@@ -8,7 +8,7 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::matrix::triplet::CooBuilder;
 use crate::{Error, Result};
 
@@ -53,18 +53,18 @@ impl IncidenceParts {
 ///
 /// Self-loops (from == to) and branches with `x == 0` (no DC susceptance)
 /// are dropped, so `m` counts only the branches that contribute a column.
-pub fn build_incidence(case: &MpcCase, conv: DcConvention) -> Result<IncidenceParts> {
+pub fn build_incidence(case: &IndexedNetwork, conv: DcConvention) -> Result<IncidenceParts> {
     let n = case.n();
 
     // Pass 1: resolve and filter, fixing the column order.
     let mut cols: Vec<Column> = Vec::new();
     for (idx, br) in case.in_service_branches() {
         let i = case
-            .bus_index(br.from_id)
-            .ok_or(Error::UnknownBus { bus_id: br.from_id, row: idx })?;
+            .bus_index(br.from)
+            .ok_or(Error::UnknownBus { bus_id: br.from, row: idx })?;
         let j = case
-            .bus_index(br.to_id)
-            .ok_or(Error::UnknownBus { bus_id: br.to_id, row: idx })?;
+            .bus_index(br.to)
+            .ok_or(Error::UnknownBus { bus_id: br.to, row: idx })?;
         if i == j || br.x == 0.0 {
             continue;
         }

--- a/casemat/src/matrix/lacpf.rs
+++ b/casemat/src/matrix/lacpf.rs
@@ -19,13 +19,13 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::Result;
 
 use super::ybus::build_ybus;
 use super::BuildOptions;
 
-pub fn build_lacpf(case: &MpcCase, opts: &BuildOptions) -> Result<CsMat<f64>> {
+pub fn build_lacpf(case: &IndexedNetwork, opts: &BuildOptions) -> Result<CsMat<f64>> {
     let parts = build_ybus(case, opts)?;
     let n = case.n();
     let two_n = 2 * n;

--- a/casemat/src/matrix/opf.rs
+++ b/casemat/src/matrix/opf.rs
@@ -9,7 +9,7 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::matrix::incidence::{IncidenceParts, diagonal};
 use crate::matrix::triplet::CooBuilder;
 use crate::{Error, Result};
@@ -65,13 +65,13 @@ pub struct OpfInstance {
 /// cost row, or [`Error::UnsupportedCostModel`] if its cost is present but not
 /// a polynomial of degree ≤ 2.
 pub fn build_opf_instance(
-    case: &MpcCase,
+    case: &IndexedNetwork,
     incidence: &IncidenceParts,
     units: Units,
 ) -> Result<OpfInstance> {
     let n = case.n();
     let m = incidence.m();
-    let base = case.base_mva;
+    let base = case.base_mva();
 
     let p_scale = match units {
         Units::PerUnit => 1.0 / base,
@@ -84,7 +84,7 @@ pub fn build_opf_instance(
         Units::Native => (1.0, 1.0),
     };
 
-    let in_service: Vec<(usize, &crate::case::Generator)> = case.in_service_gens().collect();
+    let in_service: Vec<(usize, &crate::network::Generator)> = case.in_service_gens().collect();
     let n_gen = in_service.len();
     if n_gen == 0 {
         return Err(Error::NoGenerators);
@@ -99,8 +99,8 @@ pub fn build_opf_instance(
 
     for (col, &(gidx, gen)) in in_service.iter().enumerate() {
         let bus = case
-            .bus_index(gen.bus_id)
-            .ok_or(Error::UnknownBus { bus_id: gen.bus_id, row: gidx })?;
+            .bus_index(gen.bus)
+            .ok_or(Error::UnknownBus { bus_id: gen.bus, row: gidx })?;
         // Distinguish a genuinely absent cost from a present-but-unsupported
         // one (piecewise model 1, or polynomial degree ≥ 3) so the error tells
         // the truth about which case the file hit.
@@ -124,12 +124,12 @@ pub fn build_opf_instance(
     let pmax_bus = project_gen_to_bus(&c_g, &pmax_gen);
     let pmin_bus = project_gen_to_bus(&c_g, &pmin_gen);
 
-    let p_d: Vec<f64> = case.buses.iter().map(|b| b.pd * p_scale).collect();
+    let p_d: Vec<f64> = case.pd().iter().map(|&p| p * p_scale).collect();
 
     let f_max: Vec<f64> = incidence
         .branch_of_col
         .iter()
-        .map(|&k| case.branches[k].rate_a * p_scale)
+        .map(|&k| case.branches()[k].rate_a * p_scale)
         .collect();
 
     Ok(OpfInstance {

--- a/casemat/src/matrix/sensitivity.rs
+++ b/casemat/src/matrix/sensitivity.rs
@@ -13,7 +13,7 @@
 
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::matrix::incidence::{DcConvention, IncidenceParts, build_flow_map, build_incidence};
 use crate::matrix::laplacian::{build_weighted_laplacian, ground_at};
 use crate::matrix::triplet::CooBuilder;
@@ -24,7 +24,7 @@ const PRUNE: f64 = 1e-12;
 
 /// PTDF (`m × n`): branch flows from nodal injections, `f = PTDF · p`. The
 /// reference-bus column is zero.
-pub fn build_ptdf(case: &MpcCase, conv: DcConvention) -> Result<CsMat<f64>> {
+pub fn build_ptdf(case: &IndexedNetwork, conv: DcConvention) -> Result<CsMat<f64>> {
     check_connected(case)?;
     let inc = build_incidence(case, conv)?;
     let r = case.reference_bus_index()?;
@@ -35,7 +35,7 @@ pub fn build_ptdf(case: &MpcCase, conv: DcConvention) -> Result<CsMat<f64>> {
 /// Reject a disconnected network up front so the singular grounded Laplacian
 /// reports the real cause ([`Error::DisconnectedNetwork`]) instead of the
 /// generic [`Error::SingularNetwork`] the Cholesky would otherwise raise.
-fn check_connected(case: &MpcCase) -> Result<()> {
+fn check_connected(case: &IndexedNetwork) -> Result<()> {
     let components = case.n_connected_components();
     if components > 1 {
         return Err(Error::DisconnectedNetwork { components });
@@ -46,7 +46,7 @@ fn check_connected(case: &MpcCase) -> Result<()> {
 /// LODF (`m × m`): pre-outage flow on branch `k` redistributes onto branch `l`
 /// with factor `LODF[l, k]`. Diagonal is `−1`. A branch whose outage islands
 /// the network (denominator `≈ 0`) gets a zero column.
-pub fn build_lodf(case: &MpcCase, conv: DcConvention) -> Result<CsMat<f64>> {
+pub fn build_lodf(case: &IndexedNetwork, conv: DcConvention) -> Result<CsMat<f64>> {
     check_connected(case)?;
     let inc = build_incidence(case, conv)?;
     let r = case.reference_bus_index()?;

--- a/casemat/src/matrix/tests.rs
+++ b/casemat/src/matrix/tests.rs
@@ -1,6 +1,7 @@
 use approx::assert_relative_eq;
 
 use crate::case::{Branch, Bus, BusType, MpcCase};
+use crate::indexed::IndexedNetwork;
 use crate::matrix::{
     build_bdoubleprime, build_bprime, build_lacpf, build_ybus, BuildOptions, MatrixStats, Scheme,
 };
@@ -62,7 +63,9 @@ fn three_bus() -> MpcCase {
 #[test]
 fn bprime_three_bus_has_correct_structure() {
     let case = three_bus();
-    let b = build_bprime(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let b = build_bprime(&view, &BuildOptions::default()).unwrap();
     assert_eq!(b.rows(), 3);
     assert_eq!(b.cols(), 3);
 
@@ -84,7 +87,9 @@ fn bprime_three_bus_has_correct_structure() {
 #[test]
 fn bprime_is_symmetric_and_laplacian() {
     let case = three_bus();
-    let b = build_bprime(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let b = build_bprime(&view, &BuildOptions::default()).unwrap();
     let stats = MatrixStats::from_csr(&b);
     // M-matrix sign pattern, exactly singular Laplacian (diag = sum).
     assert!(stats.m_matrix_sign);
@@ -96,7 +101,9 @@ fn bprime_is_symmetric_and_laplacian() {
 fn bprime_ignores_out_of_service() {
     let mut case = three_bus();
     case.branches[0].status = 0.0;
-    let b = build_bprime(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let b = build_bprime(&view, &BuildOptions::default()).unwrap();
     let dense = b.to_dense();
     // Bus 1 only connects via branch 1-3 (x=0.2 → 1/x=5)
     assert_relative_eq!(dense[[0, 0]], 5.0, max_relative = 1e-12);
@@ -109,8 +116,10 @@ fn xb_and_bx_disagree_when_resistance_present() {
     for b in &mut case.branches {
         b.r = 0.05;
     }
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
     let xb = build_bprime(
-        &case,
+        &view,
         &BuildOptions {
             scheme: Scheme::Xb,
             ..Default::default()
@@ -118,7 +127,7 @@ fn xb_and_bx_disagree_when_resistance_present() {
     )
     .unwrap();
     let bx = build_bprime(
-        &case,
+        &view,
         &BuildOptions {
             scheme: Scheme::Bx,
             ..Default::default()
@@ -139,7 +148,9 @@ fn bdoubleprime_with_shunts_is_strictly_dominant() {
     case.buses[0].bs = -10.0; // negative bs → -bs/baseMVA > 0 contribution
     case.buses[1].bs = -10.0;
     case.buses[2].bs = -10.0;
-    let bpp = build_bdoubleprime(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let bpp = build_bdoubleprime(&view, &BuildOptions::default()).unwrap();
     let stats = MatrixStats::from_csr(&bpp);
     assert!(stats.min_dd_margin > 0.0, "expected strict dominance");
 }
@@ -148,7 +159,9 @@ fn bdoubleprime_with_shunts_is_strictly_dominant() {
 fn ybus_reciprocity_and_symmetry() {
     // Without taps and shifts, Y_ij == Y_ji.
     let case = three_bus();
-    let parts = build_ybus(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let parts = build_ybus(&view, &BuildOptions::default()).unwrap();
     let g = parts.g.to_dense();
     let b = parts.b.to_dense();
     for i in 0..3 {
@@ -162,7 +175,9 @@ fn ybus_reciprocity_and_symmetry() {
 #[test]
 fn lacpf_block_is_2n_by_2n() {
     let case = three_bus();
-    let j = build_lacpf(&case, &BuildOptions::default()).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let j = build_lacpf(&view, &BuildOptions::default()).unwrap();
     assert_eq!(j.rows(), 6);
     assert_eq!(j.cols(), 6);
 }

--- a/casemat/src/matrix/ybus.rs
+++ b/casemat/src/matrix/ybus.rs
@@ -15,7 +15,7 @@
 use num_complex::Complex64;
 use sprs::CsMat;
 
-use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::{Error, Result};
 
 use super::triplet::CooBuilder;
@@ -37,7 +37,7 @@ pub(crate) struct YbusFlags {
     pub skip_bus_shunts: bool,
 }
 
-pub fn build_ybus(case: &MpcCase, opts: &super::BuildOptions) -> Result<YbusParts> {
+pub fn build_ybus(case: &IndexedNetwork, opts: &super::BuildOptions) -> Result<YbusParts> {
     let flags = YbusFlags {
         zero_resistance: false,
         zero_charging: false,
@@ -48,18 +48,18 @@ pub fn build_ybus(case: &MpcCase, opts: &super::BuildOptions) -> Result<YbusPart
     build_ybus_with_flags(case, flags)
 }
 
-pub(crate) fn build_ybus_with_flags(case: &MpcCase, flags: YbusFlags) -> Result<YbusParts> {
+pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> Result<YbusParts> {
     let n = case.n();
-    let mut g_coo = CooBuilder::with_capacity(n, 4 * case.branches.len() + n);
-    let mut b_coo = CooBuilder::with_capacity(n, 4 * case.branches.len() + n);
+    let mut g_coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);
+    let mut b_coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);
 
     for (row_idx, br) in case.in_service_branches() {
-        let i = case.bus_index(br.from_id).ok_or(Error::UnknownBus {
-            bus_id: br.from_id,
+        let i = case.bus_index(br.from).ok_or(Error::UnknownBus {
+            bus_id: br.from,
             row: row_idx,
         })?;
-        let j = case.bus_index(br.to_id).ok_or(Error::UnknownBus {
-            bus_id: br.to_id,
+        let j = case.bus_index(br.to).ok_or(Error::UnknownBus {
+            bus_id: br.to,
             row: row_idx,
         })?;
 
@@ -111,9 +111,10 @@ pub(crate) fn build_ybus_with_flags(case: &MpcCase, flags: YbusFlags) -> Result<
     }
 
     if !flags.skip_bus_shunts {
-        for (idx, bus) in case.buses.iter().enumerate() {
-            g_coo.add(idx, idx, bus.gs / case.base_mva);
-            b_coo.add(idx, idx, bus.bs / case.base_mva);
+        let base = case.base_mva();
+        for idx in 0..n {
+            g_coo.add(idx, idx, case.gs()[idx] / base);
+            b_coo.add(idx, idx, case.bs()[idx] / base);
         }
     }
 

--- a/casemat/src/opf_pipeline.rs
+++ b/casemat/src/opf_pipeline.rs
@@ -11,6 +11,7 @@ use serde::Serialize;
 use sprs::CsMat;
 
 use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::io::mtx::{write_mtx, write_vector_mtx};
 use crate::matrix::incidence::{DcConvention, build_flow_map, build_incidence};
 use crate::matrix::laplacian::{build_weighted_laplacian, ground_at, unit_vector};
@@ -49,16 +50,19 @@ pub fn write_dcopf_bundle(
     out_dir: impl AsRef<Path>,
     opts: &DcOpfOptions,
 ) -> Result<DcOpfOutputs> {
-    let dir = out_dir.as_ref().join(format!("{}_dcopf", case.name));
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+
+    let dir = out_dir.as_ref().join(format!("{}_dcopf", view.name()));
     std::fs::create_dir_all(&dir)?;
 
-    let r = case.reference_bus_index()?;
-    let inc = build_incidence(case, opts.convention)?;
+    let r = view.reference_bus_index()?;
+    let inc = build_incidence(&view, opts.convention)?;
     let l = build_weighted_laplacian(&inc.a, &inc.b);
     let l_grounded = ground_at(&l, r);
     let flow = build_flow_map(&inc.a, &inc.b);
-    let opf = build_opf_instance(case, &inc, opts.units)?;
-    let e_r = unit_vector(case.n(), r);
+    let opf = build_opf_instance(&view, &inc, opts.units)?;
+    let e_r = unit_vector(view.n(), r);
 
     let mut files = Vec::new();
 
@@ -87,9 +91,9 @@ pub fn write_dcopf_bundle(
     put_vec(&dir, "pmin_gen.mtx", &opf.pmin_gen, &mut files)?;
 
     let meta = DcOpfMeta {
-        case_name: case.name.clone(),
-        base_mva: case.base_mva,
-        n: case.n(),
+        case_name: view.name().to_string(),
+        base_mva: view.base_mva(),
+        n: view.n(),
         m: inc.m(),
         n_gen: opf.n_gen,
         reference_bus: r,

--- a/casemat/src/pipeline.rs
+++ b/casemat/src/pipeline.rs
@@ -13,6 +13,7 @@ use rand_chacha::ChaCha8Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::case::MpcCase;
+use crate::indexed::IndexedNetwork;
 use crate::io::meta::{CaseMetadata, MatrixMetadata, write_meta_json};
 use crate::io::mtx::{write_mtx, write_vector_mtx};
 use crate::matrix::{
@@ -114,12 +115,15 @@ impl Pipeline {
         let out_dir = out_dir.as_ref();
         std::fs::create_dir_all(out_dir)?;
 
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+
         let mut files = Vec::new();
         let mut matrices_meta = Vec::new();
 
         for &kind in &self.matrices {
-            let matrix_path = out_dir.join(format!("{}_{}.mtx", case.name, kind.slug()));
-            let matrix = self.build(case, kind)?;
+            let matrix_path = out_dir.join(format!("{}_{}.mtx", view.name(), kind.slug()));
+            let matrix = self.build(&view, kind)?;
             write_mtx(&matrix, &matrix_path)?;
             let stats = MatrixStats::from_csr(&matrix);
             let sddm = sddm_check(&matrix);
@@ -136,25 +140,22 @@ impl Pipeline {
             files.push(matrix_path);
 
             // RHS for matrices that take a RHS of length n (skip LACPF which is 2n).
-            if let Some(rhs) = self.build_rhs(case, kind)? {
-                let rhs_path = out_dir.join(format!("{}_{}_rhs.mtx", case.name, kind.slug()));
+            if let Some(rhs) = self.build_rhs(&view, kind)? {
+                let rhs_path = out_dir.join(format!("{}_{}_rhs.mtx", view.name(), kind.slug()));
                 write_vector_mtx(&rhs, &rhs_path)?;
                 files.push(rhs_path);
             }
         }
 
         // Shunt vector as a sidecar (not always meaningful, but cheap).
-        let shunt_path = out_dir.join(format!("{}_shunt.mtx", case.name));
-        let shunt: Vec<f64> = case
-            .buses
-            .iter()
-            .map(|b| b.bs / case.base_mva)
-            .collect();
+        let shunt_path = out_dir.join(format!("{}_shunt.mtx", view.name()));
+        let base = view.base_mva();
+        let shunt: Vec<f64> = view.bs().iter().map(|&b| b / base).collect();
         write_vector_mtx(&shunt, &shunt_path)?;
         files.push(shunt_path);
 
         let metadata = CaseMetadata {
-            case_name: case.name.clone(),
+            case_name: view.name().to_string(),
             source_file: self
                 .source_file
                 .as_ref()
@@ -165,9 +166,9 @@ impl Pipeline {
                 .as_ref()
                 .and_then(|p| std::fs::read(p).ok())
                 .map(|b| sha256_hex(&b)),
-            base_mva: case.base_mva,
-            n_buses: case.n(),
-            n_branches: case.branches.len(),
+            base_mva: view.base_mva(),
+            n_buses: view.n(),
+            n_branches: view.branches().len(),
             build_options: self.options.clone(),
             matrices: matrices_meta,
             casemat_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -177,13 +178,13 @@ impl Pipeline {
         files.push(meta_path);
 
         Ok(PipelineOutputs {
-            case_name: case.name.clone(),
+            case_name: view.name().to_string(),
             files,
             metadata,
         })
     }
 
-    fn build(&self, case: &MpcCase, kind: MatrixKind) -> Result<sprs::CsMat<f64>> {
+    fn build(&self, case: &IndexedNetwork, kind: MatrixKind) -> Result<sprs::CsMat<f64>> {
         match kind {
             MatrixKind::BPrime => build_bprime(case, &self.options),
             MatrixKind::BDoublePrime => build_bdoubleprime(case, &self.options),
@@ -197,7 +198,7 @@ impl Pipeline {
         }
     }
 
-    fn build_rhs(&self, case: &MpcCase, kind: MatrixKind) -> Result<Option<Vec<f64>>> {
+    fn build_rhs(&self, case: &IndexedNetwork, kind: MatrixKind) -> Result<Option<Vec<f64>>> {
         // No meaningful RHS for the 2n LACPF block or the structural adjacency.
         if matches!(self.rhs, RhsKind::None)
             || matches!(kind, MatrixKind::Lacpf | MatrixKind::Adjacency)
@@ -221,19 +222,18 @@ impl Pipeline {
                 }
                 v
             }
-            RhsKind::Injection => match kind {
-                MatrixKind::BPrime | MatrixKind::YbusG | MatrixKind::YbusB => case
-                    .buses
-                    .iter()
-                    .map(|b| -b.pd / case.base_mva)
-                    .collect(),
-                MatrixKind::BDoublePrime => case
-                    .buses
-                    .iter()
-                    .map(|b| -b.qd / case.base_mva)
-                    .collect(),
-                MatrixKind::Lacpf | MatrixKind::Adjacency => unreachable!(),
-            },
+            RhsKind::Injection => {
+                let base = case.base_mva();
+                match kind {
+                    MatrixKind::BPrime | MatrixKind::YbusG | MatrixKind::YbusB => {
+                        case.pd().iter().map(|&p| -p / base).collect()
+                    }
+                    MatrixKind::BDoublePrime => {
+                        case.qd().iter().map(|&q| -q / base).collect()
+                    }
+                    MatrixKind::Lacpf | MatrixKind::Adjacency => unreachable!(),
+                }
+            }
             RhsKind::None => unreachable!(),
         };
         Ok(Some(v))

--- a/casemat/src/tui/app.rs
+++ b/casemat/src/tui/app.rs
@@ -265,21 +265,23 @@ impl App {
             scheme: self.scheme,
             ..Default::default()
         };
+        let net = case.to_network();
+        let view = crate::IndexedNetwork::new(&net);
         let mut matrices = BTreeMap::new();
         for &kind in MatrixKind::ALL {
             let mat = match kind {
-                MatrixKind::BPrime => crate::build_bprime(&case, &opts)?,
-                MatrixKind::BDoublePrime => crate::build_bdoubleprime(&case, &opts)?,
-                MatrixKind::YbusG => crate::build_ybus(&case, &opts)?.g,
+                MatrixKind::BPrime => crate::build_bprime(&view, &opts)?,
+                MatrixKind::BDoublePrime => crate::build_bdoubleprime(&view, &opts)?,
+                MatrixKind::YbusG => crate::build_ybus(&view, &opts)?.g,
                 MatrixKind::YbusB => {
-                    let mut b = crate::build_ybus(&case, &opts)?.b;
+                    let mut b = crate::build_ybus(&view, &opts)?.b;
                     for v in b.data_mut() {
                         *v = -*v;
                     }
                     b
                 }
-                MatrixKind::Lacpf => crate::build_lacpf(&case, &opts)?,
-                MatrixKind::Adjacency => crate::build_adjacency(&case)?,
+                MatrixKind::Lacpf => crate::build_lacpf(&view, &opts)?,
+                MatrixKind::Adjacency => crate::build_adjacency(&view)?,
             };
             let stats = MatrixStats::from_csr(&mat);
             let sddm = sddm_check(&mat);

--- a/casemat/src/tui/screens.rs
+++ b/casemat/src/tui/screens.rs
@@ -502,7 +502,9 @@ fn draw_synth(frame: &mut Frame, app: &App, area: Rect) {
         .border_style(border())
         .title(" Preview ");
     if let Some(case) = &app.synth.generated {
-        if let Ok(b) = crate::build_bprime(case, &Default::default()) {
+        let net = case.to_network();
+        let view = crate::IndexedNetwork::new(&net);
+        if let Ok(b) = crate::build_bprime(&view, &Default::default()) {
             let inner = preview_block.inner(split[1]);
             frame.render_widget(preview_block, split[1]);
             frame.render_widget(Sparsity::new(&b), inner);

--- a/casemat/tests/dcopf.rs
+++ b/casemat/tests/dcopf.rs
@@ -2,6 +2,7 @@
 //! bundle. Run against vendored MATPOWER cases.
 
 use casemat::case::BusType;
+use casemat::IndexedNetwork;
 use casemat::{
     Branch, Bus, DcConvention, Error, GenCost, Generator, MpcCase, Scheme, Units, build_adjacency,
     build_bprime, build_flow_map, build_incidence, build_lodf, build_opf_instance, build_ptdf,
@@ -74,10 +75,12 @@ fn laplacian_equals_bprime_xb() {
     // L = A diag(1/x) Aᵀ is exactly B' in the XB scheme.
     for path in CASES {
         let case = load(path);
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let bp = build_bprime(
-            &case,
+            &view,
             &casemat::BuildOptions {
                 scheme: Scheme::Xb,
                 ..Default::default()
@@ -103,7 +106,9 @@ fn laplacian_equals_bprime_xb() {
 fn incidence_structure() {
     for path in CASES {
         let case = load(path);
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         let (n, m) = (inc.n(), inc.m());
         assert_eq!(inc.a.rows(), n);
         assert_eq!(inc.a.cols(), m);
@@ -130,7 +135,9 @@ fn incidence_structure() {
 fn laplacian_is_psd_with_constant_kernel() {
     for path in CASES {
         let case = load(path);
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let d = dense(&l);
         let n = d.len();
@@ -149,12 +156,14 @@ fn laplacian_is_psd_with_constant_kernel() {
 fn grounded_laplacian_is_spd() {
     for path in CASES {
         let case = load(path);
-        let r = case.reference_bus_index().unwrap();
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let r = view.reference_bus_index().unwrap();
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let lg = ground_at(&l, r);
-        assert_eq!(lg.rows(), case.n() - 1);
-        assert_eq!(lg.cols(), case.n() - 1);
+        assert_eq!(lg.rows(), view.n() - 1);
+        assert_eq!(lg.cols(), view.n() - 1);
         assert!(is_spd(&dense(&lg)), "{path}: grounded L not SPD");
     }
 }
@@ -163,7 +172,9 @@ fn grounded_laplacian_is_spd() {
 fn flow_map_reconstructs_laplacian() {
     for path in CASES {
         let case = load(path);
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         let flow = build_flow_map(&inc.a, &inc.b); // B Aᵀ, m×n
         assert_eq!(flow.rows(), inc.m());
         assert_eq!(flow.cols(), inc.n());
@@ -189,9 +200,11 @@ fn flow_map_reconstructs_laplacian() {
 fn opf_instance_shapes_and_cg() {
     for path in CASES {
         let case = load(path);
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
-        let opf = build_opf_instance(&case, &inc, Units::PerUnit).unwrap();
-        let (n, m, n_gen) = (case.n(), inc.m(), opf.n_gen);
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
+        let opf = build_opf_instance(&view, &inc, Units::PerUnit).unwrap();
+        let (n, m, n_gen) = (view.n(), inc.m(), opf.n_gen);
         assert_eq!(opf.q_bus.len(), n);
         assert_eq!(opf.c_bus.len(), n);
         assert_eq!(opf.pmax_bus.len(), n);
@@ -240,8 +253,10 @@ fn no_generators_errors() {
         seed: 1,
     };
     let case = casemat::synth::generate(&spec);
-    let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
-    let err = build_opf_instance(&case, &inc, Units::PerUnit).unwrap_err();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
+    let err = build_opf_instance(&view, &inc, Units::PerUnit).unwrap_err();
     assert!(matches!(err, Error::NoGenerators), "got {err:?}");
 }
 
@@ -286,9 +301,11 @@ fn reference_bus_count_errors() {
 fn adjacency_is_symmetric_01() {
     for path in CASES {
         let case = load(path);
-        let a = build_adjacency(&case).unwrap();
-        assert_eq!(a.rows(), case.n());
-        assert_eq!(a.cols(), case.n());
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let a = build_adjacency(&view).unwrap();
+        assert_eq!(a.rows(), view.n());
+        assert_eq!(a.cols(), view.n());
         let d = dense(&a);
         for i in 0..d.len() {
             assert!((d[i][i]).abs() < 1e-12, "{path}: nonzero diagonal");
@@ -305,13 +322,15 @@ fn ptdf_satisfies_kcl() {
     // A · PTDF = I − e_r·1ᵀ: nodal balance for every injection.
     for path in CASES {
         let case = load(path);
-        let r = case.reference_bus_index().unwrap();
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
-        let ptdf = build_ptdf(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let r = view.reference_bus_index().unwrap();
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
+        let ptdf = build_ptdf(&view, DcConvention::PaperPure).unwrap();
         assert_eq!(ptdf.rows(), inc.m());
-        assert_eq!(ptdf.cols(), case.n());
+        assert_eq!(ptdf.cols(), view.n());
         let m = dense(&(&inc.a * &ptdf)); // n × n
-        let n = case.n();
+        let n = view.n();
         for i in 0..n {
             for k in 0..n {
                 let expected = f64::from(i == k) - f64::from(i == r);
@@ -334,8 +353,10 @@ fn ptdf_satisfies_kcl() {
 fn lodf_diagonal_is_minus_one() {
     for path in CASES {
         let case = load(path);
-        let lodf = build_lodf(&case, DcConvention::PaperPure).unwrap();
-        let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
+        let net = case.to_network();
+        let view = IndexedNetwork::new(&net);
+        let lodf = build_lodf(&view, DcConvention::PaperPure).unwrap();
+        let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
         assert_eq!(lodf.rows(), inc.m());
         assert_eq!(lodf.cols(), inc.m());
         let d = dense(&lodf);
@@ -430,8 +451,10 @@ fn poly_gen(bus_id: usize, pmax: f64, c2: f64, c1: f64) -> Generator {
 /// DC-OPF instance for `case` under the default PaperPure convention. Returns
 /// the `Result` so error-path tests can assert on the failure.
 fn opf_of(case: &MpcCase, units: Units) -> casemat::Result<casemat::OpfInstance> {
-    let inc = build_incidence(case, DcConvention::PaperPure)?;
-    build_opf_instance(case, &inc, units)
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let inc = build_incidence(&view, DcConvention::PaperPure)?;
+    build_opf_instance(&view, &inc, units)
 }
 
 /// Symmetric 3-bus triangle, slack at bus 1, unit susceptance on every branch.
@@ -455,7 +478,10 @@ fn triangle() -> MpcCase {
 fn ptdf_matches_analytic_triangle() {
     // Hand-derived for the unit triangle, slack = bus 1 (column 0).
     // Inject at bus j, withdraw at slack; read the flow on each branch.
-    let ptdf = dense(&build_ptdf(&triangle(), DcConvention::PaperPure).unwrap());
+    let case = triangle();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let ptdf = dense(&build_ptdf(&view, DcConvention::PaperPure).unwrap());
     let expected = [
         [0.0, -2.0 / 3.0, -1.0 / 3.0], // e0: 1→2
         [0.0, -1.0 / 3.0, -2.0 / 3.0], // e1: 1→3
@@ -477,7 +503,10 @@ fn lodf_matches_analytic_triangle() {
     // Column k = outage of branch k; row l = the flow it pushes onto branch l.
     // Tripping any one edge of the triangle reroutes its flow around the other
     // two, giving ±1 entries.
-    let lodf = dense(&build_lodf(&triangle(), DcConvention::PaperPure).unwrap());
+    let case = triangle();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
     let expected = [
         [-1.0, 1.0, -1.0],
         [1.0, -1.0, 1.0],
@@ -504,13 +533,16 @@ fn matpower_convention_tap_and_shift() {
         vec![branch_xts(1, 2, x, tap, shift_deg)],
     );
 
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+
     // PaperPure ignores tap and shift: b = 1/x, no phase injection.
-    let pp = build_incidence(&case, DcConvention::PaperPure).unwrap();
+    let pp = build_incidence(&view, DcConvention::PaperPure).unwrap();
     assert!((pp.b[0] - 1.0 / x).abs() < 1e-12);
     assert!(pp.p_shift.iter().all(|&v| v == 0.0));
 
     // Matpower: b = 1/(x·τ); makeBdc injection ±b·shift at from/to.
-    let mp = build_incidence(&case, DcConvention::Matpower).unwrap();
+    let mp = build_incidence(&view, DcConvention::Matpower).unwrap();
     let b_e = 1.0 / (x * tap);
     let shift_rad = shift_deg.to_radians();
     assert!((mp.b[0] - b_e).abs() < 1e-12, "b_e {} != {b_e}", mp.b[0]);
@@ -526,8 +558,10 @@ fn bundle_vectors_round_trip() {
     let out = casemat::write_dcopf_bundle(&case, &dir, &casemat::DcOpfOptions::default()).unwrap();
 
     // Default options are PaperPure + PerUnit; rebuild the instance to compare.
-    let inc = build_incidence(&case, DcConvention::PaperPure).unwrap();
-    let opf = build_opf_instance(&case, &inc, Units::PerUnit).unwrap();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let inc = build_incidence(&view, DcConvention::PaperPure).unwrap();
+    let opf = build_opf_instance(&view, &inc, Units::PerUnit).unwrap();
 
     let check = |name: &str, want: &[f64]| {
         let got = casemat::io::read_vector_mtx(out.dir.join(name)).unwrap();
@@ -567,7 +601,9 @@ fn radial_lodf_is_negative_identity() {
         vec![bus(1, BusType::Ref), bus(2, BusType::Pq), bus(3, BusType::Pq)],
         vec![branch(1, 2, 0.1), branch(2, 3, 0.1)],
     );
-    let lodf = dense(&build_lodf(&case, DcConvention::PaperPure).unwrap());
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
     for l in 0..2 {
         for k in 0..2 {
             let want = if l == k { -1.0 } else { 0.0 };
@@ -594,10 +630,12 @@ fn disconnected_network_errors() {
         ],
         vec![branch(1, 2, 0.1), branch(3, 4, 0.1)],
     );
-    assert_eq!(case.n_connected_components(), 2);
-    let p = build_ptdf(&case, DcConvention::PaperPure).unwrap_err();
+    let net = case.to_network();
+    let view = IndexedNetwork::new(&net);
+    assert_eq!(view.n_connected_components(), 2);
+    let p = build_ptdf(&view, DcConvention::PaperPure).unwrap_err();
     assert!(matches!(p, Error::DisconnectedNetwork { components: 2 }), "ptdf: {p:?}");
-    let l = build_lodf(&case, DcConvention::PaperPure).unwrap_err();
+    let l = build_lodf(&view, DcConvention::PaperPure).unwrap_err();
     assert!(matches!(l, Error::DisconnectedNetwork { components: 2 }), "lodf: {l:?}");
 }
 

--- a/casemat/tests/matpower_cases.rs
+++ b/casemat/tests/matpower_cases.rs
@@ -8,6 +8,7 @@ use casemat::matrix::{
     sddm_check,
 };
 use casemat::parse_matpower_file;
+use casemat::IndexedNetwork;
 
 fn fixture(name: &str) -> PathBuf {
     let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -45,7 +46,9 @@ fn case30_parses_correctly() {
 fn bprime_is_singular_laplacian_on_real_cases() {
     for name in ["case9.m", "case14.m", "case30.m", "case57.m"] {
         let mpc = parse_matpower_file(fixture(name)).unwrap();
-        let b = build_bprime(&mpc, &BuildOptions::default()).unwrap();
+        let net = mpc.to_network();
+        let view = IndexedNetwork::new(&net);
+        let b = build_bprime(&view, &BuildOptions::default()).unwrap();
         let stats = MatrixStats::from_csr(&b);
         assert!(stats.m_matrix_sign, "{name}: B' must have M-matrix signs");
         // Singular Laplacian: diag exactly equals row-sum of |off-diag|.
@@ -63,7 +66,9 @@ fn bprime_is_singular_laplacian_on_real_cases() {
 #[test]
 fn bdoubleprime_includes_shunts_on_case30() {
     let mpc = parse_matpower_file(fixture("case30.m")).unwrap();
-    let bpp = build_bdoubleprime(&mpc, &BuildOptions::default()).unwrap();
+    let net = mpc.to_network();
+    let view = IndexedNetwork::new(&net);
+    let bpp = build_bdoubleprime(&view, &BuildOptions::default()).unwrap();
     let stats = MatrixStats::from_csr(&bpp);
     // case30 has explicit bus shunts → strict diagonal dominance.
     assert!(
@@ -75,7 +80,9 @@ fn bdoubleprime_includes_shunts_on_case30() {
 #[test]
 fn ybus_split_matches_complex_invariants() {
     let mpc = parse_matpower_file(fixture("case14.m")).unwrap();
-    let parts = build_ybus(&mpc, &BuildOptions::default()).unwrap();
+    let net = mpc.to_network();
+    let view = IndexedNetwork::new(&net);
+    let parts = build_ybus(&view, &BuildOptions::default()).unwrap();
     assert_eq!(parts.g.rows(), mpc.n());
     assert_eq!(parts.b.rows(), mpc.n());
     // Without phase shifters case14 should yield symmetric Y_bus.
@@ -92,7 +99,9 @@ fn ybus_split_matches_complex_invariants() {
 #[test]
 fn lacpf_block_dimensions() {
     let mpc = parse_matpower_file(fixture("case14.m")).unwrap();
-    let j = build_lacpf(&mpc, &BuildOptions::default()).unwrap();
+    let net = mpc.to_network();
+    let view = IndexedNetwork::new(&net);
+    let j = build_lacpf(&view, &BuildOptions::default()).unwrap();
     assert_eq!(j.rows(), 2 * mpc.n());
     assert_eq!(j.cols(), 2 * mpc.n());
 }


### PR DESCRIPTION
Stacked on #33 (Phase 0). First half of the Network-canonical refactor.

## What changes
Introduces `IndexedNetwork<'n>` (`caseio/src/indexed.rs`): a derived view that borrows a `&Network` and computes the dense bus index, per-bus aggregated `pd/qd/gs/bs`, the in-service branch/gen iterators, the reference bus, and the petgraph connectivity report. Every matrix builder, the OPF instance, and the connectivity diagnostics now take `&IndexedNetwork` instead of the MATPOWER-shaped `MpcCase`.

This is the data/analysis split: `Network` stays a format-neutral data record; the analysis substrate the numerics need lives on the view. It keeps `Network` from becoming a god type, and it's the shape issue #32 (the `caseio` Python package) and the C ABI will bind.

## Behavior-preserving
Verified independently of reading the diff: `casemat batch`, `dcopf`, and `sensitivities` over the vendored cases produce **byte-identical** output on this branch vs the base. The nodal aggregation reproduces the old folded `bus.pd/qd/gs/bs` exactly (loads/shunts summed per bus, ignoring `in_service` to match the old bus-row semantics, documented on `new`). Branch/gen order and the `status==1.0` in-service filter are preserved through `to_network()`, so incidence columns, `branch_of_col`, and OPF `gen_of_col` are unchanged.

## Transitional
The MATPOWER reader still returns `MpcCase`, so call sites build the view via `case.to_network()` then `IndexedNetwork::new(&net)`. **Phase 1b** makes `Network` the parse output, dissolves `MpcCase`, points synth/the writer at `Network`, and drops these `to_network()` conversions (and the analysis methods still duplicated on `MpcCase`). Splitting it this way keeps each PR reviewable; the byte-exact MATPOWER round-trip and the matrix correctness tests are the contract and stay green.

## Review hardening applied
- `IndexedNetwork::new` `debug_assert`s no duplicate bus id (would silently corrupt aggregates).
- `bus_id` documents its `# Panics` (inverse of the `Option`-returning `bus_index`).
- `run_sensitivities` uses `view.name()` for consistency with the other subcommands.

## Verification
`cargo test` (90 tests) green; `cargo clippy -p casemat-ext --no-deps --features extension-module -- -D warnings` clean; `cargo check -p casemat --features kkt` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)