### PR TITLE
Phase 2: caseio Python package (#32) — parse/write/convert, no numpy/scipy

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,6 +26,8 @@ jobs:
       # gate on this crate only.
       - name: Clippy (casemat-ext)
         run: cargo clippy -p casemat-ext --no-deps --features extension-module -- -D warnings
+      - name: Clippy (caseio-ext)
+        run: cargo clippy -p caseio-ext --no-deps --features extension-module -- -D warnings
 
   test:
     runs-on: ubuntu-latest
@@ -44,6 +46,9 @@ jobs:
       # Quote the extras so the shell doesn't glob `[networkx]`.
       - name: Install casemat + test deps
         run: pip install '.[networkx]' pytest
+      # The caseio wheel (no numpy/scipy) builds from its own pyproject.
+      - name: Install caseio
+        run: pip install ./caseio-ext
       - name: Run tests
         run: pytest python/tests -q
 
@@ -66,11 +71,17 @@ jobs:
         with:
           python-version: "3.x"
       # abi3-py39 → one wheel per platform covers Python 3.9+.
-      - name: Build wheels
+      - name: Build casemat wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
+          manylinux: auto
+      - name: Build caseio wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -m caseio-ext/pyproject.toml
           manylinux: auto
       - uses: actions/upload-artifact@v4
         with:
@@ -82,11 +93,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build sdist
+      - name: Build casemat sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
+      - name: Build caseio sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist -m caseio-ext/pyproject.toml
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "caseio-ext"
+version = "0.1.0"
+dependencies = [
+ "caseio",
+ "pyo3",
+]
+
+[[package]]
 name = "casemat"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
-members = ["caseio", "casemat", "casemat-ext"]
+members = ["caseio", "casemat", "casemat-ext", "caseio-ext"]
 # Bare `cargo build`/`test`/`clippy` touch only the two Rust library crates, so
-# the toolchain never compiles the PyO3 extension (which needs libpython). Build
-# the bindings explicitly with `-p casemat-ext`.
+# the toolchain never compiles the PyO3 extensions (which need libpython). Build
+# the bindings explicitly with `-p casemat-ext` / `-p caseio-ext`.
 default-members = ["caseio", "casemat"]
 resolver = "2"
 

--- a/caseio-ext/Cargo.toml
+++ b/caseio-ext/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "caseio-ext"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.86"
+description = "PyO3 extension module for caseio (builds the `caseio` Python wheel; not published to crates.io)."
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/eigenergy/caseio"
+publish = false
+
+# The compiled module is imported as `caseio._caseio`; the `caseio` Python
+# package (python/caseio/) wraps it. No numpy/scipy: parse/write/convert hand
+# back plain dicts and strings, so the wheel has no runtime dependency.
+[lib]
+name = "_caseio"
+crate-type = ["cdylib"]
+
+[features]
+# Opt-in so `cargo test`/`cargo check -p caseio-ext` don't link libpython.
+# maturin turns it on via pyproject `[tool.maturin] features`.
+extension-module = ["pyo3/extension-module"]
+
+[dependencies]
+caseio = { path = "../caseio" }
+pyo3 = { version = "0.27", features = ["abi3-py39"] }

--- a/caseio-ext/pyproject.toml
+++ b/caseio-ext/pyproject.toml
@@ -1,0 +1,37 @@
+# Second maturin build config (maturin takes one [tool.maturin] per pyproject).
+# The root pyproject builds the `casemat` wheel; this one builds `caseio`.
+# Both package trees live under the shared python/ directory.
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "caseio"
+# version is read from caseio-ext/Cargo.toml by maturin (kept single-source).
+dynamic = ["version"]
+description = "Fast, lossless power-system case-file parser and format converter (no numpy/scipy)"
+readme = "../README.md"
+requires-python = ">=3.9"
+license = { text = "MIT OR Apache-2.0" }
+keywords = ["power-systems", "matpower", "parser", "lossless", "convert", "psse"]
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+    "Operating System :: OS Independent",
+]
+# No runtime dependencies on purpose: parse/write/convert hand back plain dicts
+# and strings, so `import caseio` pulls in nothing but the interpreter.
+dependencies = []
+
+[project.urls]
+Repository = "https://github.com/eigenergy/caseio"
+
+[tool.maturin]
+# The Rust extension is this crate; the importable package is python/caseio/
+# (matching project.name), into which `_caseio` is dropped.
+manifest-path = "Cargo.toml"
+module-name = "caseio._caseio"
+python-source = "../python"
+features = ["extension-module"]
+strip = true

--- a/caseio-ext/src/lib.rs
+++ b/caseio-ext/src/lib.rs
@@ -1,0 +1,330 @@
+//! PyO3 extension behind the `caseio` Python package.
+//!
+//! The dependency-light half of the Python story: parse, lossless write, and
+//! cross-format convert, with no numpy/scipy. Everything crosses the boundary
+//! as plain dicts and strings, so `import caseio` pulls in nothing but the
+//! interpreter. The matrix builders live in the separate `casemat` package.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+
+use caseio::{BusType, IndexedNetwork, Network, TargetFormat};
+
+pyo3::create_exception!(
+    _caseio,
+    CaseioError,
+    pyo3::exceptions::PyException,
+    "Error raised by the caseio parser or converter."
+);
+
+/// I/O failures map to the matching `OSError` subclass; parse and data errors
+/// become [`CaseioError`].
+fn to_pyerr(e: caseio::Error) -> PyErr {
+    match e {
+        caseio::Error::Io(io) => io.into(),
+        other => CaseioError::new_err(other.to_string()),
+    }
+}
+
+fn bus_type_str(kind: BusType) -> &'static str {
+    match kind {
+        BusType::Pq => "PQ",
+        BusType::Pv => "PV",
+        BusType::Ref => "REF",
+        BusType::Isolated => "ISOLATED",
+    }
+}
+
+/// A parsed power network: the format-neutral [`Network`] exposed to Python as
+/// dict tables plus topology diagnostics. No matrices — those are in `casemat`.
+#[pyclass(name = "PyCase")]
+pub struct PyCase {
+    inner: Network,
+}
+
+#[pymethods]
+impl PyCase {
+    #[getter]
+    fn name(&self) -> String {
+        self.inner.name.clone()
+    }
+
+    #[getter]
+    fn base_mva(&self) -> f64 {
+        self.inner.base_mva
+    }
+
+    #[getter]
+    fn source_format(&self) -> String {
+        format!("{:?}", self.inner.source_format)
+    }
+
+    #[getter]
+    fn n(&self) -> usize {
+        self.inner.buses.len()
+    }
+
+    #[getter]
+    fn n_branches(&self) -> usize {
+        self.inner.branches.len()
+    }
+
+    #[getter]
+    fn n_gens(&self) -> usize {
+        self.inner.generators.len()
+    }
+
+    #[getter]
+    fn n_loads(&self) -> usize {
+        self.inner.loads.len()
+    }
+
+    #[getter]
+    fn n_shunts(&self) -> usize {
+        self.inner.shunts.len()
+    }
+
+    #[getter]
+    fn is_radial(&self) -> bool {
+        IndexedNetwork::new(&self.inner).is_radial()
+    }
+
+    #[getter]
+    fn n_connected_components(&self) -> usize {
+        IndexedNetwork::new(&self.inner).n_connected_components()
+    }
+
+    /// Dense `[0, n)` index of the single reference bus. Raises if not exactly
+    /// one reference bus is present.
+    fn reference_bus_index(&self) -> PyResult<usize> {
+        IndexedNetwork::new(&self.inner).reference_bus_index().map_err(to_pyerr)
+    }
+
+    #[getter]
+    fn buses<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        for b in &self.inner.buses {
+            let d = PyDict::new(py);
+            d.set_item("id", b.id)?;
+            d.set_item("type", bus_type_str(b.kind))?;
+            d.set_item("vm", b.vm)?;
+            d.set_item("va", b.va)?;
+            d.set_item("base_kv", b.base_kv)?;
+            d.set_item("area", b.area)?;
+            d.set_item("zone", b.zone)?;
+            d.set_item("vmax", b.vmax)?;
+            d.set_item("vmin", b.vmin)?;
+            list.append(d)?;
+        }
+        Ok(list)
+    }
+
+    #[getter]
+    fn loads<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        for l in &self.inner.loads {
+            let d = PyDict::new(py);
+            d.set_item("bus", l.bus)?;
+            d.set_item("p", l.p)?;
+            d.set_item("q", l.q)?;
+            d.set_item("in_service", l.in_service)?;
+            list.append(d)?;
+        }
+        Ok(list)
+    }
+
+    #[getter]
+    fn shunts<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        for s in &self.inner.shunts {
+            let d = PyDict::new(py);
+            d.set_item("bus", s.bus)?;
+            d.set_item("g", s.g)?;
+            d.set_item("b", s.b)?;
+            d.set_item("in_service", s.in_service)?;
+            list.append(d)?;
+        }
+        Ok(list)
+    }
+
+    #[getter]
+    fn branches<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        for br in &self.inner.branches {
+            let d = PyDict::new(py);
+            d.set_item("from", br.from)?;
+            d.set_item("to", br.to)?;
+            d.set_item("r", br.r)?;
+            d.set_item("x", br.x)?;
+            d.set_item("b", br.b)?;
+            d.set_item("rate_a", br.rate_a)?;
+            d.set_item("rate_b", br.rate_b)?;
+            d.set_item("rate_c", br.rate_c)?;
+            d.set_item("tap", br.tap)?;
+            d.set_item("shift", br.shift)?;
+            d.set_item("in_service", br.in_service)?;
+            d.set_item("angmin", br.angmin)?;
+            d.set_item("angmax", br.angmax)?;
+            list.append(d)?;
+        }
+        Ok(list)
+    }
+
+    #[getter]
+    fn gens<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        for g in &self.inner.generators {
+            let d = PyDict::new(py);
+            d.set_item("bus", g.bus)?;
+            d.set_item("pg", g.pg)?;
+            d.set_item("qg", g.qg)?;
+            d.set_item("pmax", g.pmax)?;
+            d.set_item("pmin", g.pmin)?;
+            d.set_item("qmax", g.qmax)?;
+            d.set_item("qmin", g.qmin)?;
+            d.set_item("vg", g.vg)?;
+            d.set_item("mbase", g.mbase)?;
+            d.set_item("in_service", g.in_service)?;
+            match &g.cost {
+                Some(c) => {
+                    let cd = PyDict::new(py);
+                    cd.set_item("model", c.model)?;
+                    cd.set_item("startup", c.startup)?;
+                    cd.set_item("shutdown", c.shutdown)?;
+                    cd.set_item("ncost", c.ncost)?;
+                    cd.set_item("coeffs", c.coeffs.clone())?;
+                    d.set_item("cost", cd)?;
+                }
+                None => d.set_item("cost", py.None())?,
+            }
+            list.append(d)?;
+        }
+        Ok(list)
+    }
+
+    fn connectivity_report<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let r = IndexedNetwork::new(&self.inner).connectivity_report();
+        let d = PyDict::new(py);
+        d.set_item("n_buses", r.n_buses)?;
+        d.set_item("n_branches_in_service", r.n_branches_in_service)?;
+        d.set_item("n_components", r.n_components)?;
+        d.set_item("isolated_buses", r.isolated_buses)?;
+        Ok(d)
+    }
+
+    /// Serialize back to the source format. For a MATPOWER-parsed case this is
+    /// the byte-exact source echo.
+    fn write(&self) -> String {
+        caseio::write_matpower(&self.inner)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "Case(name={:?}, n_buses={}, n_branches={}, n_gens={})",
+            self.inner.name,
+            self.inner.buses.len(),
+            self.inner.branches.len(),
+            self.inner.generators.len()
+        )
+    }
+}
+
+/// Parse a MATPOWER `.m` file from a path.
+#[pyfunction]
+fn parse(path: &str) -> PyResult<PyCase> {
+    let inner = caseio::parse_matpower_file(path).map_err(to_pyerr)?;
+    Ok(PyCase { inner })
+}
+
+/// Parse a MATPOWER case from in-memory `.m` text. `name` overrides the case
+/// name (defaults to "case").
+#[pyfunction]
+#[pyo3(signature = (content, name=None))]
+fn parse_string(content: &str, name: Option<&str>) -> PyResult<PyCase> {
+    let mut inner = caseio::parse_matpower(content).map_err(to_pyerr)?;
+    if let Some(n) = name {
+        inner.name = n.to_string();
+    }
+    Ok(PyCase { inner })
+}
+
+/// Serialize `case` back to MATPOWER `.m` text (byte-exact echo for a
+/// MATPOWER-parsed case).
+#[pyfunction]
+fn write(case: &PyCase) -> String {
+    case.write()
+}
+
+/// Convert a case file to another format through the neutral hub. Returns
+/// `(text, warnings)`. The input format is the file extension unless `from`
+/// overrides it.
+#[pyfunction]
+#[pyo3(signature = (path, to, from=None))]
+fn convert(path: &str, to: &str, from: Option<&str>) -> PyResult<(String, Vec<String>)> {
+    let target = fmt_from_str(to)
+        .ok_or_else(|| PyValueError::new_err(format!("unknown target format: {to}")))?;
+    let net = read_network(path, from)?;
+    let conv = caseio::write_as(&net, target);
+    Ok((conv.text, conv.warnings))
+}
+
+/// Map a format name (with common aliases) to a [`TargetFormat`].
+fn fmt_from_str(s: &str) -> Option<TargetFormat> {
+    Some(match s.to_ascii_lowercase().as_str() {
+        "matpower" | "m" => TargetFormat::Matpower,
+        "powermodels-json" | "powermodels" | "pm" => TargetFormat::PowerModelsJson,
+        "egret-json" | "egret" => TargetFormat::EgretJson,
+        "psse" | "raw" => TargetFormat::Psse,
+        "powerworld" | "aux" => TargetFormat::PowerWorld,
+        _ => return None,
+    })
+}
+
+/// Read `path` into a [`Network`], choosing the reader from `from` or the file
+/// extension. EGRET is write-only.
+fn read_network(path: &str, from: Option<&str>) -> PyResult<Network> {
+    let p = std::path::Path::new(path);
+    let fmt = match from {
+        Some(f) => fmt_from_str(f)
+            .ok_or_else(|| PyValueError::new_err(format!("unknown source format: {f}")))?,
+        None => match p.extension().and_then(|e| e.to_str()) {
+            Some("m") => TargetFormat::Matpower,
+            Some("json") => TargetFormat::PowerModelsJson,
+            Some("raw") => TargetFormat::Psse,
+            Some("aux") => TargetFormat::PowerWorld,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "cannot infer input format from extension {other:?}; pass from="
+                )))
+            }
+        },
+    };
+    let read_str = || std::fs::read_to_string(p).map_err(|e| PyValueError::new_err(e.to_string()));
+    let net = match fmt {
+        TargetFormat::Matpower => caseio::parse_matpower_file(path).map_err(to_pyerr)?,
+        TargetFormat::PowerModelsJson => {
+            caseio::parse_powermodels_json(&read_str()?).map_err(to_pyerr)?
+        }
+        TargetFormat::Psse => caseio::parse_psse(&read_str()?).map_err(to_pyerr)?,
+        TargetFormat::PowerWorld => caseio::parse_powerworld(&read_str()?).map_err(to_pyerr)?,
+        TargetFormat::EgretJson => {
+            return Err(PyValueError::new_err(
+                "reading EGRET JSON is not supported yet (write-only)",
+            ))
+        }
+    };
+    Ok(net)
+}
+
+#[pymodule]
+fn _caseio(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("CaseioError", m.py().get_type::<CaseioError>())?;
+    m.add_class::<PyCase>()?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_string, m)?)?;
+    m.add_function(wrap_pyfunction!(write, m)?)?;
+    m.add_function(wrap_pyfunction!(convert, m)?)?;
+    Ok(())
+}

--- a/python/caseio/__init__.py
+++ b/python/caseio/__init__.py
@@ -1,0 +1,68 @@
+"""caseio: fast, lossless power-system case-file parsing and conversion.
+
+No numpy/scipy. Parse, write, and convert return plain dicts and strings::
+
+    import caseio
+
+    case = caseio.parse("case9.m")
+    print(case.n, case.base_mva)         # 9 100.0
+    text = case.write()                  # byte-exact MATPOWER echo
+    raw, warnings = caseio.convert("case9.m", "psse")
+
+The compiled core (``caseio._caseio``) does the parsing/conversion in Rust.
+The matrix builders (B', Y_bus, PTDF, DC-OPF, …) live in the separate
+``casemat`` package, which pulls in scipy; this package deliberately does not.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from typing import Optional
+
+from . import _caseio
+from ._caseio import CaseioError, PyCase as Case, __version__
+
+__all__ = [
+    "Case",
+    "Conversion",
+    "CaseioError",
+    "parse",
+    "parse_string",
+    "write",
+    "convert",
+    "__version__",
+]
+
+Conversion = namedtuple("Conversion", ["text", "warnings"])
+Conversion.__doc__ = """Output of :func:`convert`.
+
+``text`` is the converted file contents; ``warnings`` lists the fields the
+target format could not represent (empty for a faithful conversion).
+"""
+
+
+def parse(path) -> Case:
+    """Parse a MATPOWER ``.m`` file from a path into a :class:`Case`."""
+    return _caseio.parse(str(path))
+
+
+def parse_string(text: str, name: Optional[str] = None) -> Case:
+    """Parse a MATPOWER case from in-memory ``.m`` text."""
+    return _caseio.parse_string(text, name)
+
+
+def write(case: Case) -> str:
+    """Serialize ``case`` to MATPOWER ``.m`` (byte-exact echo when it was
+    parsed from MATPOWER)."""
+    return _caseio.write(case)
+
+
+def convert(path, to: str, from_: Optional[str] = None) -> Conversion:
+    """Convert a case file to another format through the neutral hub.
+
+    ``to``/``from_`` are format names (``matpower``, ``powermodels``, ``psse``,
+    ``powerworld``, ``egret``); the source format is inferred from the file
+    extension when ``from_`` is omitted.
+    """
+    text, warnings = _caseio.convert(str(path), to, from_)
+    return Conversion(text, warnings)

--- a/python/tests/test_caseio.py
+++ b/python/tests/test_caseio.py
@@ -1,0 +1,78 @@
+"""Tests for the `caseio` Python bindings — the dependency-light package.
+
+Run with `pytest python/tests` after building the caseio wheel, e.g.
+`maturin develop -m caseio-ext/pyproject.toml`.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import caseio
+
+DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
+
+
+def test_parse_basic():
+    case = caseio.parse(DATA / "case9.m")
+    assert case.n == 9
+    assert case.n_branches == 9
+    assert case.base_mva == 100.0
+    assert len(case.buses) == 9
+    assert case.n_gens == 3
+    assert not case.is_radial  # case9 is meshed
+    assert case.n_connected_components == 1
+
+
+def test_loads_and_shunts_are_first_class():
+    case = caseio.parse(DATA / "case30.m")
+    # MATPOWER folds demand onto the bus row; caseio splits it back out.
+    assert case.n_loads > 0
+    assert all({"bus", "p", "q", "in_service"} <= set(l) for l in case.loads)
+    # buses carry no pd/qd (that's what loads are for)
+    assert "pd" not in case.buses[0]
+
+
+def test_parse_string():
+    src = (DATA / "case9.m").read_text()
+    case = caseio.parse_string(src, name="c9")
+    assert case.name == "c9"
+    assert case.n == 9
+
+
+def test_roundtrip_byte_exact():
+    src = (DATA / "case9.m").read_text()
+    case = caseio.parse(DATA / "case9.m")
+    assert case.write() == src
+
+
+def test_convert_matpower_echo_is_byte_exact():
+    src = (DATA / "case14.m").read_text()
+    conv = caseio.convert(DATA / "case14.m", "matpower")
+    assert conv.text == src
+    assert conv.warnings == []
+
+
+def test_convert_to_psse_produces_output():
+    conv = caseio.convert(DATA / "case30.m", "psse")
+    assert conv.text.strip()
+    assert isinstance(conv.warnings, list)
+
+
+def test_connectivity_report():
+    case = caseio.parse(DATA / "case14.m")
+    rep = case.connectivity_report()
+    assert rep["n_buses"] == 14
+    assert rep["n_components"] == 1
+
+
+def test_import_pulls_in_no_numpy_or_scipy():
+    # The whole point of the caseio package: zero scientific-stack deps. Run in a
+    # fresh interpreter so another test having imported casemat can't pollute it.
+    code = (
+        "import sys, caseio\n"
+        "assert 'numpy' not in sys.modules, 'caseio dragged in numpy'\n"
+        "assert 'scipy' not in sys.modules, 'caseio dragged in scipy'\n"
+    )
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr


### PR DESCRIPTION
Closes the core of #32. Stacked on #35 (Phase 1b).

A second Python wheel, `caseio`, mirroring the Rust split: it binds the light `caseio` crate directly, so a consumer gets the parser/converter without the numpy/scipy stack the `casemat` package pulls in.

## What's here
- **`caseio-ext/`**: new PyO3 crate (`[lib] name = _caseio`, cdylib), depends only on `caseio`, **no numpy**. Surface:
  - `parse(path)` / `parse_string(text, name=None)` → a typed `Case` exposing `buses`/`loads`/`shunts`/`branches`/`gens` as dict lists, plus `connectivity_report()`, `reference_bus_index()`, `is_radial`, `n_connected_components`, `n`/`n_branches`/`n_gens`/`n_loads`/`n_shunts`, `name`, `base_mva`, `source_format`.
  - `case.write()` → byte-exact MATPOWER echo.
  - `convert(path, to, from_=None)` → `Conversion(text, warnings)`.
- **`caseio-ext/pyproject.toml`**: the second maturin config (`module-name = caseio._caseio`, `python-source = ../python`, `manifest-path = Cargo.toml`), so the one `python/` tree ships both packages and the root pyproject still builds `casemat`.
- **`python/caseio/`**: pure-Python wrapper (`parse`/`parse_string`/`write`/`convert` + `Case`/`Conversion`). No runtime deps.
- **`python/tests/test_caseio.py`**: parse/roundtrip/convert, and a subprocess test asserting `import caseio` pulls in neither numpy nor scipy.
- **workspace**: `caseio-ext` added to members (not default-members, like `casemat-ext`).
- **CI** (`python.yml`): lints, tests, builds, and sdists both wheels.

Loads/shunts are first-class on the caseio `Case` (the `Network` shape), so buses carry no `pd`/`qd`.

## Acceptance (#32)
- [x] `pip install caseio` in a numpy/scipy-free env; `import caseio` works (no deps declared).
- [x] `caseio.parse(...).write()` round-trips a vendored case byte-for-byte.
- [x] `caseio.convert("case30.m", "psse")` returns text + warnings (same Rust `write_as` path as `casemat.convert`).
- [x] A test asserts `import caseio` pulls in neither numpy nor scipy.
- [ ] **Follow-up**: `casemat` re-exports caseio's `parse`/`convert`/`Case` and `casemat-ext` drops its own `convert`. The two compiled extensions don't share Rust type identity across the `.so` boundary (the constraint #32 flags), so this cross-package coupling is its own change — tracked, not in this PR.

## Note
maturin isn't available in the dev sandbox, so the Rust side is verified by `cargo clippy -p caseio-ext --features extension-module` and the Python by `py_compile`; the pytest suite runs in CI where the wheel is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)