### PR TITLE
perf: parse speedups across every benchmarked case

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -81,7 +81,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -m caseio-ext/pyproject.toml
+          args: --release --out dist -m caseio-ext/Cargo.toml
           manylinux: auto
       - uses: actions/upload-artifact@v4
         with:
@@ -102,7 +102,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
-          args: --out dist -m caseio-ext/pyproject.toml
+          args: --out dist -m caseio-ext/Cargo.toml
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # caseio
 
-The fast, lossless parser, data layer, and **format converter** for power-system case files. Parse a MATPOWER `.m` case, work with a typed model, write it back **byte-for-byte**, or convert between formats through a neutral hub. Dependency-light on purpose, so other tools can embed it without dragging in a matrix or solver stack.
+Fast, lossless parser and format converter for power-system case files. Parse a MATPOWER `.m` case, work with a typed model, write it back byte-for-byte, or convert between formats through a neutral hub. Light on dependencies, so other tools can embed it without a matrix or solver stack.
 
 Three crates in this workspace (the third builds the Python wheel):
 
-- **`caseio`** — the parser, the typed `MpcCase`, the format-neutral `Network` hub (the converters meet here), the lossless writer, and the format converters. Readers for MATPOWER, PowerModels JSON, PSS/E, and PowerWorld; writers for those plus EGRET JSON. Six dependencies, no sparse-matrix or TUI baggage.
-- **`casemat`** — sparse matrices and graph views built on caseio: B'/B''/Y_bus, PTDF/LODF, incidence, weighted Laplacian, the LACPF block, adjacency, and the DC-OPF instance bundle, plus a CLI/TUI.
-- **`casemat-ext`** — the PyO3 extension behind the `casemat` Python package. maturin compiles it to the native module `casemat._casemat`; the pure-Python wrapper in `python/casemat/` assembles the results into `scipy.sparse` matrices and networkx graphs, so scipy/networkx stay out of the Rust build. `pip install casemat` gets parsing, conversion, and the matrices under one import.
+- **`caseio`** — the parser, the typed `MpcCase`, the format-neutral `Network` hub where the converters meet, the lossless writer, and the converters. Readers for MATPOWER, PowerModels JSON, PSS/E, and PowerWorld; writers for those plus EGRET JSON. Six dependencies, no matrix or TUI stack.
+- **`casemat`** — sparse matrices and graph views on top of caseio: B'/B''/Y_bus, PTDF/LODF, incidence, weighted Laplacian, the LACPF block, adjacency, the DC-OPF instance bundle, and a CLI/TUI.
+- **`casemat-ext`** — the PyO3 extension behind the `casemat` Python package. maturin compiles it to `casemat._casemat`; the pure-Python wrapper in `python/casemat/` turns the results into `scipy.sparse` matrices and networkx graphs, so scipy/networkx stay out of the Rust build.
 
 ## Lossless round-trip
 
-`parse → write → parse` reproduces the source file byte-for-byte — every `mpc.*` field (including ones the typed model doesn't interpret), in-matrix column-header comments, and exact numeric tokens like `7e-05` that an `f64`-based writer would mangle. The parse retains the original source text and the writer echoes it, so round-trip costs no extra parse pass. This is the property other lightweight parsers lack: ExaPowerIO has no writer, and PowerModels' MATPOWER export is lossy.
+`parse → write → parse` reproduces the source byte-for-byte — every `mpc.*` field (including ones the typed model doesn't interpret), in-matrix column-header comments, and exact tokens like `7e-05` that an `f64`-based writer would mangle. The parser keeps the original text and the writer echoes it, so the round-trip costs no extra parse pass. ExaPowerIO has no writer; PowerModels' MATPOWER export is lossy.
 
 ## Convert
 
-Conversion goes through a format-neutral hub, `Network` (first-class buses, loads, shunts, branches, generators, storage, HVDC), with every reader producing it and every writer consuming it — N readers × M writers, not pairwise. caseio's contract is two-tier, and explicit about what survives:
+Every reader produces a format-neutral `Network` (first-class buses, loads, shunts, branches, generators, storage, HVDC) and every writer consumes it — N readers × M writers, not pairwise. The fidelity contract is two-tier:
 
 - **Same-format round-trip is byte-exact.** Each reader keeps its source text; writing back to that format echoes it.
 - **Cross-format keeps maximal fidelity with itemized loss.** Anything the target can't represent is reported in `Conversion::warnings`, never dropped silently.
 
-Fully lossless conversion between every pair isn't possible (formats model different things), so the converter tells you exactly where a conversion loses information instead of pretending it doesn't. PowerModels JSON and PSS/E are validated against `PowerModels.jl` (which reads both): the writers value-for-value on the vendored cases, and the PSS/E reader against real PTI `.raw` files (`benchmarks/validate_powermodels.jl`, `benchmarks/validate_psse.jl`, both need Julia). The all-pairs round-trip harness (`caseio/tests/roundtrip_formats.rs`) pins core preservation, reader∘writer idempotence, and the byte-exact same-format echo for every reader, in plain `cargo test`.
+PowerModels JSON and PSS/E are validated against `PowerModels.jl` (which reads both): the writers value-for-value on the vendored cases, and the PSS/E reader against real PTI `.raw` files (`benchmarks/validate_powermodels.jl`, `benchmarks/validate_psse.jl`, both need Julia). The all-pairs harness (`caseio/tests/roundtrip_formats.rs`) pins core preservation, reader∘writer idempotence, and the byte-exact echo in plain `cargo test`.
 
-caseio targets the **transmission planning / OPF** interchange formats. It is deliberately not a CIM tool and not a distribution-feeder modeler — CIM-based hubs (CIMHub, MG-RAVENS) own that, with heavyweight semantic models, a triplestore or schema stack, and Python/Java runtimes. caseio is the complement: a fast, embeddable, lossless converter for the bus/branch/gen/load/shunt family, suitable as the ingest/conversion layer feeding those hubs or a solver.
+caseio covers the transmission planning / OPF interchange formats — the bus/branch/gen/load/shunt family — not CIM or distribution feeders, which the CIM hubs (CIMHub, MG-RAVENS) own. It fits as the ingest/conversion layer feeding such a hub or a solver.
 
-**Readers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33), PowerWorld `.aux`. **Writers**: those plus EGRET JSON. Every format reads to and writes from the same `Network`, so each new format is one reader/writer at the hub, not a pairwise converter.
+**Readers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33), PowerWorld `.aux`. **Writers**: those plus EGRET JSON. Every format reads to and writes from the same `Network`, so a new format is one reader/writer at the hub.
 
 | reader ↓ \ writer → | MATPOWER | PowerModels JSON | EGRET JSON | PSS/E | PowerWorld |
 | --- | --- | --- | --- | --- | --- |
@@ -59,7 +59,7 @@ open("case14.json", "w").write(r.text)
 
 ## Benchmark
 
-Median parse time, same machine (Apple M-series, release build), all three timed in one process under the same harness — caseio through its C ABI, so every parser reads the file from disk alike. Full table, method, and the cross-tool correctness checks in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+Median parse time, same machine (Apple M-series, release build), all three timed in one process under the same harness — caseio through its C ABI, so every parser reads the file from disk alike. Full table and method in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 | case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
@@ -69,7 +69,7 @@ Median parse time, same machine (Apple M-series, release build), all three timed
 | case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
 | case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
 
-caseio is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases (European, number-dense) and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it does *more* work: it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops, for its byte-exact round-trip. It's also ~10× faster than pandapower's `.m` reader. And the edge isn't only speed: caseio is the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime — and its parse, conversions, and Y_bus are validated value for value against PowerModels, ExaPowerIO, and pandapower (`benchmarks/run_validation.sh`, which spells out what each tool checks). Full table: [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+caseio is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops. It's also ~10× faster than pandapower's `.m` reader. And it's the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime; its parse, conversions, and Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
 
 ## caseio: parse and write
 
@@ -83,7 +83,7 @@ let bus0 = case.buses[0].name.as_deref();           // bus_name, dclines, ...
 let m = write_matpower(&case);                       // reproduces the source
 ```
 
-`caseio` depends only on `thiserror`, `num-complex`, `petgraph`, `serde`, `serde_json`, and `fast-float` — light enough to vendor as a parser.
+`caseio` depends only on `thiserror`, `num-complex`, `petgraph`, `serde`, `serde_json`, and `fast-float`.
 
 ## casemat: matrices on top
 
@@ -140,7 +140,7 @@ More over the `Network` hub, tracked in the issues:
 - A RAVENS-JSON export sink (and positioning caseio as a fast ingest backend for MG-RAVENS).
 - An MCP `convert`/`validate` tool over the Python binding.
 
-The C ABI (`caseio-capi`) for C/C++/Julia is done — it's also what the benchmark harness times caseio through. CIM stays out of scope — it's a different (much heavier) problem owned by the CIM hubs.
+The C ABI (`caseio-capi`) for C/C++/Julia is done — it's also what the benchmark harness times caseio through. CIM stays out of scope; it's a heavier problem owned by the CIM hubs.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Median parse time, same machine (Apple M-series, release build), all three timed
 
 | case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case2869pegase | 2869 / 4582 | **2.33 ms** | 2.92 ms | 123 ms |
-| case_ACTIVSg2000 | 2000 / 3206 | 2.48 ms | **2.12 ms** | 128 ms |
-| case9241pegase | 9241 / 16049 | **7.84 ms** | 9.12 ms | 547 ms |
-| case13659pegase | 13659 / 20467 | **11.8 ms** | 13.6 ms | 781 ms |
-| case193k | 192768 / 228574 | 200 ms | **180 ms** | — |
+| case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
+| case9241pegase | 9241 / 16049 | **5.67 ms** | 8.94 ms | 558 ms |
+| case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
+| case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
 
-caseio is 50–70× faster than PowerModels' parser and trades the lead with ExaPowerIO (the focused Julia reader): ~20–25% faster on the pegase cases (European, number-dense), ~10–20% behind on the ACTIVSg / SyntheticUSA / US cases, where ExaPowerIO drops the `gentype` / `genfuel` / `bus_name` cell arrays caseio parses and keeps for its byte-exact round-trip. It's also ~10× faster than pandapower's `.m` reader. The durable edge isn't speed: caseio is the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime — and its parse, conversions, and Y_bus are validated value for value against PowerModels, ExaPowerIO, and pandapower (`benchmarks/run_validation.sh`, which spells out what each tool checks). Full table: [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+caseio is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases (European, number-dense) and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it does *more* work: it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops, for its byte-exact round-trip. It's also ~10× faster than pandapower's `.m` reader. And the edge isn't only speed: caseio is the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime — and its parse, conversions, and Y_bus are validated value for value against PowerModels, ExaPowerIO, and pandapower (`benchmarks/run_validation.sh`, which spells out what each tool checks). Full table: [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
 ## caseio: parse and write
 

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -22,31 +22,36 @@ two, whose returned data is collected after the sample rather than inside it.
 
 | case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case2869pegase | 2869 / 4582 | **2.33 ms** | 2.92 ms | 123 ms |
-| case_ACTIVSg2000 | 2000 / 3206 | 2.48 ms | **2.12 ms** | 128 ms |
-| case9241pegase | 9241 / 16049 | **7.84 ms** | 9.12 ms | 547 ms |
-| case13659pegase | 13659 / 20467 | **11.8 ms** | 13.6 ms | 781 ms |
-| case_ACTIVSg10k | 10000 / 12706 | 10.8 ms | **9.21 ms** | — |
-| case_ACTIVSg25k | 25000 / 32230 | 26.4 ms | **22.6 ms** | — |
-| case_ACTIVSg70k | 70000 / 88207 | 73.4 ms | **60.6 ms** | — |
-| case_SyntheticUSA | 82000 / 104121 | 85.8 ms | **79.5 ms** | — |
-| case99k | 99396 / 117860 | 101 ms | **94.7 ms** | — |
-| case193k | 192768 / 228574 | 200 ms | **180 ms** | — |
+| case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
+| case9241pegase | 9241 / 16049 | **5.67 ms** | 8.94 ms | 558 ms |
+| case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
+| case_ACTIVSg10k | 10000 / 12706 | **8.93 ms** | 9.09 ms | — |
+| case_ACTIVSg25k | 25000 / 32230 | **22.0 ms** | 22.3 ms | — |
+| case_ACTIVSg70k | 70000 / 88207 | **59.5 ms** | 64.5 ms | — |
+| case_SyntheticUSA | 82000 / 104121 | **71.3 ms** | 76.6 ms | — |
+| case99k | 99396 / 117860 | **80.7 ms** | 90.2 ms | — |
+| case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
 
 (PowerModels skipped past case13659 — it takes minutes there and the gap is settled.)
 
 ### Read
 
 - **vs PowerModels.jl**: 50–70× faster wherever PowerModels is practical to run
-  (53× on case2869pegase, 70× on case9241pegase).
-- **vs ExaPowerIO.jl**: split, and which way it falls tracks what's in the file.
-  caseio is ~20–25% faster on the pegase cases (European, number-dense decimals,
-  no cell arrays). ExaPowerIO is ~8–21% faster on the ACTIVSg / SyntheticUSA / US
-  cases: those carry large `gentype` / `genfuel` / `bus_name` cell arrays, which
-  ExaPowerIO skips (it logs "Unrecognized assignment" and drops them) while caseio
-  parses `bus_name` into the model and retains the full source for a byte-exact
-  round-trip. caseio does strictly more work there; it is a focused lossless reader
-  against a focused lossy one, and stays within a small constant either way.
+  (68× on case2869pegase, 98× on case9241pegase).
+- **vs ExaPowerIO.jl**: caseio is faster or tied on every case — ~35% on the pegase
+  cases (European, number-dense decimals, no cell arrays) and ~2–12% on the ACTIVSg
+  / SyntheticUSA / US cases, where it does *more* work: those carry large `gentype`
+  / `genfuel` / `bus_name` cell arrays that ExaPowerIO skips (it logs "Unrecognized
+  assignment" and drops them), while caseio parses `bus_name` into the model and
+  retains the full source for a byte-exact round-trip. The earlier read of these
+  cases had caseio a few percent behind, which looked like the cost of losslessness.
+  It wasn't: profiling found the gap was overhead unrelated to what caseio keeps — a
+  `BTreeSet` reference-validation pass, a `split_ascii_whitespace` row tokenizer, a
+  per-generator string-keyed map, and a materialized line index. Replacing those
+  (HashSet, a byte tokenizer, a typed `[Option<f64>; 11]` for the gen capability
+  columns, a streamed locate) cut parse time ~25–35% and put caseio ahead while it
+  keeps strictly more of the file than ExaPowerIO does.
 - **The pure parse is a touch faster than the table.** `cio_parse` reads the file
   from disk on every sample (as ExaPowerIO / PowerModels do); the Rust `timeparse`
   example parses an already-in-memory string and so excludes the per-sample read.
@@ -55,7 +60,7 @@ two, whose returned data is collected after the sample rather than inside it.
   at case118, 51% at case2869); the current path drops it and the file reader moves
   its buffer straight into the retained source, so a parse never copies the whole
   file twice.
-- **The durable edge isn't raw speed.** caseio is the only one of the three that is
+- **And the edge isn't only speed.** caseio is the only one of the three that is
   lossless and round-trips byte for byte — verified at 56 MB / 193k buses — and the
   only one callable from Rust, the CLI, Python, and C/Julia (the C ABI) with no
   runtime. ExaPowerIO has no writer; PowerModels' export is lossy.

--- a/caseio/src/format/powermodels.rs
+++ b/caseio/src/format/powermodels.rs
@@ -189,14 +189,10 @@ fn gen_obj(g: &Generator, idx: usize, p: f64, base: f64) -> Value {
     m.insert("pmin".into(), jnum(g.pmin * p));
     // Gen capability columns, in PowerModels' field order, for those present. Only
     // the ramp rates are per-unitized; the PQ curve points and apf stay raw.
-    for key in GEN_EXTRA_KEYS {
-        if let Some(v) = g.extras.get(key) {
-            let scaled = if GEN_PU_KEYS.contains(&key) {
-                jnum(v.as_f64().unwrap_or(f64::NAN) * p)
-            } else {
-                v.clone()
-            };
-            m.insert(key.into(), scaled);
+    for (i, key) in GEN_EXTRA_KEYS.iter().enumerate() {
+        if let Some(v) = g.caps[i] {
+            let scaled = if GEN_PU_KEYS.contains(key) { jnum(v * p) } else { jnum(v) };
+            m.insert((*key).into(), scaled);
         }
     }
     if let Some(cost) = &g.cost {
@@ -504,12 +500,11 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64) -> Branch {
 }
 
 fn read_gen(v: &Value, pscale: f64, base_mva: f64, per_unit: bool) -> Generator {
-    let mut extras = crate::network::Extras::new();
-    for key in GEN_EXTRA_KEYS {
-        if let Some(val) = v.get(key).and_then(Value::as_f64) {
+    let mut caps: crate::network::GenCaps = [None; GEN_EXTRA_KEYS.len()];
+    for (i, key) in GEN_EXTRA_KEYS.iter().enumerate() {
+        if let Some(val) = v.get(*key).and_then(Value::as_f64) {
             // Only the ramp rates are per-unit; the PQ curve points and apf are raw.
-            let scaled = if GEN_PU_KEYS.contains(&key) { val * pscale } else { val };
-            extras.insert(key.to_string(), jnum(scaled));
+            caps[i] = Some(if GEN_PU_KEYS.contains(key) { val * pscale } else { val });
         }
     }
     let cost = v.get("model").map(|_| read_cost(v, base_mva, per_unit));
@@ -527,7 +522,7 @@ fn read_gen(v: &Value, pscale: f64, base_mva: f64, per_unit: bool) -> Generator 
         mbase: f_or(v, "mbase", base_mva),
         in_service: flag(v, "gen_status"),
         cost,
-        extras,
+        caps,
     }
 }
 

--- a/caseio/src/format/powerworld.rs
+++ b/caseio/src/format/powerworld.rs
@@ -352,7 +352,7 @@ fn read_gen(r: &Row) -> Generator {
         mbase: f_or(r, "GenMVABase", 100.0),
         in_service: on(r, "GenStatus"),
         cost: None,
-        extras: Extras::new(),
+        caps: Default::default(),
     }
 }
 

--- a/caseio/src/format/psse.rs
+++ b/caseio/src/format/psse.rs
@@ -380,7 +380,7 @@ fn read_gen(f: &[String]) -> Generator {
         pmax: num_at(f, 16),
         pmin: num_at(f, 17),
         cost: None,
-        extras: Extras::new(),
+        caps: Default::default(),
     }
 }
 

--- a/caseio/src/network.rs
+++ b/caseio/src/network.rs
@@ -230,8 +230,16 @@ pub struct Generator {
     pub mbase: f64,
     pub in_service: bool,
     pub cost: Option<GenCost>,
-    pub extras: Extras,
+    /// The MATPOWER gen capability / ramp columns past `PMIN`, aligned to
+    /// [`GEN_EXTRA_KEYS`] by index (`None` for a column the source omitted).
+    /// A fixed array, not an [`Extras`] map: a string-keyed map per generator
+    /// costs 11 heap allocations each, which dominates the parse of a large
+    /// generator-heavy case. Surfaced into formats that name them (PowerModels).
+    pub caps: GenCaps,
 }
+
+/// A generator's capability / ramp columns, one slot per [`GEN_EXTRA_KEYS`] name.
+pub type GenCaps = [Option<f64>; GEN_EXTRA_KEYS.len()];
 
 #[derive(Debug, Clone)]
 pub struct Storage {
@@ -278,8 +286,8 @@ pub struct Hvdc {
     pub extras: Extras,
 }
 
-/// The MATPOWER gen capability / ramp columns past `PMIN`, in order. Carried as
-/// generator extras so they survive into formats that name them (PowerModels).
+/// The MATPOWER gen capability / ramp columns past `PMIN`, in order. The index
+/// into this array is the slot index into a [`GenCaps`].
 pub(crate) const GEN_EXTRA_KEYS: [&str; 11] = [
     "pc1", "pc2", "qc1min", "qc1max", "qc2min", "qc2max", "ramp_agc", "ramp_10",
     "ramp_30", "ramp_q", "apf",

--- a/caseio/src/network.rs
+++ b/caseio/src/network.rs
@@ -318,7 +318,11 @@ impl Network {
     /// (which would otherwise default to a placeholder and silently re-wire the
     /// network) fails loudly instead.
     pub(crate) fn check_references(&self, format: &'static str) -> crate::Result<()> {
-        let mut ids = std::collections::BTreeSet::new();
+        // HashSet, not BTreeSet: building the id set and probing it once per branch
+        // endpoint / load / shunt / gen is the dominant cost of a large parse, and
+        // a BTreeSet pays a log-n pointer-chasing probe each time. Pre-size to skip
+        // rehashing.
+        let mut ids = std::collections::HashSet::with_capacity(self.buses.len());
         for b in &self.buses {
             if !ids.insert(b.id) {
                 return Err(Error::FormatRead {

--- a/caseio/src/parser/matpower/locate.rs
+++ b/caseio/src/parser/matpower/locate.rs
@@ -6,25 +6,13 @@
 //! text and the writer echoes it, so this module only has to find where each
 //! field's text begins and ends.
 
-use std::ops::Range;
-
 use super::tokens;
 
-/// Logical lines of `content` as `(range, slice)` with the line terminator
-/// trimmed off the range — `str::lines` semantics, but keeping each line's byte
-/// offsets into `content`.
-fn logical_lines(content: &str) -> Vec<(Range<usize>, &str)> {
-    let mut out = Vec::new();
-    let mut off = 0usize;
-    for piece in content.split_inclusive('\n') {
-        let start = off;
-        off += piece.len();
-        let trimmed = piece
-            .strip_suffix('\n')
-            .map_or(piece, |s| s.strip_suffix('\r').unwrap_or(s));
-        out.push((start..start + trimmed.len(), trimmed));
-    }
-    out
+/// A line's text with its `\n`/`\r\n` terminator trimmed off (`str::lines`
+/// semantics) given a `split_inclusive('\n')` piece.
+#[inline]
+fn trim_eol(piece: &str) -> &str {
+    piece.strip_suffix('\n').map_or(piece, |s| s.strip_suffix('\r').unwrap_or(s))
 }
 
 /// Locate each `mpc.<field> = <rhs>;` assignment's text, borrowing `(field, full)`
@@ -33,38 +21,50 @@ fn logical_lines(content: &str) -> Vec<(Range<usize>, &str)> {
 /// the quote-aware depth FSM only for `{ … }` cell arrays (whose strings may hold
 /// `]`/`}`). Infallible: an unclosed block runs to EOF and
 /// [`super::matlab::for_each_matrix_row`] reports the truncation.
+///
+/// One forward pass over `content.split_inclusive('\n')` with a running byte
+/// offset — no materialized `Vec` of every line (which on a 56 MB / 192k-bus case
+/// is tens of MB written before a single field is found). A multi-line block
+/// consumes following lines from the same iterator, so the next assignment starts
+/// after the block's closing line.
 pub(crate) fn locate_assignments(content: &str) -> Vec<(&str, &str)> {
-    let lines = logical_lines(content);
     let mut out = Vec::new();
-    let mut i = 0;
-    while i < lines.len() {
-        let (code, _comment) = tokens::comment_split(lines[i].1);
+    let mut off = 0usize;
+    let mut lines = content.split_inclusive('\n');
+    while let Some(piece) = lines.next() {
+        let start = off;
+        off += piece.len();
+        let line = trim_eol(piece);
+        let mut end = start + line.len();
+        let (code, _comment) = tokens::comment_split(line);
         if let Some((field, rhs)) = parse_assignment_start(code) {
-            let start = lines[i].0.start;
-            let mut end = lines[i].0.end;
             if rhs.starts_with('[') {
-                // Numeric matrix: the first un-commented `]` closes it. Reuse the
-                // opening line's `code` (it holds the `]` for a single-line matrix).
+                // Numeric matrix: the first un-commented `]` closes it. The opening
+                // line's `code` already holds the `]` for a single-line matrix.
                 if !code.contains(']') {
-                    while i + 1 < lines.len() {
-                        i += 1;
-                        end = lines[i].0.end;
-                        if tokens::comment_split(lines[i].1).0.contains(']') {
+                    for piece in lines.by_ref() {
+                        let s = off;
+                        off += piece.len();
+                        let l = trim_eol(piece);
+                        end = s + l.len();
+                        if tokens::comment_split(l).0.contains(']') {
                             break;
                         }
                     }
                 }
             } else if rhs.starts_with('{') {
                 let mut depth = net_bracket_depth(code);
-                while depth > 0 && i + 1 < lines.len() {
-                    i += 1;
-                    end = lines[i].0.end;
-                    depth += net_bracket_depth(tokens::comment_split(lines[i].1).0);
+                while depth > 0 {
+                    let Some(piece) = lines.next() else { break };
+                    let s = off;
+                    off += piece.len();
+                    let l = trim_eol(piece);
+                    end = s + l.len();
+                    depth += net_bracket_depth(tokens::comment_split(l).0);
                 }
             }
             out.push((field, &content[start..end]));
         }
-        i += 1;
     }
     out
 }

--- a/caseio/src/parser/matpower/matlab.rs
+++ b/caseio/src/parser/matpower/matlab.rs
@@ -88,27 +88,44 @@ where
             code = &code[..close];
             done = true;
         }
-        let mut segments = code.split(';').peekable();
-        while let Some(seg) = segments.next() {
-            let terminated = segments.peek().is_some(); // a `;` followed this segment
-            for tok in seg.split_ascii_whitespace() {
-                let t = tok.trim_end_matches(',');
-                if t.is_empty() {
-                    continue;
-                }
-                buf.push(parse_float(t).ok_or_else(|| Error::BadFloat {
-                    field: leak_field(field),
-                    row,
-                    value: t.to_string(),
-                })?);
-            }
-            if terminated {
+        // One byte-level pass over the line's code: `;` ends a row, ASCII
+        // whitespace separates tokens, and a trailing comma is stripped (MATPOWER
+        // rows are space/semicolon-delimited). This replaces split(';') +
+        // split_ascii_whitespace — the generic Unicode searcher was the dominant
+        // tokenizing cost — and feeds the raw bytes straight to fast-float.
+        let bytes = code.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b';' {
                 if !buf.is_empty() {
                     f(&buf, row)?;
                     row += 1;
+                    buf.clear();
                 }
-                buf.clear();
+                i += 1;
+                continue;
             }
+            if b.is_ascii_whitespace() {
+                i += 1;
+                continue;
+            }
+            let start = i;
+            while i < bytes.len() && !matches!(bytes[i], b';') && !bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            let mut tok = &bytes[start..i];
+            while tok.last() == Some(&b',') {
+                tok = &tok[..tok.len() - 1];
+            }
+            if tok.is_empty() {
+                continue;
+            }
+            buf.push(parse_float(tok).ok_or_else(|| Error::BadFloat {
+                field: leak_field(field),
+                row,
+                value: String::from_utf8_lossy(tok).into_owned(),
+            })?);
         }
     }
     // Entered the matrix (`[`) but never saw the closing `]`: the assignment is
@@ -126,13 +143,14 @@ where
     Ok(())
 }
 
-fn parse_float(tok: &str) -> Option<f64> {
+fn parse_float(tok: &[u8]) -> Option<f64> {
     match tok {
-        "Inf" | "inf" | "+Inf" | "+inf" => Some(f64::INFINITY),
-        "-Inf" | "-inf" => Some(f64::NEG_INFINITY),
-        "NaN" | "nan" => Some(f64::NAN),
+        b"Inf" | b"inf" | b"+Inf" | b"+inf" => Some(f64::INFINITY),
+        b"-Inf" | b"-inf" => Some(f64::NEG_INFINITY),
+        b"NaN" | b"nan" => Some(f64::NAN),
         // fast-float is IEEE-correct (same value as std) but several times
-        // faster, and float tokens dominate large-case parse time.
+        // faster, and float tokens dominate large-case parse time. It takes the
+        // raw bytes, so the tokenizer passes a slice with no &str round-trip.
         _ => fast_float::parse(tok).ok(),
     }
 }

--- a/caseio/src/parser/matpower/matlab.rs
+++ b/caseio/src/parser/matpower/matlab.rs
@@ -111,7 +111,7 @@ where
                 continue;
             }
             let start = i;
-            while i < bytes.len() && !matches!(bytes[i], b';') && !bytes[i].is_ascii_whitespace() {
+            while i < bytes.len() && bytes[i] != b';' && !bytes[i].is_ascii_whitespace() {
                 i += 1;
             }
             let mut tok = &bytes[start..i];

--- a/caseio/src/parser/matpower/rows.rs
+++ b/caseio/src/parser/matpower/rows.rs
@@ -5,16 +5,11 @@
 //! into a [`Bus`] plus an optional [`Load`] and [`Shunt`] (MATPOWER folds
 //! demand and shunts onto the bus row; the hub keeps them first-class).
 
-use serde_json::Value;
-
 use crate::network::{
-    Branch, Bus, BusType, Extras, GenCost, Generator, Hvdc, Load, Shunt, Storage, GEN_EXTRA_KEYS,
+    Branch, Bus, BusType, Extras, GenCaps, GenCost, Generator, Hvdc, Load, Shunt, Storage,
+    GEN_EXTRA_KEYS,
 };
 use crate::{Error, Result};
-
-fn num(x: f64) -> Value {
-    serde_json::Number::from_f64(x).map_or(Value::Null, Value::Number)
-}
 
 /// MATPOWER in-service flag: the status column is exactly 0 or 1 in the file,
 /// so the equality is the intended exact compare.
@@ -195,11 +190,13 @@ pub(super) fn branch_row(row: &[f64], i: usize) -> Result<Branch> {
 /// pre-dissolution path; the byte-exact MATPOWER round-trip echoes the source.
 pub(super) fn gen_row(row: &[f64], i: usize) -> Result<Generator> {
     require("gen", row, i, gen_col::REQUIRED)?;
-    let extras: Extras = GEN_EXTRA_KEYS
-        .iter()
-        .zip(&row[gen_col::REQUIRED..])
-        .map(|(&k, &v)| (k.to_string(), num(v)))
-        .collect();
+    // The capability/ramp columns past PMIN, by position, into the fixed GenCaps
+    // array — no per-key string allocation. A row that stops early leaves the
+    // remaining slots `None`.
+    let mut caps: GenCaps = [None; GEN_EXTRA_KEYS.len()];
+    for (slot, &v) in caps.iter_mut().zip(&row[gen_col::REQUIRED..]) {
+        *slot = Some(v);
+    }
     Ok(Generator {
         bus: row[gen_col::GEN_BUS] as usize,
         pg: row[gen_col::PG],
@@ -212,7 +209,7 @@ pub(super) fn gen_row(row: &[f64], i: usize) -> Result<Generator> {
         pmin: row[gen_col::PMIN],
         in_service: is_in_service(row[gen_col::GEN_STATUS]),
         cost: None,
-        extras,
+        caps,
     })
 }
 

--- a/caseio/tests/roundtrip.rs
+++ b/caseio/tests/roundtrip.rs
@@ -104,7 +104,7 @@ fn captures_extra_generator_columns() {
     // be silently dropped.
     let case = parse_matpower_file(data_dir().join("case9.m")).unwrap();
     assert!(
-        !case.generators[0].extras.is_empty(),
+        case.generators[0].caps.iter().any(Option::is_some),
         "generator columns past PMIN were dropped"
     );
 }

--- a/casemat/tests/dcopf.rs
+++ b/casemat/tests/dcopf.rs
@@ -415,7 +415,7 @@ fn gen_with_cost(bus: usize, cost: Option<GenCost>) -> Generator {
         pmin: 0.0,
         in_service: true,
         cost,
-        extras: Extras::new(),
+        caps: Default::default(),
     }
 }
 


### PR DESCRIPTION
Stacked on #43 (`bench/cross-tool-validation`). The review of #43 found, via profiling, that caseio's parse was a few percent behind ExaPowerIO on the ACTIVSg / SyntheticUSA / US cases — and that the gap was **not** the cost of losslessness (the cell arrays caseio keeps cost ~1%), but unrelated overhead. This PR removes that overhead. caseio is now faster than or tied with ExaPowerIO on **every** benchmarked case, while still parsing and retaining strictly more of the file.

## Changes (each independent, none touches the byte-exact round-trip or `Bus.name`)

1. **`check_references` uses a `HashSet`, not a `BTreeSet`.** Building the bus-id set and probing it once per branch endpoint / load / shunt / gen was the single largest cost of a large parse; a `BTreeSet` paid a log-n pointer-chasing probe each time. (~17% on US cases, ~30% on pegase.)
2. **Byte tokenizer for matrix rows.** The row tokenizer used `split_ascii_whitespace` (the generic Unicode `CharSearcher`) plus a `&str`→bytes round-trip into fast-float. Replaced with one byte-level pass — `;` ends a row, ASCII whitespace separates tokens, trailing comma stripped — feeding the raw slice to fast-float. Same grammar and errors.
3. **Typed gen capability columns.** Each generator built a `BTreeMap<String, Value>` for its 11 MATPOWER capability/ramp columns (~270k string allocations on a 24k-generator case, much paid again at drop). Replaced with a fixed `[Option<f64>; 11]` aligned to `GEN_EXTRA_KEYS`; the PowerModels reader/writer index it positionally. Cross-format output unchanged (validated field-for-field).
4. **Streamed `locate_assignments`.** It materialized a `Vec` of every line (tens of MB on a 56 MB case) before finding a field. Now one forward pass over `split_inclusive('\n')` with a byte cursor; same quote-aware bracket handling.

## Result (median parse, one session, Apple M-series; same harness, caseio via its C ABI)

| case | caseio | ExaPowerIO | was (caseio) |
| --- | --- | --- | --- |
| case2869pegase | **1.78 ms** | 2.72 ms | 2.33 |
| case9241pegase | **5.67 ms** | 8.94 ms | 7.84 |
| case13659pegase | **8.57 ms** | 13.1 ms | 11.8 |
| case_ACTIVSg2000 | **2.07 ms** | 2.07 ms | 2.48 |
| case_ACTIVSg10k | **8.93 ms** | 9.09 ms | 10.8 |
| case_ACTIVSg25k | **22.0 ms** | 22.3 ms | 26.4 |
| case_ACTIVSg70k | **59.5 ms** | 64.5 ms | 73.4 |
| case_SyntheticUSA | **71.3 ms** | 76.6 ms | 85.8 |
| case99k | **80.7 ms** | 90.2 ms | 101 |
| case193k | **158 ms** | 169 ms | 200 |

(Numbers vary a few percent run to run; the relative picture — caseio leads or ties across the board — is stable. The ACTIVSg family went from a few percent behind to even-or-ahead, driven by change #3.)

## Verification

- `cargo test` green; `cargo clippy --all-targets -p caseio -p casemat -p caseio-capi -- -D warnings` clean.
- Full `benchmarks/run_validation.sh` matrix all pass (PowerModels / PSS-E / ExaPowerIO / pandapower) — correctness unchanged.
- Byte-exact same-format round-trip still holds (`caseio/tests/roundtrip_formats.rs`); the `7e-05` / trailing-comma / NaN-Inf / unbalanced-bracket and locate tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
