### PR TITLE
Docs: overhaul to PowerIO + drop false hyphenation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,31 @@ Guidance for Codex working in this repo.
 
 ## Purpose
 
-A Cargo workspace of three Rust crates plus a Python package. Parses power
-network case files, converts losslessly between formats, and emits sparse
-matrices and graph views for any downstream solver. (Planned) feeds the GridFM
-ML pipeline.
+A Cargo workspace of Rust crates plus a Python package. Parses power network
+case files, converts losslessly between formats, and emits sparse matrices and
+graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
 
-- **`caseio`** — the parser, typed `MpcCase`, the format-neutral `Network` hub,
-  the lossless writer, and the format converters. Light deps (thiserror,
-  num-complex, petgraph, serde, serde_json, fast-float); no matrix or TUI stack.
-- **`casemat`** — sparse matrices and graph views built on `caseio` (which it
-  re-exports), plus the `casemat` CLI/TUI.
-- **`casemat-ext`** — PyO3 extension behind the `casemat` Python package
-  (`python/casemat/`); hands back COO triplets that scipy assembles.
+- **`powerio`** — the parser, the format-neutral `Network` hub, the lossless
+  writer, and the format converters. Light deps (thiserror, num-complex,
+  petgraph, serde, serde_json, fast-float); no matrix or TUI stack.
+- **`powerio-matrix`** — sparse matrices and graph views built on `powerio`
+  (which it re-exports).
+- **`powerio-cli`** — the `powerio` binary: the clap CLI and the ratatui TUI
+  over `powerio-matrix`.
+- **`powerio-py`** — PyO3 extension behind the `powerio` Python package
+  (`python/powerio/`); hands back COO triplets that scipy assembles.
+- **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
+  polyglot substrate for C/C++/Julia.
+
+`Network` is the one canonical model (format-neutral, loads/shunts first-class);
+`IndexedNetwork` is the dense-indexed analysis view derived from it.
 
 Formats. Readers: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33),
 PowerWorld `.aux`. Writers: those plus EGRET JSON. Every format meets at
 `Network`, so a new format is one reader/writer at the hub, not a pairwise
 converter.
 
-Matrix outputs (casemat):
+Matrix outputs (powerio-matrix):
 - B' (FDPF, shuntless). Singular positive Laplacian, rank n-1.
 - B'' (FDPF, with shunts and taps). SDDM when bus shunts are present.
 - `Re(Y_bus)`, `-Im(Y_bus)` (full).
@@ -35,51 +41,55 @@ Matrix outputs (casemat):
 ## Commands
 
 ```
-cargo build --release        # caseio + casemat (default-members)
-cargo test                   # caseio + casemat
+cargo build --release        # powerio + powerio-matrix + powerio-cli (default-members)
+cargo test                   # powerio + powerio-matrix
 cargo clippy --all-targets
+cargo fmt --all --check      # rustfmt is enforced (edition 2024)
 
-# casemat CLI (binary is `casemat`):
-casemat                                                   # TUI
-casemat batch -i tests/data -o out --matrices bprime,bdoubleprime
-casemat gen --topology lattice --n 1024 -o out
-casemat verify tests/data/case30.m --kind bdoubleprime
-casemat dcopf tests/data/case30.m -o out
-casemat sensitivities tests/data/case30.m -o out
-casemat convert tests/data/case14.m --to psse -o case14.raw
+# CLI (the binary is `powerio`):
+powerio                                                   # TUI
+powerio batch -i tests/data -o out --matrices bprime,bdoubleprime
+powerio gen --topology lattice --n 1024 -o out
+powerio verify tests/data/case30.m --kind bdoubleprime
+powerio dcopf tests/data/case30.m -o out
+powerio sensitivities tests/data/case30.m -o out
+powerio convert tests/data/case14.m --to psse -o case14.raw
 
-# Python bindings (PyO3 crate needs libpython, so it is NOT in default-members):
-cargo build -p casemat-ext   # plain cargo build of the extension
-maturin develop              # build + install into the active venv
+# C ABI (cdylib + staticlib; header powerio-capi/include/powerio.h):
+cargo build -p powerio-capi
+
+# Python (PyO3 crate needs libpython, so it is NOT in default-members):
+cargo build -p powerio-py    # plain cargo build of the extension
+maturin develop              # build + install the `powerio` wheel into the active venv
+maturin develop -E all       # also pull scipy/numpy/networkx for the matrix + graph paths
 pytest python/tests
 ```
 
 ## Layout
 
 ```
-caseio/                       # parser + Network hub + converters
+powerio/                      # parser + Network hub + converters
 ├── src/lib.rs               # public re-exports
 ├── src/error.rs             # thiserror Error
-├── src/case.rs              # MpcCase, Bus, Branch, Generator, GenCost,
-│                            #   Storage, DcLine, ConnectivityReport
-│                            #   + petgraph view: to_petgraph, is_radial,
-│                            #     n_connected_components, connectivity_report
-├── src/network.rs           # Network, SourceFormat (format-neutral hub)
-├── src/parser/
-│   ├── mod.rs               # format dispatcher
-│   └── matpower/            # parse_matpower(_file), tokens, matlab, locate,
-│                            #   writer (the lossless source-retaining path)
-├── src/format/             # converters at the hub
-│   ├── mod.rs              # write_as, TargetFormat, Conversion
-│   ├── powermodels.rs     # PowerModels JSON reader + writer
-│   ├── psse.rs            # PSS/E .raw reader + writer
-│   ├── powerworld.rs      # PowerWorld .aux reader + writer
-│   └── egret.rs           # EGRET JSON writer
-└── tests/                  # convert, roundtrip, roundtrip_formats
+├── src/network.rs           # Network, Bus, Load, Shunt, Branch, Generator,
+│                            #   GenCost, Storage, Hvdc, BusType, SourceFormat;
+│                            #   to_json / from_json (the structured transport)
+├── src/indexed.rs           # IndexCore, IndexedNetwork (dense-indexed analysis
+│                            #   view), ConnectivityReport; petgraph view:
+│                            #   to_petgraph, is_radial, connectivity_report
+├── src/format/
+│   ├── mod.rs               # hub: parse, parse_str, read_path, write_as,
+│   │                        #   TargetFormat, Conversion, target_format_from_name
+│   ├── matpower/            # tokens, matlab, locate, rows, writer
+│   │                        #   (the lossless source-retaining path)
+│   ├── powermodels.rs       # PowerModels JSON reader + writer
+│   ├── psse.rs              # PSS/E .raw reader + writer
+│   ├── powerworld.rs        # PowerWorld .aux reader + writer
+│   └── egret.rs             # EGRET JSON writer
+└── tests/                   # convert, roundtrip, roundtrip_formats
 
-casemat/                      # matrices + CLI/TUI on caseio
-├── src/lib.rs               # re-exports caseio + matrix builders
-├── src/main.rs              # clap CLI: tui/batch/gen/verify/dcopf/sensitivities/convert
+powerio-matrix/               # matrices + graph views on powerio
+├── src/lib.rs               # re-exports powerio + matrix builders
 ├── src/matrix/
 │   ├── mod.rs               # BuildOptions, Scheme, MatrixStats, sddm_check
 │   ├── triplet.rs           # CooBuilder (HashMap, O(nnz); new_rect for rectangular)
@@ -87,34 +97,43 @@ casemat/                      # matrices + CLI/TUI on caseio
 │   ├── incidence.rs         # A, b, B Aᵀ, P_shift; DcConvention
 │   ├── laplacian.rs         # L = A diag(w) Aᵀ, ground_at, GroundMap, e_r
 │   ├── sensitivity.rs       # PTDF, LODF (self-contained dense Cholesky)
-│   └── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
+│   ├── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
+│   └── kkt.rs               # DC-OPF interior point operators (feature = "kkt")
 ├── src/io/                  # mtx (lower-triangle symmetric), meta
 ├── src/pipeline.rs          # case → square MatrixKind family
 ├── src/opf_pipeline.rs      # case → DC-OPF bundle directory + manifest
-├── src/synth/               # tree, lattice, pegase-like generators
-└── src/tui/                 # ratatui app (in lib so it's testable)
+└── src/synth/               # tree, lattice, pegase-like generators
 
-casemat-ext/src/lib.rs       # PyO3 extension → COO triplets
-python/casemat/              # importable package (scipy/networkx assembly)
-python/tests/test_bindings.py
+powerio-cli/                  # the `powerio` binary (CLI + TUI)
+├── src/main.rs              # clap CLI: tui/batch/gen/verify/dcopf/sensitivities/convert
+└── src/tui/                 # ratatui app (app.rs, screens.rs, log_pane.rs, sparsity.rs, theme.rs)
+
+powerio-py/src/lib.rs        # PyO3 extension → COO triplets (module `_powerio`)
+python/powerio/              # importable package (scipy/networkx assembly, lazy)
+python/tests/test_powerio.py
+powerio-capi/                # C ABI (pio_*, include/powerio.h, examples/smoke.c)
 tests/data/                  # shared fixtures (used by CLI examples)
 benchmarks/                  # parse benchmarks + Julia validation harnesses
 ```
 
 ## Things to know before editing
 
-- **Workspace split.** `casemat` depends on `caseio` and re-exports it, so the
-  matrix modules' `crate::case` / `crate::Error` / `crate::parser` paths resolve
-  unchanged and a single `use casemat::...` pulls in both layers. Keep the
-  parser/converter in `caseio` (light deps) and matrices in `casemat`.
-- **Python packaging is two halves (maturin mixed layout).** `casemat-ext/` is
-  the Rust PyO3 crate; it compiles to one native module, `casemat._casemat`
-  (`[lib] name = _casemat`, `crate-type = cdylib`). `python/casemat/` is the
-  pure-Python wrapper (`python-source = python` in pyproject) that turns the
-  extension's COO triplets into `scipy.sparse`/networkx, keeping scipy out of
-  the Rust build. `maturin develop` builds the crate and drops the `.so` into
-  `python/casemat/`. One binding only: the `casemat` package surfaces caseio's
-  parse/convert plus the matrices — there is no separate `caseio` Python package.
+- **Workspace split.** `powerio-matrix` depends on `powerio` and re-exports it,
+  so the matrix modules' `crate::network` / `crate::Error` / `crate::format`
+  paths resolve unchanged and a single `use powerio_matrix::...` pulls in both
+  layers. Keep the parser/converter in `powerio` (light deps) and matrices in
+  `powerio-matrix`.
+- **One Python wheel (maturin mixed layout).** `powerio-py/` is the Rust PyO3
+  crate; it compiles to one native module, `powerio._powerio` (`[lib] name =
+  _powerio`, `crate-type = cdylib`). `python/powerio/` is the pure-Python
+  wrapper (`python-source = python` in the root pyproject) that turns the
+  extension's COO triplets into `scipy.sparse`/networkx. No numpy at the Rust
+  layer: the triplets cross as plain Python lists, so `import powerio` and
+  parse/write/convert pull in nothing but the interpreter. scipy/numpy/networkx
+  are optional extras (`powerio[matrix]`, `[graph]`, `[all]`); a missing one
+  raises a clear ImportError. `maturin develop` drops the `.so` into
+  `python/powerio/`. One package surfaces both halves: parse/convert and the
+  matrices.
 - **Lossless round-trip.** The MATPOWER parse retains the original source text
   and the writer echoes it, so `parse → write → parse` is byte-for-byte —
   every `mpc.*` field, in-matrix comments, and exact tokens like `7e-05`. Don't
@@ -122,25 +141,29 @@ benchmarks/                  # parse benchmarks + Julia validation harnesses
 - **Two-tier fidelity contract.** Same-format round-trip is byte-exact.
   Cross-format conversion keeps maximal fidelity and reports anything the target
   can't represent in `Conversion::warnings` — never drop it silently.
-- **Adding a format.** A reader and/or writer in `caseio/src/format/<name>.rs`
+- **Adding a format.** A reader and/or writer in `powerio/src/format/<name>.rs`
   that produces/consumes `Network`; register in `format/mod.rs`, re-export from
-  `caseio/src/lib.rs`, add a CLI/`TargetFormat` arm. `Network` is the unifying
-  hub; `MpcCase` is the MATPOWER-faithful typed model.
+  `powerio/src/lib.rs`, add a CLI/`TargetFormat` arm. `Network` is the unifying
+  hub.
+- **JSON transport.** `Network::to_json`/`from_json` (serde) is the structured
+  transport; over the C ABI it is `pio_to_json`/`pio_from_json`. The retained
+  `source` text is `#[serde(skip)]`, so JSON carries the tables, not the
+  byte-exact echo, and a `from_json` round-trip returns `source` as `None`.
 - **Sign convention.** Positive Laplacian: off diag negative, diag positive, `diag = sum |off-diag|` for B'. The positive (M-matrix) Laplacian form SDDM solvers expect.
-- **Bus IDs.** MATPOWER 1 based; `MpcCase::bus_index(id)` is the only mapping into dense `[0, n)`. Don't clamp out of range — return `Error::UnknownBus`.
+- **Bus IDs.** MATPOWER 1 based; `IndexedNetwork::bus_index(id)` is the only mapping into dense `[0, n)`. Don't clamp out of range — return `Error::UnknownBus`.
 - **`BR_B` is already per unit.** Never divide by `base_mva` again.
 - **`tap == 0` ⇒ `tap = 1`.** Use `Branch::effective_tap()`.
 - **B' ignores taps and shifts. B'' zeros only shifts. Y_bus keeps both.**
 - **DC-OPF Laplacian.** `L = A diag(b) Aᵀ` is built from the same `A`, `b` factors `build_incidence` returns (so `L` and the reweighted `L₁` share a factorization), and equals `build_bprime` in the XB scheme. Default `b = 1/x` (paper-pure); `DcConvention::Matpower` uses `1/(x·τ)` plus a phase-shift injection.
-- **DC-OPF is bus-indexed.** Generation is nodal (`p_g ∈ ℝⁿ`), so `Q`, `c`, and bounds are length-n (zero at load buses), scattered from generator space through `C_g`; gen-space vectors ride along as provenance. Cost map: MATPOWER `c2 p² + c1 p` → `q = 2c2`, `c = c1`. Per-unit by default (`Units::PerUnit` scales `q` by `base²`, `c` by `base`).
-- **`gen`/`gencost` are optional.** A power-flow-only case parses with `gens` empty; the OPF builders return `Error::NoGenerators`. Exactly one `BusType::Ref` is required (`MpcCase::reference_bus_index`).
+- **DC-OPF is bus-indexed.** Generation is nodal (`p_g ∈ ℝⁿ`), so `Q`, `c`, and bounds are length-n (zero at load buses), scattered from generator space through `C_g`; gen-space vectors (`OpfInstance::gen_costs`) ride along as provenance. Cost map: MATPOWER `c2 p² + c1 p` → `q = 2c2`, `c = c1`. Per-unit by default (`Units::PerUnit` scales `q` by `base²`, `c` by `base`).
+- **`gen`/`gencost` are optional.** A power flow case with no `mpc.gen` parses with `gens` empty; the OPF builders return `Error::NoGenerators`. Exactly one `BusType::Ref` is required (`IndexedNetwork::reference_bus_index`).
 - **PTDF/LODF need a solve.** They factor the slack-grounded Laplacian `ground_at(L, r)` (SPD) with a self-contained dense Cholesky (`matrix::sensitivity`) — no external solver dep. PTDF is dense `m×n`; large-scale sparse PTDF is future work.
 - **MTX output is lower triangle, 1 based, spec compliant.** `sprs::io::write_matrix_market_sym` writes the *upper* triangle, so `io::mtx::write_mtx` ships its own writer.
 - **`CooBuilder`.** HashMap COO with O(nnz) inserts; replaces the old O(nnz²) Vec search.
-- **TUI lives in the library.** `casemat/src/tui/`, behind the `cli` feature. Testable via `ratatui::backend::TestBackend`. Binary calls `casemat::tui::run`.
-- **petgraph view.** `MpcCase::to_petgraph()` returns `UnGraph<usize, usize>` where node weight = dense bus index, edge weight = branch index. Use it for connectivity, radial detection, spanning trees (LinDist3Flow).
-- **`kkt` feature is experimental and local-only.** `src/matrix/kkt.rs` (repo root) is gitignored; the DC-OPF interior point operators behind `--features kkt` are not part of the default build.
-- **Format validation needs Julia.** `benchmarks/validate_powermodels.jl` and `validate_psse.jl` check the writers/reader against PowerModels.jl; they don't run in plain `cargo test` (the all-pairs `caseio/tests/roundtrip_formats.rs` does).
+- **TUI lives in the CLI crate.** `powerio-cli/src/tui/`, part of the `powerio` binary. Testable via `ratatui::backend::TestBackend`.
+- **petgraph view.** `IndexedNetwork::to_petgraph()` returns `UnGraph<usize, usize>` where node weight = dense bus index, edge weight = branch index. Use it for connectivity, radial detection, spanning trees (LinDist3Flow).
+- **`kkt` feature is experimental and off by default.** `powerio-matrix/src/matrix/kkt.rs` holds the DC-OPF interior point operators behind `--features kkt`; not part of the default build or the main CI jobs.
+- **Format validation needs Julia.** `benchmarks/validate_powermodels.jl` and `validate_psse.jl` check the writers/reader against PowerModels.jl; they don't run in plain `cargo test` (the all-pairs `powerio/tests/roundtrip_formats.rs` does).
 
 ## Test fixtures
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,31 @@ Guidance for Claude Code working in this repo.
 
 ## Purpose
 
-A Cargo workspace of three Rust crates plus a Python package. Parses power
-network case files, converts losslessly between formats, and emits sparse
-matrices and graph views for any downstream solver. (Planned) feeds the GridFM
-ML pipeline.
+A Cargo workspace of Rust crates plus a Python package. Parses power network
+case files, converts losslessly between formats, and emits sparse matrices and
+graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
 
-- **`caseio`** — the parser, typed `MpcCase`, the format-neutral `Network` hub,
-  the lossless writer, and the format converters. Light deps (thiserror,
-  num-complex, petgraph, serde, serde_json, fast-float); no matrix or TUI stack.
-- **`casemat`** — sparse matrices and graph views built on `caseio` (which it
-  re-exports), plus the `casemat` CLI/TUI.
-- **`casemat-ext`** — PyO3 extension behind the `casemat` Python package
-  (`python/casemat/`); hands back COO triplets that scipy assembles.
+- **`powerio`** — the parser, the format-neutral `Network` hub, the lossless
+  writer, and the format converters. Light deps (thiserror, num-complex,
+  petgraph, serde, serde_json, fast-float); no matrix or TUI stack.
+- **`powerio-matrix`** — sparse matrices and graph views built on `powerio`
+  (which it re-exports).
+- **`powerio-cli`** — the `powerio` binary: the clap CLI and the ratatui TUI
+  over `powerio-matrix`.
+- **`powerio-py`** — PyO3 extension behind the `powerio` Python package
+  (`python/powerio/`); hands back COO triplets that scipy assembles.
+- **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
+  polyglot substrate for C/C++/Julia.
+
+`Network` is the one canonical model (format-neutral, loads/shunts first-class);
+`IndexedNetwork` is the dense-indexed analysis view derived from it.
 
 Formats. Readers: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33),
 PowerWorld `.aux`. Writers: those plus EGRET JSON. Every format meets at
 `Network`, so a new format is one reader/writer at the hub, not a pairwise
 converter.
 
-Matrix outputs (casemat):
+Matrix outputs (powerio-matrix):
 - B' (FDPF, shuntless). Singular positive Laplacian, rank n-1.
 - B'' (FDPF, with shunts and taps). SDDM when bus shunts are present.
 - `Re(Y_bus)`, `-Im(Y_bus)` (full).
@@ -35,51 +41,55 @@ Matrix outputs (casemat):
 ## Commands
 
 ```
-cargo build --release        # caseio + casemat (default-members)
-cargo test                   # caseio + casemat
+cargo build --release        # powerio + powerio-matrix + powerio-cli (default-members)
+cargo test                   # powerio + powerio-matrix
 cargo clippy --all-targets
+cargo fmt --all --check      # rustfmt is enforced (edition 2024)
 
-# casemat CLI (binary is `casemat`):
-casemat                                                   # TUI
-casemat batch -i tests/data -o out --matrices bprime,bdoubleprime
-casemat gen --topology lattice --n 1024 -o out
-casemat verify tests/data/case30.m --kind bdoubleprime
-casemat dcopf tests/data/case30.m -o out
-casemat sensitivities tests/data/case30.m -o out
-casemat convert tests/data/case14.m --to psse -o case14.raw
+# CLI (the binary is `powerio`):
+powerio                                                   # TUI
+powerio batch -i tests/data -o out --matrices bprime,bdoubleprime
+powerio gen --topology lattice --n 1024 -o out
+powerio verify tests/data/case30.m --kind bdoubleprime
+powerio dcopf tests/data/case30.m -o out
+powerio sensitivities tests/data/case30.m -o out
+powerio convert tests/data/case14.m --to psse -o case14.raw
 
-# Python bindings (PyO3 crate needs libpython, so it is NOT in default-members):
-cargo build -p casemat-ext   # plain cargo build of the extension
-maturin develop              # build + install into the active venv
+# C ABI (cdylib + staticlib; header powerio-capi/include/powerio.h):
+cargo build -p powerio-capi
+
+# Python (PyO3 crate needs libpython, so it is NOT in default-members):
+cargo build -p powerio-py    # plain cargo build of the extension
+maturin develop              # build + install the `powerio` wheel into the active venv
+maturin develop -E all       # also pull scipy/numpy/networkx for the matrix + graph paths
 pytest python/tests
 ```
 
 ## Layout
 
 ```
-caseio/                       # parser + Network hub + converters
+powerio/                      # parser + Network hub + converters
 ├── src/lib.rs               # public re-exports
 ├── src/error.rs             # thiserror Error
-├── src/case.rs              # MpcCase, Bus, Branch, Generator, GenCost,
-│                            #   Storage, DcLine, ConnectivityReport
-│                            #   + petgraph view: to_petgraph, is_radial,
-│                            #     n_connected_components, connectivity_report
-├── src/network.rs           # Network, SourceFormat (format-neutral hub)
-├── src/parser/
-│   ├── mod.rs               # format dispatcher
-│   └── matpower/            # parse_matpower(_file), tokens, matlab, locate,
-│                            #   writer (the lossless source-retaining path)
-├── src/format/             # converters at the hub
-│   ├── mod.rs              # write_as, TargetFormat, Conversion
-│   ├── powermodels.rs     # PowerModels JSON reader + writer
-│   ├── psse.rs            # PSS/E .raw reader + writer
-│   ├── powerworld.rs      # PowerWorld .aux reader + writer
-│   └── egret.rs           # EGRET JSON writer
-└── tests/                  # convert, roundtrip, roundtrip_formats
+├── src/network.rs           # Network, Bus, Load, Shunt, Branch, Generator,
+│                            #   GenCost, Storage, Hvdc, BusType, SourceFormat;
+│                            #   to_json / from_json (the structured transport)
+├── src/indexed.rs           # IndexCore, IndexedNetwork (dense-indexed analysis
+│                            #   view), ConnectivityReport; petgraph view:
+│                            #   to_petgraph, is_radial, connectivity_report
+├── src/format/
+│   ├── mod.rs               # hub: parse, parse_str, read_path, write_as,
+│   │                        #   TargetFormat, Conversion, target_format_from_name
+│   ├── matpower/            # tokens, matlab, locate, rows, writer
+│   │                        #   (the lossless source-retaining path)
+│   ├── powermodels.rs       # PowerModels JSON reader + writer
+│   ├── psse.rs              # PSS/E .raw reader + writer
+│   ├── powerworld.rs        # PowerWorld .aux reader + writer
+│   └── egret.rs             # EGRET JSON writer
+└── tests/                   # convert, roundtrip, roundtrip_formats
 
-casemat/                      # matrices + CLI/TUI on caseio
-├── src/lib.rs               # re-exports caseio + matrix builders
-├── src/main.rs              # clap CLI: tui/batch/gen/verify/dcopf/sensitivities/convert
+powerio-matrix/               # matrices + graph views on powerio
+├── src/lib.rs               # re-exports powerio + matrix builders
 ├── src/matrix/
 │   ├── mod.rs               # BuildOptions, Scheme, MatrixStats, sddm_check
 │   ├── triplet.rs           # CooBuilder (HashMap, O(nnz); new_rect for rectangular)
@@ -87,34 +97,43 @@ casemat/                      # matrices + CLI/TUI on caseio
 │   ├── incidence.rs         # A, b, B Aᵀ, P_shift; DcConvention
 │   ├── laplacian.rs         # L = A diag(w) Aᵀ, ground_at, GroundMap, e_r
 │   ├── sensitivity.rs       # PTDF, LODF (self-contained dense Cholesky)
-│   └── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
+│   ├── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
+│   └── kkt.rs               # DC-OPF interior point operators (feature = "kkt")
 ├── src/io/                  # mtx (lower-triangle symmetric), meta
 ├── src/pipeline.rs          # case → square MatrixKind family
 ├── src/opf_pipeline.rs      # case → DC-OPF bundle directory + manifest
-├── src/synth/               # tree, lattice, pegase-like generators
-└── src/tui/                 # ratatui app (in lib so it's testable)
+└── src/synth/               # tree, lattice, pegase-like generators
 
-casemat-ext/src/lib.rs       # PyO3 extension → COO triplets
-python/casemat/              # importable package (scipy/networkx assembly)
-python/tests/test_bindings.py
+powerio-cli/                  # the `powerio` binary (CLI + TUI)
+├── src/main.rs              # clap CLI: tui/batch/gen/verify/dcopf/sensitivities/convert
+└── src/tui/                 # ratatui app (app.rs, screens.rs, log_pane.rs, sparsity.rs, theme.rs)
+
+powerio-py/src/lib.rs        # PyO3 extension → COO triplets (module `_powerio`)
+python/powerio/              # importable package (scipy/networkx assembly, lazy)
+python/tests/test_powerio.py
+powerio-capi/                # C ABI (pio_*, include/powerio.h, examples/smoke.c)
 tests/data/                  # shared fixtures (used by CLI examples)
 benchmarks/                  # parse benchmarks + Julia validation harnesses
 ```
 
 ## Things to know before editing
 
-- **Workspace split.** `casemat` depends on `caseio` and re-exports it, so the
-  matrix modules' `crate::case` / `crate::Error` / `crate::parser` paths resolve
-  unchanged and a single `use casemat::...` pulls in both layers. Keep the
-  parser/converter in `caseio` (light deps) and matrices in `casemat`.
-- **Python packaging is two halves (maturin mixed layout).** `casemat-ext/` is
-  the Rust PyO3 crate; it compiles to one native module, `casemat._casemat`
-  (`[lib] name = _casemat`, `crate-type = cdylib`). `python/casemat/` is the
-  pure-Python wrapper (`python-source = python` in pyproject) that turns the
-  extension's COO triplets into `scipy.sparse`/networkx, keeping scipy out of
-  the Rust build. `maturin develop` builds the crate and drops the `.so` into
-  `python/casemat/`. One binding only: the `casemat` package surfaces caseio's
-  parse/convert plus the matrices — there is no separate `caseio` Python package.
+- **Workspace split.** `powerio-matrix` depends on `powerio` and re-exports it,
+  so the matrix modules' `crate::network` / `crate::Error` / `crate::format`
+  paths resolve unchanged and a single `use powerio_matrix::...` pulls in both
+  layers. Keep the parser/converter in `powerio` (light deps) and matrices in
+  `powerio-matrix`.
+- **One Python wheel (maturin mixed layout).** `powerio-py/` is the Rust PyO3
+  crate; it compiles to one native module, `powerio._powerio` (`[lib] name =
+  _powerio`, `crate-type = cdylib`). `python/powerio/` is the pure-Python
+  wrapper (`python-source = python` in the root pyproject) that turns the
+  extension's COO triplets into `scipy.sparse`/networkx. No numpy at the Rust
+  layer: the triplets cross as plain Python lists, so `import powerio` and
+  parse/write/convert pull in nothing but the interpreter. scipy/numpy/networkx
+  are optional extras (`powerio[matrix]`, `[graph]`, `[all]`); a missing one
+  raises a clear ImportError. `maturin develop` drops the `.so` into
+  `python/powerio/`. One package surfaces both halves: parse/convert and the
+  matrices.
 - **Lossless round-trip.** The MATPOWER parse retains the original source text
   and the writer echoes it, so `parse → write → parse` is byte-for-byte —
   every `mpc.*` field, in-matrix comments, and exact tokens like `7e-05`. Don't
@@ -122,25 +141,29 @@ benchmarks/                  # parse benchmarks + Julia validation harnesses
 - **Two-tier fidelity contract.** Same-format round-trip is byte-exact.
   Cross-format conversion keeps maximal fidelity and reports anything the target
   can't represent in `Conversion::warnings` — never drop it silently.
-- **Adding a format.** A reader and/or writer in `caseio/src/format/<name>.rs`
+- **Adding a format.** A reader and/or writer in `powerio/src/format/<name>.rs`
   that produces/consumes `Network`; register in `format/mod.rs`, re-export from
-  `caseio/src/lib.rs`, add a CLI/`TargetFormat` arm. `Network` is the unifying
-  hub; `MpcCase` is the MATPOWER-faithful typed model.
+  `powerio/src/lib.rs`, add a CLI/`TargetFormat` arm. `Network` is the unifying
+  hub.
+- **JSON transport.** `Network::to_json`/`from_json` (serde) is the structured
+  transport; over the C ABI it is `pio_to_json`/`pio_from_json`. The retained
+  `source` text is `#[serde(skip)]`, so JSON carries the tables, not the
+  byte-exact echo, and a `from_json` round-trip returns `source` as `None`.
 - **Sign convention.** Positive Laplacian: off diag negative, diag positive, `diag = sum |off-diag|` for B'. The positive (M-matrix) Laplacian form SDDM solvers expect.
-- **Bus IDs.** MATPOWER 1 based; `MpcCase::bus_index(id)` is the only mapping into dense `[0, n)`. Don't clamp out of range — return `Error::UnknownBus`.
+- **Bus IDs.** MATPOWER 1 based; `IndexedNetwork::bus_index(id)` is the only mapping into dense `[0, n)`. Don't clamp out of range — return `Error::UnknownBus`.
 - **`BR_B` is already per unit.** Never divide by `base_mva` again.
 - **`tap == 0` ⇒ `tap = 1`.** Use `Branch::effective_tap()`.
 - **B' ignores taps and shifts. B'' zeros only shifts. Y_bus keeps both.**
 - **DC-OPF Laplacian.** `L = A diag(b) Aᵀ` is built from the same `A`, `b` factors `build_incidence` returns (so `L` and the reweighted `L₁` share a factorization), and equals `build_bprime` in the XB scheme. Default `b = 1/x` (paper-pure); `DcConvention::Matpower` uses `1/(x·τ)` plus a phase-shift injection.
-- **DC-OPF is bus-indexed.** Generation is nodal (`p_g ∈ ℝⁿ`), so `Q`, `c`, and bounds are length-n (zero at load buses), scattered from generator space through `C_g`; gen-space vectors ride along as provenance. Cost map: MATPOWER `c2 p² + c1 p` → `q = 2c2`, `c = c1`. Per-unit by default (`Units::PerUnit` scales `q` by `base²`, `c` by `base`).
-- **`gen`/`gencost` are optional.** A power-flow-only case parses with `gens` empty; the OPF builders return `Error::NoGenerators`. Exactly one `BusType::Ref` is required (`MpcCase::reference_bus_index`).
+- **DC-OPF is bus-indexed.** Generation is nodal (`p_g ∈ ℝⁿ`), so `Q`, `c`, and bounds are length-n (zero at load buses), scattered from generator space through `C_g`; gen-space vectors (`OpfInstance::gen_costs`) ride along as provenance. Cost map: MATPOWER `c2 p² + c1 p` → `q = 2c2`, `c = c1`. Per-unit by default (`Units::PerUnit` scales `q` by `base²`, `c` by `base`).
+- **`gen`/`gencost` are optional.** A power flow case with no `mpc.gen` parses with `gens` empty; the OPF builders return `Error::NoGenerators`. Exactly one `BusType::Ref` is required (`IndexedNetwork::reference_bus_index`).
 - **PTDF/LODF need a solve.** They factor the slack-grounded Laplacian `ground_at(L, r)` (SPD) with a self-contained dense Cholesky (`matrix::sensitivity`) — no external solver dep. PTDF is dense `m×n`; large-scale sparse PTDF is future work.
 - **MTX output is lower triangle, 1 based, spec compliant.** `sprs::io::write_matrix_market_sym` writes the *upper* triangle, so `io::mtx::write_mtx` ships its own writer.
 - **`CooBuilder`.** HashMap COO with O(nnz) inserts; replaces the old O(nnz²) Vec search.
-- **TUI lives in the library.** `casemat/src/tui/`, behind the `cli` feature. Testable via `ratatui::backend::TestBackend`. Binary calls `casemat::tui::run`.
-- **petgraph view.** `MpcCase::to_petgraph()` returns `UnGraph<usize, usize>` where node weight = dense bus index, edge weight = branch index. Use it for connectivity, radial detection, spanning trees (LinDist3Flow).
-- **`kkt` feature is experimental and off by default.** `src/matrix/kkt.rs` (repo root, a pre-workspace-split holdover reached via `#[path]`) holds the DC-OPF interior point operators behind `--features kkt`; not part of the default build or the main CI jobs.
-- **Format validation needs Julia.** `benchmarks/validate_powermodels.jl` and `validate_psse.jl` check the writers/reader against PowerModels.jl; they don't run in plain `cargo test` (the all-pairs `caseio/tests/roundtrip_formats.rs` does).
+- **TUI lives in the CLI crate.** `powerio-cli/src/tui/`, part of the `powerio` binary. Testable via `ratatui::backend::TestBackend`.
+- **petgraph view.** `IndexedNetwork::to_petgraph()` returns `UnGraph<usize, usize>` where node weight = dense bus index, edge weight = branch index. Use it for connectivity, radial detection, spanning trees (LinDist3Flow).
+- **`kkt` feature is experimental and off by default.** `powerio-matrix/src/matrix/kkt.rs` holds the DC-OPF interior point operators behind `--features kkt`; not part of the default build or the main CI jobs.
+- **Format validation needs Julia.** `benchmarks/validate_powermodels.jl` and `validate_psse.jl` check the writers/reader against PowerModels.jl; they don't run in plain `cargo test` (the all-pairs `powerio/tests/roundtrip_formats.rs` does).
 
 ## Test fixtures
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,42 @@
 # PowerIO
 
-Fast, lossless parser and format converter for power system case files. Parse a MATPOWER `.m` case into a typed, format-neutral model, write it back byte-for-byte, convert between formats through a neutral hub, and emit the sparse matrices and graph views a solver needs. Light on dependencies, so other tools and languages can embed it without a matrix or solver stack.
-
-PowerIO is the data layer: one fast, lossless reader/writer every tool and language can share. It parses MATPOWER, PSS/E, PowerWorld, and PowerModels JSON into a single format-neutral `Network`, converts between them with explicit fidelity reporting (never a silent drop), and emits the matrices and graph views solvers consume. The same Rust core is callable from Rust, Python, C/C++, and Julia, so a case reads identically everywhere. PowerIO does the IO and the linear algebra views, then hands clean data to the solvers and frameworks you already use rather than competing with them.
-
-What's distinct:
-
-- **Byte-exact same-format round-trip.** `parse → write → parse` reproduces the source, comments and exact numeric tokens included. PowerModels and pandapower are lossy on write; ExaPowerIO has no writer.
-- **Hub topology.** N readers and M writers meet at `Network`, so a new format is one module, not N×M converters.
-- **Dependency-light core**, no solver or matrix stack required, with a polyglot surface (Rust crate, one Python wheel, C ABI, Julia package) sharing a single parser.
-- **Fastest of the set measured** — faster than ExaPowerIO on every case, ~50–70× PowerModels, ~10× pandapower — with validation harnesses against all three.
+Fast, lossless IO and format conversion for power system case files. Parse
+MATPOWER `.m`, PSS/E `.raw`, PowerWorld `.aux`, and PowerModels JSON into one
+format-neutral `Network`; write any of them back (MATPOWER round-trips
+byte-for-byte); convert between them with explicit fidelity reporting; and emit
+the sparse matrices and graph views a solver needs. The same Rust core is
+callable from Rust, Python, C/C++, and Julia. The core crate has six
+dependencies and no matrix or solver stack.
 
 ## Workspace
 
 ```
-powerio          parser, typed Network hub, lossless writer, format converters. Six light deps.
+powerio          parser, typed Network hub, lossless writer, format converters.
 powerio-matrix   sparse matrices + graph views on top of powerio (re-exports it).
-powerio-cli      the `powerio` binary + TUI.
-powerio-py       PyO3 extension → the one `powerio` Python wheel.
-powerio-capi     C ABI → the polyglot substrate (C, C++, Julia).
+powerio-cli      the `powerio` binary: CLI + TUI.
+powerio-py       PyO3 extension behind the one `powerio` Python wheel.
+powerio-capi     C ABI (`pio_*`), the substrate for C, C++, and Julia.
 ```
 
-`cargo add powerio` gives the light parser; `cargo install powerio-cli` gives the `powerio` command.
+Full API docs are on [docs.rs/powerio](https://docs.rs/powerio) and
+[docs.rs/powerio-matrix](https://docs.rs/powerio-matrix).
 
-## Lossless round-trip
+## Install
 
-`parse → write → parse` reproduces the source byte-for-byte — every `mpc.*` field (including ones the typed model doesn't interpret), in-matrix column-header comments, and exact tokens like `7e-05` that an `f64`-based writer would mangle. The parser keeps the original text and the writer echoes it, so the round-trip costs no extra parse pass. ExaPowerIO has no writer; PowerModels' MATPOWER export is lossy.
+```
+cargo add powerio            # the parser + converters
+cargo install powerio-cli    # the `powerio` command + TUI
+pip install powerio          # zero-dependency parse + convert, Python 3.9+
+pip install 'powerio[all]'   # + scipy/numpy/networkx for the matrices and graph view
+```
 
-## Convert
+## Formats
 
-Every reader produces a format-neutral `Network` (first-class buses, loads, shunts, branches, generators, storage, HVDC) and every writer consumes it — N readers × M writers, not pairwise. The fidelity contract is two-tier:
+Every reader produces a `Network` and every writer consumes one, so a new format
+is one module at the hub, not an N×M matrix of pairwise converters.
 
-- **Same-format round-trip is byte-exact.** Each reader keeps its source text; writing back to that format echoes it.
-- **Cross-format keeps maximal fidelity with itemized loss.** Anything the target can't represent is reported in `Conversion::warnings`, never dropped silently.
-
-PowerModels JSON and PSS/E are validated against `PowerModels.jl` (which reads both): the writers value-for-value on the vendored cases, and the PSS/E reader against real PTI `.raw` files (`benchmarks/validate_powermodels.jl`, `benchmarks/validate_psse.jl`, both need Julia). The all-pairs harness (`powerio/tests/roundtrip_formats.rs`) pins core preservation, reader∘writer idempotence, and the byte-exact echo in plain `cargo test`.
-
-PowerIO covers the transmission planning / OPF interchange formats — the bus/branch/gen/load/shunt family — not CIM or distribution feeders, which the CIM hubs (CIMHub, MG-RAVENS) own. It fits as the ingest/conversion layer feeding such a hub or a solver.
-
-**Readers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33), PowerWorld `.aux`. **Writers**: those plus EGRET JSON. Every format reads to and writes from the same `Network`, so a new format is one reader/writer at the hub.
+**Readers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33), PowerWorld
+`.aux`. **Writers**: those plus EGRET JSON.
 
 | reader ↓ \ writer → | MATPOWER | PowerModels JSON | EGRET JSON | PSS/E | PowerWorld |
 | --- | --- | --- | --- | --- | --- |
@@ -47,7 +45,23 @@ PowerIO covers the transmission planning / OPF interchange formats — the bus/b
 | **PSS/E** | core | core | schema-faithful | byte-exact | core + warnings |
 | **PowerWorld** | core | core | schema-faithful | core + warnings | byte-exact |
 
-*byte-exact* = same-format source echo; *core* = bus/branch/gen/load/shunt preserved, with anything the target can't hold reported in `warnings`.
+The fidelity contract is two-tier: same-format round-trip is byte-exact (the
+reader keeps its source text and the writer echoes it, comments and exact tokens
+like `7e-05` included), and cross-format conversion keeps maximal fidelity,
+reporting anything the target can't represent in `Conversion::warnings` rather
+than dropping it silently. The PowerModels and PSS/E paths are checked value for
+value against `PowerModels.jl`; see [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+
+## Matrices
+
+`powerio-matrix` builds, from the dense-indexed `IndexedNetwork` view: signed
+incidence `A`, the weighted Laplacian `L = A diag(b) Aᵀ` and its slack-grounded
+form, B'/B''/`Re(Y_bus)`/`-Im(Y_bus)`, the LACPF block, PTDF/LODF, the DC-OPF
+instance bundle, adjacency, and a petgraph view — as Matrix Market or in memory.
+The sign, tap, per-unit, and DC-OPF conventions are documented in the
+[crate docs](https://docs.rs/powerio-matrix).
+
+## Use
 
 ```rust
 use powerio::{parse_matpower_file, write_as, TargetFormat};
@@ -58,114 +72,60 @@ for w in &conv.warnings { eprintln!("fidelity: {w}"); }    // what couldn't be r
 std::fs::write("case14.json", conv.text)?;
 ```
 
-From the CLI and Python (input format inferred from the extension):
-
-```
-powerio convert case14.m --to psse -o case14.raw       # → PSS/E .raw
-powerio convert case14.raw --to powermodels-json       # PSS/E → PowerModels JSON, to stdout
-```
-
 ```python
 import powerio
-r = powerio.convert("case14.m", "egret-json")
-print(r.warnings)            # fields EGRET couldn't represent
-open("case14.json", "w").write(r.text)
+case = powerio.parse("case9.m")        # format inferred from the extension
+B = case.bprime()                      # scipy.sparse FDPF B'  (needs powerio[matrix])
+raw, warnings = powerio.convert("case9.m", "psse")
+```
+
+```
+powerio convert case14.m --to psse -o case14.raw   # convert
+powerio dcopf case30.m -o out                       # DC-OPF instance bundle
+powerio sensitivities case30.m -o out               # PTDF + LODF
+powerio                                              # TUI
 ```
 
 ## Benchmark
 
-Median parse time, same machine (Apple M-series, release build), all three timed in one process under the same harness — PowerIO through its C ABI, so every parser reads the file from disk alike. Full table and method in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+Median parse time, one Apple M-series laptop, release build, all timed in one
+process under the same harness — powerio through its C ABI, so every parser reads
+from disk alike. Full table and method in
+[benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
-| case | buses / branches | **powerio** | ExaPowerIO.jl | PowerModels.jl |
+| case | buses / branches | powerio | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
-| case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
-| case9241pegase | 9241 / 16049 | **5.67 ms** | 8.94 ms | 558 ms |
-| case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
-| case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
+| case2869pegase | 2869 / 4582 | 1.73 ms | 2.86 ms | 122.2 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | 2.07 ms | 2.11 ms | 127.8 ms |
+| case9241pegase | 9241 / 16049 | 5.81 ms | 9.15 ms | 553.2 ms |
+| case13659pegase | 13659 / 20467 | 8.6 ms | 13.76 ms | 822.2 ms |
+| case193k | 192768 / 228574 | 161.9 ms | 174.98 ms | — |
 
-PowerIO is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops. It's also ~10× faster than pandapower's `.m` reader. And it's the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime; its parse, conversions, and Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
-
-## powerio: parse and write
-
-```rust
-use powerio::{parse_matpower_file, write_matpower, IndexedNetwork};
-
-let net = parse_matpower_file("case14.m")?;          // typed Network
-assert!(IndexedNetwork::new(&net).connectivity_report().is_single_island());
-let bus0 = net.buses[0].name.as_deref();             // bus_name, dclines, ...
-
-let m = write_matpower(&net);                        // reproduces the source
-```
-
-`powerio` depends only on `thiserror`, `num-complex`, `petgraph`, `serde`, `serde_json`, and `fast-float`.
-
-## powerio-matrix: matrices on top
-
-```rust
-use powerio_matrix::{parse_matpower_file, IndexedNetwork, build_bprime, build_incidence,
-                     build_weighted_laplacian, BuildOptions, DcConvention};
-
-let net = parse_matpower_file("case14.m")?;          // powerio, re-exported
-let g = IndexedNetwork::new(&net);                   // dense-indexed analysis view
-let b = build_bprime(&g, &BuildOptions::default())?;
-let inc = build_incidence(&g, DcConvention::PaperPure)?;     // A, b
-let l = build_weighted_laplacian(&inc.a, &inc.b);           // L = A diag(b) Aᵀ
-```
-
-Outputs: signed incidence `A`, adjacency, weighted Laplacian and its slack-grounded form, B'/B'', `Re(Y_bus)`/`-Im(Y_bus)`, PTDF/LODF, the LACPF block, the DC-OPF instance bundle, and a petgraph view — as Matrix Market or in memory.
-
-### CLI
-
-```
-powerio                                                  # TUI
-powerio batch -i tests/data -o out --matrices bprime,bdoubleprime
-powerio dcopf tests/data/case30.m -o out                 # DC-OPF instance bundle
-powerio sensitivities tests/data/case30.m -o out         # PTDF + LODF
-```
-
-### Python
-
-```
-pip install powerio                # zero-dep parse + convert; wheels for Linux/macOS/Windows, 3.9+
-pip install 'powerio[all]'         # + scipy/numpy/networkx for matrices and the graph view
-```
-
-```python
-import powerio
-case = powerio.parse_matpower("case9.m")
-B = case.bprime()             # scipy.sparse.csr_matrix   (needs powerio[matrix])
-Y = case.ybus()               # complex csr_matrix, G + jB
-g = case.to_networkx()        # needs powerio[graph]
-```
-
-`import powerio` and parse/write/convert pull in nothing but the interpreter; scipy/numpy/networkx are optional extras (`powerio[matrix]`, `[graph]`, `[all]`), and a missing one raises a clear ImportError.
-
-## Conventions
-
-- Positive Laplacian: negative off-diagonal, positive diagonal, `diag = sum |off-diag|` for B'.
-- MATPOWER 1-based bus IDs preserved; `IndexedNetwork::bus_index(id)` maps to dense `[0, n)`.
-- `tap == 0` ⇒ `tap = 1`. B' ignores taps and shifts; B'' zeros only shifts.
-- `BR_B` is already per unit; never divide by `base_mva` again.
-- DC-OPF is bus-indexed (`p_g ∈ ℝⁿ`); default `b = 1/x` (paper-pure), `--convention matpower` uses `1/(x·τ)` plus a phase-shift injection.
+powerio is faster than ExaPowerIO on every case measured, 62–96× PowerModels'
+parser, and ~14× pandapower's `.m` reader. It is also the only one of the three
+that round-trips byte-for-byte (verified at 54 MB / 192768 buses) and is callable
+from Rust, the CLI, Python, and C/Julia with no runtime. Parse, conversions, and
+Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
 
 ## Roadmap
 
-More over the `Network` hub, tracked in the issues:
+Tracked in the issues, all over the `Network` hub:
 
-- An EGRET-JSON **reader** (the writer is done) to make EGRET two-way.
-- Broader format coverage: PSS/E `.rawx` (JSON v35), IIDM `.xiidm`, UCTE `.uct`, GE EPC `.epc`.
-- PSS/E fidelity: 3-winding transformers, non-unit `CZ`/`CW` impedance bases, switched shunts; and an external validation for PowerWorld `.aux`.
-- A RAVENS-JSON export sink (and positioning PowerIO as a fast ingest backend for MG-RAVENS).
-- An MCP `convert`/`validate` tool over the Python binding.
-- A registered `PowerIO.jl` over the C ABI, with native bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl.
+- An EGRET-JSON reader (the writer is done), to make EGRET two-way.
+- Broader format coverage: PSS/E `.rawx` (v35), IIDM `.xiidm`, UCTE `.uct`, GE EPC `.epc`.
+- PSS/E fidelity: 3-winding transformers, non-unit `CZ`/`CW` impedance bases, switched shunts.
+- A RAVENS-JSON export sink (positioning PowerIO as an ingest backend for MG-RAVENS).
+- A registered [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl) over the C ABI, with
+  native bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl (scaffolded there now).
+- LinDist3Flow and Parquet output (gridfm-datakit schema).
 
-The C ABI (`powerio-capi`) for C/C++/Julia is done — it carries a `pio_to_json`/`pio_from_json` transport alongside the dense table extractors, and it's what the benchmark harness times PowerIO through. CIM stays out of scope; it's a heavier problem owned by the CIM hubs.
+CIM stays out of scope; it's a heavier problem owned by the CIM hubs (CIMHub,
+MG-RAVENS), which PowerIO can feed as an ingest layer.
 
 ## Tests
 
 ```
-cargo test            # powerio + powerio-matrix
+cargo test            # powerio + powerio-matrix, including the all-pairs round-trip
 cargo run --release -p powerio --example timeparse -- tests/data/case2869pegase.m
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
-# caseio
+# PowerIO
 
-Fast, lossless parser and format converter for power-system case files. Parse a MATPOWER `.m` case, work with a typed model, write it back byte-for-byte, or convert between formats through a neutral hub. Light on dependencies, so other tools can embed it without a matrix or solver stack.
+Fast, lossless parser and format converter for power system case files. Parse a MATPOWER `.m` case into a typed, format-neutral model, write it back byte-for-byte, convert between formats through a neutral hub, and emit the sparse matrices and graph views a solver needs. Light on dependencies, so other tools and languages can embed it without a matrix or solver stack.
 
-Three crates in this workspace (the third builds the Python wheel):
+PowerIO is the data layer: one fast, lossless reader/writer every tool and language can share. It parses MATPOWER, PSS/E, PowerWorld, and PowerModels JSON into a single format-neutral `Network`, converts between them with explicit fidelity reporting (never a silent drop), and emits the matrices and graph views solvers consume. The same Rust core is callable from Rust, Python, C/C++, and Julia, so a case reads identically everywhere. PowerIO does the IO and the linear algebra views, then hands clean data to the solvers and frameworks you already use rather than competing with them.
 
-- **`caseio`** — the parser, the typed `MpcCase`, the format-neutral `Network` hub where the converters meet, the lossless writer, and the converters. Readers for MATPOWER, PowerModels JSON, PSS/E, and PowerWorld; writers for those plus EGRET JSON. Six dependencies, no matrix or TUI stack.
-- **`casemat`** — sparse matrices and graph views on top of caseio: B'/B''/Y_bus, PTDF/LODF, incidence, weighted Laplacian, the LACPF block, adjacency, the DC-OPF instance bundle, and a CLI/TUI.
-- **`casemat-ext`** — the PyO3 extension behind the `casemat` Python package. maturin compiles it to `casemat._casemat`; the pure-Python wrapper in `python/casemat/` turns the results into `scipy.sparse` matrices and networkx graphs, so scipy/networkx stay out of the Rust build.
+What's distinct:
+
+- **Byte-exact same-format round-trip.** `parse → write → parse` reproduces the source, comments and exact numeric tokens included. PowerModels and pandapower are lossy on write; ExaPowerIO has no writer.
+- **Hub topology.** N readers and M writers meet at `Network`, so a new format is one module, not N×M converters.
+- **Dependency-light core**, no solver or matrix stack required, with a polyglot surface (Rust crate, one Python wheel, C ABI, Julia package) sharing a single parser.
+- **Fastest of the set measured** — faster than ExaPowerIO on every case, ~50–70× PowerModels, ~10× pandapower — with validation harnesses against all three.
+
+## Workspace
+
+```
+powerio          parser, typed Network hub, lossless writer, format converters. Six light deps.
+powerio-matrix   sparse matrices + graph views on top of powerio (re-exports it).
+powerio-cli      the `powerio` binary + TUI.
+powerio-py       PyO3 extension → the one `powerio` Python wheel.
+powerio-capi     C ABI → the polyglot substrate (C, C++, Julia).
+```
+
+`cargo add powerio` gives the light parser; `cargo install powerio-cli` gives the `powerio` command.
 
 ## Lossless round-trip
 
@@ -19,9 +34,9 @@ Every reader produces a format-neutral `Network` (first-class buses, loads, shun
 - **Same-format round-trip is byte-exact.** Each reader keeps its source text; writing back to that format echoes it.
 - **Cross-format keeps maximal fidelity with itemized loss.** Anything the target can't represent is reported in `Conversion::warnings`, never dropped silently.
 
-PowerModels JSON and PSS/E are validated against `PowerModels.jl` (which reads both): the writers value-for-value on the vendored cases, and the PSS/E reader against real PTI `.raw` files (`benchmarks/validate_powermodels.jl`, `benchmarks/validate_psse.jl`, both need Julia). The all-pairs harness (`caseio/tests/roundtrip_formats.rs`) pins core preservation, reader∘writer idempotence, and the byte-exact echo in plain `cargo test`.
+PowerModels JSON and PSS/E are validated against `PowerModels.jl` (which reads both): the writers value-for-value on the vendored cases, and the PSS/E reader against real PTI `.raw` files (`benchmarks/validate_powermodels.jl`, `benchmarks/validate_psse.jl`, both need Julia). The all-pairs harness (`powerio/tests/roundtrip_formats.rs`) pins core preservation, reader∘writer idempotence, and the byte-exact echo in plain `cargo test`.
 
-caseio covers the transmission planning / OPF interchange formats — the bus/branch/gen/load/shunt family — not CIM or distribution feeders, which the CIM hubs (CIMHub, MG-RAVENS) own. It fits as the ingest/conversion layer feeding such a hub or a solver.
+PowerIO covers the transmission planning / OPF interchange formats — the bus/branch/gen/load/shunt family — not CIM or distribution feeders, which the CIM hubs (CIMHub, MG-RAVENS) own. It fits as the ingest/conversion layer feeding such a hub or a solver.
 
 **Readers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33), PowerWorld `.aux`. **Writers**: those plus EGRET JSON. Every format reads to and writes from the same `Network`, so a new format is one reader/writer at the hub.
 
@@ -35,9 +50,9 @@ caseio covers the transmission planning / OPF interchange formats — the bus/br
 *byte-exact* = same-format source echo; *core* = bus/branch/gen/load/shunt preserved, with anything the target can't hold reported in `warnings`.
 
 ```rust
-use caseio::{parse_matpower_file, write_as, TargetFormat};
+use powerio::{parse_matpower_file, write_as, TargetFormat};
 
-let net = parse_matpower_file("case14.m")?.to_network();   // MATPOWER → neutral hub
+let net = parse_matpower_file("case14.m")?;                // MATPOWER → neutral hub
 let conv = write_as(&net, TargetFormat::PowerModelsJson);  // → PowerModels JSON
 for w in &conv.warnings { eprintln!("fidelity: {w}"); }    // what couldn't be represented
 std::fs::write("case14.json", conv.text)?;
@@ -46,22 +61,22 @@ std::fs::write("case14.json", conv.text)?;
 From the CLI and Python (input format inferred from the extension):
 
 ```
-casemat convert case14.m --to psse -o case14.raw       # → PSS/E .raw
-casemat convert case14.raw --to powermodels-json       # PSS/E → PowerModels JSON, to stdout
+powerio convert case14.m --to psse -o case14.raw       # → PSS/E .raw
+powerio convert case14.raw --to powermodels-json       # PSS/E → PowerModels JSON, to stdout
 ```
 
 ```python
-import casemat as cm
-r = cm.convert("case14.m", "egret-json")
+import powerio
+r = powerio.convert("case14.m", "egret-json")
 print(r.warnings)            # fields EGRET couldn't represent
 open("case14.json", "w").write(r.text)
 ```
 
 ## Benchmark
 
-Median parse time, same machine (Apple M-series, release build), all three timed in one process under the same harness — caseio through its C ABI, so every parser reads the file from disk alike. Full table and method in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+Median parse time, same machine (Apple M-series, release build), all three timed in one process under the same harness — PowerIO through its C ABI, so every parser reads the file from disk alike. Full table and method in [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
-| case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
+| case | buses / branches | **powerio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
 | case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
 | case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
@@ -69,32 +84,33 @@ Median parse time, same machine (Apple M-series, release build), all three timed
 | case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
 | case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
 
-caseio is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops. It's also ~10× faster than pandapower's `.m` reader. And it's the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime; its parse, conversions, and Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
+PowerIO is 50–70× faster than PowerModels' parser and faster than (or tied with) ExaPowerIO, the focused Julia reader, on every case here — ~35% on the pegase cases and ~2–12% on the ACTIVSg / SyntheticUSA / US cases, where it parses and keeps the `gentype` / `genfuel` / `bus_name` cell arrays ExaPowerIO drops. It's also ~10× faster than pandapower's `.m` reader. And it's the only one of the three that is lossless, round-trips byte-for-byte (verified at 193k buses), and is callable from Rust, the CLI, Python, and C/Julia with no runtime; its parse, conversions, and Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
 
-## caseio: parse and write
+## powerio: parse and write
 
 ```rust
-use caseio::{parse_matpower_file, write_matpower};
+use powerio::{parse_matpower_file, write_matpower, IndexedNetwork};
 
-let case = parse_matpower_file("case14.m")?;        // typed MpcCase
-assert!(case.connectivity_report().is_single_island());
-let bus0 = case.buses[0].name.as_deref();           // bus_name, dclines, ...
+let net = parse_matpower_file("case14.m")?;          // typed Network
+assert!(IndexedNetwork::new(&net).connectivity_report().is_single_island());
+let bus0 = net.buses[0].name.as_deref();             // bus_name, dclines, ...
 
-let m = write_matpower(&case);                       // reproduces the source
+let m = write_matpower(&net);                        // reproduces the source
 ```
 
-`caseio` depends only on `thiserror`, `num-complex`, `petgraph`, `serde`, `serde_json`, and `fast-float`.
+`powerio` depends only on `thiserror`, `num-complex`, `petgraph`, `serde`, `serde_json`, and `fast-float`.
 
-## casemat: matrices on top
+## powerio-matrix: matrices on top
 
 ```rust
-use casemat::{parse_matpower_file, build_bprime, build_incidence, build_weighted_laplacian,
-              BuildOptions, DcConvention};
+use powerio_matrix::{parse_matpower_file, IndexedNetwork, build_bprime, build_incidence,
+                     build_weighted_laplacian, BuildOptions, DcConvention};
 
-let mpc = parse_matpower_file("case14.m")?;          // caseio, re-exported
-let b = build_bprime(&mpc, &BuildOptions::default())?;
-let inc = build_incidence(&mpc, DcConvention::PaperPure)?;   // A, b
-let l = build_weighted_laplacian(&inc.a, &inc.b);            // L = A diag(b) Aᵀ
+let net = parse_matpower_file("case14.m")?;          // powerio, re-exported
+let g = IndexedNetwork::new(&net);                   // dense-indexed analysis view
+let b = build_bprime(&g, &BuildOptions::default())?;
+let inc = build_incidence(&g, DcConvention::PaperPure)?;     // A, b
+let l = build_weighted_laplacian(&inc.a, &inc.b);           // L = A diag(b) Aᵀ
 ```
 
 Outputs: signed incidence `A`, adjacency, weighted Laplacian and its slack-grounded form, B'/B'', `Re(Y_bus)`/`-Im(Y_bus)`, PTDF/LODF, the LACPF block, the DC-OPF instance bundle, and a petgraph view — as Matrix Market or in memory.
@@ -102,30 +118,33 @@ Outputs: signed incidence `A`, adjacency, weighted Laplacian and its slack-groun
 ### CLI
 
 ```
-casemat                                                  # TUI
-casemat batch -i tests/data -o out --matrices bprime,bdoubleprime
-casemat dcopf tests/data/case30.m -o out                 # DC-OPF instance bundle
-casemat sensitivities tests/data/case30.m -o out         # PTDF + LODF
+powerio                                                  # TUI
+powerio batch -i tests/data -o out --matrices bprime,bdoubleprime
+powerio dcopf tests/data/case30.m -o out                 # DC-OPF instance bundle
+powerio sensitivities tests/data/case30.m -o out         # PTDF + LODF
 ```
 
 ### Python
 
 ```
-pip install casemat            # wheels for Linux / macOS / Windows, Python 3.9+
+pip install powerio                # zero-dep parse + convert; wheels for Linux/macOS/Windows, 3.9+
+pip install 'powerio[all]'         # + scipy/numpy/networkx for matrices and the graph view
 ```
 
 ```python
-import casemat as cm
-case = cm.parse_matpower("case9.m")
-B = case.bprime()             # scipy.sparse.csr_matrix
+import powerio
+case = powerio.parse_matpower("case9.m")
+B = case.bprime()             # scipy.sparse.csr_matrix   (needs powerio[matrix])
 Y = case.ybus()               # complex csr_matrix, G + jB
-g = case.to_networkx()
+g = case.to_networkx()        # needs powerio[graph]
 ```
+
+`import powerio` and parse/write/convert pull in nothing but the interpreter; scipy/numpy/networkx are optional extras (`powerio[matrix]`, `[graph]`, `[all]`), and a missing one raises a clear ImportError.
 
 ## Conventions
 
 - Positive Laplacian: negative off-diagonal, positive diagonal, `diag = sum |off-diag|` for B'.
-- MATPOWER 1-based bus IDs preserved; `MpcCase::bus_index(id)` maps to dense `[0, n)`.
+- MATPOWER 1-based bus IDs preserved; `IndexedNetwork::bus_index(id)` maps to dense `[0, n)`.
 - `tap == 0` ⇒ `tap = 1`. B' ignores taps and shifts; B'' zeros only shifts.
 - `BR_B` is already per unit; never divide by `base_mva` again.
 - DC-OPF is bus-indexed (`p_g ∈ ℝⁿ`); default `b = 1/x` (paper-pure), `--convention matpower` uses `1/(x·τ)` plus a phase-shift injection.
@@ -137,16 +156,17 @@ More over the `Network` hub, tracked in the issues:
 - An EGRET-JSON **reader** (the writer is done) to make EGRET two-way.
 - Broader format coverage: PSS/E `.rawx` (JSON v35), IIDM `.xiidm`, UCTE `.uct`, GE EPC `.epc`.
 - PSS/E fidelity: 3-winding transformers, non-unit `CZ`/`CW` impedance bases, switched shunts; and an external validation for PowerWorld `.aux`.
-- A RAVENS-JSON export sink (and positioning caseio as a fast ingest backend for MG-RAVENS).
+- A RAVENS-JSON export sink (and positioning PowerIO as a fast ingest backend for MG-RAVENS).
 - An MCP `convert`/`validate` tool over the Python binding.
+- A registered `PowerIO.jl` over the C ABI, with native bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl.
 
-The C ABI (`caseio-capi`) for C/C++/Julia is done — it's also what the benchmark harness times caseio through. CIM stays out of scope; it's a heavier problem owned by the CIM hubs.
+The C ABI (`powerio-capi`) for C/C++/Julia is done — it carries a `pio_to_json`/`pio_from_json` transport alongside the dense table extractors, and it's what the benchmark harness times PowerIO through. CIM stays out of scope; it's a heavier problem owned by the CIM hubs.
 
 ## Tests
 
 ```
-cargo test            # caseio + casemat
-cargo run --release -p caseio --example timeparse -- tests/data/case2869pegase.m
+cargo test            # powerio + powerio-matrix
+cargo run --release -p powerio --example timeparse -- tests/data/case2869pegase.m
 ```
 
 ## License

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,96 +1,85 @@
 # Parser benchmark and cross-tool validation
 
-Benchmarks live in two places, and they don't overlap. `powerio/benches/parse.rs`
-(`cargo bench --bench parse`) is the in-process micro-benchmark: it times the
-Rust parser and writers against themselves, with no other tool in the loop. This
-directory is the cross-tool comparison: it times powerio against the other
-parsers and checks its output value for value against theirs, calling each
-through its own runtime (Julia, Python). Use the micro-benchmark to catch a
-regression in our own code; use this suite to compare against the field.
+Two benchmark suites live in the repo and don't overlap. `powerio/benches/parse.rs`
+(`cargo bench --bench parse`) is the in-process microbenchmark: it times the Rust
+parser and writers against themselves, no other tool in the loop. This directory
+is the cross-tool comparison: it times powerio against the other parsers and
+checks its output value for value against theirs, calling each through its own
+runtime (Julia, Python). Use the microbenchmark to catch a regression in our own
+code; use this suite to compare against the field.
 
-Two things measured here, both on the vendored and large MATPOWER cases:
+Two things are measured here, both on the vendored and large MATPOWER cases:
 
-1. **Speed** — powerio against the parsers it competes with (ExaPowerIO.jl,
-   PowerModels.jl, pandapower's reader), from small cases up to a 193k-bus, 56 MB
-   file.
+1. **Speed** — powerio against ExaPowerIO.jl, PowerModels.jl, and pandapower's
+   reader, from small cases up to a 192768-bus, 54 MB file.
 2. **Correctness** — powerio's parse, conversions, and Y_bus checked value for
    value against PowerModels.jl, ExaPowerIO.jl, and pandapower.
 
-Numbers below are median time, one session, Apple M-series, release build. They
-vary a few percent run to run; the relative picture is stable.
+Numbers below are median wall time from one session on an Apple M-series laptop,
+release build. They vary a few percent run to run; the relative picture is stable.
 
-## Speed: parsers, head to head
+## Speed: parsers head to head
 
-All three parsers are timed in one Julia process under the same
-`BenchmarkTools.@benchmark` harness (`benchmarks/bench_julia.jl`). powerio is called
-through its C ABI (`pio_parse`, built with `cargo build --release -p powerio-capi`),
-so it reads the file from disk and builds its case exactly as ExaPowerIO and
-PowerModels do. The powerio case is freed in an untimed teardown, matching the other
-two, whose returned data is collected after the sample rather than inside it.
+All three parsers run in one Julia process under the same
+`BenchmarkTools.@benchmark` harness (`benchmarks/bench_julia.jl`). powerio is
+called through its C ABI (`pio_parse`, built with `cargo build --release -p
+powerio-capi`), so it reads the file from disk and builds its case the way
+ExaPowerIO and PowerModels do. The powerio handle is freed in an untimed
+teardown, matching the other two, whose returned data is collected after the
+sample rather than inside it.
 
-| case | buses / branches | **powerio** | ExaPowerIO.jl | PowerModels.jl |
+| case | buses / branches | powerio | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
-| case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
-| case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
-| case9241pegase | 9241 / 16049 | **5.67 ms** | 8.94 ms | 558 ms |
-| case13659pegase | 13659 / 20467 | **8.57 ms** | 13.1 ms | 781 ms |
-| case_ACTIVSg10k | 10000 / 12706 | **8.93 ms** | 9.09 ms | — |
-| case_ACTIVSg25k | 25000 / 32230 | **22.0 ms** | 22.3 ms | — |
-| case_ACTIVSg70k | 70000 / 88207 | **59.5 ms** | 64.5 ms | — |
-| case_SyntheticUSA | 82000 / 104121 | **71.3 ms** | 76.6 ms | — |
-| case99k | 99396 / 117860 | **80.7 ms** | 90.2 ms | — |
-| case193k | 192768 / 228574 | **158 ms** | 169 ms | — |
+| case2869pegase | 2869 / 4582 | 1.73 ms | 2.86 ms | 122.2 ms |
+| case_ACTIVSg2000 | 2000 / 3206 | 2.07 ms | 2.11 ms | 127.8 ms |
+| case9241pegase | 9241 / 16049 | 5.81 ms | 9.15 ms | 553.2 ms |
+| case13659pegase | 13659 / 20467 | 8.6 ms | 13.76 ms | 822.2 ms |
+| case_ACTIVSg10k | 10000 / 12706 | 9.22 ms | 9.35 ms | — |
+| case_ACTIVSg25k | 25000 / 32230 | 22.58 ms | 22.75 ms | — |
+| case_ACTIVSg70k | 70000 / 88207 | 60.95 ms | 62.75 ms | — |
+| case_SyntheticUSA | 82000 / 104121 | 73.1 ms | 82.65 ms | — |
+| case99k | 99396 / 117860 | 84.27 ms | 94.88 ms | — |
+| case193k | 192768 / 228574 | 161.9 ms | 174.98 ms | — |
 
-(PowerModels skipped past case13659 — it takes minutes there and the gap is settled.)
+(PowerModels is skipped past case13659, where it takes minutes and the gap is
+already settled.)
 
-### Read
+- **vs PowerModels.jl**: 62–96× faster on the cases PowerModels was run on (71×
+  on case2869pegase, 96× on case13659pegase).
+- **vs ExaPowerIO.jl**: faster on every case in this run — by ~36–40% on the
+  pegase cases (European, number-dense decimals, no cell arrays), narrowing to
+  near parity on the smaller ACTIVSg cases and up to ~12% on case_SyntheticUSA
+  and case99k. On the latter group powerio does more work and is still ahead:
+  those cases carry large `gentype` / `genfuel` / `bus_name` cell arrays that
+  ExaPowerIO drops (it logs "Unrecognized assignment"), while powerio parses
+  `bus_name` into the model and retains the full source for a byte-exact
+  round-trip.
+- **Lossless and polyglot.** powerio is the only one of the three that
+  round-trips byte for byte — verified at 54 MB / 192768 buses — and the only one
+  callable from Rust, the CLI, Python, and C/Julia with no runtime. ExaPowerIO
+  has no writer; PowerModels' export is lossy.
 
-- **vs PowerModels.jl**: 50–70× faster wherever PowerModels is practical to run
-  (68× on case2869pegase, 98× on case9241pegase).
-- **vs ExaPowerIO.jl**: powerio is faster or tied on every case — ~35% on the pegase
-  cases (European, number-dense decimals, no cell arrays) and ~2–12% on the ACTIVSg
-  / SyntheticUSA / US cases, where it does *more* work: those carry large `gentype`
-  / `genfuel` / `bus_name` cell arrays that ExaPowerIO skips (it logs "Unrecognized
-  assignment" and drops them), while powerio parses `bus_name` into the model and
-  retains the full source for a byte-exact round-trip. The earlier read of these
-  cases had powerio a few percent behind, which looked like the cost of losslessness.
-  It wasn't: profiling found the gap was overhead unrelated to what powerio keeps — a
-  `BTreeSet` reference-validation pass, a `split_ascii_whitespace` row tokenizer, a
-  per-generator string-keyed map, and a materialized line index. Replacing those
-  (HashSet, a byte tokenizer, a typed `[Option<f64>; 11]` for the gen capability
-  columns, a streamed locate) cut parse time ~25–35% and put powerio ahead while it
-  keeps strictly more of the file than ExaPowerIO does.
-- **The pure parse is a touch faster than the table.** `pio_parse` reads the file
-  from disk on every sample (as ExaPowerIO / PowerModels do); the Rust `timeparse`
-  example parses an already-in-memory string and so excludes the per-sample read.
-  The single source-retaining parse path is what makes the byte-exact round-trip
-  free — an earlier design ran a second pass to record byte ranges (~38% of parse
-  at case118, 51% at case2869); the current path drops it and the file reader moves
-  its buffer straight into the retained source, so a parse never copies the whole
-  file twice.
-- **And the edge isn't only speed.** powerio is the only one of the three that is
-  lossless and round-trips byte for byte — verified at 56 MB / 193k buses — and the
-  only one callable from Rust, the CLI, Python, and C/Julia (the C ABI) with no
-  runtime. ExaPowerIO has no writer; PowerModels' export is lossy.
-
-### vs pandapower
+## vs pandapower
 
 pandapower reads MATPOWER `.m` through `matpowercaseframes` (a pandas reader) and
-then `from_mpc` builds its `net` model. `benchmarks/bench_parse.py`, same machine:
+then `from_mpc` builds its `net`. `benchmarks/bench_parse.py`, same machine,
+median wall time:
 
-| case | **powerio** parse | matpowercaseframes (pandapower's `.m` reader) |
+| case | powerio parse | matpowercaseframes (pandapower's `.m` reader) |
 | --- | --- | --- |
-| case2869pegase | **2.5 ms** | 26.1 ms |
-| case9241pegase | **8.6 ms** | 87.5 ms |
-| case13659pegase | **13.1 ms** | 142.8 ms |
-| case193k | **218 ms** | 2302 ms |
+| case2869pegase | 1.8 ms | 25.6 ms |
+| case9241pegase | 5.7 ms | 85.9 ms |
+| case13659pegase | 8.9 ms | 139.9 ms |
+| case193k | 165.4 ms | 2214.3 ms |
 
-powerio's parse is ~10× faster than pandapower's reader, and that's before
-`from_mpc` builds the `net` (case30: `from_mpc` ≈ 65 ms vs powerio < 1 ms;
-`from_mpc` also raises `IndexError` on case118 and the pegase cases in pandapower
-3.2.2, so it isn't a general MATPOWER path). The `powerio: parse` row uses the
-zero-dependency `powerio` package; `powerio[matrix]: parse + Y_bus + B'` (the
-scipy path) runs about 2× the parse alone.
+powerio's parse is ~14× faster than pandapower's `.m` reader, and that is before
+`from_mpc` builds the `net` (case30: `from_mpc` ≈ 59 ms vs powerio under 1 ms).
+`from_mpc` raises `IndexError` on case118 and the pegase cases in pandapower
+3.2.2, so it isn't a general MATPOWER path. The `powerio: parse` row uses the
+zero-dependency `powerio` package and reads from disk, so it matches the C ABI
+column in the Julia table above to within run-to-run noise. The scipy matrix path
+`powerio[matrix]: parse + Y_bus + B'` measured 9.2 / 27.2 / 34.6 / 533 ms on the
+same four cases — roughly 3–5× the bare parse.
 
 ## Correctness: validated against all three
 
@@ -116,8 +105,8 @@ What each column checks:
   the way PowerModels does.
 - **PMread** (`pm_export.jl` + `validate_powermodels.jl`) — powerio's PowerModels
   JSON *reader*: PowerModels exports the `.m` to JSON, powerio reads that and
-  re-emits, and the two are compared. Exercises powerio reading real PowerModels
-  output, not just its own.
+  re-emits, and the two are compared. This exercises the powerio reader on
+  genuine PowerModels output; the PMjson check above covers only its writer.
 - **PSS/E** (`validate_psse.jl`) — powerio's PSS/E `.raw` vs PowerModels.jl on the
   write side (`.m` → `.raw`), and powerio's PowerModels JSON of a real `.raw` on the
   read side; counts and demand/generation totals, switched shunts noted (not
@@ -133,8 +122,9 @@ What each column checks:
   MATPOWER uses). Compares counts, per-branch r/x/b/tap/shift, per-bus demand and
   shunt, and the full Y_bus element for element (re-indexed to powerio's bus order;
   endpoints renumbered to dense positions so makeYbus handles the gappy pegase bus
-  ids). `_m2ppc` is used instead of `from_mpc` because it runs before the
-  `from_ppc` step that raises on dclines and parallel branches.
+  ids). powerio's first-class loads and shunts are summed back onto their bus for
+  the per-bus comparison. `_m2ppc` is used instead of `from_mpc` because it runs
+  before the `from_ppc` step that raises on dclines and parallel branches.
 
 **Coverage gaps.** PowerWorld `.aux` and EGRET JSON have no external validator here:
 there is no independent `.aux` reader to check against, EGRET has no powerio reader
@@ -148,7 +138,7 @@ tool.
 ```
 bash benchmarks/fetch_cases.sh                 # large cases into gitignored tests/data/large
 cargo build --release -p powerio-capi           # the C ABI the Julia harness calls
-maturin develop --release                      # the powerio wheel into the active venv
+maturin develop --release -E all,bench         # the powerio wheel + scipy/pandapower into the venv
 julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'
 
 julia --project=benchmarks benchmarks/bench_julia.jl       # parser speed table
@@ -156,6 +146,6 @@ python benchmarks/bench_parse.py tests/data/case2869pegase.m   # Python / pandap
 bash benchmarks/run_validation.sh                          # correctness matrix
 ```
 
-Julia pins (`benchmarks/Project.toml` / `Manifest.toml`): PowerModels 0.21.6,
-ExaPowerIO 0.3.0, BenchmarkTools 1.8.0. Python: pandapower 3.2.2,
-matpowercaseframes 2.1.0.
+Versions for the run above: Julia 1.12.6 with PowerModels 0.21.6, ExaPowerIO
+0.3.0, BenchmarkTools 1.8.0 (`benchmarks/Project.toml` / `Manifest.toml`);
+Python with pandapower 3.2.2, matpowercaseframes 2.1.0, scipy 1.13.1, numpy 2.0.2.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -10,10 +10,10 @@ regression in our own code; use this suite to compare against the field.
 
 Two things measured here, both on the vendored and large MATPOWER cases:
 
-1. **Speed** — caseio against the parsers it competes with (ExaPowerIO.jl,
+1. **Speed** — powerio against the parsers it competes with (ExaPowerIO.jl,
    PowerModels.jl, pandapower's reader), from small cases up to a 193k-bus, 56 MB
    file.
-2. **Correctness** — caseio's parse, conversions, and Y_bus checked value for
+2. **Correctness** — powerio's parse, conversions, and Y_bus checked value for
    value against PowerModels.jl, ExaPowerIO.jl, and pandapower.
 
 Numbers below are median time, one session, Apple M-series, release build. They
@@ -22,13 +22,13 @@ vary a few percent run to run; the relative picture is stable.
 ## Speed: parsers, head to head
 
 All three parsers are timed in one Julia process under the same
-`BenchmarkTools.@benchmark` harness (`benchmarks/bench_julia.jl`). caseio is called
-through its C ABI (`cio_parse`, built with `cargo build --release -p caseio-capi`),
+`BenchmarkTools.@benchmark` harness (`benchmarks/bench_julia.jl`). powerio is called
+through its C ABI (`pio_parse`, built with `cargo build --release -p powerio-capi`),
 so it reads the file from disk and builds its case exactly as ExaPowerIO and
-PowerModels do. The caseio case is freed in an untimed teardown, matching the other
+PowerModels do. The powerio case is freed in an untimed teardown, matching the other
 two, whose returned data is collected after the sample rather than inside it.
 
-| case | buses / branches | **caseio** | ExaPowerIO.jl | PowerModels.jl |
+| case | buses / branches | **powerio** | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
 | case2869pegase | 2869 / 4582 | **1.78 ms** | 2.72 ms | 121 ms |
 | case_ACTIVSg2000 | 2000 / 3206 | **2.07 ms** | 2.07 ms | 122 ms |
@@ -47,20 +47,20 @@ two, whose returned data is collected after the sample rather than inside it.
 
 - **vs PowerModels.jl**: 50–70× faster wherever PowerModels is practical to run
   (68× on case2869pegase, 98× on case9241pegase).
-- **vs ExaPowerIO.jl**: caseio is faster or tied on every case — ~35% on the pegase
+- **vs ExaPowerIO.jl**: powerio is faster or tied on every case — ~35% on the pegase
   cases (European, number-dense decimals, no cell arrays) and ~2–12% on the ACTIVSg
   / SyntheticUSA / US cases, where it does *more* work: those carry large `gentype`
   / `genfuel` / `bus_name` cell arrays that ExaPowerIO skips (it logs "Unrecognized
-  assignment" and drops them), while caseio parses `bus_name` into the model and
+  assignment" and drops them), while powerio parses `bus_name` into the model and
   retains the full source for a byte-exact round-trip. The earlier read of these
-  cases had caseio a few percent behind, which looked like the cost of losslessness.
-  It wasn't: profiling found the gap was overhead unrelated to what caseio keeps — a
+  cases had powerio a few percent behind, which looked like the cost of losslessness.
+  It wasn't: profiling found the gap was overhead unrelated to what powerio keeps — a
   `BTreeSet` reference-validation pass, a `split_ascii_whitespace` row tokenizer, a
   per-generator string-keyed map, and a materialized line index. Replacing those
   (HashSet, a byte tokenizer, a typed `[Option<f64>; 11]` for the gen capability
-  columns, a streamed locate) cut parse time ~25–35% and put caseio ahead while it
+  columns, a streamed locate) cut parse time ~25–35% and put powerio ahead while it
   keeps strictly more of the file than ExaPowerIO does.
-- **The pure parse is a touch faster than the table.** `cio_parse` reads the file
+- **The pure parse is a touch faster than the table.** `pio_parse` reads the file
   from disk on every sample (as ExaPowerIO / PowerModels do); the Rust `timeparse`
   example parses an already-in-memory string and so excludes the per-sample read.
   The single source-retaining parse path is what makes the byte-exact round-trip
@@ -68,7 +68,7 @@ two, whose returned data is collected after the sample rather than inside it.
   at case118, 51% at case2869); the current path drops it and the file reader moves
   its buffer straight into the retained source, so a parse never copies the whole
   file twice.
-- **And the edge isn't only speed.** caseio is the only one of the three that is
+- **And the edge isn't only speed.** powerio is the only one of the three that is
   lossless and round-trips byte for byte — verified at 56 MB / 193k buses — and the
   only one callable from Rust, the CLI, Python, and C/Julia (the C ABI) with no
   runtime. ExaPowerIO has no writer; PowerModels' export is lossy.
@@ -78,19 +78,19 @@ two, whose returned data is collected after the sample rather than inside it.
 pandapower reads MATPOWER `.m` through `matpowercaseframes` (a pandas reader) and
 then `from_mpc` builds its `net` model. `benchmarks/bench_parse.py`, same machine:
 
-| case | **caseio** parse | matpowercaseframes (pandapower's `.m` reader) |
+| case | **powerio** parse | matpowercaseframes (pandapower's `.m` reader) |
 | --- | --- | --- |
 | case2869pegase | **2.5 ms** | 26.1 ms |
 | case9241pegase | **8.6 ms** | 87.5 ms |
 | case13659pegase | **13.1 ms** | 142.8 ms |
 | case193k | **218 ms** | 2302 ms |
 
-caseio's parse is ~10× faster than pandapower's reader, and that's before
-`from_mpc` builds the `net` (case30: `from_mpc` ≈ 65 ms vs caseio < 1 ms;
+powerio's parse is ~10× faster than pandapower's reader, and that's before
+`from_mpc` builds the `net` (case30: `from_mpc` ≈ 65 ms vs powerio < 1 ms;
 `from_mpc` also raises `IndexError` on case118 and the pegase cases in pandapower
-3.2.2, so it isn't a general MATPOWER path). The `caseio: parse` row uses the
-zero-dependency `caseio` package; `casemat: parse + Y_bus + B'` (the scipy path)
-runs about 2× the parse alone.
+3.2.2, so it isn't a general MATPOWER path). The `powerio: parse` row uses the
+zero-dependency `powerio` package; `powerio[matrix]: parse + Y_bus + B'` (the
+scipy path) runs about 2× the parse alone.
 
 ## Correctness: validated against all three
 
@@ -108,38 +108,38 @@ prints a pass/fail matrix. Latest run — all checks pass:
 
 What each column checks:
 
-- **PMjson** (`validate_powermodels.jl`) — caseio's PowerModels JSON *writer* vs
+- **PMjson** (`validate_powermodels.jl`) — powerio's PowerModels JSON *writer* vs
   PowerModels.jl's own parse of the `.m`, field by field over bus / branch / gen /
-  load / shunt. caseio emits idiomatic `per_unit=true` JSON (the form PowerModels
+  load / shunt. powerio emits idiomatic `per_unit=true` JSON (the form PowerModels
   itself writes), so this runs on PowerModels' default `validate=true` with no
-  workarounds — including the dcline case, whose per-end bounds caseio now derives
+  workarounds — including the dcline case, whose per-end bounds powerio now derives
   the way PowerModels does.
-- **PMread** (`pm_export.jl` + `validate_powermodels.jl`) — caseio's PowerModels
-  JSON *reader*: PowerModels exports the `.m` to JSON, caseio reads that and
-  re-emits, and the two are compared. Exercises caseio reading real PowerModels
+- **PMread** (`pm_export.jl` + `validate_powermodels.jl`) — powerio's PowerModels
+  JSON *reader*: PowerModels exports the `.m` to JSON, powerio reads that and
+  re-emits, and the two are compared. Exercises powerio reading real PowerModels
   output, not just its own.
-- **PSS/E** (`validate_psse.jl`) — caseio's PSS/E `.raw` vs PowerModels.jl on the
-  write side (`.m` → `.raw`), and caseio's PowerModels JSON of a real `.raw` on the
+- **PSS/E** (`validate_psse.jl`) — powerio's PSS/E `.raw` vs PowerModels.jl on the
+  write side (`.m` → `.raw`), and powerio's PowerModels JSON of a real `.raw` on the
   read side; counts and demand/generation totals, switched shunts noted (not
   modeled).
-- **ExaPowerIO** (`validate_exapowerio.jl`) — caseio (through the C ABI) vs
+- **ExaPowerIO** (`validate_exapowerio.jl`) — powerio (through the C ABI) vs
   ExaPowerIO's default `filtered=true` parse, value for value over bus / branch /
-  gen. caseio's in-service rows are filtered to match ExaPowerIO's dropped
+  gen. powerio's in-service rows are filtered to match ExaPowerIO's dropped
   out-of-service elements (see `t_case9_oos`). Encodings reconciled: per unit
   (×baseMVA), `b_fr + b_to` = total `b`, radians vs degrees, tap 0→1; bus types
   aren't compared (ExaPowerIO rewrites them from generator placement).
-- **pandapower** (`validate_pandapower.py`) — caseio's parse and Y_bus vs
+- **pandapower** (`validate_pandapower.py`) — powerio's parse and Y_bus vs
   pandapower's `_m2ppc` + `makeYbus` (PYPOWER's admittance kernel, the same one
   MATPOWER uses). Compares counts, per-branch r/x/b/tap/shift, per-bus demand and
-  shunt, and the full Y_bus element for element (re-indexed to caseio's bus order;
+  shunt, and the full Y_bus element for element (re-indexed to powerio's bus order;
   endpoints renumbered to dense positions so makeYbus handles the gappy pegase bus
   ids). `_m2ppc` is used instead of `from_mpc` because it runs before the
   `from_ppc` step that raises on dclines and parallel branches.
 
 **Coverage gaps.** PowerWorld `.aux` and EGRET JSON have no external validator here:
-there is no independent `.aux` reader to check against, EGRET has no caseio reader
+there is no independent `.aux` reader to check against, EGRET has no powerio reader
 and the `egret` package isn't installed. Both are covered by the in-tree all-pairs
-round-trip tests (`caseio/tests/roundtrip_formats.rs`: core preservation,
+round-trip tests (`powerio/tests/roundtrip_formats.rs`: core preservation,
 reader∘writer idempotence, byte-exact same-format echo), not against a third-party
 tool.
 
@@ -147,9 +147,8 @@ tool.
 
 ```
 bash benchmarks/fetch_cases.sh                 # large cases into gitignored tests/data/large
-cargo build --release -p caseio-capi           # the C ABI the Julia harness calls
-maturin develop --release                      # casemat into the active venv
-maturin develop --release -m caseio-ext/Cargo.toml   # caseio into the active venv
+cargo build --release -p powerio-capi           # the C ABI the Julia harness calls
+maturin develop --release                      # the powerio wheel into the active venv
 julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'
 
 julia --project=benchmarks benchmarks/bench_julia.jl       # parser speed table

--- a/benchmarks/bench_parse.py
+++ b/benchmarks/bench_parse.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python3
-"""Benchmark the caseio/casemat Python packages against pandapower's stack.
+"""Benchmark the powerio Python package against pandapower's stack.
 
 Four rows, from leanest to fullest:
 
-- ``caseio: parse`` — the zero-dependency parser (no numpy/scipy). This is the
+- ``powerio: parse`` — the zero-dependency parser (no numpy/scipy). This is the
   apples-to-apples number against matpowercaseframes: parse a MATPOWER file into
   the tool's in-memory model, nothing more.
-- ``casemat: parse + Y_bus + B'`` — caseio's parse plus building the two matrices
-  scipy callers usually want, against issue #5's 100 ms target for case2869pegase.
+- ``powerio[matrix]: parse + Y_bus + B'`` — powerio's parse plus building the two
+  matrices scipy callers usually want, against issue #5's 100 ms target for
+  case2869pegase.
 - ``matpowercaseframes: parse`` — pandapower's ``.m`` reader (pandas DataFrames).
 - ``pandapower: from_mpc`` — the full convert-into-``net`` path.
 
     python benchmarks/bench_parse.py [path/to/case.m ...]
 
 Run it with the venv that has the extensions built (`maturin develop --release`).
-Install the comparison baselines with `pip install 'casemat[bench]'`.
+Install the comparison baselines with `pip install 'powerio[bench]'`.
 """
 
 import logging
@@ -24,8 +25,7 @@ import time
 import warnings
 from pathlib import Path
 
-import caseio
-import casemat
+import powerio
 
 # pandapower/matpowercaseframes emit a wall of dtype FutureWarnings, mixed-cost
 # UserWarnings, and logger lines that drown the table; none are ours to fix.
@@ -63,7 +63,7 @@ def samples_for(nbuses):
 
 
 def bench_case(path: Path):
-    case = caseio.parse(str(path))
+    case = powerio.parse(str(path))
     print(
         f"case {path.name}: {case.n} buses, {case.n_branches} branches, "
         f"{case.n_gens} gens"
@@ -73,14 +73,14 @@ def bench_case(path: Path):
     def timed(fn):
         return best_median(fn, n, warm)
 
-    rows = [("caseio: parse", *timed(lambda: caseio.parse(str(path))))]
+    rows = [("powerio: parse", *timed(lambda: powerio.parse(str(path))))]
 
     def full_path():
-        c = casemat.parse_matpower(str(path))
+        c = powerio.parse_matpower(str(path))
         c.ybus()
         c.bprime()
 
-    rows.append(("casemat: parse + Y_bus + B'", *timed(full_path)))
+    rows.append(("powerio[matrix]: parse + Y_bus + B'", *timed(full_path)))
 
     try:
         from matpowercaseframes import CaseFrames
@@ -91,7 +91,7 @@ def bench_case(path: Path):
         if getattr(exc, "name", None) not in ("matpowercaseframes", None):
             raise
         print("matpowercaseframes not installed; skipping the baseline row.")
-        print("  pip install 'casemat[bench]'")
+        print("  pip install 'powerio[bench]'")
 
     # pandapower reads .m via matpowercaseframes, then builds its `net`. This is
     # the apples-to-apples "convert a MATPOWER file into the tool's model" row.

--- a/benchmarks/pm_export.jl
+++ b/benchmarks/pm_export.jl
@@ -1,6 +1,6 @@
 # Export a case to PowerModels JSON the way PowerModels itself writes it
-# (per_unit=true). Used by run_validation.sh to test caseio's PowerModels JSON
-# *reader* against real PowerModels output: PowerModels writes the JSON, caseio
+# (per_unit=true). Used by run_validation.sh to test powerio's PowerModels JSON
+# *reader* against real PowerModels output: PowerModels writes the JSON, powerio
 # reads it and re-emits, and the two are compared.
 #
 #   julia --project=benchmarks pm_export.jl <case.m> <out.json>

--- a/benchmarks/run_validation.sh
+++ b/benchmarks/run_validation.sh
@@ -16,8 +16,8 @@
 # PSS/E .raw fixtures are checked on the read side only (powerio reads the .raw,
 # emits PowerModels JSON, compared against PowerModels.jl reading the same .raw).
 #
-# Prereqs: `cargo build --release -p powerio-capi`, the casemat/powerio Python
-# extensions built into .venv (`maturin develop --release`), and the Julia env
+# Prereqs: `cargo build --release -p powerio-capi`, the powerio Python extension
+# built into .venv (`maturin develop --release`), and the Julia env
 # instantiated (`julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'`).
 #
 #   bash benchmarks/run_validation.sh
@@ -49,14 +49,14 @@ RAWCASES=(tests/data/psse/case5.raw tests/data/psse/case14.raw)
 fails=0
 rows=()
 
-# Convert a case to another format via the casemat Python package (no CLI build).
+# Convert a case to another format via the powerio Python package (no CLI build).
 convert() { # <in> <to> <out>
     "$PY" - "$@" <<'EOF'
 import sys, warnings
 warnings.filterwarnings("ignore")
-import casemat
+import powerio
 inp, to, out = sys.argv[1], sys.argv[2], sys.argv[3]
-open(out, "w").write(casemat.convert(inp, to).text)
+open(out, "w").write(powerio.convert(inp, to).text)
 EOF
     local rc=$?
     # Guard against a silent success that wrote nothing — validating an empty file

--- a/benchmarks/validate_pandapower.py
+++ b/benchmarks/validate_pandapower.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate caseio's parse and Y_bus against pandapower on a MATPOWER case.
+"""Validate powerio's parse and Y_bus against pandapower on a MATPOWER case.
 
 pandapower is an independent MATPOWER reader (via matpowercaseframes) and carries
 PYPOWER's `makeYbus`, the same admittance kernel MATPOWER uses. We compare the two
@@ -14,17 +14,18 @@ We read pandapower's ppc directly with `_m2ppc` (the raw MATPOWER-per-unit case)
 rather than `from_mpc`, which builds a `net`: `from_mpc` reorders buses, adds
 auxiliary buses, and raises on dclines / parallel branches inside `from_ppc`.
 `_m2ppc` runs before any of that, so it works on every case (pegase included) and
-keeps the bus order aligned with caseio's file order.
+keeps the bus order aligned with powerio's file order.
 
     python benchmarks/validate_pandapower.py tests/data/case14.m
 
-Exit 0 on a full match, 1 on any mismatch. Needs the `casemat` package and
-pandapower (`pip install 'casemat[bench]'`).
+Exit 0 on a full match, 1 on any mismatch. Needs the `powerio` package and
+pandapower (`pip install 'powerio[bench]'`).
 """
 
 import logging
 import sys
 import warnings
+from collections import defaultdict
 from pathlib import Path
 
 import numpy as np
@@ -33,7 +34,7 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 logging.getLogger("pandapower").setLevel(logging.ERROR)
 
-import casemat
+import powerio
 from pandapower.converter.matpower.from_mpc import _m2ppc
 from pandapower.pypower.idx_brch import BR_B, BR_B_ASYM, BR_R, BR_X, F_BUS, SHIFT, T_BUS, TAP
 from pandapower.pypower.idx_bus import BS, BUS_I, GS, PD, QD
@@ -51,6 +52,17 @@ def eff_tap(t):
     return np.where(np.asarray(t) == 0.0, 1.0, t)
 
 
+def sum_by_bus(elems, ka, kb):
+    """Sum two element fields onto their bus id. powerio models loads and shunts
+    as first-class elements (potentially several per bus), so fold them back onto
+    the bus to compare against pandapower's raw per-bus columns."""
+    a, b = defaultdict(float), defaultdict(float)
+    for e in elems:
+        a[e["bus"]] += e[ka]
+        b[e["bus"]] += e[kb]
+    return a, b
+
+
 def main():
     if len(sys.argv) != 2:
         print("usage: validate_pandapower.py <case.m>", file=sys.stderr)
@@ -58,7 +70,7 @@ def main():
     path = Path(sys.argv[1])
     name = path.name
 
-    case = casemat.parse_matpower(str(path))
+    case = powerio.parse_matpower(str(path))
     ppc = _m2ppc(str(path), "mpc")
     bus, branch, gen = ppc["bus"], ppc["branch"], ppc["gen"]
     base_mva = float(ppc["baseMVA"])
@@ -70,31 +82,33 @@ def main():
     m = len(case.branches)
     ng = len(case.gens)
     if n != bus.shape[0]:
-        problems.append(f"bus count: caseio={n} pandapower={bus.shape[0]}")
+        problems.append(f"bus count: powerio={n} pandapower={bus.shape[0]}")
     if m != branch.shape[0]:
-        problems.append(f"branch count: caseio={m} pandapower={branch.shape[0]}")
+        problems.append(f"branch count: powerio={m} pandapower={branch.shape[0]}")
     if ng != gen.shape[0]:
-        problems.append(f"gen count: caseio={ng} pandapower={gen.shape[0]}")
+        problems.append(f"gen count: powerio={ng} pandapower={gen.shape[0]}")
     if problems:
         report(name, problems)
         return 1
 
     # --- bus-id alignment (both should be file order) -------------------
-    caseio_ids = [b["id"] for b in case.buses]
+    powerio_ids = [b["id"] for b in case.buses]
     pp_ids = (bus[:, BUS_I].astype(int) + 1).tolist()
-    if sorted(caseio_ids) != sorted(pp_ids):
-        problems.append("bus id sets differ between caseio and pandapower")
+    if sorted(powerio_ids) != sorted(pp_ids):
+        problems.append("bus id sets differ between powerio and pandapower")
         report(name, problems)
         return 1
     pp_row_of_id = {bid: r for r, bid in enumerate(pp_ids)}
-    order = np.array([pp_row_of_id[bid] for bid in caseio_ids])  # pp rows, caseio order
+    order = np.array([pp_row_of_id[bid] for bid in powerio_ids])  # pp rows, powerio order
 
     # --- per-bus demand / shunt -----------------------------------------
     cb = case.buses
-    check_vec(problems, "bus.pd", [b["pd"] for b in cb], bus[order, PD])
-    check_vec(problems, "bus.qd", [b["qd"] for b in cb], bus[order, QD])
-    check_vec(problems, "bus.gs", [b["gs"] for b in cb], bus[order, GS])
-    check_vec(problems, "bus.bs", [b["bs"] for b in cb], bus[order, BS])
+    pd_by_id, qd_by_id = sum_by_bus(case.loads, "p", "q")
+    gs_by_id, bs_by_id = sum_by_bus(case.shunts, "g", "b")
+    check_vec(problems, "bus.pd", [pd_by_id.get(b["id"], 0.0) for b in cb], bus[order, PD])
+    check_vec(problems, "bus.qd", [qd_by_id.get(b["id"], 0.0) for b in cb], bus[order, QD])
+    check_vec(problems, "bus.gs", [gs_by_id.get(b["id"], 0.0) for b in cb], bus[order, GS])
+    check_vec(problems, "bus.bs", [bs_by_id.get(b["id"], 0.0) for b in cb], bus[order, BS])
 
     # --- per-branch r/x/b/tap/shift (file order, row by row) ------------
     br = case.branches
@@ -102,7 +116,7 @@ def main():
         cf, ct = br[k]["from_id"], br[k]["to_id"]
         pf, pt = int(branch[k, F_BUS]) + 1, int(branch[k, T_BUS]) + 1
         if (cf, ct) != (pf, pt):
-            problems.append(f"branch[{k}] endpoints: caseio=({cf},{ct}) pandapower=({pf},{pt})")
+            problems.append(f"branch[{k}] endpoints: powerio=({cf},{ct}) pandapower=({pf},{pt})")
     check_vec(problems, "branch.r", [b["r"] for b in br], branch[:, BR_R])
     check_vec(problems, "branch.x", [b["x"] for b in br], branch[:, BR_X])
     check_vec(problems, "branch.b", [b["b"] for b in br], branch[:, BR_B])
@@ -112,10 +126,10 @@ def main():
     # --- generators (file order) ----------------------------------------
     gn = case.gens
     for k in range(ng):
-        cgb = gn[k]["bus_id"]
+        cgb = gn[k]["bus"]
         pgb = int(gen[k, GEN_BUS]) + 1
         if cgb != pgb:
-            problems.append(f"gen[{k}] bus: caseio={cgb} pandapower={pgb}")
+            problems.append(f"gen[{k}] bus: powerio={cgb} pandapower={pgb}")
     check_vec(problems, "gen.pg", [g["pg"] for g in gn], gen[:, PG])
     check_vec(problems, "gen.pmax", [g["pmax"] for g in gn], gen[:, PMAX])
     check_vec(problems, "gen.pmin", [g["pmin"] for g in gn], gen[:, PMIN])
@@ -133,9 +147,9 @@ def main():
     by[:, F_BUS] = [pos_of_id0[int(v)] for v in branch[:, F_BUS]]
     by[:, T_BUS] = [pos_of_id0[int(v)] for v in branch[:, T_BUS]]
     yp, _, _ = makeYbus(base_mva, bus, by)
-    yp = yp.tocsr()[order][:, order]  # pandapower Ybus in caseio bus order
+    yp = yp.tocsr()[order][:, order]  # pandapower Ybus in powerio bus order
     if yc.shape != yp.shape:
-        problems.append(f"ybus shape: caseio={yc.shape} pandapower={yp.shape}")
+        problems.append(f"ybus shape: powerio={yc.shape} pandapower={yp.shape}")
     else:
         # Elementwise relative check, not a single global-max scale: a localized
         # error on a small admittance entry can't hide under the largest diagonal.
@@ -164,7 +178,7 @@ def check_vec(problems, label, a, b, atol=ATOL, rtol=RTOL):
     bad = ~np.isclose(a, b, atol=atol, rtol=rtol, equal_nan=True)
     if bad.any():
         i = int(np.argmax(bad))
-        problems.append(f"{label}: {int(bad.sum())} differ, first at {i} caseio={a[i]} pandapower={b[i]}")
+        problems.append(f"{label}: {int(bad.sum())} differ, first at {i} powerio={a[i]} pandapower={b[i]}")
 
 
 def report(name, problems):

--- a/benchmarks/validate_powermodels.jl
+++ b/benchmarks/validate_powermodels.jl
@@ -1,9 +1,9 @@
-# Validate caseio's PowerModels JSON against PowerModels' own parse of the .m,
+# Validate powerio's PowerModels JSON against PowerModels' own parse of the .m,
 # value for value over bus/branch/gen/load/shunt.
 # Usage: julia --project=benchmarks validate_powermodels.jl case.m our.json
 #
 # Two checks:
-#  1. Consumability — caseio writes idiomatic per_unit=true JSON, so PowerModels'
+#  1. Consumability — powerio writes idiomatic per_unit=true JSON, so PowerModels'
 #     default parse_file (validate=true, which runs correct_network_data! and the
 #     dcline correction) must load it without error. This is the interop property
 #     that motivated emitting per_unit=true.
@@ -11,18 +11,18 @@
 #     explicitly. validate=false matters: correct_network_data! clamps angmin/angmax
 #     to ±60° (default_pad) and normalizes branch direction / thermal limits, which
 #     would rewrite BOTH sides into agreement and hide a scaling bug. make_per_unit!
-#     is a no-op on data already flagged per_unit=true (caseio's JSON), so it only
+#     is a no-op on data already flagged per_unit=true (powerio's JSON), so it only
 #     per-unitizes the native .m reference.
 using PowerModels
 PowerModels.silence()
 
 ref_m, our_json = ARGS[1], ARGS[2]
 
-# 1. Consumability: the caseio JSON must load under PowerModels' default validate=true.
+# 1. Consumability: the powerio JSON must load under PowerModels' default validate=true.
 try
     PowerModels.parse_file(our_json)
 catch e
-    println("MISMATCH: ", basename(ref_m), " — caseio JSON rejected by PowerModels validate=true: ", e)
+    println("MISMATCH: ", basename(ref_m), " — powerio JSON rejected by PowerModels validate=true: ", e)
     exit(1)
 end
 

--- a/benchmarks/validate_psse.jl
+++ b/benchmarks/validate_psse.jl
@@ -1,12 +1,12 @@
-# Validate caseio's PSS/E support against PowerModels (which reads PSS/E `.raw`).
+# Validate powerio's PSS/E support against PowerModels (which reads PSS/E `.raw`).
 # Generic comparator: parse two PowerModels-readable files, make_per_unit both,
 # and compare the electrical core. bus/branch/gen/load and the demand/generation
-# totals are strict; shunt count is informational (caseio models fixed shunts but
+# totals are strict; shunt count is informational (powerio models fixed shunts but
 # not PSS/E switched shunts).
 #
-# Two uses, driven by `casemat convert` (see the loop in the PR's validation run):
-#   write side:  ref = case.m         test = caseio's case.raw
-#   read side:   ref = real.raw       test = caseio's PowerModels JSON of real.raw
+# Two uses, driven by `powerio convert` (see the loop in the PR's validation run):
+#   write side:  ref = case.m         test = powerio's case.raw
+#   read side:   ref = real.raw       test = powerio's PowerModels JSON of real.raw
 #
 #   julia --project=benchmarks benchmarks/validate_psse.jl <ref> <test>
 using PowerModels

--- a/docs/dcopf-bundle.md
+++ b/docs/dcopf-bundle.md
@@ -1,6 +1,6 @@
 # DC-OPF bundle schema
 
-`casemat dcopf <case>.m -o <out>` (or `opf_pipeline::write_dcopf_bundle`) writes
+`powerio dcopf <case>.m -o <out>` (or `opf_pipeline::write_dcopf_bundle`) writes
 `<out>/<case>_dcopf/`: a set of Matrix Market files plus `dcopf_meta.json`.
 Everything is a pure function of the case. This documents what each file is and
 the conventions a consumer (e.g. a C++ Laplacian solver) needs.
@@ -46,7 +46,7 @@ unlimited per MATPOWER). Generator-space provenance (length n_gen): `q_gen`,
 ## Manifest (`dcopf_meta.json`)
 
 `case_name, base_mva, n, m, n_gen, reference_bus` (0-based), `convention`,
-`units`, `files[]`, `casemat_version`.
+`units`, `files[]`, `powerio_version`.
 
 ## Solving with it
 

--- a/powerio-capi/Cargo.toml
+++ b/powerio-capi/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.86"
 description = "C ABI for powerio: parse any power system case format, query it, convert losslessly, and extract the numeric tables. The polyglot substrate consumed by Julia (ccall), C, and C++."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/eigenergy/caseio"
+repository = "https://github.com/eigenergy/powerio"
 publish = false
 
 # A C-consumable shared + static library. The header is checked in at

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -1,6 +1,6 @@
 # powerio-capi
 
-A C ABI over `powerio`: parse any supported power-system case format, query it,
+A C ABI over `powerio`: parse any supported power system case format, query it,
 convert losslessly, and pull out the numeric tables a solver needs to assemble
 matrices. This is the polyglot substrate — anything that speaks C (C, C++,
 Julia, Python ctypes, …) can drive powerio through it.
@@ -79,10 +79,20 @@ ccall((:pio_branches, LIB), Cvoid,
 ccall((:pio_case_free, LIB), Cvoid, (Ptr{Cvoid},), h)
 ```
 
+## JSON transport
+
+For consumers that want the whole case rather than the dense table slices,
+`pio_to_json` serializes the entire `Network` (buses, loads, shunts, branches,
+generators, storage, HVDC, and extras) to a string, and `pio_from_json` rebuilds
+a handle from it. This is the transport the Julia package consumes — one call
+instead of stitching the ~dozen table extractors together. The retained source
+text is not part of the JSON, so a `from_json` handle reformats on write rather
+than echoing a byte-exact original.
+
 ## Scope
 
 powerio-capi covers the `powerio` surface: parse / write / convert / query / table
-extraction. It deliberately has no matrix builders — those live in `casemat`. A
-future `casemat-capi` can hand back assembled CSR matrices (B', Y_bus, PTDF,
-DC-OPF) over the same ABI style; for now a consumer builds matrices from the
-extracted tables.
+and JSON extraction. It deliberately has no matrix builders — those live in
+`powerio-matrix`. A future `powerio-matrix-capi` can hand back assembled CSR
+matrices (B', Y_bus, PTDF, DC-OPF) over the same ABI style; for now a consumer
+builds matrices from the extracted tables.

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -54,6 +54,10 @@ int main(void) {
 
 ## Julia (`ccall`)
 
+For a typed Julia API, use [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl),
+which wraps this ABI (`set_library!`, `parse_case`, `convert_case`, and ecosystem
+bridges). The raw `ccall` below is the low-level reference it builds on.
+
 ```julia
 const LIB = "libpowerio_capi"  # on the load path
 

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -1,4 +1,4 @@
-/* powerio C ABI — parse any power-system case format, query it, convert
+/* powerio C ABI — parse any power system case format, query it, convert
  * losslessly, and extract the numeric tables for matrix assembly.
  *
  * Memory: strings returned by pio_write_matpower / pio_convert are owned by the

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1,6 +1,6 @@
 //! C ABI for `powerio` — the polyglot substrate.
 //!
-//! Parse any supported power-system case format into an opaque handle, query it,
+//! Parse any supported power system case format into an opaque handle, query it,
 //! convert losslessly to another format, and pull out the numeric tables a
 //! downstream solver needs to assemble matrices. Every entry point is `extern
 //! "C"`, catches panics at the boundary, and returns error text into a

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["command-line-utilities", "science"]
 [[bin]]
 name = "powerio"
 path = "src/main.rs"
+# The binary shares its name with the `powerio` lib crate, which collides in
+# `cargo doc`'s output tree (rust-lang/cargo#6313). The CLI's docs are `--help`.
+doc = false
 
 [dependencies]
 powerio-matrix = { path = "../powerio-matrix" }

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.86"
 description = "Command line interface and ratatui TUI for powerio: parse and convert power system case files and emit matrices."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/eigenergy/caseio"
-keywords = ["power-systems", "matpower", "cli", "tui"]
+keywords = ["matpower", "cli", "tui"]
 categories = ["command-line-utilities", "science"]
 
 [[bin]]

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.86"
 description = "Command line interface and ratatui TUI for powerio: parse and convert power system case files and emit matrices."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/eigenergy/caseio"
+repository = "https://github.com/eigenergy/powerio"
 keywords = ["matpower", "cli", "tui"]
 categories = ["command-line-utilities", "science"]
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1,3 +1,9 @@
+//! The `powerio` binary: a clap CLI and a ratatui TUI over `powerio-matrix`.
+//!
+//! Subcommands: `batch` (matrix families), `gen` (synthetic cases), `verify`,
+//! `dcopf` (DC-OPF bundle), `sensitivities` (PTDF/LODF), and `convert`. With no
+//! subcommand it launches the TUI. Run `powerio --help` for the full surface.
+
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.86"
 description = "Sparse matrices and graph views for power system case files: B'/B'', Y_bus, PTDF, LODF, incidence, weighted Laplacian, adjacency, and DC-OPF instance data. Built on powerio."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/eigenergy/caseio"
-keywords = ["power-systems", "matpower", "sparse", "ptdf", "dc-opf"]
+keywords = ["matpower", "sparse", "ptdf", "dc-opf"]
 categories = ["science", "mathematics"]
 
 [features]

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.86"
 description = "Sparse matrices and graph views for power system case files: B'/B'', Y_bus, PTDF, LODF, incidence, weighted Laplacian, adjacency, and DC-OPF instance data. Built on powerio."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/eigenergy/caseio"
+repository = "https://github.com/eigenergy/powerio"
 keywords = ["matpower", "sparse", "ptdf", "dc-opf"]
 categories = ["science", "mathematics"]
 

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -1,9 +1,36 @@
 //! `powerio-matrix`: sparse matrices and graph views for power system case files,
-//! built on [`powerio`].
+//! built on [`powerio`] (re-exported, so one `use powerio_matrix::...` pulls in
+//! both layers).
 //!
 //! Signed incidence `A`, weighted Laplacian `L = A diag(b) Aᵀ` and its
 //! slack-grounded form, B'/B''/Y_bus, PTDF/LODF, adjacency, the LACPF block,
-//! and the DC-OPF instance bundle, plus a petgraph view and a TUI.
+//! and the DC-OPF instance bundle, plus a petgraph view. The builders take the
+//! dense-indexed [`IndexedNetwork`] view of a [`Network`].
+//!
+//! ```
+//! use powerio_matrix::{parse_matpower_file, IndexedNetwork, build_bprime, BuildOptions};
+//!
+//! # let case = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/case14.m");
+//! let net = parse_matpower_file(case)?;        // re-exported from powerio
+//! let g = IndexedNetwork::new(&net);           // dense [0, n) analysis view
+//! let bprime = build_bprime(&g, &BuildOptions::default())?;
+//! assert_eq!(bprime.rows(), g.n());            // B' is n×n
+//! # Ok::<(), powerio_matrix::Error>(())
+//! ```
+//!
+//! # Conventions
+//!
+//! - **Positive Laplacian.** Off-diagonal negative, diagonal positive, with
+//!   `diag = sum |off-diag|` for B' — the M-matrix form SDDM/Cholesky solvers
+//!   expect.
+//! - **Bus indexing.** MATPOWER 1-based bus ids are preserved on the model;
+//!   [`IndexedNetwork`] maps them to a dense `[0, n)` for the builders.
+//! - **Taps and shifts.** `tap == 0` means `tap = 1`. B' ignores taps and
+//!   shifts; B'' keeps taps and zeros only shifts; Y_bus keeps both.
+//! - **`BR_B` is already per unit** — never divide by `base_mva` again.
+//! - **DC-OPF is bus-indexed** (`p_g ∈ ℝⁿ`); the default susceptance is
+//!   `b = 1/x` (paper-pure), and [`DcConvention::Matpower`] uses `1/(x·τ)` plus
+//!   a phase-shift injection.
 
 // Re-export the powerio data layer so this crate is a one-stop import, and so
 // the matrix modules' `crate::Error` / `crate::network` / `crate::format` paths

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -1,4 +1,4 @@
-//! `powerio-matrix`: sparse matrices and graph views for power-system case files,
+//! `powerio-matrix`: sparse matrices and graph views for power system case files,
 //! built on [`powerio`].
 //!
 //! Signed incidence `A`, weighted Laplacian `L = A diag(b) Aᵀ` and its

--- a/powerio-py/Cargo.toml
+++ b/powerio-py/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.86"
 description = "PyO3 extension module for powerio (builds the `powerio` Python wheel; not published to crates.io)."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/eigenergy/caseio"
+repository = "https://github.com/eigenergy/powerio"
 publish = false
 
 # The compiled module is imported as `powerio._powerio`; the `powerio` Python

--- a/powerio/Cargo.toml
+++ b/powerio/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.86"
 description = "Fast, lossless parser and typed data model for power system case files. Parse MATPOWER .m and write it back byte-for-byte."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/eigenergy/caseio"
-keywords = ["power-systems", "matpower", "parser", "lossless"]
+keywords = ["matpower", "parser", "lossless"]
 categories = ["science", "parsing"]
 
 [dependencies]

--- a/powerio/Cargo.toml
+++ b/powerio/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.86"
 description = "Fast, lossless parser and typed data model for power system case files. Parse MATPOWER .m and write it back byte-for-byte."
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/eigenergy/caseio"
+repository = "https://github.com/eigenergy/powerio"
 keywords = ["matpower", "parser", "lossless"]
 categories = ["science", "parsing"]
 

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -1,5 +1,5 @@
 //! The format hub: readers and writers for every supported file format, all
-//! meeting at the shared [`Network`](crate::Network).
+//! meeting at the shared [`Network`].
 //!
 //! Each format is one module here, owning its reader and/or writer — MATPOWER
 //! `.m`, PowerModels JSON, PSS/E `.raw`, PowerWorld `.aux`, plus the write-only
@@ -8,6 +8,17 @@
 //! detecting the format from its extension; [`write_as`] serializes a `Network`
 //! to a target. Non-finite numeric values (a MATPOWER `Inf`/`NaN` angle limit,
 //! say) are written as JSON `null`.
+//!
+//! # Fidelity contract
+//!
+//! Conversion is two-tier:
+//!
+//! - **Same-format round-trip is byte-exact.** A reader keeps its source text
+//!   (see [`Network`]), so writing back to the *same* format echoes it
+//!   verbatim — every field, comment, and numeric token.
+//! - **Cross-format keeps maximal fidelity with itemized loss.** Whatever the
+//!   target format cannot represent is reported in the [`Conversion`] `warnings`,
+//!   never dropped silently.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;

--- a/powerio/src/indexed.rs
+++ b/powerio/src/indexed.rs
@@ -52,7 +52,7 @@ impl IndexCore {
     /// # Correctness
     /// Bus ids must be unique; a duplicate collapses two buses onto one dense
     /// index and silently corrupts every aggregate. All format readers and the
-    /// MATPOWER reader run [`Network::check_references`] before this, so a parsed
+    /// MATPOWER reader run `Network::check_references` before this, so a parsed
     /// network always satisfies it; a hand-built [`Network`] must too. Checked
     /// with a `debug_assert`.
     #[must_use]
@@ -169,7 +169,7 @@ impl<'n> IndexedNetwork<'n> {
     /// [`bus_index`](Self::bus_index).
     ///
     /// # Panics
-    /// Panics if `idx >= n`. Pass a dense index (e.g. from [`bus_index`] or a
+    /// Panics if `idx >= n`. Pass a dense index (e.g. from [`bus_index`](Self::bus_index) or a
     /// matrix row), not a raw bus id.
     #[inline]
     pub fn bus_id(&self, idx: usize) -> usize {

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -2,11 +2,37 @@
 //! case files.
 //!
 //! Parse a MATPOWER `.m` case, work with the typed [`Network`], and write it
-//! back out byte-for-byte — `parse → write → parse` reproduces the source,
+//! back out byte-for-byte: `parse → write → parse` reproduces the source,
 //! preserving every `mpc.*` field, in-matrix comments, and exact numeric
-//! tokens. The crate is dependency-light on purpose so other tools can take it
-//! as a parser without a matrix/solver stack; the matrices live in
-//! `powerio-matrix`.
+//! tokens. The crate keeps a small dependency set so other tools can embed it
+//! as a parser without a matrix or solver stack; the matrices live in the
+//! `powerio-matrix` crate.
+//!
+//! Readers cover MATPOWER `.m`, PowerModels JSON, PSS/E `.raw`, and PowerWorld
+//! `.aux`; writers add EGRET JSON. Every format meets at [`Network`], and
+//! [`write_as`] reports whatever a target format cannot represent — see the
+//! [`crate::format`] module for the two-tier fidelity contract.
+//!
+//! ```
+//! use powerio::{parse_matpower, write_matpower};
+//!
+//! let src = "\
+//! function mpc = example
+//! mpc.version = '2';
+//! mpc.baseMVA = 100;
+//! mpc.bus = [
+//! \t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+//! \t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+//! ];
+//! mpc.branch = [
+//! \t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+//! ];
+//! ";
+//! let net = parse_matpower(src)?;
+//! assert_eq!(net.buses.len(), 2);
+//! assert_eq!(write_matpower(&net), src); // byte-exact echo of the retained source
+//! # Ok::<(), powerio::Error>(())
+//! ```
 
 pub mod error;
 pub mod format;

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -1,11 +1,12 @@
-//! `powerio`: fast, lossless parsing and a typed data model for power-system
+//! `powerio`: fast, lossless parsing and a typed data model for power system
 //! case files.
 //!
 //! Parse a MATPOWER `.m` case, work with the typed [`Network`], and write it
 //! back out byte-for-byte — `parse → write → parse` reproduces the source,
 //! preserving every `mpc.*` field, in-matrix comments, and exact numeric
 //! tokens. The crate is dependency-light on purpose so other tools can take it
-//! as a parser without a matrix/solver stack; the matrices live in `casemat`.
+//! as a parser without a matrix/solver stack; the matrices live in
+//! `powerio-matrix`.
 
 pub mod error;
 pub mod format;

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -238,14 +238,14 @@ pub struct Generator {
     pub in_service: bool,
     pub cost: Option<GenCost>,
     /// The MATPOWER gen capability / ramp columns past `PMIN`, aligned to
-    /// [`GEN_EXTRA_KEYS`] by index (`None` for a column the source omitted).
+    /// `GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).
     /// A fixed array, not an [`Extras`] map: a string-keyed map per generator
     /// costs 11 heap allocations each, which dominates the parse of a large
     /// generator-heavy case. Surfaced into formats that name them (PowerModels).
     pub caps: GenCaps,
 }
 
-/// A generator's capability / ramp columns, one slot per [`GEN_EXTRA_KEYS`] name.
+/// A generator's capability / ramp columns, one slot per `GEN_EXTRA_KEYS` name.
 pub type GenCaps = [Option<f64>; GEN_EXTRA_KEYS.len()];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ all = ["numpy>=1.21", "scipy>=1.7", "networkx>=2.6"]
 bench = ["matpowercaseframes", "pandapower"]
 
 [project.urls]
-Repository = "https://github.com/eigenergy/caseio"
+Repository = "https://github.com/eigenergy/powerio"
 
 [tool.maturin]
 # The Rust extension lives in the powerio-py workspace member; the importable

--- a/tests/data/t_case9_oos.m
+++ b/tests/data/t_case9_oos.m
@@ -1,7 +1,7 @@
 function mpc = t_case9_oos
 %T_CASE9_OOS  case9 with one out-of-service generator and branch, for testing.
 %   Derived from case9.m: generator 2 (bus 2) and branch 5-6 are set
-%   out of service (status 0). Used to check that caseio's in-service
+%   out of service (status 0). Used to check that powerio's in-service
 %   filtering reproduces ExaPowerIO's filtered=true parse.
 %   Please see CASEFORMAT for details on the case file format.
 %


### PR DESCRIPTION
Draft — do not merge yet. Stacked on #45 (`refactor/rename-to-powerio`); review/merge that first.

PR2 of the PowerIO rename: the documentation overhaul. No code behaviour changes — docs, rustdoc, crate descriptions, and crates.io keywords only.

## What changed
- **README** — rewritten to PowerIO: the five-crate map, a value-proposition section, every `caseio::`/`casemat::` example → `powerio`/`powerio_matrix` (and `MpcCase` → `Network`/`IndexedNetwork`), CLI examples → the `powerio` binary, Python → `import powerio` + the optional extras, benchmark label.
- **CLAUDE.md + AGENTS.md** — rewritten to the new layout, the one Python wheel, the JSON transport, kkt's new home in `powerio-matrix`, and `IndexedNetwork` accessors.
- **powerio-capi/README.md** — documents `pio_to_json`/`pio_from_json`; `casemat` → `powerio-matrix`.
- **docs/dcopf-bundle.md** — `powerio dcopf`, `powerio_version` manifest key.
- **benchmarks/RESULTS.md** — `caseio`/`cio_` → `powerio`/`pio_`, one maturin build line.
- **rustdoc `//!`**, the C header comment, and the three crate descriptions.

## Hyphenation sweep
False `power-system(s)` → `power system(s)` in all prose and rustdoc, and the hyphenated `power-systems` crates.io keyword dropped from the three published crates.

## Kept on purpose
`repository = eigenergy/caseio` URLs in the `Cargo.toml`s stay until the GitHub repo is renamed (the last step of the rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
