### PR TITLE
feat: GridFM Parquet export + zero-copy Arrow network transport over the C ABI (#4)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,12 @@ jobs:
     # the C ABI crate explicitly so its end-to-end ABI tests run in CI too.
     - name: Run tests
       run: cargo test -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi --verbose
+    # The gridfm Parquet export is behind a cargo feature; exercise it (and its
+    # clippy) explicitly so coverage doesn't depend on CLI feature unification.
+    - name: Clippy + tests (gridfm feature)
+      run: |
+        cargo clippy -p powerio-matrix --all-targets --features gridfm -- -D warnings
+        cargo test -p powerio-matrix --features gridfm --verbose
 
   c-abi:
     name: C ABI (header parity + C smoke test)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,3 +74,35 @@ jobs:
         cc -I powerio-capi/include powerio-capi/examples/smoke.c \
            -L target/release -lpowerio_capi -o pio_smoke
         LD_LIBRARY_PATH=target/release ./pio_smoke tests/data/case9.m
+
+  c-abi-arrow:
+    name: C ABI (arrow feature)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - uses: Swatinem/rust-cache@v2
+    - name: Build powerio-capi --features arrow
+      run: cargo build -p powerio-capi --release --features arrow
+    # The cfg-gated pio_export_arrow still appears in the source symbol grep, so
+    # it must be declared in the header (inside #ifdef PIO_ARROW); parity holds.
+    - name: Header symbol parity
+      run: |
+        grep -oE 'extern "C" fn pio_[a-z_]+' powerio-capi/src/lib.rs \
+          | grep -oE 'pio_[a-z_]+' | sort -u > rs_syms
+        grep -oE 'pio_[a-z_]+ *\(' powerio-capi/include/powerio.h \
+          | grep -oE 'pio_[a-z_]+' | sort -u > h_syms
+        diff rs_syms h_syms
+    # Compile the smoke test with -DPIO_ARROW so it exercises the Arrow C Data
+    # Interface export against the arrow-featured library.
+    - name: Compile and run the C smoke test (arrow)
+      run: |
+        cc -DPIO_ARROW -I powerio-capi/include powerio-capi/examples/smoke.c \
+           -L target/release -lpowerio_capi -o pio_smoke_arrow
+        LD_LIBRARY_PATH=target/release ./pio_smoke_arrow tests/data/case9.m
+    - name: Tests + clippy (arrow feature)
+      run: |
+        cargo test -p powerio-capi --features arrow --verbose
+        cargo clippy -p powerio-capi --all-targets --features arrow -- -D warnings

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
   (`python/powerio/`); hands back COO triplets that scipy assembles.
 - **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
   polyglot substrate for C/C++/Julia. `--features arrow` adds `pio_export_arrow`,
-  a zero-copy raw-network export over the Arrow C Data Interface.
+  a zero-copy raw network export over the Arrow C Data Interface.
 
 `Network` is the one canonical model (format-neutral, loads/shunts first-class);
 `IndexedNetwork` is the dense-indexed analysis view derived from it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
 - **`powerio-py`** — PyO3 extension behind the `powerio` Python package
   (`python/powerio/`); hands back COO triplets that scipy assembles.
 - **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
-  polyglot substrate for C/C++/Julia.
+  polyglot substrate for C/C++/Julia. `--features arrow` adds `pio_export_arrow`,
+  a zero-copy raw-network export over the Arrow C Data Interface.
 
 `Network` is the one canonical model (format-neutral, loads/shunts first-class);
 `IndexedNetwork` is the dense-indexed analysis view derived from it.
@@ -36,7 +37,8 @@ Matrix outputs (powerio-matrix):
 - Adjacency (`MatrixKind::Adjacency`); PTDF and LODF (DC sensitivities, `sensitivities` subcommand).
 - DC-OPF instance bundle (`dcopf` subcommand, `opf_pipeline::write_dcopf_bundle`): signed incidence `A` (n×m), branch susceptance `b`, weighted Laplacian `L = A diag(b) Aᵀ` and its slack-grounded form, flow map `B Aᵀ`, generator cost `Q`/`c`, bounds, thermal limits `f̄`, generator→bus `C_g`, nodal load `p_d`, `e_r`.
 - petgraph `UnGraph<bus_idx, branch_idx>` view + connectivity / radial diagnostics.
-- Planned: LinDist3Flow, Parquet (gridfm-datakit schema).
+- gridfm-datakit Parquet dataset (`gridfm` subcommand, `io::gridfm::write_gridfm_dataset`, `--features gridfm`): the `bus_data`/`gen_data`/`branch_data`/`y_bus_data` tables a single parsed case maps to, matching gridfm-datakit's column schema so gridfm-graphkit trains on it directly.
+- Planned: LinDist3Flow.
 
 ## Commands
 
@@ -54,9 +56,11 @@ powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
 powerio sensitivities tests/data/case30.m -o out
 powerio convert tests/data/case14.m --to psse -o case14.raw
+powerio gridfm tests/data/case14.m -o out      # gridfm-datakit Parquet dataset
 
 # C ABI (cdylib + staticlib; header powerio-capi/include/powerio.h):
 cargo build -p powerio-capi
+cargo build -p powerio-capi --features arrow   # + pio_export_arrow (Arrow C Data Interface)
 
 # Python (PyO3 crate needs libpython, so it is NOT in default-members):
 cargo build -p powerio-py    # plain cargo build of the extension
@@ -99,7 +103,8 @@ powerio-matrix/               # matrices + graph views on powerio
 │   ├── sensitivity.rs       # PTDF, LODF (self-contained dense Cholesky)
 │   ├── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
 │   └── kkt.rs               # DC-OPF interior point operators (feature = "kkt")
-├── src/io/                  # mtx (lower-triangle symmetric), meta
+├── src/io/                  # mtx (lower-triangle symmetric), meta,
+│                            #   gridfm (gridfm-datakit Parquet, feature = "gridfm")
 ├── src/pipeline.rs          # case → square MatrixKind family
 ├── src/opf_pipeline.rs      # case → DC-OPF bundle directory + manifest
 └── src/synth/               # tree, lattice, pegase-like generators
@@ -112,6 +117,7 @@ powerio-py/src/lib.rs        # PyO3 extension → COO triplets (module `_powerio
 python/powerio/              # importable package (scipy/networkx assembly, lazy)
 python/tests/test_powerio.py
 powerio-capi/                # C ABI (pio_*, include/powerio.h, examples/smoke.c)
+│                            #   src/arrow_export.rs: pio_export_arrow (feature = "arrow")
 tests/data/                  # shared fixtures (used by CLI examples)
 benchmarks/                  # parse benchmarks + Julia validation harnesses
 ```
@@ -174,4 +180,4 @@ new sizes by curl from upstream.
 
 ## Relationship to GridFM
 
-Intended as the fast Rust data layer beneath `gridfm-datakit` (Python, scenario generation) and `gridfm-graphkit` (PyTorch Geometric, GNN training). Planned Parquet output (issue #4) matches gridfm-datakit's column schemas.
+Intended as the fast Rust data layer beneath `gridfm-datakit` (Python, scenario generation) and `gridfm-graphkit` (PyTorch Geometric, GNN training). The `gridfm` subcommand (`io::gridfm`, `--features gridfm`, issue #4) writes the `bus_data`/`gen_data`/`branch_data`/`y_bus_data` Parquet tables matching gridfm-datakit's column schema, under `<out>/<case>/raw/`, so gridfm-graphkit's `HeteroGridDatasetDisk` loads powerio output directly. powerio has no solver, so a case is one snapshot (`scenario 0`): voltages/dispatch are the case's stored values and branch flows are computed from them. Per-scenario expansion is the scenario-batch path (issue #14).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ Matrix outputs (powerio-matrix):
 - Adjacency (`MatrixKind::Adjacency`); PTDF and LODF (DC sensitivities, `sensitivities` subcommand).
 - DC-OPF instance bundle (`dcopf` subcommand, `opf_pipeline::write_dcopf_bundle`): signed incidence `A` (n×m), branch susceptance `b`, weighted Laplacian `L = A diag(b) Aᵀ` and its slack-grounded form, flow map `B Aᵀ`, generator cost `Q`/`c`, bounds, thermal limits `f̄`, generator→bus `C_g`, nodal load `p_d`, `e_r`.
 - petgraph `UnGraph<bus_idx, branch_idx>` view + connectivity / radial diagnostics.
-- Planned: LinDist3Flow, Parquet (gridfm-datakit schema).
+- gridfm-datakit Parquet dataset (`gridfm` subcommand, `io::gridfm::write_gridfm_dataset`, `--features gridfm`): the `bus_data`/`gen_data`/`branch_data`/`y_bus_data` tables a single parsed case maps to, matching gridfm-datakit's column schema so gridfm-graphkit trains on it directly.
+- Planned: LinDist3Flow.
 
 ## Commands
 
@@ -54,6 +55,7 @@ powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
 powerio sensitivities tests/data/case30.m -o out
 powerio convert tests/data/case14.m --to psse -o case14.raw
+powerio gridfm tests/data/case14.m -o out      # gridfm-datakit Parquet dataset
 
 # C ABI (cdylib + staticlib; header powerio-capi/include/powerio.h):
 cargo build -p powerio-capi
@@ -99,7 +101,8 @@ powerio-matrix/               # matrices + graph views on powerio
 │   ├── sensitivity.rs       # PTDF, LODF (self-contained dense Cholesky)
 │   ├── opf.rs               # OpfInstance: Q, c, bounds, f̄, C_g, p_d; Units
 │   └── kkt.rs               # DC-OPF interior point operators (feature = "kkt")
-├── src/io/                  # mtx (lower-triangle symmetric), meta
+├── src/io/                  # mtx (lower-triangle symmetric), meta,
+│                            #   gridfm (gridfm-datakit Parquet, feature = "gridfm")
 ├── src/pipeline.rs          # case → square MatrixKind family
 ├── src/opf_pipeline.rs      # case → DC-OPF bundle directory + manifest
 └── src/synth/               # tree, lattice, pegase-like generators
@@ -174,4 +177,4 @@ new sizes by curl from upstream.
 
 ## Relationship to GridFM
 
-Intended as the fast Rust data layer beneath `gridfm-datakit` (Python, scenario generation) and `gridfm-graphkit` (PyTorch Geometric, GNN training). Planned Parquet output (issue #4) matches gridfm-datakit's column schemas.
+Intended as the fast Rust data layer beneath `gridfm-datakit` (Python, scenario generation) and `gridfm-graphkit` (PyTorch Geometric, GNN training). The `gridfm` subcommand (`io::gridfm`, `--features gridfm`, issue #4) writes the `bus_data`/`gen_data`/`branch_data`/`y_bus_data` Parquet tables matching gridfm-datakit's column schema, under `<out>/<case>/raw/`, so gridfm-graphkit's `HeteroGridDatasetDisk` loads powerio output directly. powerio has no solver, so a case is one snapshot (`scenario 0`): voltages/dispatch are the case's stored values and branch flows are computed from them. Per-scenario expansion is the scenario-batch path (issue #14).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
   (`python/powerio/`); hands back COO triplets that scipy assembles.
 - **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
   polyglot substrate for C/C++/Julia. `--features arrow` adds `pio_export_arrow`,
-  a zero-copy raw-network export over the Arrow C Data Interface.
+  a zero-copy raw network export over the Arrow C Data Interface.
 
 `Network` is the one canonical model (format-neutral, loads/shunts first-class);
 `IndexedNetwork` is the dense-indexed analysis view derived from it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
 - **`powerio-py`** — PyO3 extension behind the `powerio` Python package
   (`python/powerio/`); hands back COO triplets that scipy assembles.
 - **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
-  polyglot substrate for C/C++/Julia.
+  polyglot substrate for C/C++/Julia. `--features arrow` adds `pio_export_arrow`,
+  a zero-copy raw-network export over the Arrow C Data Interface.
 
 `Network` is the one canonical model (format-neutral, loads/shunts first-class);
 `IndexedNetwork` is the dense-indexed analysis view derived from it.
@@ -59,6 +60,7 @@ powerio gridfm tests/data/case14.m -o out      # gridfm-datakit Parquet dataset
 
 # C ABI (cdylib + staticlib; header powerio-capi/include/powerio.h):
 cargo build -p powerio-capi
+cargo build -p powerio-capi --features arrow   # + pio_export_arrow (Arrow C Data Interface)
 
 # Python (PyO3 crate needs libpython, so it is NOT in default-members):
 cargo build -p powerio-py    # plain cargo build of the extension
@@ -115,6 +117,7 @@ powerio-py/src/lib.rs        # PyO3 extension → COO triplets (module `_powerio
 python/powerio/              # importable package (scipy/networkx assembly, lazy)
 python/tests/test_powerio.py
 powerio-capi/                # C ABI (pio_*, include/powerio.h, examples/smoke.c)
+│                            #   src/arrow_export.rs: pio_export_arrow (feature = "arrow")
 tests/data/                  # shared fixtures (used by CLI examples)
 benchmarks/                  # parse benchmarks + Julia validation harnesses
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,9 @@ name = "arrow-schema"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "arrow-select"
@@ -1739,6 +1742,7 @@ dependencies = [
 name = "powerio-capi"
 version = "0.1.0"
 dependencies = [
+ "arrow",
  "powerio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +30,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anes"
@@ -84,6 +107,188 @@ name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "arrow"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
@@ -164,6 +369,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +416,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -278,6 +516,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,6 +543,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -557,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +836,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "finl_unicode"
@@ -584,6 +860,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "fnv"
@@ -639,6 +925,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -670,6 +967,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -723,6 +1021,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +1089,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "is-terminal"
@@ -849,6 +1177,63 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -1023,6 +1408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,6 +1459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1092,6 +1488,15 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1148,6 +1553,40 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "twox-hash",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
@@ -1323,7 +1762,9 @@ name = "powerio-matrix"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "arrow",
  "num-complex",
+ "parquet",
  "powerio",
  "rand 0.9.4",
  "rand_chacha",
@@ -1332,6 +1773,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sprs",
+ "tempfile",
  "walkdir",
 ]
 
@@ -1708,6 +2150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,6 +2219,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,6 +2272,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "sprs"
@@ -1893,6 +2353,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,7 +2407,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -2005,6 +2478,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2508,15 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinytemplate"
@@ -2095,6 +2588,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
@@ -2343,7 +2842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2405,10 +2904,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/README.md
+++ b/README.md
@@ -92,8 +92,19 @@ raw, warnings = powerio.convert("case9.m", "psse")
 powerio convert case14.m --to psse -o case14.raw   # convert
 powerio dcopf case30.m -o out                       # DC-OPF instance bundle
 powerio sensitivities case30.m -o out               # PTDF + LODF
+powerio gridfm case14.m -o out                      # gridfm-datakit Parquet dataset
 powerio                                              # TUI
 ```
+
+## GridFM
+
+`powerio gridfm <case> -o <dir>` (the `gridfm` cargo feature) writes the
+gridfm-datakit Parquet schema — `bus_data`, `gen_data`, `branch_data`,
+`y_bus_data` under `<dir>/<case>/raw/` — so [gridfm-graphkit](https://github.com/gridfm)'s
+`HeteroGridDatasetDisk` trains on powerio output directly. A parsed case is one
+snapshot (`scenario 0`): voltages and dispatch are the case's stored values, and
+branch flows are computed from them. Per-scenario expansion is future work
+(issue #14).
 
 ## Benchmark
 
@@ -125,7 +136,8 @@ Tracked in the issues, all over the `Network` hub:
 - A RAVENS-JSON export sink (positioning PowerIO as an ingest backend for MG-RAVENS).
 - A registered [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl) over the C ABI, with
   native bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl (scaffolded there now).
-- LinDist3Flow and Parquet output (gridfm-datakit schema).
+- LinDist3Flow matrices, and the scenario-batch path that stacks many perturbed
+  scenarios into the gridfm Parquet tables (issue #14).
 
 CIM stays out of scope; it's a heavier problem owned by the CIM hubs (CIMHub,
 MG-RAVENS), which PowerIO can feed as an ingest layer.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ snapshot (`scenario 0`): voltages and dispatch are the case's stored values, and
 branch flows are computed from them. Per-scenario expansion is future work
 (issue #14).
 
+## C ABI
+
+`powerio-capi` exposes the parser over a C ABI (`pio_*`, header
+`powerio-capi/include/powerio.h`) for C, C++, and Julia: parse, query, convert,
+the byte-exact echo, the JSON transport (`pio_to_json`/`pio_from_json`), and the
+numeric table extractors. Built with `--features arrow`, it also offers
+`pio_export_arrow` — a zero-copy export of the raw network tables
+(bus/branch/gen/load/shunt) over the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html),
+so pyarrow / Arrow.jl / Arrow C++ / polars / DuckDB pull a whole table in process
+with no copy and no temp file (the typed, in-memory sibling of `pio_to_json`).
+
 ## Benchmark
 
 Median parse time, one Apple M-series laptop, release build, all timed in one

--- a/powerio-capi/Cargo.toml
+++ b/powerio-capi/Cargo.toml
@@ -14,5 +14,12 @@ publish = false
 name = "powerio_capi"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
+[features]
+# Zero-copy raw-network export over the Arrow C Data Interface (`pio_export_arrow`).
+# Off by default so the base ABI pulls in nothing but `powerio`.
+arrow = ["dep:arrow"]
+
 [dependencies]
 powerio = { path = "../powerio" }
+# Only the C Data Interface (`ffi`) is needed; the heavy arrow defaults stay off.
+arrow = { version = "58", default-features = false, features = ["ffi"], optional = true }

--- a/powerio-capi/Cargo.toml
+++ b/powerio-capi/Cargo.toml
@@ -15,7 +15,7 @@ name = "powerio_capi"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
-# Zero-copy raw-network export over the Arrow C Data Interface (`pio_export_arrow`).
+# Zero-copy raw network export over the Arrow C Data Interface (`pio_export_arrow`).
 # Off by default so the base ABI pulls in nothing but `powerio`.
 arrow = ["dep:arrow"]
 

--- a/powerio-capi/cbindgen.toml
+++ b/powerio-capi/cbindgen.toml
@@ -9,5 +9,12 @@ style = "type"
 prefix = ""
 include = ["PioCase"]
 
+# Gate the optional Arrow export behind `#ifdef PIO_ARROW` (the `arrow` feature).
+# The Arrow C Data Interface block in include/powerio.h (forward declarations of
+# ArrowArray/ArrowSchema, the PIO_ARROW_TABLE_* selectors, and pio_export_arrow)
+# is hand-maintained alongside the other doc comments in that header.
+[defines]
+"feature = arrow" = "PIO_ARROW"
+
 [parse]
 parse_deps = false

--- a/powerio-capi/examples/arrow_c_data_interface.h
+++ b/powerio-capi/examples/arrow_c_data_interface.h
@@ -1,0 +1,49 @@
+/* The Apache Arrow C Data Interface struct definitions, verbatim from the spec
+ * (https://arrow.apache.org/docs/format/CDataInterface.html), Apache-2.0.
+ *
+ * Vendored here for the smoke test only — NOT part of the shipped public header
+ * (include/powerio.h forward-declares these structs; a real consumer includes
+ * its own Arrow ABI header, e.g. arrow/c/abi.h or nanoarrow). */
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#include <stdint.h>
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+    /* Array type description */
+    const char *format;
+    const char *name;
+    const char *metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema **children;
+    struct ArrowSchema *dictionary;
+
+    /* Release callback */
+    void (*release)(struct ArrowSchema *);
+    /* Opaque producer-specific data */
+    void *private_data;
+};
+
+struct ArrowArray {
+    /* Array data description */
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void **buffers;
+    struct ArrowArray **children;
+    struct ArrowArray *dictionary;
+
+    /* Release callback */
+    void (*release)(struct ArrowArray *);
+    /* Opaque producer-specific data */
+    void *private_data;
+};
+
+#endif /* ARROW_C_DATA_INTERFACE */

--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -11,6 +11,10 @@
  */
 #include "powerio.h"
 
+#ifdef PIO_ARROW
+#include "arrow_c_data_interface.h" /* full ArrowArray/ArrowSchema definitions */
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,6 +80,24 @@ int main(int argc, char **argv) {
           "JSON round-trip changed the table sizes");
     pio_string_free(json);
     pio_case_free(c2);
+
+#ifdef PIO_ARROW
+    /* Zero-copy Arrow C Data Interface export: pull the bus table, check the row
+     * count, then release the producer-owned buffers. */
+    {
+        struct ArrowArray arr;
+        struct ArrowSchema sch;
+        memset(&arr, 0, sizeof arr);
+        memset(&sch, 0, sizeof sch);
+        int rc = pio_export_arrow(c, PIO_ARROW_TABLE_BUS, &arr, &sch, err, sizeof err);
+        CHECK(rc == 0, err);
+        CHECK(arr.length == (int64_t)nb, "arrow bus table row count mismatch");
+        CHECK(arr.release != NULL && sch.release != NULL, "missing arrow release callbacks");
+        arr.release(&arr);
+        sch.release(&sch);
+        printf("arrow export OK: %zu bus rows\n", nb);
+    }
+#endif
 
     /* NULL handle is the documented safe default. */
     CHECK(pio_n_buses(NULL) == 0, "NULL handle did not return 0");

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -14,7 +14,7 @@
  * default (NULL, 0, -1, 0.0, or no-op) rather than unwinding across the ABI.
  *
  * Optional: build with `--features arrow` to get pio_export_arrow, a zero-copy
- * raw-network export over the Arrow C Data Interface (guarded by PIO_ARROW).
+ * raw network export over the Arrow C Data Interface (guarded by PIO_ARROW).
  *
  * This header is checked in; regenerate from the Rust source with
  *   cbindgen --config cbindgen.toml --crate powerio-capi --output include/powerio.h
@@ -84,7 +84,7 @@ void pio_nodal_demand(const PioCase *c, double *pd, double *qd);
 void pio_nodal_shunt(const PioCase *c, double *gs, double *bs);
 
 #ifdef PIO_ARROW
-/* Zero-copy raw-network export over the Arrow C Data Interface (powerio-capi
+/* Zero-copy raw network export over the Arrow C Data Interface (powerio-capi
  * built with `--features arrow`). ArrowArray / ArrowSchema are the standard C
  * Data Interface structs; include the Arrow ABI header (arrow/c/abi.h, or the
  * vendored examples/arrow_c_data_interface.h) for their definitions — this
@@ -98,7 +98,7 @@ struct ArrowSchema;
 #define PIO_ARROW_TABLE_LOAD   3
 #define PIO_ARROW_TABLE_SHUNT  4
 
-/* Export raw-network table `table` (one of PIO_ARROW_TABLE_*) as a single Arrow
+/* Export raw network table `table` (one of PIO_ARROW_TABLE_*) as a single Arrow
  * array + schema, zero-copy. Columns are the parsed network fields with EXTERNAL
  * bus ids (the pio_bus_ids id space), not the gridfm schema. On success (0)
  * *out_array and *out_schema are populated and owned by the caller — release

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -13,6 +13,9 @@
  * Every entry point catches Rust panics at the boundary and returns the failure
  * default (NULL, 0, -1, 0.0, or no-op) rather than unwinding across the ABI.
  *
+ * Optional: build with `--features arrow` to get pio_export_arrow, a zero-copy
+ * raw-network export over the Arrow C Data Interface (guarded by PIO_ARROW).
+ *
  * This header is checked in; regenerate from the Rust source with
  *   cbindgen --config cbindgen.toml --crate powerio-capi --output include/powerio.h
  */
@@ -79,6 +82,32 @@ void pio_gens(const PioCase *c, int64_t *bus, double *pg, double *pmax,
 /* Demand / shunt summed per bus, dense order, length pio_n_buses. */
 void pio_nodal_demand(const PioCase *c, double *pd, double *qd);
 void pio_nodal_shunt(const PioCase *c, double *gs, double *bs);
+
+#ifdef PIO_ARROW
+/* Zero-copy raw-network export over the Arrow C Data Interface (powerio-capi
+ * built with `--features arrow`). ArrowArray / ArrowSchema are the standard C
+ * Data Interface structs; include the Arrow ABI header (arrow/c/abi.h, or the
+ * vendored examples/arrow_c_data_interface.h) for their definitions — this
+ * header only forward-declares them. */
+struct ArrowArray;
+struct ArrowSchema;
+
+#define PIO_ARROW_TABLE_BUS    0
+#define PIO_ARROW_TABLE_BRANCH 1
+#define PIO_ARROW_TABLE_GEN    2
+#define PIO_ARROW_TABLE_LOAD   3
+#define PIO_ARROW_TABLE_SHUNT  4
+
+/* Export raw-network table `table` (one of PIO_ARROW_TABLE_*) as a single Arrow
+ * array + schema, zero-copy. Columns are the parsed network fields with EXTERNAL
+ * bus ids (the pio_bus_ids id space), not the gridfm schema. On success (0)
+ * *out_array and *out_schema are populated and owned by the caller — release
+ * each via its `release` callback. On error (-1) the message is written into
+ * errbuf and the out-params are left untouched. */
+int pio_export_arrow(const PioCase *c, int table,
+                     struct ArrowArray *out_array, struct ArrowSchema *out_schema,
+                     char *errbuf, size_t errlen);
+#endif /* PIO_ARROW */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -1,0 +1,220 @@
+//! Raw-network tables over the Arrow C Data Interface.
+//!
+//! Builds the parsed [`Network`] element tables (bus/branch/gen/load/shunt) as
+//! Arrow record batches and lends them across the C ABI zero-copy via
+//! [`arrow::ffi::to_ffi`]. This is the in-memory, self-describing sibling of
+//! [`pio_to_json`](crate::pio_to_json) and the `pio_branches`-style numeric
+//! extractors: any Arrow consumer (pyarrow, Arrow.jl, Arrow C++, polars, DuckDB)
+//! can pull a whole table without a copy or a temp file.
+//!
+//! These are the *raw* network fields, with EXTERNAL bus ids (the same id space
+//! as `pio_bus_ids`), not the gridfm-datakit schema — no admittances or flows
+//! (that schema needs the matrix layer; see issue #38).
+
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, Float64Array, Int64Array, StructArray, UInt8Array};
+use arrow::datatypes::{Field, Schema};
+use arrow::error::ArrowError;
+use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema, to_ffi};
+use arrow::record_batch::RecordBatch;
+use powerio::{BusId, Network};
+
+/// Table selectors for [`pio_export_arrow`](crate::pio_export_arrow); the C
+/// header mirrors these as `PIO_ARROW_TABLE_*`.
+pub const PIO_ARROW_TABLE_BUS: i32 = 0;
+pub const PIO_ARROW_TABLE_BRANCH: i32 = 1;
+pub const PIO_ARROW_TABLE_GEN: i32 = 2;
+pub const PIO_ARROW_TABLE_LOAD: i32 = 3;
+pub const PIO_ARROW_TABLE_SHUNT: i32 = 4;
+
+/// Build the requested table and export it over the C Data Interface. The
+/// returned FFI structs own the columnar buffers until the consumer releases
+/// them.
+pub fn export(net: &Network, table: i32) -> Result<(FFI_ArrowArray, FFI_ArrowSchema), String> {
+    let rb = match table {
+        PIO_ARROW_TABLE_BUS => bus_batch(net),
+        PIO_ARROW_TABLE_BRANCH => branch_batch(net),
+        PIO_ARROW_TABLE_GEN => gen_batch(net),
+        PIO_ARROW_TABLE_LOAD => load_batch(net),
+        PIO_ARROW_TABLE_SHUNT => shunt_batch(net),
+        other => return Err(format!("unknown Arrow table id {other}")),
+    }
+    .map_err(|e| e.to_string())?;
+
+    // The C Data Interface represents a record batch as a struct array.
+    let data = StructArray::from(rb).into_data();
+    to_ffi(&data).map_err(|e| e.to_string())
+}
+
+fn bus_batch(net: &Network) -> Result<RecordBatch, ArrowError> {
+    let b = &net.buses;
+    batch(vec![
+        ("id", i64s(b.iter().map(|x| ext(x.id)).collect())),
+        (
+            "kind",
+            i64s(b.iter().map(|x| i64::from(x.kind as u8)).collect()),
+        ),
+        ("vm", f64s(b.iter().map(|x| x.vm).collect())),
+        ("va", f64s(b.iter().map(|x| x.va).collect())),
+        ("base_kv", f64s(b.iter().map(|x| x.base_kv).collect())),
+        ("vmax", f64s(b.iter().map(|x| x.vmax).collect())),
+        ("vmin", f64s(b.iter().map(|x| x.vmin).collect())),
+        ("area", i64s(b.iter().map(|x| usz(x.area)).collect())),
+        ("zone", i64s(b.iter().map(|x| usz(x.zone)).collect())),
+    ])
+}
+
+fn branch_batch(net: &Network) -> Result<RecordBatch, ArrowError> {
+    let br = &net.branches;
+    batch(vec![
+        ("from", i64s(br.iter().map(|x| ext(x.from)).collect())),
+        ("to", i64s(br.iter().map(|x| ext(x.to)).collect())),
+        ("r", f64s(br.iter().map(|x| x.r).collect())),
+        ("x", f64s(br.iter().map(|x| x.x).collect())),
+        ("b", f64s(br.iter().map(|x| x.b).collect())),
+        ("rate_a", f64s(br.iter().map(|x| x.rate_a).collect())),
+        ("rate_b", f64s(br.iter().map(|x| x.rate_b).collect())),
+        ("rate_c", f64s(br.iter().map(|x| x.rate_c).collect())),
+        ("tap", f64s(br.iter().map(|x| x.tap).collect())),
+        ("shift", f64s(br.iter().map(|x| x.shift).collect())),
+        (
+            "in_service",
+            u8s(br.iter().map(|x| u8::from(x.in_service)).collect()),
+        ),
+        ("angmin", f64s(br.iter().map(|x| x.angmin).collect())),
+        ("angmax", f64s(br.iter().map(|x| x.angmax).collect())),
+    ])
+}
+
+fn gen_batch(net: &Network) -> Result<RecordBatch, ArrowError> {
+    let g = &net.generators;
+    batch(vec![
+        ("bus", i64s(g.iter().map(|x| ext(x.bus)).collect())),
+        ("pg", f64s(g.iter().map(|x| x.pg).collect())),
+        ("qg", f64s(g.iter().map(|x| x.qg).collect())),
+        ("pmax", f64s(g.iter().map(|x| x.pmax).collect())),
+        ("pmin", f64s(g.iter().map(|x| x.pmin).collect())),
+        ("qmax", f64s(g.iter().map(|x| x.qmax).collect())),
+        ("qmin", f64s(g.iter().map(|x| x.qmin).collect())),
+        ("vg", f64s(g.iter().map(|x| x.vg).collect())),
+        ("mbase", f64s(g.iter().map(|x| x.mbase).collect())),
+        (
+            "in_service",
+            u8s(g.iter().map(|x| u8::from(x.in_service)).collect()),
+        ),
+    ])
+}
+
+fn load_batch(net: &Network) -> Result<RecordBatch, ArrowError> {
+    let l = &net.loads;
+    batch(vec![
+        ("bus", i64s(l.iter().map(|x| ext(x.bus)).collect())),
+        ("p", f64s(l.iter().map(|x| x.p).collect())),
+        ("q", f64s(l.iter().map(|x| x.q).collect())),
+        (
+            "in_service",
+            u8s(l.iter().map(|x| u8::from(x.in_service)).collect()),
+        ),
+    ])
+}
+
+fn shunt_batch(net: &Network) -> Result<RecordBatch, ArrowError> {
+    let s = &net.shunts;
+    batch(vec![
+        ("bus", i64s(s.iter().map(|x| ext(x.bus)).collect())),
+        ("g", f64s(s.iter().map(|x| x.g).collect())),
+        ("b", f64s(s.iter().map(|x| x.b).collect())),
+        (
+            "in_service",
+            u8s(s.iter().map(|x| u8::from(x.in_service)).collect()),
+        ),
+    ])
+}
+
+fn batch(cols: Vec<(&str, ArrayRef)>) -> Result<RecordBatch, ArrowError> {
+    let fields: Vec<Field> = cols
+        .iter()
+        .map(|(name, arr)| Field::new(*name, arr.data_type().clone(), false))
+        .collect();
+    let arrays: Vec<ArrayRef> = cols.into_iter().map(|(_, arr)| arr).collect();
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
+}
+
+/// External bus id as i64 (`-1` if it somehow overflows), matching `pio_branches`.
+fn ext(id: BusId) -> i64 {
+    i64::try_from(id.0).unwrap_or(-1)
+}
+
+fn usz(n: usize) -> i64 {
+    i64::try_from(n).unwrap_or(-1)
+}
+
+fn i64s(v: Vec<i64>) -> ArrayRef {
+    Arc::new(Int64Array::from(v))
+}
+
+fn f64s(v: Vec<f64>) -> ArrayRef {
+    Arc::new(Float64Array::from(v))
+}
+
+fn u8s(v: Vec<u8>) -> ArrayRef {
+    Arc::new(UInt8Array::from(v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::ffi::from_ffi;
+
+    fn net(name: &str) -> Network {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data")
+            .join(name);
+        powerio::read_path(&path, None).unwrap()
+    }
+
+    fn round_trip(net: &Network, table: i32) -> StructArray {
+        let (array, schema) = export(net, table).unwrap();
+        // from_ffi consumes the array and borrows the schema (zero-copy import).
+        let data = unsafe { from_ffi(array, &schema) }.unwrap();
+        StructArray::from(data)
+    }
+
+    #[test]
+    fn bus_table_round_trips_with_external_ids() {
+        let n = net("case9.m");
+        let sa = round_trip(&n, PIO_ARROW_TABLE_BUS);
+        assert_eq!(sa.len(), n.buses.len());
+        let ids = sa
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), i64::try_from(n.buses[0].id.0).unwrap());
+    }
+
+    #[test]
+    fn every_table_has_the_expected_row_count() {
+        // case30 carries buses, branches, gens, loads, and shunts.
+        let n = net("case30.m");
+        assert_eq!(round_trip(&n, PIO_ARROW_TABLE_BUS).len(), n.buses.len());
+        assert_eq!(
+            round_trip(&n, PIO_ARROW_TABLE_BRANCH).len(),
+            n.branches.len()
+        );
+        assert_eq!(
+            round_trip(&n, PIO_ARROW_TABLE_GEN).len(),
+            n.generators.len()
+        );
+        assert_eq!(round_trip(&n, PIO_ARROW_TABLE_LOAD).len(), n.loads.len());
+        assert_eq!(round_trip(&n, PIO_ARROW_TABLE_SHUNT).len(), n.shunts.len());
+    }
+
+    #[test]
+    fn unknown_table_id_errors() {
+        let n = net("case9.m");
+        assert!(export(&n, 99).is_err());
+    }
+}

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -1,4 +1,4 @@
-//! Raw-network tables over the Arrow C Data Interface.
+//! Raw network tables over the Arrow C Data Interface.
 //!
 //! Builds the parsed [`Network`] element tables (bus/branch/gen/load/shunt) as
 //! Arrow record batches and lends them across the C ABI zero-copy via

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -28,6 +28,17 @@ pub const PIO_ARROW_TABLE_GEN: i32 = 2;
 pub const PIO_ARROW_TABLE_LOAD: i32 = 3;
 pub const PIO_ARROW_TABLE_SHUNT: i32 = 4;
 
+// These values are the ABI: the `PIO_ARROW_TABLE_*` macros in include/powerio.h
+// are hand-synced to them. Pin them so a Rust-side edit that drifts from the
+// header fails the build instead of silently exporting the wrong table.
+const _: () = assert!(
+    PIO_ARROW_TABLE_BUS == 0
+        && PIO_ARROW_TABLE_BRANCH == 1
+        && PIO_ARROW_TABLE_GEN == 2
+        && PIO_ARROW_TABLE_LOAD == 3
+        && PIO_ARROW_TABLE_SHUNT == 4
+);
+
 /// Build the requested table and export it over the C Data Interface. The
 /// returned FFI structs own the columnar buffers until the consumer releases
 /// them.
@@ -192,7 +203,23 @@ mod tests {
             .as_any()
             .downcast_ref::<Int64Array>()
             .unwrap();
-        assert_eq!(ids.value(0), i64::try_from(n.buses[0].id.0).unwrap());
+        // The whole id column survives, in order (a reversed/offset column would
+        // pass a single-cell check).
+        let expected: Vec<i64> = n
+            .buses
+            .iter()
+            .map(|b| i64::try_from(b.id.0).unwrap())
+            .collect();
+        assert_eq!(ids.values(), expected.as_slice());
+    }
+
+    #[test]
+    fn empty_table_exports_zero_rows() {
+        // case9 has no shunts: a length-0 table must cross the C Data Interface
+        // and import back without faulting (a common producer mishandling).
+        let n = net("case9.m");
+        assert_eq!(n.shunts.len(), 0);
+        assert_eq!(round_trip(&n, PIO_ARROW_TABLE_SHUNT).len(), 0);
     }
 
     #[test]

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -436,7 +436,7 @@ pub unsafe extern "C" fn pio_nodal_shunt(case: *const PioCase, gs: *mut f64, bs:
     }
 }
 
-/// Export one raw-network table over the Arrow C Data Interface (zero-copy).
+/// Export one raw network table over the Arrow C Data Interface (zero-copy).
 ///
 /// `table` is one of the `PIO_ARROW_TABLE_*` selectors (bus/branch/gen/load/
 /// shunt); the columns are the parsed network fields with EXTERNAL bus ids (the

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -783,4 +783,26 @@ mod tests {
             .expect("buffer must be NUL-terminated");
         assert!(nul <= 15);
     }
+
+    #[cfg(feature = "arrow")]
+    #[test]
+    fn export_arrow_null_out_params_return_error() {
+        // A NULL out_array/out_schema must be reported (-1), not dereferenced.
+        let c = case9();
+        let mut err = [0 as c_char; 256];
+        let rc = unsafe {
+            pio_export_arrow(
+                c,
+                PIO_ARROW_TABLE_BUS,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                err.as_mut_ptr(),
+                err.len(),
+            )
+        };
+        assert_eq!(rc, -1);
+        let msg = unsafe { CStr::from_ptr(err.as_ptr()) }.to_str().unwrap();
+        assert!(!msg.is_empty(), "expected an error message");
+        unsafe { pio_case_free(c) };
+    }
 }

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -17,6 +17,14 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use powerio::{IndexCore, IndexedNetwork, Network};
 
+#[cfg(feature = "arrow")]
+mod arrow_export;
+#[cfg(feature = "arrow")]
+pub use arrow_export::{
+    PIO_ARROW_TABLE_BRANCH, PIO_ARROW_TABLE_BUS, PIO_ARROW_TABLE_GEN, PIO_ARROW_TABLE_LOAD,
+    PIO_ARROW_TABLE_SHUNT,
+};
+
 /// Opaque parsed case handle. Carries the parsed [`Network`] plus the
 /// [`IndexCore`] derived from it once at parse time, so every indexed query
 /// reuses the same bus-id map and nodal aggregates instead of rebuilding them.
@@ -425,6 +433,55 @@ pub unsafe extern "C" fn pio_nodal_shunt(case: *const PioCase, gs: *mut f64, bs:
                 fill(bs, v.bs().iter().copied());
             }
         })
+    }
+}
+
+/// Export one raw-network table over the Arrow C Data Interface (zero-copy).
+///
+/// `table` is one of the `PIO_ARROW_TABLE_*` selectors (bus/branch/gen/load/
+/// shunt); the columns are the parsed network fields with EXTERNAL bus ids (the
+/// `pio_bus_ids` id space), not the gridfm schema. On success (returns `0`),
+/// `out_array` and `out_schema` are populated with owned C Data Interface structs
+/// and the caller MUST release each via its `release` callback. On error
+/// (returns `-1`) the message is written into `errbuf` and the out-params are
+/// left untouched. Only built with the `arrow` cargo feature.
+#[cfg(feature = "arrow")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_export_arrow(
+    case: *const PioCase,
+    table: i32,
+    out_array: *mut arrow::ffi::FFI_ArrowArray,
+    out_schema: *mut arrow::ffi::FFI_ArrowSchema,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> i32 {
+    unsafe {
+        let r = catch_unwind(AssertUnwindSafe(|| {
+            if out_array.is_null() || out_schema.is_null() {
+                return Err("out_array or out_schema is NULL".to_string());
+            }
+            let c = case_ref(case).ok_or_else(|| "case is NULL".to_string())?;
+            arrow_export::export(&c.net, table)
+        }));
+        match r {
+            Ok(Ok((array, schema))) => {
+                // Move the FFI structs into caller memory: ptr::write does not
+                // drop the (caller-zeroed) destination and does not run Drop on
+                // `array`/`schema`, so the producer release callbacks transfer to
+                // the caller — exactly one owner.
+                std::ptr::write(out_array, array);
+                std::ptr::write(out_schema, schema);
+                0
+            }
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                -1
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while exporting Arrow");
+                -1
+            }
+        }
     }
 }
 

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-powerio-matrix = { path = "../powerio-matrix" }
+powerio-matrix = { path = "../powerio-matrix", features = ["gridfm"] }
 sprs = { version = "0.11", default-features = false }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -495,6 +495,13 @@ fn run_gridfm(
     };
     let outputs = write_gridfm_dataset(&net, output, &opts)
         .with_context(|| format!("export gridfm dataset for {}", input.display()))?;
+    if outputs.dropped_zero_impedance > 0 || outputs.degenerate_cost_gens > 0 {
+        tracing::warn!(
+            zeroed_branches = outputs.dropped_zero_impedance,
+            degenerate_cost_gens = outputs.degenerate_cost_gens,
+            "gridfm: some columns were zeroed; see gridfm_meta.json"
+        );
+    }
     tracing::info!(
         case = %net.name,
         dir = %outputs.dir.display(),

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1,13 +1,15 @@
 //! The `powerio` binary: a clap CLI and a ratatui TUI over `powerio-matrix`.
 //!
 //! Subcommands: `batch` (matrix families), `gen` (synthetic cases), `verify`,
-//! `dcopf` (DC-OPF bundle), `sensitivities` (PTDF/LODF), and `convert`. With no
-//! subcommand it launches the TUI. Run `powerio --help` for the full surface.
+//! `dcopf` (DC-OPF bundle), `sensitivities` (PTDF/LODF), `gridfm` (gridfm-datakit
+//! Parquet), and `convert`. With no subcommand it launches the TUI. Run
+//! `powerio --help` for the full surface.
 
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
+use powerio_matrix::io::gridfm::{GridfmOptions, write_gridfm_dataset};
 use powerio_matrix::matrix::{BuildOptions, DcConvention, Scheme, Units, sddm_check};
 use powerio_matrix::opf_pipeline::{DcOpfOptions, write_dcopf_bundle};
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
@@ -101,6 +103,20 @@ enum Command {
         /// DC susceptance convention.
         #[arg(long, value_enum, default_value = "paper-pure")]
         convention: DcConvArg,
+    },
+    /// Write the gridfm-datakit Parquet dataset for one case.
+    Gridfm {
+        /// Input case file (format inferred from the extension unless `--from`).
+        input: PathBuf,
+        /// Output directory; the dataset lands in `<output>/<case>/raw/`.
+        #[arg(short, long)]
+        output: PathBuf,
+        /// Override the inferred input format.
+        #[arg(long, value_enum)]
+        from: Option<FormatArg>,
+        /// Scenario id stamped into the rows (a parsed case is one snapshot).
+        #[arg(long, default_value_t = 0)]
+        scenario: i64,
     },
     /// Convert a case file to another format through the neutral hub.
     Convert {
@@ -316,6 +332,12 @@ fn main() -> anyhow::Result<()> {
             output,
             convention,
         } => run_sensitivities(&input, &output, convention.into()),
+        Command::Gridfm {
+            input,
+            output,
+            from,
+            scenario,
+        } => run_gridfm(&input, &output, from, scenario),
         Command::Convert {
             input,
             to,
@@ -456,6 +478,28 @@ fn run_dcopf(
         dir = %outputs.dir.display(),
         files = outputs.files.len(),
         "wrote DC-OPF bundle"
+    );
+    Ok(())
+}
+
+fn run_gridfm(
+    input: &Path,
+    output: &Path,
+    from: Option<FormatArg>,
+    scenario: i64,
+) -> anyhow::Result<()> {
+    let net = read_network(input, from)?;
+    let opts = GridfmOptions {
+        scenario,
+        ..Default::default()
+    };
+    let outputs = write_gridfm_dataset(&net, output, &opts)
+        .with_context(|| format!("export gridfm dataset for {}", input.display()))?;
+    tracing::info!(
+        case = %net.name,
+        dir = %outputs.dir.display(),
+        files = outputs.files.len(),
+        "wrote gridfm dataset"
     );
     Ok(())
 }

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -12,6 +12,9 @@ categories = ["science", "mathematics"]
 [features]
 # Experimental DC-OPF interior point operators (optional).
 kkt = []
+# GridFM interchange: write the gridfm-datakit Parquet schema (and the shared
+# Arrow record batches behind it). Pulls in arrow + parquet, off by default.
+gridfm = ["dep:arrow", "dep:parquet"]
 
 [lib]
 name = "powerio_matrix"
@@ -28,9 +31,14 @@ rand_chacha = "0.9"
 walkdir = "2"
 rayon = "1"
 sha2 = "0.10"
+# arrow and parquet release in lockstep and share `RecordBatch`; keep both on the
+# same major. `snap` matches the Snappy compression pandas/datakit write by default.
+arrow = { version = "58", default-features = false, optional = true }
+parquet = { version = "58", default-features = false, features = ["arrow", "snap"], optional = true }
 
 [dev-dependencies]
 approx = "0.5"
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/powerio-matrix/src/io/gridfm.rs
+++ b/powerio-matrix/src/io/gridfm.rs
@@ -14,21 +14,26 @@
 //! values, and branch flows `pf/qf/pt/qt` are computed from those voltages and
 //! the branch admittances ([`branch_flows`]). For a solved MATPOWER case the
 //! stored voltages are the converged operating point, so the flows match what a
-//! solver would report to float tolerance; for an unsolved/flat-start case they
+//! solver would report to float tolerance; for an unsolved/flat start case they
 //! are the flows at the stored voltages, not a re-solved dispatch.
 //!
 //! # Units
 //!
-//! - `Pd, Qd, Pg, Qg, p_mw, q_mvar, pf, qf, pt, qt` in MW/MVAr (per-unit ×
-//!   `base_mva`).
+//! - `Pd, Qd, Pg, Qg, p_mw, q_mvar` are MW/MVAr, passed through from the case
+//!   (loads and generator setpoints are already MW/MVAr). The branch flows
+//!   `pf, qf, pt, qt` are MW/MVAr too, computed in per-unit and scaled by
+//!   `base_mva`.
 //! - `Vm` per-unit, `Va` degrees; `r, x, b` and the `Y**` admittances per-unit.
 //! - `GS, BS` are the MATPOWER shunt values (MW/MVAr at V = 1) divided by
 //!   `base_mva`, matching datakit's normalization.
 //! - Costs are the raw MATPOWER coefficients: `cp2 = c2`, `cp1 = c1`,
-//!   `cp0 = c0`. Piecewise or missing cost rows emit zeros (graphkit ignores the
-//!   cost columns) and are counted in the manifest.
+//!   `cp0 = c0`. A cost row gridfm can't represent (piecewise, missing,
+//!   malformed, or cubic and higher) emits zeros — graphkit ignores the cost
+//!   columns — and is counted in the manifest. The `_eur` suffixes are
+//!   datakit's column names, not a unit powerio converts to.
 //! - `bus`, `from_bus`, `to_bus` are dense `[0, n)` indices; `idx` is the
-//!   0-based generator/branch row.
+//!   0-based generator/branch row. An out-of-service branch keeps its physical
+//!   `Y**` admittances but carries zero flows (its `br_status` is 0).
 
 // Bus/branch indices and Y_bus nnz counts cast to `i64` for the Arrow columns;
 // they are bounded far below `i64::MAX`, so the wrap clippy warns about can't
@@ -93,8 +98,10 @@ impl GridfmOptions {
     }
 }
 
-/// The gridfm-datakit tables as Arrow record batches. Both the Parquet writer
-/// and (later) the Arrow C Data Interface export build from these.
+/// The gridfm-datakit tables as Arrow record batches. The Parquet writer builds
+/// from these; a deferred gridfm-schema Arrow C Data Interface export (issue #38)
+/// would reuse them. (The raw-network Arrow export that ships in powerio-capi is
+/// a different, lighter schema.)
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct GridfmTables {
@@ -104,11 +111,17 @@ pub struct GridfmTables {
     pub y_bus: RecordBatch,
 }
 
-/// What [`write_gridfm_dataset`] wrote.
+/// What [`write_gridfm_dataset`] wrote, plus the counts of columns it had to zero
+/// (see the manifest) so a caller can surface them.
 #[derive(Debug, Clone)]
 pub struct GridfmOutputs {
     pub dir: PathBuf,
     pub files: Vec<PathBuf>,
+    /// Branches with `r² + x² = 0`, whose admittance/flow columns were zeroed.
+    pub dropped_zero_impedance: usize,
+    /// Generators whose cost row gridfm couldn't represent, whose `cp*` columns
+    /// were zeroed.
+    pub degenerate_cost_gens: usize,
 }
 
 #[derive(Serialize)]
@@ -124,8 +137,8 @@ struct GridfmMeta {
     reference_bus: usize,
     /// Branches with `r² + x² = 0`: their admittance/flow columns are zeroed.
     dropped_zero_impedance: usize,
-    /// Generators whose cost row gridfm can't represent (piecewise or missing):
-    /// their `cp*` columns are zeroed.
+    /// Generators whose cost row gridfm can't represent (piecewise, missing,
+    /// malformed, or cubic and higher): their `cp*` columns are zeroed.
     degenerate_cost_gens: usize,
     files: Vec<String>,
     powerio_version: String,
@@ -135,8 +148,9 @@ struct GridfmMeta {
 ///
 /// # Errors
 /// [`Error::ReferenceBusCount`] unless the case has exactly one reference bus
-/// (graphkit needs a slack), and [`Error::NonFiniteSusceptance`] for a branch
-/// with NaN/Inf impedance.
+/// (graphkit needs a slack), [`Error::NonFiniteSusceptance`] for a branch with
+/// NaN/Inf impedance, and [`Error::UnknownBus`] if a generator or branch
+/// references a bus the network doesn't define.
 pub fn gridfm_record_batches(net: &Network, opts: &GridfmOptions) -> Result<GridfmTables> {
     let view = IndexedNetwork::new(net);
     let ref_bus = view.reference_bus_index()?;
@@ -185,6 +199,17 @@ pub fn write_gridfm_dataset(
         put_parquet(&dir, "y_bus_data.parquet", &tables.y_bus, &mut files)?;
     }
 
+    let dropped_zero_impedance = net
+        .branches
+        .iter()
+        .filter(|br| br.r * br.r + br.x * br.x == 0.0)
+        .count();
+    let degenerate_cost_gens = net
+        .generators
+        .iter()
+        .filter(|g| !cost_representable(g.cost.as_ref()))
+        .count();
+
     let meta = GridfmMeta {
         case_name: net.name.clone(),
         base_mva: net.base_mva,
@@ -195,16 +220,8 @@ pub fn write_gridfm_dataset(
         n_branches_in_service: net.branches.iter().filter(|b| b.in_service).count(),
         n_gens: net.generators.len(),
         reference_bus: ref_bus,
-        dropped_zero_impedance: net
-            .branches
-            .iter()
-            .filter(|br| br.r * br.r + br.x * br.x == 0.0)
-            .count(),
-        degenerate_cost_gens: net
-            .generators
-            .iter()
-            .filter(|g| !cost_representable(g.cost.as_ref()))
-            .count(),
+        dropped_zero_impedance,
+        degenerate_cost_gens,
         files: files
             .iter()
             .filter_map(|p| p.file_name().and_then(|s| s.to_str()).map(str::to_string))
@@ -216,7 +233,12 @@ pub fn write_gridfm_dataset(
     std::fs::write(&meta_path, json)?;
     files.push(meta_path);
 
-    Ok(GridfmOutputs { dir, files })
+    Ok(GridfmOutputs {
+        dir,
+        files,
+        dropped_zero_impedance,
+        degenerate_cost_gens,
+    })
 }
 
 // --- table builders --------------------------------------------------------
@@ -531,6 +553,7 @@ fn one_hot(buses: &[Bus], kind: BusType) -> ArrayRef {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::network::{BusId, Extras};
     use arrow::array::{Float64Array, Int64Array};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
@@ -742,5 +765,179 @@ mod tests {
             assert_eq!(slack.value(i) == 1, bus.value(i) as usize == ref_bus);
         }
         assert!(slack.values().contains(&1), "no slack generator");
+    }
+
+    #[test]
+    fn branch_flows_close_the_power_balance_on_a_solved_case() {
+        // case14 ships a converged operating point, so the active flows must obey
+        // KCL: total branch loss = generation - demand - shunt draw. This is the
+        // value-level guard on branch_flows (a missing ×base, a sign flip, or a
+        // wrong conj would break it). Every branch's real loss is also ≥ 0.
+        let net = case14();
+        let view = IndexedNetwork::new(&net);
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let br = &tables.branch;
+        let (pf, pt, status) = (
+            col_f64(br, "pf"),
+            col_f64(br, "pt"),
+            col_i64(br, "br_status"),
+        );
+
+        let mut loss = 0.0;
+        for i in 0..br.num_rows() {
+            if status.value(i) == 1 {
+                let l = pf.value(i) + pt.value(i);
+                assert!(l >= -1e-6, "branch {i} has negative real loss {l}");
+                loss += l;
+            }
+        }
+        assert!(loss > 1.0, "case14 has ~13 MW of real loss, got {loss}");
+
+        let gen_p: f64 = net
+            .generators
+            .iter()
+            .filter(|g| g.in_service)
+            .map(|g| g.pg)
+            .sum();
+        let load_p: f64 = net.loads.iter().map(|l| l.p).sum();
+        // Real shunt draw at the stored voltages: gs() is MW at V = 1.
+        let shunt_p: f64 = (0..view.n())
+            .map(|i| view.gs()[i] * net.buses[i].vm.powi(2))
+            .sum();
+        assert!(
+            (loss - (gen_p - load_p - shunt_p)).abs() < 0.5,
+            "power balance off: loss {loss} vs gen-load-shunt {}",
+            gen_p - load_p - shunt_p
+        );
+    }
+
+    #[test]
+    fn zero_impedance_branch_zeros_columns_and_is_counted() {
+        // No vendored fixture has r = x = 0, so build one: branch 0 is a zero-
+        // impedance tie, branch 1 is normal. The tie's admittance and flow columns
+        // must be zero (never NaN), and the manifest must count it.
+        let net = Network::in_memory(
+            "zeroimp",
+            100.0,
+            vec![
+                bus(1, BusType::Ref),
+                bus(2, BusType::Pq),
+                bus(3, BusType::Pq),
+            ],
+            vec![branch(1, 2, 0.0, 0.0), branch(2, 3, 0.01, 0.1)],
+        );
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let br = &tables.branch;
+        for col in [
+            "Yff_r", "Yff_i", "Yft_r", "Yft_i", "Ytf_r", "Ytf_i", "Ytt_r", "Ytt_i", "pf", "qf",
+            "pt", "qt",
+        ] {
+            let v = col_f64(br, col).value(0);
+            assert!(
+                v == 0.0,
+                "{col} should be 0 for the zero-impedance branch, got {v}"
+            );
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = write_gridfm_dataset(&net, dir.path(), &GridfmOptions::default()).unwrap();
+        assert_eq!(out.dropped_zero_impedance, 1);
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(out.dir.join("gridfm_meta.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(meta["dropped_zero_impedance"], 1);
+    }
+
+    #[test]
+    fn gridfm_cost_maps_every_arm_to_raw_coefficients() {
+        // Polynomial coeffs are highest-order first: [c2, c1, c0] -> (cp0, cp1, cp2).
+        assert_eq!(
+            gridfm_cost(Some(&gencost(2, 3, vec![2.0, 3.0, 4.0]))),
+            (4.0, 3.0, 2.0)
+        );
+        assert_eq!(
+            gridfm_cost(Some(&gencost(2, 2, vec![3.0, 4.0]))),
+            (4.0, 3.0, 0.0)
+        );
+        assert_eq!(
+            gridfm_cost(Some(&gencost(2, 1, vec![4.0]))),
+            (4.0, 0.0, 0.0)
+        );
+        // Unrepresentable rows collapse to zeros and report as not representable.
+        let piecewise = gencost(1, 2, vec![0.0, 0.0, 1.0, 1.0]);
+        let malformed = gencost(2, 3, vec![1.0]); // fewer coeffs than ncost claims
+        assert_eq!(gridfm_cost(Some(&piecewise)), (0.0, 0.0, 0.0));
+        assert_eq!(gridfm_cost(Some(&malformed)), (0.0, 0.0, 0.0));
+        assert_eq!(gridfm_cost(None), (0.0, 0.0, 0.0));
+        assert!(!cost_representable(Some(&piecewise)));
+        assert!(!cost_representable(Some(&malformed)));
+        assert!(!cost_representable(None));
+        assert!(cost_representable(Some(&gencost(
+            2,
+            3,
+            vec![1.0, 2.0, 3.0]
+        ))));
+    }
+
+    #[test]
+    fn missing_reference_bus_errors() {
+        // gridfm_record_batches' documented precondition: exactly one ref bus.
+        let net = Network::in_memory(
+            "noref",
+            100.0,
+            vec![bus(1, BusType::Pq), bus(2, BusType::Pq)],
+            vec![branch(1, 2, 0.01, 0.1)],
+        );
+        let err = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap_err();
+        assert!(
+            matches!(err, Error::ReferenceBusCount { .. }),
+            "got {err:?}"
+        );
+    }
+
+    fn bus(id: usize, kind: BusType) -> Bus {
+        Bus {
+            id: BusId(id),
+            kind,
+            vm: 1.0,
+            va: 0.0,
+            base_kv: 1.0,
+            vmax: 1.1,
+            vmin: 0.9,
+            area: 1,
+            zone: 1,
+            name: None,
+            extras: Extras::new(),
+        }
+    }
+
+    fn branch(from: usize, to: usize, r: f64, x: f64) -> Branch {
+        Branch {
+            from: BusId(from),
+            to: BusId(to),
+            r,
+            x,
+            b: 0.0,
+            rate_a: 0.0,
+            rate_b: 0.0,
+            rate_c: 0.0,
+            tap: 0.0,
+            shift: 0.0,
+            in_service: true,
+            angmin: -360.0,
+            angmax: 360.0,
+            extras: Extras::new(),
+        }
+    }
+
+    fn gencost(model: u8, ncost: usize, coeffs: Vec<f64>) -> GenCost {
+        GenCost {
+            model,
+            startup: 0.0,
+            shutdown: 0.0,
+            ncost,
+            coeffs,
+        }
     }
 }

--- a/powerio-matrix/src/io/gridfm.rs
+++ b/powerio-matrix/src/io/gridfm.rs
@@ -1,0 +1,746 @@
+//! GridFM interchange: a parsed case as the gridfm-datakit Parquet schema.
+//!
+//! [`gridfm-datakit`](https://github.com/gridfm) writes per-scenario Parquet
+//! tables that [`gridfm-graphkit`](https://github.com/gridfm)'s
+//! `HeteroGridDatasetDisk` trains a GNN on. This module emits the same four
+//! tables — `bus_data`, `gen_data`, `branch_data`, `y_bus_data` — from one
+//! parsed [`Network`], so graphkit can train on powerio output directly and the
+//! scenario-batch path (issue #14) has its on-disk format.
+//!
+//! # The snapshot contract
+//!
+//! powerio has no power flow solver. One parsed case is one snapshot
+//! (`scenario = 0`): voltages and generator dispatch are the case's stored
+//! values, and branch flows `pf/qf/pt/qt` are computed from those voltages and
+//! the branch admittances ([`branch_flows`]). For a solved MATPOWER case the
+//! stored voltages are the converged operating point, so the flows match what a
+//! solver would report to float tolerance; for an unsolved/flat-start case they
+//! are the flows at the stored voltages, not a re-solved dispatch.
+//!
+//! # Units
+//!
+//! - `Pd, Qd, Pg, Qg, p_mw, q_mvar, pf, qf, pt, qt` in MW/MVAr (per-unit ×
+//!   `base_mva`).
+//! - `Vm` per-unit, `Va` degrees; `r, x, b` and the `Y**` admittances per-unit.
+//! - `GS, BS` are the MATPOWER shunt values (MW/MVAr at V = 1) divided by
+//!   `base_mva`, matching datakit's normalization.
+//! - Costs are the raw MATPOWER coefficients: `cp2 = c2`, `cp1 = c1`,
+//!   `cp0 = c0`. Piecewise or missing cost rows emit zeros (graphkit ignores the
+//!   cost columns) and are counted in the manifest.
+//! - `bus`, `from_bus`, `to_bus` are dense `[0, n)` indices; `idx` is the
+//!   0-based generator/branch row.
+
+// Bus/branch indices and Y_bus nnz counts cast to `i64` for the Arrow columns;
+// they are bounded far below `i64::MAX`, so the wrap clippy warns about can't
+// happen.
+#![allow(clippy::cast_possible_wrap)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, Float64Array, Int64Array};
+use arrow::datatypes::{Field, Schema};
+use arrow::record_batch::RecordBatch;
+use num_complex::Complex64;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use serde::Serialize;
+
+use crate::indexed::IndexedNetwork;
+use crate::matrix::{BuildOptions, YbusFlags, branch_admittance, branch_flows, build_ybus};
+use crate::network::{Branch, Bus, BusType};
+use crate::{Error, GenCost, Network, Result};
+
+/// Options for the gridfm export.
+#[derive(Debug, Clone)]
+pub struct GridfmOptions {
+    /// Scenario id stamped into the `scenario` and `load_scenario_idx` columns.
+    /// A parsed case is one snapshot, so the default is `0`.
+    pub scenario: i64,
+    /// Also write `y_bus_data.parquet`. graphkit reconstructs admittances from
+    /// the branch table and ignores it, but datakit emits it, so the default is
+    /// `true` for parity.
+    pub include_y_bus: bool,
+    /// Apply transformer tap ratios to the admittances. Default `true` (the
+    /// physical admittances datakit stores).
+    pub include_taps: bool,
+    /// Apply phase shifts to the admittances. Default `true`.
+    pub include_shifts: bool,
+}
+
+impl Default for GridfmOptions {
+    fn default() -> Self {
+        Self {
+            scenario: 0,
+            include_y_bus: true,
+            include_taps: true,
+            include_shifts: true,
+        }
+    }
+}
+
+impl GridfmOptions {
+    /// The Y_bus build flags these options select (only taps and shifts matter
+    /// for the gridfm admittances; the B'/B'' scheme and zero-impedance policy
+    /// don't apply).
+    fn build_options(&self) -> BuildOptions {
+        BuildOptions {
+            include_taps: self.include_taps,
+            include_shifts: self.include_shifts,
+            ..Default::default()
+        }
+    }
+}
+
+/// The gridfm-datakit tables as Arrow record batches. Both the Parquet writer
+/// and (later) the Arrow C Data Interface export build from these.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct GridfmTables {
+    pub bus: RecordBatch,
+    pub generator: RecordBatch,
+    pub branch: RecordBatch,
+    pub y_bus: RecordBatch,
+}
+
+/// What [`write_gridfm_dataset`] wrote.
+#[derive(Debug, Clone)]
+pub struct GridfmOutputs {
+    pub dir: PathBuf,
+    pub files: Vec<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct GridfmMeta {
+    case_name: String,
+    base_mva: f64,
+    scenario: i64,
+    schema: &'static str,
+    n_buses: usize,
+    n_branches: usize,
+    n_branches_in_service: usize,
+    n_gens: usize,
+    reference_bus: usize,
+    /// Branches with `r² + x² = 0`: their admittance/flow columns are zeroed.
+    dropped_zero_impedance: usize,
+    /// Generators whose cost row gridfm can't represent (piecewise or missing):
+    /// their `cp*` columns are zeroed.
+    degenerate_cost_gens: usize,
+    files: Vec<String>,
+    powerio_version: String,
+}
+
+/// Build the four gridfm tables for one network. Pure (no I/O).
+///
+/// # Errors
+/// [`Error::ReferenceBusCount`] unless the case has exactly one reference bus
+/// (graphkit needs a slack), and [`Error::NonFiniteSusceptance`] for a branch
+/// with NaN/Inf impedance.
+pub fn gridfm_record_batches(net: &Network, opts: &GridfmOptions) -> Result<GridfmTables> {
+    let view = IndexedNetwork::new(net);
+    let ref_bus = view.reference_bus_index()?;
+    tables_from_view(&view, ref_bus, opts)
+}
+
+/// The four tables from an already-built view and resolved reference bus, so the
+/// writer doesn't re-index the network just to fill the manifest.
+fn tables_from_view(
+    view: &IndexedNetwork,
+    ref_bus: usize,
+    opts: &GridfmOptions,
+) -> Result<GridfmTables> {
+    Ok(GridfmTables {
+        bus: bus_batch(view, opts.scenario)?,
+        generator: gen_batch(view, opts.scenario, ref_bus)?,
+        branch: branch_batch(view, opts)?,
+        y_bus: y_bus_batch(view, opts)?,
+    })
+}
+
+/// Write the gridfm-datakit Parquet dataset for one case under
+/// `out_dir/<network_name>/raw/`, matching datakit's directory layout. Writes
+/// `bus_data.parquet`, `gen_data.parquet`, `branch_data.parquet`, optionally
+/// `y_bus_data.parquet`, and a `gridfm_meta.json` manifest.
+///
+/// # Errors
+/// Propagates [`gridfm_record_batches`] and any filesystem/Parquet error.
+pub fn write_gridfm_dataset(
+    net: &Network,
+    out_dir: impl AsRef<Path>,
+    opts: &GridfmOptions,
+) -> Result<GridfmOutputs> {
+    let view = IndexedNetwork::new(net);
+    let ref_bus = view.reference_bus_index()?;
+    let tables = tables_from_view(&view, ref_bus, opts)?;
+
+    let dir = out_dir.as_ref().join(&net.name).join("raw");
+    std::fs::create_dir_all(&dir)?;
+
+    let mut files = Vec::new();
+    put_parquet(&dir, "bus_data.parquet", &tables.bus, &mut files)?;
+    put_parquet(&dir, "gen_data.parquet", &tables.generator, &mut files)?;
+    put_parquet(&dir, "branch_data.parquet", &tables.branch, &mut files)?;
+    if opts.include_y_bus {
+        put_parquet(&dir, "y_bus_data.parquet", &tables.y_bus, &mut files)?;
+    }
+
+    let meta = GridfmMeta {
+        case_name: net.name.clone(),
+        base_mva: net.base_mva,
+        scenario: opts.scenario,
+        schema: "gridfm-datakit",
+        n_buses: net.buses.len(),
+        n_branches: net.branches.len(),
+        n_branches_in_service: net.branches.iter().filter(|b| b.in_service).count(),
+        n_gens: net.generators.len(),
+        reference_bus: ref_bus,
+        dropped_zero_impedance: net
+            .branches
+            .iter()
+            .filter(|br| br.r * br.r + br.x * br.x == 0.0)
+            .count(),
+        degenerate_cost_gens: net
+            .generators
+            .iter()
+            .filter(|g| !cost_representable(g.cost.as_ref()))
+            .count(),
+        files: files
+            .iter()
+            .filter_map(|p| p.file_name().and_then(|s| s.to_str()).map(str::to_string))
+            .collect(),
+        powerio_version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let meta_path = dir.join("gridfm_meta.json");
+    let json = serde_json::to_string_pretty(&meta).map_err(|e| Error::Parquet(e.to_string()))?;
+    std::fs::write(&meta_path, json)?;
+    files.push(meta_path);
+
+    Ok(GridfmOutputs { dir, files })
+}
+
+// --- table builders --------------------------------------------------------
+
+fn bus_batch(view: &IndexedNetwork, scenario: i64) -> Result<RecordBatch> {
+    let n = view.n();
+    let base = view.base_mva();
+    let buses = &view.network().buses;
+
+    // Per-bus generation, summed over in-service generators (dense order).
+    let mut pg = vec![0.0; n];
+    let mut qg = vec![0.0; n];
+    for (_, g) in view.in_service_gens() {
+        if let Some(i) = view.bus_index(g.bus) {
+            pg[i] += g.pg;
+            qg[i] += g.qg;
+        }
+    }
+
+    let bus = i64_range(n);
+    batch(vec![
+        ("scenario", const_i64(scenario, n)),
+        ("load_scenario_idx", const_i64(scenario, n)),
+        ("bus", bus),
+        ("Pd", f64s(view.pd().to_vec())),
+        ("Qd", f64s(view.qd().to_vec())),
+        ("Pg", f64s(pg)),
+        ("Qg", f64s(qg)),
+        ("Vm", f64s(buses.iter().map(|b| b.vm).collect())),
+        ("Va", f64s(buses.iter().map(|b| b.va).collect())),
+        ("PQ", one_hot(buses, BusType::Pq)),
+        ("PV", one_hot(buses, BusType::Pv)),
+        ("REF", one_hot(buses, BusType::Ref)),
+        ("vn_kv", f64s(buses.iter().map(|b| b.base_kv).collect())),
+        ("min_vm_pu", f64s(buses.iter().map(|b| b.vmin).collect())),
+        ("max_vm_pu", f64s(buses.iter().map(|b| b.vmax).collect())),
+        ("GS", f64s(view.gs().iter().map(|g| g / base).collect())),
+        ("BS", f64s(view.bs().iter().map(|b| b / base).collect())),
+    ])
+}
+
+fn gen_batch(view: &IndexedNetwork, scenario: i64, ref_bus: usize) -> Result<RecordBatch> {
+    let gens = view.generators();
+    let m = gens.len();
+
+    let mut bus = Vec::with_capacity(m);
+    let mut is_slack = Vec::with_capacity(m);
+    let (mut cp0, mut cp1, mut cp2) = (
+        Vec::with_capacity(m),
+        Vec::with_capacity(m),
+        Vec::with_capacity(m),
+    );
+    for (row, g) in gens.iter().enumerate() {
+        let i = view.bus_index(g.bus).ok_or(Error::UnknownBus {
+            bus_id: g.bus,
+            element_index: row,
+        })?;
+        bus.push(i as i64);
+        is_slack.push(i64::from(i == ref_bus));
+        let (c0, c1, c2) = gridfm_cost(g.cost.as_ref());
+        cp0.push(c0);
+        cp1.push(c1);
+        cp2.push(c2);
+    }
+
+    batch(vec![
+        ("scenario", const_i64(scenario, m)),
+        ("load_scenario_idx", const_i64(scenario, m)),
+        ("idx", i64_range(m)),
+        ("bus", i64s(bus)),
+        ("p_mw", f64s(gens.iter().map(|g| g.pg).collect())),
+        ("q_mvar", f64s(gens.iter().map(|g| g.qg).collect())),
+        ("min_p_mw", f64s(gens.iter().map(|g| g.pmin).collect())),
+        ("max_p_mw", f64s(gens.iter().map(|g| g.pmax).collect())),
+        ("min_q_mvar", f64s(gens.iter().map(|g| g.qmin).collect())),
+        ("max_q_mvar", f64s(gens.iter().map(|g| g.qmax).collect())),
+        ("cp0_eur", f64s(cp0)),
+        ("cp1_eur_per_mw", f64s(cp1)),
+        ("cp2_eur_per_mw2", f64s(cp2)),
+        (
+            "in_service",
+            i64s(gens.iter().map(|g| i64::from(g.in_service)).collect()),
+        ),
+        ("is_slack_gen", i64s(is_slack)),
+    ])
+}
+
+#[allow(clippy::too_many_lines, clippy::many_single_char_names)]
+fn branch_batch(view: &IndexedNetwork, opts: &GridfmOptions) -> Result<RecordBatch> {
+    let base = view.base_mva();
+    let branches = view.branches();
+    let m = branches.len();
+    let buses = &view.network().buses;
+
+    // Same flags the Y_bus builder derives, so the branch admittance columns and
+    // y_bus_data come from one kernel.
+    let flags = YbusFlags {
+        unity_taps: !opts.include_taps,
+        zero_shifts: !opts.include_shifts,
+        ..Default::default()
+    };
+    // Complex bus voltages `vm·e^{jθ}`, dense order, for the flow evaluation.
+    let v: Vec<Complex64> = buses
+        .iter()
+        .map(|b| Complex64::from_polar(b.vm, b.va.to_radians()))
+        .collect();
+
+    let mut from_bus = Vec::with_capacity(m);
+    let mut to_bus = Vec::with_capacity(m);
+    let (mut pf, mut qf, mut pt, mut qt) = (
+        Vec::with_capacity(m),
+        Vec::with_capacity(m),
+        Vec::with_capacity(m),
+        Vec::with_capacity(m),
+    );
+    let (mut yff_r, mut yff_i) = (Vec::with_capacity(m), Vec::with_capacity(m));
+    let (mut yft_r, mut yft_i) = (Vec::with_capacity(m), Vec::with_capacity(m));
+    let (mut ytf_r, mut ytf_i) = (Vec::with_capacity(m), Vec::with_capacity(m));
+    let (mut ytt_r, mut ytt_i) = (Vec::with_capacity(m), Vec::with_capacity(m));
+
+    for (row, br) in branches.iter().enumerate() {
+        let i = view.bus_index(br.from).ok_or(Error::UnknownBus {
+            bus_id: br.from,
+            element_index: row,
+        })?;
+        let j = view.bus_index(br.to).ok_or(Error::UnknownBus {
+            bus_id: br.to,
+            element_index: row,
+        })?;
+        from_bus.push(i as i64);
+        to_bus.push(j as i64);
+
+        // Zero-impedance branch → `None` → zeroed admittance/flow columns (never NaN).
+        let block = branch_admittance(br, flags, row)?;
+        let [y_ff, y_ft, y_tf, y_tt] = block.unwrap_or([Complex64::new(0.0, 0.0); 4]);
+        yff_r.push(y_ff.re);
+        yff_i.push(y_ff.im);
+        yft_r.push(y_ft.re);
+        yft_i.push(y_ft.im);
+        ytf_r.push(y_tf.re);
+        ytf_i.push(y_tf.im);
+        ytt_r.push(y_tt.re);
+        ytt_i.push(y_tt.im);
+
+        let (sf, st) = if br.in_service && block.is_some() {
+            branch_flows(&[y_ff, y_ft, y_tf, y_tt], v[i], v[j])
+        } else {
+            (Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0))
+        };
+        pf.push(sf.re * base);
+        qf.push(sf.im * base);
+        pt.push(st.re * base);
+        qt.push(st.im * base);
+    }
+
+    batch(vec![
+        ("scenario", const_i64(opts.scenario, m)),
+        ("load_scenario_idx", const_i64(opts.scenario, m)),
+        ("idx", i64_range(m)),
+        ("from_bus", i64s(from_bus)),
+        ("to_bus", i64s(to_bus)),
+        ("pf", f64s(pf)),
+        ("qf", f64s(qf)),
+        ("pt", f64s(pt)),
+        ("qt", f64s(qt)),
+        ("r", f64s(branches.iter().map(|b| b.r).collect())),
+        ("x", f64s(branches.iter().map(|b| b.x).collect())),
+        ("b", f64s(branches.iter().map(|b| b.b).collect())),
+        ("Yff_r", f64s(yff_r)),
+        ("Yff_i", f64s(yff_i)),
+        ("Yft_r", f64s(yft_r)),
+        ("Yft_i", f64s(yft_i)),
+        ("Ytf_r", f64s(ytf_r)),
+        ("Ytf_i", f64s(ytf_i)),
+        ("Ytt_r", f64s(ytt_r)),
+        ("Ytt_i", f64s(ytt_i)),
+        (
+            "tap",
+            f64s(branches.iter().map(Branch::effective_tap).collect()),
+        ),
+        ("shift", f64s(branches.iter().map(|b| b.shift).collect())),
+        ("ang_min", f64s(branches.iter().map(|b| b.angmin).collect())),
+        ("ang_max", f64s(branches.iter().map(|b| b.angmax).collect())),
+        ("rate_a", f64s(branches.iter().map(|b| b.rate_a).collect())),
+        (
+            "br_status",
+            i64s(branches.iter().map(|b| i64::from(b.in_service)).collect()),
+        ),
+    ])
+}
+
+fn y_bus_batch(view: &IndexedNetwork, opts: &GridfmOptions) -> Result<RecordBatch> {
+    let parts = build_ybus(view, &opts.build_options())?;
+    // G and B don't share a sparsity pattern: a lossless branch (r = 0) is a pure
+    // reactance, so its G entries are structurally zero where B's aren't. datakit
+    // keys y_bus rows on the complex value being nonzero, i.e. the union of the G
+    // and B positions. Merge into a sorted (row, col) map so the output is
+    // row-major like `np.nonzero`, then drop any all-zero position.
+    let mut entries: std::collections::BTreeMap<(usize, usize), (f64, f64)> =
+        std::collections::BTreeMap::new();
+    for (row, g_row) in parts.g.outer_iterator().enumerate() {
+        for (col, &gv) in g_row.iter() {
+            entries.entry((row, col)).or_default().0 = gv;
+        }
+    }
+    for (row, b_row) in parts.b.outer_iterator().enumerate() {
+        for (col, &bv) in b_row.iter() {
+            entries.entry((row, col)).or_default().1 = bv;
+        }
+    }
+
+    let mut index1 = Vec::with_capacity(entries.len());
+    let mut index2 = Vec::with_capacity(entries.len());
+    let mut g_vals = Vec::with_capacity(entries.len());
+    let mut b_vals = Vec::with_capacity(entries.len());
+    for ((row, col), (gv, bv)) in entries {
+        if gv == 0.0 && bv == 0.0 {
+            continue;
+        }
+        index1.push(row as i64);
+        index2.push(col as i64);
+        g_vals.push(gv);
+        b_vals.push(bv);
+    }
+    let len = index1.len();
+    batch(vec![
+        ("scenario", const_i64(opts.scenario, len)),
+        ("load_scenario_idx", const_i64(opts.scenario, len)),
+        ("index1", i64s(index1)),
+        ("index2", i64s(index2)),
+        ("G", f64s(g_vals)),
+        ("B", f64s(b_vals)),
+    ])
+}
+
+// --- small helpers ---------------------------------------------------------
+
+/// `(cp0, cp1, cp2)` = raw MATPOWER `(c0, c1, c2)` from a polynomial cost row.
+/// Coefficients are highest-order first, so `ncost == 3` is `[c2, c1, c0]`.
+/// Piecewise, missing, or malformed rows give zeros.
+fn gridfm_cost(cost: Option<&GenCost>) -> (f64, f64, f64) {
+    match cost {
+        Some(c) if c.model == 2 && c.coeffs.len() >= c.ncost => match c.ncost {
+            3 => (c.coeffs[2], c.coeffs[1], c.coeffs[0]),
+            2 => (c.coeffs[1], c.coeffs[0], 0.0),
+            1 => (c.coeffs[0], 0.0, 0.0),
+            _ => (0.0, 0.0, 0.0),
+        },
+        _ => (0.0, 0.0, 0.0),
+    }
+}
+
+/// Whether [`gridfm_cost`] can represent this cost row (used for the manifest's
+/// degenerate-cost count).
+fn cost_representable(cost: Option<&GenCost>) -> bool {
+    matches!(cost, Some(c) if c.model == 2 && c.coeffs.len() >= c.ncost && (1..=3).contains(&c.ncost))
+}
+
+fn put_parquet(
+    dir: &Path,
+    name: &str,
+    batch: &RecordBatch,
+    files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let path = dir.join(name);
+    let file = std::fs::File::create(&path)?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut writer = ArrowWriter::try_new(file, batch.schema(), Some(props))
+        .map_err(|e| Error::Parquet(e.to_string()))?;
+    writer
+        .write(batch)
+        .map_err(|e| Error::Parquet(e.to_string()))?;
+    writer.close().map_err(|e| Error::Parquet(e.to_string()))?;
+    files.push(path);
+    Ok(())
+}
+
+/// Assemble a [`RecordBatch`] from named columns, in order; field types are read
+/// off the arrays and all columns are non-null.
+fn batch(columns: Vec<(&str, ArrayRef)>) -> Result<RecordBatch> {
+    let fields: Vec<Field> = columns
+        .iter()
+        .map(|(name, arr)| Field::new(*name, arr.data_type().clone(), false))
+        .collect();
+    let arrays: Vec<ArrayRef> = columns.into_iter().map(|(_, arr)| arr).collect();
+    RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
+        .map_err(|e| Error::Parquet(e.to_string()))
+}
+
+fn const_i64(value: i64, len: usize) -> ArrayRef {
+    Arc::new(Int64Array::from(vec![value; len]))
+}
+
+fn i64_range(len: usize) -> ArrayRef {
+    Arc::new(Int64Array::from((0..len as i64).collect::<Vec<_>>()))
+}
+
+fn i64s(v: Vec<i64>) -> ArrayRef {
+    Arc::new(Int64Array::from(v))
+}
+
+fn f64s(v: Vec<f64>) -> ArrayRef {
+    Arc::new(Float64Array::from(v))
+}
+
+fn one_hot(buses: &[Bus], kind: BusType) -> ArrayRef {
+    i64s(buses.iter().map(|b| i64::from(b.kind == kind)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int64Array};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    const BUS_COLS: &[&str] = &[
+        "scenario",
+        "load_scenario_idx",
+        "bus",
+        "Pd",
+        "Qd",
+        "Pg",
+        "Qg",
+        "Vm",
+        "Va",
+        "PQ",
+        "PV",
+        "REF",
+        "vn_kv",
+        "min_vm_pu",
+        "max_vm_pu",
+        "GS",
+        "BS",
+    ];
+    const GEN_COLS: &[&str] = &[
+        "scenario",
+        "load_scenario_idx",
+        "idx",
+        "bus",
+        "p_mw",
+        "q_mvar",
+        "min_p_mw",
+        "max_p_mw",
+        "min_q_mvar",
+        "max_q_mvar",
+        "cp0_eur",
+        "cp1_eur_per_mw",
+        "cp2_eur_per_mw2",
+        "in_service",
+        "is_slack_gen",
+    ];
+    const BRANCH_COLS: &[&str] = &[
+        "scenario",
+        "load_scenario_idx",
+        "idx",
+        "from_bus",
+        "to_bus",
+        "pf",
+        "qf",
+        "pt",
+        "qt",
+        "r",
+        "x",
+        "b",
+        "Yff_r",
+        "Yff_i",
+        "Yft_r",
+        "Yft_i",
+        "Ytf_r",
+        "Ytf_i",
+        "Ytt_r",
+        "Ytt_i",
+        "tap",
+        "shift",
+        "ang_min",
+        "ang_max",
+        "rate_a",
+        "br_status",
+    ];
+    const YBUS_COLS: &[&str] = &[
+        "scenario",
+        "load_scenario_idx",
+        "index1",
+        "index2",
+        "G",
+        "B",
+    ];
+
+    fn case14() -> Network {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/case14.m");
+        crate::parse_matpower_file(path).unwrap()
+    }
+
+    fn names(b: &RecordBatch) -> Vec<String> {
+        b.schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect()
+    }
+
+    fn col_i64<'a>(b: &'a RecordBatch, name: &str) -> &'a Int64Array {
+        b.column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref()
+            .unwrap()
+    }
+
+    fn col_f64<'a>(b: &'a RecordBatch, name: &str) -> &'a Float64Array {
+        b.column_by_name(name)
+            .unwrap()
+            .as_any()
+            .downcast_ref()
+            .unwrap()
+    }
+
+    fn read(path: &Path) -> RecordBatch {
+        let file = std::fs::File::open(path).unwrap();
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        // case14 fits in one row group / batch.
+        reader.next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn schema_and_row_counts_match_case14() {
+        let net = case14();
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+
+        assert_eq!(names(&tables.bus), BUS_COLS);
+        assert_eq!(names(&tables.generator), GEN_COLS);
+        assert_eq!(names(&tables.branch), BRANCH_COLS);
+        assert_eq!(names(&tables.y_bus), YBUS_COLS);
+
+        assert_eq!(tables.bus.num_rows(), net.buses.len()); // 14
+        assert_eq!(tables.generator.num_rows(), net.generators.len()); // 5
+        assert_eq!(tables.branch.num_rows(), net.branches.len()); // 20
+    }
+
+    #[test]
+    fn parquet_round_trips_through_reader() {
+        let net = case14();
+        let dir = tempfile::tempdir().unwrap();
+        let out = write_gridfm_dataset(&net, dir.path(), &GridfmOptions::default()).unwrap();
+
+        let raw = dir.path().join("case14").join("raw");
+        assert_eq!(out.dir, raw);
+        for f in ["bus_data", "gen_data", "branch_data", "y_bus_data"] {
+            assert!(raw.join(format!("{f}.parquet")).is_file(), "missing {f}");
+        }
+        assert!(raw.join("gridfm_meta.json").is_file());
+
+        let bus = read(&raw.join("bus_data.parquet"));
+        assert_eq!(names(&bus), BUS_COLS);
+        assert_eq!(bus.num_rows(), net.buses.len());
+        assert_eq!(names(&read(&raw.join("gen_data.parquet"))), GEN_COLS);
+        assert_eq!(names(&read(&raw.join("branch_data.parquet"))), BRANCH_COLS);
+        assert_eq!(names(&read(&raw.join("y_bus_data.parquet"))), YBUS_COLS);
+    }
+
+    #[test]
+    fn bus_table_values_are_consistent() {
+        let net = case14();
+        let view = IndexedNetwork::new(&net);
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let bus = &tables.bus;
+
+        // Exactly one reference bus; PQ/PV/REF partition every bus.
+        let (pq, pv, r) = (col_i64(bus, "PQ"), col_i64(bus, "PV"), col_i64(bus, "REF"));
+        assert_eq!(r.values().iter().sum::<i64>(), 1);
+        for i in 0..bus.num_rows() {
+            assert_eq!(pq.value(i) + pv.value(i) + r.value(i), 1);
+        }
+
+        // GS/BS are the per-bus shunt aggregate divided by base_mva.
+        let base = net.base_mva;
+        let gs = col_f64(bus, "GS");
+        for i in 0..bus.num_rows() {
+            assert!((gs.value(i) - view.gs()[i] / base).abs() < 1e-12);
+        }
+
+        // `bus` column is the dense 0..n range.
+        let bus_idx = col_i64(bus, "bus");
+        for i in 0..bus.num_rows() {
+            assert_eq!(bus_idx.value(i), i as i64);
+        }
+    }
+
+    #[test]
+    fn branch_admittance_columns_match_build_ybus() {
+        // The branch table's Y** columns are the same kernel build_ybus scatters,
+        // so a known in-service branch's block must equal branch_admittance.
+        let net = case14();
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let br = &tables.branch;
+
+        let yff_r = col_f64(br, "Yff_r");
+        let yff_i = col_f64(br, "Yff_i");
+        for (row, branch) in net.branches.iter().enumerate() {
+            if let Some(block) = branch_admittance(branch, YbusFlags::default(), row).unwrap() {
+                assert!((yff_r.value(row) - block[0].re).abs() < 1e-12);
+                assert!((yff_i.value(row) - block[0].im).abs() < 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn is_slack_gen_marks_the_reference_bus() {
+        let net = case14();
+        let view = IndexedNetwork::new(&net);
+        let ref_bus = view.reference_bus_index().unwrap();
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let g = &tables.generator;
+
+        let bus = col_i64(g, "bus");
+        let slack = col_i64(g, "is_slack_gen");
+        for i in 0..g.num_rows() {
+            assert_eq!(slack.value(i) == 1, bus.value(i) as usize == ref_bus);
+        }
+        assert!(slack.values().contains(&1), "no slack generator");
+    }
+}

--- a/powerio-matrix/src/io/gridfm.rs
+++ b/powerio-matrix/src/io/gridfm.rs
@@ -100,7 +100,7 @@ impl GridfmOptions {
 
 /// The gridfm-datakit tables as Arrow record batches. The Parquet writer builds
 /// from these; a deferred gridfm-schema Arrow C Data Interface export (issue #38)
-/// would reuse them. (The raw-network Arrow export that ships in powerio-capi is
+/// would reuse them. (The raw network Arrow export that ships in powerio-capi is
 /// a different, lighter schema.)
 #[derive(Debug, Clone)]
 #[non_exhaustive]
@@ -553,7 +553,7 @@ fn one_hot(buses: &[Bus], kind: BusType) -> ArrayRef {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::network::{BusId, Extras};
+    use crate::network::{BusId, Extras, Generator};
     use arrow::array::{Float64Array, Int64Array};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
@@ -939,5 +939,95 @@ mod tests {
             ncost,
             coeffs,
         }
+    }
+
+    fn gen_at(bus: usize, cost: GenCost) -> Generator {
+        Generator {
+            bus: BusId(bus),
+            pg: 0.0,
+            qg: 0.0,
+            pmax: 100.0,
+            pmin: 0.0,
+            qmax: 50.0,
+            qmin: -50.0,
+            vg: 1.0,
+            mbase: 100.0,
+            in_service: true,
+            cost: Some(cost),
+            caps: [None; 11],
+        }
+    }
+
+    #[test]
+    fn degenerate_cost_gen_zeros_columns_and_is_counted() {
+        // Counterpart to the zero-impedance test: a piecewise (model 1) cost row
+        // gets zeroed cp* columns and is counted; a polynomial row is kept.
+        let mut net = Network::in_memory(
+            "degen",
+            100.0,
+            vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+            vec![branch(1, 2, 0.01, 0.1)],
+        );
+        net.generators
+            .push(gen_at(1, gencost(1, 2, vec![0.0, 0.0, 1.0, 1.0]))); // piecewise
+        net.generators
+            .push(gen_at(2, gencost(2, 3, vec![0.01, 5.0, 0.0]))); // polynomial
+
+        let tables = gridfm_record_batches(&net, &GridfmOptions::default()).unwrap();
+        let g = &tables.generator;
+        let (cp0, cp1, cp2) = (
+            col_f64(g, "cp0_eur"),
+            col_f64(g, "cp1_eur_per_mw"),
+            col_f64(g, "cp2_eur_per_mw2"),
+        );
+        assert_eq!((cp0.value(0), cp1.value(0), cp2.value(0)), (0.0, 0.0, 0.0));
+        assert_eq!((cp0.value(1), cp1.value(1), cp2.value(1)), (0.0, 5.0, 0.01));
+
+        let dir = tempfile::tempdir().unwrap();
+        let out = write_gridfm_dataset(&net, dir.path(), &GridfmOptions::default()).unwrap();
+        assert_eq!(out.degenerate_cost_gens, 1);
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(out.dir.join("gridfm_meta.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(meta["degenerate_cost_gens"], 1);
+    }
+
+    #[test]
+    fn scenario_id_and_tap_toggle_take_effect() {
+        let net = case14();
+
+        // The scenario id reaches both id columns.
+        let opts = GridfmOptions {
+            scenario: 7,
+            ..Default::default()
+        };
+        let bus = gridfm_record_batches(&net, &opts).unwrap().bus;
+        assert_eq!(col_i64(&bus, "scenario").value(0), 7);
+        assert_eq!(col_i64(&bus, "load_scenario_idx").value(0), 7);
+
+        // Turning taps off changes a transformer's admittance columns.
+        let on = gridfm_record_batches(&net, &GridfmOptions::default())
+            .unwrap()
+            .branch;
+        let off = gridfm_record_batches(
+            &net,
+            &GridfmOptions {
+                include_taps: false,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .branch;
+        let tap = col_f64(&on, "tap");
+        let xfmr = (0..on.num_rows())
+            .find(|&i| (tap.value(i) - 1.0).abs() > 1e-9)
+            .expect("case14 has off-nominal transformers");
+        // case14 transformers are lossless (r = 0), so compare the susceptance
+        // (imaginary) part, which scales with 1/tap².
+        assert!(
+            (col_f64(&on, "Yff_i").value(xfmr) - col_f64(&off, "Yff_i").value(xfmr)).abs() > 1e-9,
+            "taps off should change the transformer's Yff"
+        );
     }
 }

--- a/powerio-matrix/src/io/mod.rs
+++ b/powerio-matrix/src/io/mod.rs
@@ -1,7 +1,14 @@
-//! File I/O: Matrix Market (`.mtx`) and JSON metadata.
+//! File I/O: Matrix Market (`.mtx`) and JSON metadata, plus the gridfm-datakit
+//! Parquet export (`--features gridfm`).
 
+#[cfg(feature = "gridfm")]
+pub mod gridfm;
 pub mod meta;
 pub mod mtx;
 
+#[cfg(feature = "gridfm")]
+pub use gridfm::{
+    GridfmOptions, GridfmOutputs, GridfmTables, gridfm_record_batches, write_gridfm_dataset,
+};
 pub use meta::{CaseMetadata, MatrixMetadata, write_meta_json};
 pub use mtx::{read_mtx, read_vector_mtx, write_mtx, write_vector_mtx};

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -58,3 +58,6 @@ pub use matrix::{
 };
 pub use opf_pipeline::{DcOpfOptions, DcOpfOutputs, write_dcopf_bundle};
 pub use pipeline::{MatrixKind, Pipeline, PipelineOutputs, RhsKind, build_kind};
+
+#[cfg(feature = "gridfm")]
+pub use io::gridfm::{GridfmOptions, GridfmOutputs, GridfmTables, write_gridfm_dataset};

--- a/powerio-matrix/src/matrix/mod.rs
+++ b/powerio-matrix/src/matrix/mod.rs
@@ -36,6 +36,10 @@ pub use laplacian::{GroundMap, build_weighted_laplacian, ground_at, unit_vector}
 pub use opf::{BusCosts, GenCosts, OpfInstance, Units, build_opf_instance};
 pub use sensitivity::{build_lodf, build_ptdf, build_ptdf_lodf};
 pub use ybus::{YbusParts, build_ybus};
+// Crate-internal: the gridfm columnar export reuses the per-branch admittance and
+// flow kernels so its branch table and Y_bus agree with `build_ybus` by construction.
+#[cfg(feature = "gridfm")]
+pub(crate) use ybus::{YbusFlags, branch_admittance, branch_flows};
 
 use sprs::CsMat;
 

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -70,40 +70,10 @@ pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> 
             element_index: row_idx,
         })?;
 
-        let r = if flags.zero_resistance { 0.0 } else { br.r };
-        let x = br.x;
-        let denom = r * r + x * x;
-        if denom == 0.0 {
+        let Some([y_ii, y_ij, y_ji, y_jj]) = branch_admittance(br, flags, row_idx)? else {
+            // Zero-impedance branch (r² + x² = 0): no admittance to scatter.
             continue;
-        }
-        // NaN/Inf r or x makes `denom` non-finite (and slips past `== 0.0`),
-        // which would write NaN into Y_bus and silently break the downstream
-        // M-matrix/SDDM checks. Reject it the same way `incidence` does.
-        if !denom.is_finite() {
-            return Err(Error::NonFiniteSusceptance { row: row_idx });
-        }
-        let y_series = Complex64::new(r / denom, -x / denom);
-
-        let b_charging = if flags.zero_charging { 0.0 } else { br.b };
-        let y_shunt_half = Complex64::new(0.0, b_charging / 2.0);
-
-        let tap_mag = if flags.unity_taps {
-            1.0
-        } else {
-            br.effective_tap()
         };
-        let shift_rad = if flags.zero_shifts {
-            0.0
-        } else {
-            br.shift.to_radians()
-        };
-        let a = Complex64::from_polar(tap_mag, shift_rad);
-        let a_norm_sqr = tap_mag * tap_mag;
-
-        let y_ii = (y_series + y_shunt_half) / a_norm_sqr;
-        let y_jj = y_series + y_shunt_half;
-        let y_ij = -y_series / a.conj();
-        let y_ji = -y_series / a;
 
         if i == j {
             // Self-loop branch: combine all four contributions onto bus i.
@@ -135,4 +105,82 @@ pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> 
         g: g_coo.finish_csr(),
         b: b_coo.finish_csr(),
     })
+}
+
+/// The four entries of a branch's 2×2 nodal admittance block, in per-unit:
+/// `[Yff, Yft, Ytf, Ytt]` (= `[y_ii, y_ij, y_ji, y_jj]` in `makeYbus` notation).
+/// A pure function of the branch — no bus indexing, no shunt fold — so the Y_bus
+/// assembly and the gridfm branch table compute the same numbers from one place.
+/// `flags` lets the Y_bus builder zero taps/shifts/charging; pass
+/// [`YbusFlags::default`] for the physical admittances (taps and shifts on).
+///
+/// Returns `Ok(None)` for a zero-impedance branch (`r² + x² = 0`), which the
+/// callers skip (Y_bus) or zero out (gridfm). `row` only labels the error.
+///
+/// # Errors
+/// [`Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad value can't
+/// slip a NaN into Y_bus or a Parquet column.
+#[allow(clippy::many_single_char_names)]
+pub(crate) fn branch_admittance(
+    br: &crate::network::Branch,
+    flags: YbusFlags,
+    row: usize,
+) -> Result<Option<[Complex64; 4]>> {
+    let r = if flags.zero_resistance { 0.0 } else { br.r };
+    let x = br.x;
+    let denom = r * r + x * x;
+    if denom == 0.0 {
+        return Ok(None);
+    }
+    // NaN/Inf r or x makes `denom` non-finite (and slips past `== 0.0`), which
+    // would write NaN into Y_bus and silently break the downstream M-matrix/SDDM
+    // checks. Reject it the same way `incidence` does.
+    if !denom.is_finite() {
+        return Err(Error::NonFiniteSusceptance { row });
+    }
+    let y_series = Complex64::new(r / denom, -x / denom);
+
+    let b_charging = if flags.zero_charging { 0.0 } else { br.b };
+    let y_shunt_half = Complex64::new(0.0, b_charging / 2.0);
+
+    let tap_mag = if flags.unity_taps {
+        1.0
+    } else {
+        br.effective_tap()
+    };
+    let shift_rad = if flags.zero_shifts {
+        0.0
+    } else {
+        br.shift.to_radians()
+    };
+    let a = Complex64::from_polar(tap_mag, shift_rad);
+    let a_norm_sqr = tap_mag * tap_mag;
+
+    let y_ff = (y_series + y_shunt_half) / a_norm_sqr;
+    let y_tt = y_series + y_shunt_half;
+    let y_ft = -y_series / a.conj();
+    let y_tf = -y_series / a;
+    Ok(Some([y_ff, y_ft, y_tf, y_tt]))
+}
+
+/// Complex from/to power injections for one branch at the given bus voltages, in
+/// MVA before the per-unit → MW scaling the caller applies. `vi`/`vj` are complex
+/// bus voltages `vm·e^{jθ}` (θ in radians) and `y = [Yff, Yft, Ytf, Ytt]`:
+///
+/// ```text
+/// S_from = vi · conj(Yff·vi + Yft·vj)
+/// S_to   = vj · conj(Ytf·vi + Ytt·vj)
+/// ```
+///
+/// At a converged operating point these are the line flows; powerio computes them
+/// at the case's stored voltages (the parsed snapshot), not from a fresh solve.
+#[cfg(feature = "gridfm")]
+pub(crate) fn branch_flows(
+    y: &[Complex64; 4],
+    vi: Complex64,
+    vj: Complex64,
+) -> (Complex64, Complex64) {
+    let i_from = y[0] * vi + y[1] * vj;
+    let i_to = y[2] * vi + y[3] * vj;
+    (vi * i_from.conj(), vj * i_to.conj())
 }

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -86,6 +86,9 @@ pub enum Error {
     #[error("matrix-market I/O: {0}")]
     Mtx(String),
 
+    #[error("gridfm Parquet export: {0}")]
+    Parquet(String),
+
     #[error("{format} read error: {message}")]
     FormatRead {
         format: &'static str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ matrix = ["numpy>=1.21", "scipy>=1.7"]
 graph = ["networkx>=2.6"]
 all = ["numpy>=1.21", "scipy>=1.7", "networkx>=2.6"]
 bench = ["matpowercaseframes", "pandapower"]
+# Reading the gridfm Parquet export (`powerio gridfm`) in the test suite.
+gridfm = ["pandas>=2", "pyarrow>=14"]
 
 [project.urls]
 Repository = "https://github.com/eigenergy/powerio"

--- a/python/tests/test_gridfm.py
+++ b/python/tests/test_gridfm.py
@@ -1,0 +1,139 @@
+"""Tests for the gridfm Parquet export (`powerio gridfm`).
+
+These drive the `powerio` CLI binary and read its Parquet with pandas/pyarrow,
+so they need the `gridfm` extra (`pip install '.[gridfm]'`) and a built binary.
+Both are optional: the module skips cleanly when either is missing.
+
+The binary is found via `$POWERIO_BIN`, else `target/{release,debug}/powerio`
+under the repo root. Build it with `cargo build -p powerio-cli` (the CLI always
+compiles the `gridfm` feature).
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "tests" / "data"
+
+# The on-disk schema, byte-for-byte from gridfm-datakit's column_names.py. Same
+# lists the Rust round-trip test asserts.
+BUS_COLS = [
+    "scenario", "load_scenario_idx", "bus", "Pd", "Qd", "Pg", "Qg", "Vm", "Va",
+    "PQ", "PV", "REF", "vn_kv", "min_vm_pu", "max_vm_pu", "GS", "BS",
+]
+GEN_COLS = [
+    "scenario", "load_scenario_idx", "idx", "bus", "p_mw", "q_mvar", "min_p_mw",
+    "max_p_mw", "min_q_mvar", "max_q_mvar", "cp0_eur", "cp1_eur_per_mw",
+    "cp2_eur_per_mw2", "in_service", "is_slack_gen",
+]
+BRANCH_COLS = [
+    "scenario", "load_scenario_idx", "idx", "from_bus", "to_bus", "pf", "qf",
+    "pt", "qt", "r", "x", "b", "Yff_r", "Yff_i", "Yft_r", "Yft_i", "Ytf_r",
+    "Ytf_i", "Ytt_r", "Ytt_i", "tap", "shift", "ang_min", "ang_max", "rate_a",
+    "br_status",
+]
+YBUS_COLS = ["scenario", "load_scenario_idx", "index1", "index2", "G", "B"]
+
+
+def powerio_bin():
+    env = os.environ.get("POWERIO_BIN")
+    candidates = [Path(env)] if env else []
+    candidates += [ROOT / "target" / p / "powerio" for p in ("release", "debug")]
+    for c in candidates:
+        if c.is_file():
+            return c
+    pytest.skip("powerio binary not found; run `cargo build -p powerio-cli`")
+
+
+@pytest.fixture(scope="module")
+def case14_raw(tmp_path_factory):
+    out = tmp_path_factory.mktemp("gridfm")
+    subprocess.run(
+        [str(powerio_bin()), "gridfm", str(DATA / "case14.m"), "-o", str(out)],
+        check=True,
+    )
+    return out / "case14" / "raw"
+
+
+def test_writes_the_four_tables_and_manifest(case14_raw):
+    for name in ("bus_data", "gen_data", "branch_data", "y_bus_data"):
+        assert (case14_raw / f"{name}.parquet").is_file()
+    assert (case14_raw / "gridfm_meta.json").is_file()
+
+
+def test_schema_matches_datakit(case14_raw):
+    cases = {
+        "bus_data": (BUS_COLS, 14),
+        "gen_data": (GEN_COLS, 5),
+        "branch_data": (BRANCH_COLS, 20),
+        "y_bus_data": (YBUS_COLS, None),
+    }
+    for name, (cols, rows) in cases.items():
+        df = pd.read_parquet(case14_raw / f"{name}.parquet")
+        assert list(df.columns) == cols, name
+        if rows is not None:
+            assert len(df) == rows, name
+
+
+def test_basic_invariants(case14_raw):
+    bus = pd.read_parquet(case14_raw / "bus_data.parquet")
+    # PQ/PV/REF one-hot partitions every bus; exactly one reference.
+    assert ((bus[["PQ", "PV", "REF"]].sum(axis=1)) == 1).all()
+    assert int(bus["REF"].sum()) == 1
+    # Dense, contiguous bus index.
+    assert bus["bus"].tolist() == list(range(14))
+
+    gen = pd.read_parquet(case14_raw / "gen_data.parquet")
+    assert gen["is_slack_gen"].sum() >= 1
+
+
+def test_satisfies_graphkit_feature_contract(case14_raw):
+    """The columns gridfm-graphkit's HeteroGridDatasetDisk reads, and the
+    gen->bus reactive-limit aggregation it does, must work on our output.
+
+    Replicates graphkit's column selection (powergrid_hetero_dataset.py) without
+    importing torch, so it proves the contract without the training stack.
+    """
+    bus = pd.read_parquet(case14_raw / "bus_data.parquet")
+    gen = pd.read_parquet(case14_raw / "gen_data.parquet")
+    branch = pd.read_parquet(case14_raw / "branch_data.parquet")
+
+    # Columns graphkit reads straight off bus_data (it derives min/max_q_mvar
+    # itself, below).
+    bus_direct = ["Pd", "Qd", "Qg", "Vm", "Va", "PQ", "PV", "REF",
+                  "min_vm_pu", "max_vm_pu", "GS", "BS", "vn_kv"]
+    assert set(bus_direct) <= set(bus.columns)
+
+    gen_feats = ["p_mw", "min_p_mw", "max_p_mw", "cp0_eur", "cp1_eur_per_mw",
+                 "cp2_eur_per_mw2", "in_service"]
+    assert set(gen_feats) <= set(gen.columns)
+
+    edge_cols = ["from_bus", "to_bus", "pf", "qf", "pt", "qt",
+                 "Yff_r", "Yff_i", "Yft_r", "Yft_i", "Ytt_r", "Ytt_i",
+                 "Ytf_r", "Ytf_i", "tap", "ang_min", "ang_max", "rate_a",
+                 "br_status"]
+    assert set(edge_cols) <= set(branch.columns)
+
+    # graphkit's bus-level reactive limits: sum gen min/max_q_mvar per (scenario,
+    # bus). Must yield a finite value for every bus that has a generator.
+    agg = gen.groupby(["scenario", "bus"])[["min_q_mvar", "max_q_mvar"]].sum()
+    assert not agg.empty
+    assert agg.to_numpy().sum() != 0 or (gen[["min_q_mvar", "max_q_mvar"]] == 0).all().all()
+
+
+def test_graphkit_loads_dataset(case14_raw):
+    """Optional end-to-end: if gridfm-graphkit (and torch) are installed, build
+    the actual HeteroData graph from our output. Skips otherwise; runs only in an
+    environment that has the full training stack."""
+    pytest.importorskip("torch")
+    mod = pytest.importorskip("gridfm_graphkit.datasets.powergrid_hetero_dataset")
+    # The PyG Dataset roots at the network dir, whose `raw/` holds our parquet.
+    ds = mod.HeteroGridDatasetDisk(root=str(case14_raw.parent))
+    assert len(ds) >= 1
+    assert ds[0]["bus"].x.shape[0] == 14


### PR DESCRIPTION
Two complementary GridFM/interop transports, both over the columnar (Arrow) layout.

## 1. GridFM Parquet export (the on-disk training path)

`powerio gridfm <case> -o <dir>` (and `write_gridfm_dataset`, behind the `gridfm` feature) writes the four gridfm-datakit tables — `bus_data`, `gen_data`, `branch_data`, `y_bus_data` — under `<dir>/<case>/raw/`, matching gridfm-datakit's `column_names.py` byte for byte, so [gridfm-graphkit](https://github.com/gridfm)'s `HeteroGridDatasetDisk` trains on powerio output directly.

A parsed case is **one snapshot** (`scenario 0`): voltages/dispatch are the case's stored values, and branch flows `pf/qf/pt/qt` are computed from those voltages and the branch admittances — powerio has no solver and adds none. Per-scenario expansion is #14. Reuses the Y_bus kernel (`branch_admittance`/`branch_flows` extracted from `ybus.rs`), so the branch admittance columns and `y_bus_data` are what `build_ybus` scatters.

## 2. Zero-copy Arrow network transport (the in-memory path)

`pio_export_arrow(case, table, out_array, out_schema, errbuf, errlen)` (behind a new `arrow` feature on **powerio-capi**) hands the parsed network's element tables — bus/branch/gen/load/shunt, with external bus ids — across the C ABI as Arrow arrays **zero-copy** via `arrow::ffi::to_ffi`. Any Arrow consumer (pyarrow, Arrow.jl, Arrow C++, polars, DuckDB) pulls a whole table in process with no copy and no temp file: the typed, in-memory sibling of `pio_to_json`.

These are the **raw `Network` fields**, not the gridfm schema (no admittances/flows — that needs the matrix layer; the gridfm-schema in-memory Arrow stays scoped to #38). powerio-capi stays light: `powerio` + optional `arrow` (only the `ffi` feature). The export moves the FFI structs into caller memory (`ptr::write`); the caller owns them and releases each via its `release` callback.

## How the two relate

Parquet persists the columnar data to **disk** for later/other-machine use (training datasets); the Arrow C Data Interface hands **live** columnar buffers to an in-process consumer with zero copy. Same columnar idea, two deliveries. (a) raw-network Arrow is general interop with a broad existing consumer (the Arrow ecosystem); the gridfm-schema in-memory Arrow (b) waits for a consumer, since graphkit reads Parquet files — see #38.

## Tests & CI

- gridfm: Rust round-trip + value tests (`--features gridfm`); Python schema/contract test (`python/tests/test_gridfm.py`); a `--features gridfm` CI step.
- arrow: Rust `from_ffi` round-trip (row counts + external ids survive); a `#ifdef PIO_ARROW` block in `examples/smoke.c` (vendored `arrow_c_data_interface.h`); a new `c-abi-arrow` CI job (build, arrow smoke, tests, clippy). The default C ABI build/header/smoke are untouched.

Everything verified locally: `cargo test`/`clippy -D warnings`/`fmt` clean across all crates and both features; `pandas.read_parquet` reads all four GridFM tables; the C smoke test exports + releases an Arrow bus table.

Related: #14 (scenario batch on top of the Parquet writer), #38 (matrix-capi / the gridfm-schema Arrow's home), #50 (zero-impedance accounting), #8 (C ABI roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4
