### PR TITLE
feat: tandem CI with PowerIO.jl, benchmark + docs automation, doc rewrite

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in *.rs) rustfmt \"$file\" >/dev/null 2>&1 || true ;; esac"
+          },
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in */powerio-capi/src/lib.rs) root=\"${file%/powerio-capi/src/lib.rs}\"; command -v cbindgen >/dev/null 2>&1 && (cd \"$root\" && cbindgen --config powerio-capi/cbindgen.toml --crate powerio-capi --output powerio-capi/include/powerio.h >/dev/null 2>&1) || true ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in */powerio-capi/src/lib.rs) root=\"${file%/powerio-capi/src/lib.rs}\"; command -v cbindgen >/dev/null 2>&1 && (cd \"$root\" && cbindgen --config powerio-capi/cbindgen.toml --crate powerio-capi --output powerio-capi/include/powerio.h >/dev/null 2>&1) || true ;; esac"
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in */powerio-capi/src/*.rs) root=\"${file%/powerio-capi/src/*}\"; command -v cbindgen >/dev/null 2>&1 && (cd \"$root\" && cbindgen --config powerio-capi/cbindgen.toml --crate powerio-capi --output powerio-capi/include/powerio.h >/dev/null) || true ;; esac"
           }
         ]
       }

--- a/.claude/skills/refresh-benchmarks/SKILL.md
+++ b/.claude/skills/refresh-benchmarks/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: refresh-benchmarks
+description: >-
+  Re-run the local speed benchmarks (Julia + Python) and the correctness
+  validators, regenerate the marker-delimited speed tables in README.md and
+  benchmarks/RESULTS.md from machine-readable JSON, and show the diff. Heavy,
+  side-effecting, and machine-specific — run it on the benchmarking laptop, not in
+  CI. Does not commit.
+disable-model-invocation: true
+---
+
+# refresh-benchmarks
+
+Stop hand-copying benchmark numbers into two files. The bench scripts emit JSON;
+`render_tables.py` rewrites only the `<!-- BENCH:* -->` table regions from it.
+
+Scope: the three speed tables (`README.md` BENCH:speed-main, `benchmarks/RESULTS.md`
+BENCH:speed-julia and BENCH:speed-pandapower). The correctness matrix and the
+version block in RESULTS.md are hand-maintained — call them out if they changed, but
+don't rewrite them. The numbers are per-machine, so this never runs in CI; CI gates
+only correctness (`run_validation.sh`, exit code).
+
+## Steps
+
+1. **Prereqs.** Confirm the build inputs exist; offer to run any that are missing
+   before doing heavy installs:
+   - `cargo build --release -p powerio-capi` (the C ABI the Julia bench calls)
+   - `maturin develop --release` (the `powerio` wheel for the Python bench)
+   - `julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'`
+   - `pip install -r benchmarks/requirements.txt` (pandapower + egret oracles)
+
+2. **Large cases.** The speed tables cover cases up to 54 MB / 192768 buses that
+   live in gitignored `tests/data/large/`. Offer to run `bash benchmarks/fetch_cases.sh`.
+   If the user declines, the missing cases are skipped and `render_tables.py` leaves
+   any table that needs them unchanged (with a warning) rather than shrinking it.
+
+3. **Run the producers with `--json`:**
+   ```
+   julia --project=benchmarks benchmarks/bench_julia.jl --json
+   python benchmarks/bench_parse.py --json \
+       tests/data/case2869pegase.m \
+       tests/data/large/case9241pegase.m \
+       tests/data/large/case13659pegase.m \
+       tests/data/large/case193k.m
+   ```
+   They write `benchmarks/results/{speed_julia,speed_python}.json` (gitignored).
+
+4. **Regenerate the tables:** `python benchmarks/render_tables.py`. It rewrites only
+   the marked regions; prose outside them is untouched.
+
+5. **Re-run correctness:** `bash benchmarks/run_validation.sh`. Report the pass/fail
+   summary. A FAIL is a regression — surface it prominently.
+
+6. **Report, don't commit.** `git diff -- README.md benchmarks/RESULTS.md`, summarize
+   what moved, and note if the hand-maintained correctness matrix or version block in
+   RESULTS.md now looks stale (new fixture, changed tool version). Leave the changes
+   staged for the user to review; do not commit or push.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+# Build the workspace rustdoc and publish it to GitHub Pages. This renders all
+# four library crates, including powerio-capi and powerio-py (publish = false),
+# whose //! docs docs.rs would never host. docs.rs takes over for powerio and
+# powerio-matrix once those are published to crates.io.
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One Pages deploy at a time; a newer push supersedes an in-flight build.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    # -D warnings turns a broken intra-doc link into a failed build, so the docs
+    # can't rot silently. --all-features renders the gridfm/arrow/kkt surface.
+    - name: Build docs
+      env:
+        RUSTDOCFLAGS: "-D warnings"
+      run: cargo doc --no-deps --all-features -p powerio -p powerio-matrix -p powerio-capi -p powerio-py
+    # cargo doc leaves target/doc with no top-level index; redirect to the main crate.
+    - name: Landing redirect
+      run: echo '<meta http-equiv="refresh" content="0; url=powerio/index.html">' > target/doc/index.html
+    - uses: actions/upload-pages-artifact@v3
+      with:
+        path: target/doc
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -1,9 +1,11 @@
 name: Julia binding
 
-# Contract test: build this commit's C ABI and run PowerIO.jl's suite against it,
-# so a change to the pio_* surface or the Network JSON schema that breaks the Julia
-# binding fails here, in the repo that caused it. Path-filtered to the code that
-# can affect the ABI, so doc-only PRs skip it.
+# Contract test: build this commit's C ABI and run PowerIO.jl's suite against it, so
+# a change to the pio_* surface or the Network JSON schema that breaks the Julia
+# binding fails here, in the repo that caused it. PowerIO.jl is private, so the
+# cross-repo checkout needs a token with read access to it: add a fine-grained PAT
+# (or an org token) as the TANDEM_REPO_TOKEN secret. Without it the job skips the
+# contract test and passes, so it never blocks a PR. Path-filtered to ABI-affecting code.
 on:
   push:
     branches: [ "main" ]
@@ -19,24 +21,39 @@ jobs:
   contract:
     name: PowerIO.jl against this capi
     runs-on: ubuntu-latest
+    env:
+      # secrets can't be read in `if:` directly; surface it as an env var to gate on.
+      TANDEM_TOKEN: ${{ secrets.TANDEM_REPO_TOKEN }}
     steps:
+    - name: Skip notice (no tandem token)
+      if: env.TANDEM_TOKEN == ''
+      run: echo "TANDEM_REPO_TOKEN is not set — skipping the PowerIO.jl contract test. Add a token with read access to eigenergy/PowerIO.jl as the TANDEM_REPO_TOKEN secret (org- or repo-level) to enable it."
     - uses: actions/checkout@v4
+      if: env.TANDEM_TOKEN != ''
     - uses: dtolnay/rust-toolchain@stable
+      if: env.TANDEM_TOKEN != ''
     - uses: Swatinem/rust-cache@v2
+      if: env.TANDEM_TOKEN != ''
     - name: Build powerio-capi
+      if: env.TANDEM_TOKEN != ''
       run: cargo build -p powerio-capi --release
     - name: Check out PowerIO.jl
+      if: env.TANDEM_TOKEN != ''
       uses: actions/checkout@v4
       with:
         repository: eigenergy/PowerIO.jl
         path: PowerIO.jl
+        token: ${{ secrets.TANDEM_REPO_TOKEN }}
     - uses: julia-actions/setup-julia@v2
+      if: env.TANDEM_TOKEN != ''
       with:
         version: '1'
     - uses: julia-actions/cache@v2
+      if: env.TANDEM_TOKEN != ''
     # PowerIO.jl's ccall tests auto-skip when the cdylib is absent; POWERIO_CAPI
     # points them at the library just built, so they run for real.
     - name: Test PowerIO.jl against the built library
+      if: env.TANDEM_TOKEN != ''
       env:
         POWERIO_CAPI: ${{ github.workspace }}/target/release/libpowerio_capi.so
       run: julia --project=PowerIO.jl -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -36,7 +36,9 @@ jobs:
       if: env.TANDEM_TOKEN != ''
     - name: Build powerio-capi
       if: env.TANDEM_TOKEN != ''
-      run: cargo build -p powerio-capi --release
+      # --features arrow so PowerIO.jl's zero-copy Arrow tests run against a real
+      # pio_export_arrow symbol rather than skipping.
+      run: cargo build -p powerio-capi --release --features arrow
     - name: Check out PowerIO.jl
       if: env.TANDEM_TOKEN != ''
       uses: actions/checkout@v4

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -1,0 +1,42 @@
+name: Julia binding
+
+# Contract test: build this commit's C ABI and run PowerIO.jl's suite against it,
+# so a change to the pio_* surface or the Network JSON schema that breaks the Julia
+# binding fails here, in the repo that caused it. Path-filtered to the code that
+# can affect the ABI, so doc-only PRs skip it.
+on:
+  push:
+    branches: [ "main" ]
+    paths: [ "powerio/**", "powerio-capi/**", ".github/workflows/julia-binding.yml" ]
+  pull_request:
+    branches: [ "main" ]
+    paths: [ "powerio/**", "powerio-capi/**", ".github/workflows/julia-binding.yml" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  contract:
+    name: PowerIO.jl against this capi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Build powerio-capi
+      run: cargo build -p powerio-capi --release
+    - name: Check out PowerIO.jl
+      uses: actions/checkout@v4
+      with:
+        repository: eigenergy/PowerIO.jl
+        path: PowerIO.jl
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+    - uses: julia-actions/cache@v2
+    # PowerIO.jl's ccall tests auto-skip when the cdylib is absent; POWERIO_CAPI
+    # points them at the library just built, so they run for real.
+    - name: Test PowerIO.jl against the built library
+      env:
+        POWERIO_CAPI: ${{ github.workspace }}/target/release/libpowerio_capi.so
+      run: julia --project=PowerIO.jl -e 'using Pkg; Pkg.instantiate(); Pkg.test()'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -40,6 +40,14 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+    # Cache the pip wheels (pandapower + scipy/numpy, egret + pyomo, matpowercaseframes);
+    # setup-python's own cache only covers the interpreter, not site-packages. Keyed on
+    # the requirements file so a dependency bump re-resolves.
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: pip-validate-${{ runner.os }}-${{ hashFiles('benchmarks/requirements.txt') }}
+        restore-keys: pip-validate-${{ runner.os }}-
     # run_validation.sh defaults to .venv/bin/python; build the powerio wheel into
     # that venv and add the pandapower + egret oracles (egret is optional — the
     # matrix leg skips if it's absent).

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,53 @@
+name: Validation
+
+# Cross-tool correctness gate: run benchmarks/run_validation.sh (the same pass/fail
+# matrix the maintainer runs locally) and fail the PR on any regression. Only the
+# machine-independent correctness checks run here — the speed benchmarks are
+# per-machine and stay a local on-demand task (the refresh-benchmarks skill).
+#
+# This pulls a Julia + Python oracle stack (PowerModels.jl, ExaPowerIO.jl,
+# pandapower, egret), so it's heavier than the other jobs; the path filter keeps it
+# off doc-only PRs. The fixtures are all vendored, so no large-case fetch is needed.
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - "powerio/**"
+      - "powerio-matrix/**"
+      - "powerio-capi/**"
+      - "powerio-py/**"
+      - "benchmarks/**"
+      - ".github/workflows/validation.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+    - name: Build powerio-capi
+      run: cargo build --release -p powerio-capi
+    - uses: julia-actions/setup-julia@v2
+      with:
+        version: '1'
+    - uses: julia-actions/cache@v2
+    - name: Instantiate the Julia oracle env
+      run: julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    # run_validation.sh defaults to .venv/bin/python; build the powerio wheel into
+    # that venv and add the pandapower + egret oracles (egret is optional — the
+    # matrix leg skips if it's absent).
+    - name: Build the powerio wheel and oracles into .venv
+      run: |
+        python -m venv .venv
+        .venv/bin/pip install --upgrade pip maturin
+        .venv/bin/maturin develop --release
+        .venv/bin/pip install -r benchmarks/requirements.txt
+    - name: Run the validation matrix
+      run: bash benchmarks/run_validation.sh

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -44,10 +44,16 @@ jobs:
     # that venv and add the pandapower + egret oracles (egret is optional — the
     # matrix leg skips if it's absent).
     - name: Build the powerio wheel and oracles into .venv
+      env:
+        VIRTUAL_ENV: ${{ github.workspace }}/.venv
       run: |
         python -m venv .venv
         .venv/bin/pip install --upgrade pip maturin
         .venv/bin/maturin develop --release
         .venv/bin/pip install -r benchmarks/requirements.txt
+    # In CI the oracle stack must be present: a broken egret or pandapower import
+    # would otherwise let run_validation.sh skip the 5x5 matrix leg and still pass.
+    - name: Verify the oracle stack imports
+      run: .venv/bin/python -c "import egret, pandapower"
     - name: Run the validation matrix
       run: bash benchmarks/run_validation.sh

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,11 @@ __pycache__/
 .pytest_cache/
 .venv/
 tests/data/large/
+
+# Machine-readable bench output (render_tables.py reads it; numbers are per-machine)
+benchmarks/results/
+
+# asv working dirs (built envs, raw results, generated dashboard)
+benchmarks/asv/env/
+benchmarks/asv/results/
+benchmarks/asv/html/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,10 @@ graph views for any downstream solver. (Planned) feeds the GridFM ML pipeline.
 - **`powerio-py`** — PyO3 extension behind the `powerio` Python package
   (`python/powerio/`); hands back COO triplets that scipy assembles.
 - **`powerio-capi`** — C ABI over `powerio` (`pio_*`, header `powerio.h`); the
-  polyglot substrate for C/C++/Julia. `--features arrow` adds `pio_export_arrow`,
-  a zero-copy raw network export over the Arrow C Data Interface.
+  polyglot substrate for C/C++/Julia. `pio_abi_version` (+ the `PIO_ABI_VERSION`
+  header macro) is the load-time compatibility check; `pio_version` is the crate
+  version string. `--features arrow` adds `pio_export_arrow`, a zero-copy raw
+  network export over the Arrow C Data Interface.
 
 `Network` is the one canonical model (format-neutral, loads/shunts first-class);
 `IndexedNetwork` is the dense-indexed analysis view derived from it.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # PowerIO
 
-Lossless IO and format conversion for power system case files. Parse MATPOWER
-`.m`, PSS/E `.raw`, PowerWorld `.aux`, PowerModels JSON, and EGRET JSON into one
-format neutral `Network`; write any of them back (same-format round trips are byte
-for byte); convert between them with explicit fidelity reporting; and emit the
-sparse matrices and graph views a solver needs. The same Rust core is callable
-from Rust, Python, C/C++, and Julia. The core crate has six dependencies and no
-matrix or solver stack.
+Lossless IO and format conversion for power system case files. Reads MATPOWER
+`.m`, PSS/E `.raw`, PowerWorld `.aux`, PowerModels JSON, and EGRET JSON into a
+format neutral `Network` and writes any of them back. Same format round trips are
+byte for byte. Cross format conversion reports what the target drops. Emits the
+sparse matrices and graph views a solver needs. Callable from Rust, Python, C,
+C++, and Julia. The `powerio` crate has six dependencies and no matrix or solver
+stack.
 
 ## Workspace
 
@@ -18,22 +18,21 @@ powerio-py       PyO3 extension behind the one `powerio` Python wheel.
 powerio-capi     C ABI (`pio_*`), the substrate for C, C++, and Julia.
 ```
 
-Full API docs are on [docs.rs/powerio](https://docs.rs/powerio) and
-[docs.rs/powerio-matrix](https://docs.rs/powerio-matrix).
+API docs: <https://eigenergy.github.io/powerio/> (moves to docs.rs on a crates.io release).
 
 ## Install
 
 ```
 cargo add powerio            # the parser + converters
 cargo install powerio-cli    # the `powerio` command + TUI
-pip install powerio          # zero-dependency parse + convert, Python 3.9+
+pip install powerio          # parse + convert, no extra deps, Python 3.9+
 pip install 'powerio[all]'   # + scipy/numpy/networkx for the matrices and graph view
 ```
 
 ## Formats
 
-Every reader produces a `Network` and every writer consumes one, so a new format
-is one module at the hub, not an N×M matrix of pairwise converters.
+Every reader produces a `Network` and every writer consumes one; a new format is
+one module at the hub, not a converter for each pair.
 
 **Readers and writers**: MATPOWER `.m`, PowerModels JSON, PSS/E `.raw` (v33),
 PowerWorld `.aux`, and EGRET JSON.
@@ -50,25 +49,23 @@ Legend: 🟩 byte-exact · 🟦 full · 🟨 partial (drops are logged in `Conve
 
 **🟩 byte-exact**: writing back to the source format reproduces the file verbatim,
 comments and exact tokens like `7e-05` included. **🟦 full**: every field the source
-carries survives. **🟨 partial**: the target cannot represent some fields (PSS/E and
-PowerWorld have no cost curves; EGRET has no HVDC or storage), and each dropped
-field is reported in `Conversion::warnings`, not dropped silently. Two target
-caveats fold into this: canonical MATPOWER output omits dcline and storage, and the
-PowerModels writer maps them best-effort.
+carries survives. **🟨 partial**: the target can't represent some fields (PSS/E and
+PowerWorld have no cost curves; EGRET has no HVDC or storage); each dropped field is
+reported in `Conversion::warnings`, not dropped silently. Canonical MATPOWER output
+omits dcline and storage; the PowerModels writer maps both.
 
-Every reader and writer is validated against an independent tool, PowerModels.jl,
-the EGRET package, ExaPowerIO.jl, and pandapower, over the full conversion matrix.
-See [benchmarks/RESULTS.md](benchmarks/RESULTS.md) and
-[docs/format-fidelity.md](docs/format-fidelity.md).
+Validated against PowerModels.jl, the EGRET package, ExaPowerIO.jl, and pandapower,
+over the full conversion matrix. See [benchmarks/RESULTS.md](benchmarks/RESULTS.md)
+and [docs/format-fidelity.md](docs/format-fidelity.md).
 
 ## Matrices
 
-`powerio-matrix` builds, from the dense-indexed `IndexedNetwork` view: signed
-incidence `A`, the weighted Laplacian `L = A diag(b) Aᵀ` and its slack-grounded
-form, B'/B''/`Re(Y_bus)`/`-Im(Y_bus)`, the LACPF block, PTDF/LODF, the DC-OPF
-instance bundle, adjacency, and a petgraph view, as Matrix Market or in memory.
-The sign, tap, per unit, and DC-OPF conventions are documented in the
-[crate docs](https://docs.rs/powerio-matrix).
+From the dense-indexed `IndexedNetwork` view, `powerio-matrix` builds signed
+incidence `A`, the weighted Laplacian `L = A diag(b) Aᵀ` and the same matrix
+grounded at the slack, B'/B''/`Re(Y_bus)`/`-Im(Y_bus)`, the LACPF block, PTDF/LODF,
+the DC-OPF instance bundle, adjacency, and a petgraph view, as Matrix Market or in
+memory. The sign, tap, per unit, and DC conventions are in
+[docs/matrices.md](docs/matrices.md).
 
 ## Use
 
@@ -100,40 +97,38 @@ powerio                                              # TUI
 
 `powerio gridfm <case> -o <dir>` (the `gridfm` cargo feature) writes the
 gridfm-datakit Parquet schema — `bus_data`, `gen_data`, `branch_data`,
-`y_bus_data` under `<dir>/<case>/raw/` — so [gridfm-graphkit](https://github.com/gridfm)'s
-`HeteroGridDatasetDisk` trains on powerio output directly. A parsed case is one
-snapshot (`scenario 0`): voltages and dispatch are the case's stored values, and
-branch flows are computed from them.
+`y_bus_data` under `<dir>/<case>/raw/`, which [gridfm-graphkit](https://github.com/gridfm)'s
+`HeteroGridDatasetDisk` loads directly. powerio has no solver, so a case is one
+snapshot (`scenario 0`): voltages and dispatch are the stored values, branch flows
+computed from them.
 
 Pass several inputs — `powerio gridfm <case-0> <case-1> … -o <dir>` — to
 row-stack a **scenario batch** into one dataset, keyed by the `scenario` column
 (the k-th input is stamped `--scenario` + k). The inputs share a base element set
-— the same bus, branch, and generator counts in the same bus order — so the
-dense bus index lines up across scenarios; within that, load, dispatch,
-voltages, branch status, bus type, and costs may vary, the same way datakit's topology
-variants toggle line status on a fixed element set. powerio stacks the snapshots,
-it doesn't generate them. From Python (the `gridfm` extra):
-`case.write_gridfm(dir)` and `powerio.write_gridfm_batch([case0, case1], dir)`
-(issue #14).
+— the same bus, branch, and generator counts in the same bus order — so the dense
+bus index lines up across scenarios; within that, load, dispatch, voltages, branch
+status, bus type, and costs may vary, the way datakit's topology variants toggle
+line status on a fixed element set. powerio stacks the snapshots, it doesn't
+generate them. From Python (the `gridfm` extra): `case.write_gridfm(dir)` and
+`powerio.write_gridfm_batch([case0, case1], dir)`.
 
 ## C ABI
 
-`powerio-capi` exposes the parser over a C ABI (`pio_*`, header
-`powerio-capi/include/powerio.h`) for C, C++, and Julia: parse, query, convert,
-the byte-exact echo, the JSON transport (`pio_to_json`/`pio_from_json`), and the
-numeric table extractors. Built with `--features arrow`, it also offers
-`pio_export_arrow` — a zero-copy export of the raw network tables
-(bus/branch/gen/load/shunt) over the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html),
-so pyarrow / Arrow.jl / Arrow C++ / polars / DuckDB pull a whole table in process
-with no copy and no temp file (the typed, in-memory sibling of `pio_to_json`).
+`powerio-capi` is the C ABI (`pio_*`, header `powerio-capi/include/powerio.h`) for
+C, C++, and Julia: parse, query, convert, the byte-exact echo, the JSON transport
+(`pio_to_json`/`pio_from_json`), and the numeric table extractors. `--features
+arrow` adds `pio_export_arrow`, which exports the raw network tables (bus, branch,
+gen, load, shunt) over the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
+pyarrow, Arrow.jl, Arrow C++, polars, and DuckDB read a table in process without a
+copy or a temp file. It is the in memory form of `pio_to_json`.
 
 ## Benchmark
 
-Median parse time, one Apple M-series laptop, release build, all timed in one
-process under the same harness, powerio through its C ABI, so every parser reads
-from disk alike. Full table and method in
-[benchmarks/RESULTS.md](benchmarks/RESULTS.md).
+Median parse time, one Apple M-series laptop, release build. Every parser runs in
+one process under the same harness, powerio through its C ABI, so all read from
+disk alike. Method and full table: [benchmarks/RESULTS.md](benchmarks/RESULTS.md).
 
+<!-- BENCH:speed-main START -->
 | case | buses / branches | powerio | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
 | case2869pegase | 2869 / 4582 | 1.73 ms | 2.86 ms | 122.2 ms |
@@ -141,30 +136,26 @@ from disk alike. Full table and method in
 | case9241pegase | 9241 / 16049 | 5.81 ms | 9.15 ms | 553.2 ms |
 | case13659pegase | 13659 / 20467 | 8.6 ms | 13.76 ms | 822.2 ms |
 | case193k | 192768 / 228574 | 161.9 ms | 174.98 ms | n/a |
+<!-- BENCH:speed-main END -->
 
-powerio is faster than ExaPowerIO on every case measured, 62–96× PowerModels'
-parser, and ~14× pandapower's `.m` reader. It is also the only one of the three
-that round trips byte for byte (verified at 54 MB / 192768 buses) and is callable
-from Rust, the CLI, Python, and C/Julia with no runtime. Parse, conversions, and
-Y_bus are validated value for value against all three (`benchmarks/run_validation.sh`).
+Across these cases powerio parses faster than ExaPowerIO, 62–96× PowerModels'
+parser, and ~14× pandapower's `.m` reader. It round trips byte for byte (verified at
+54 MB, 192768 buses); the other two don't. Parse, conversions, and Y_bus are checked
+value for value against all three (`benchmarks/run_validation.sh`).
 
 ## Roadmap
 
-Tracked in the issues, all over the `Network` hub:
+Tracked in the issues, all on the `Network` hub:
 
-- Broader format coverage: PSS/E `.rawx` (v35), IIDM `.xiidm`, UCTE `.uct`, GE EPC `.epc`.
+- More formats: PSS/E `.rawx` (v35), IIDM `.xiidm`, UCTE `.uct`, GE EPC `.epc`.
 - PSS/E fidelity: 3-winding transformers and non-unit `CZ`/`CW` impedance bases.
-- A RAVENS-JSON export sink (positioning PowerIO as an ingest backend for MG-RAVENS).
-- A registered [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl) over the C ABI, with
-  native bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl (scaffolded there now).
+- A RAVENS-JSON export sink, so powerio feeds MG-RAVENS.
+- A registered [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl) over the C ABI,
+  with bridges to PowerModels.jl, ExaModelsPower.jl, and PowerDiff.jl.
 - LinDist3Flow matrices.
 
-The scenario-batch path that stacks many perturbed scenarios into the gridfm
-Parquet tables (issue #14) has shipped — `write_gridfm_batch` in Rust, multiple
-inputs to `powerio gridfm`, and `powerio.write_gridfm_batch` in Python.
-
-CIM stays out of scope; it's a heavier problem owned by the CIM hubs (CIMHub,
-MG-RAVENS), which PowerIO can feed as an ingest layer.
+CIM stays out of scope: a heavier problem owned by the CIM hubs (CIMHub,
+MG-RAVENS), which powerio can feed.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ generate them. From Python (the `gridfm` extra): `case.write_gridfm(dir)` and
 
 `powerio-capi` is the C ABI (`pio_*`, header `powerio-capi/include/powerio.h`) for
 C, C++, and Julia: parse, query, convert, the byte-exact echo, the JSON transport
-(`pio_to_json`/`pio_from_json`), and the numeric table extractors. `--features
+(`pio_to_json`/`pio_from_json`), and the numeric table extractors. `pio_abi_version`
+(and the `PIO_ABI_VERSION` header macro) lets a consumer reject a stale or
+mismatched library at load; `pio_version` reports the crate version. `--features
 arrow` adds `pio_export_arrow`, which exports the raw network tables (bus, branch,
 gen, load, shunt) over the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
 pyarrow, Arrow.jl, Arrow C++, polars, and DuckDB read a table in process without a

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -28,6 +28,7 @@ ExaPowerIO and PowerModels do. The powerio handle is freed in an untimed
 teardown, matching the other two, whose returned data is collected after the
 sample rather than inside it.
 
+<!-- BENCH:speed-julia START -->
 | case | buses / branches | powerio | ExaPowerIO.jl | PowerModels.jl |
 | --- | --- | --- | --- | --- |
 | case2869pegase | 2869 / 4582 | 1.73 ms | 2.86 ms | 122.2 ms |
@@ -40,6 +41,7 @@ sample rather than inside it.
 | case_SyntheticUSA | 82000 / 104121 | 73.1 ms | 82.65 ms | n/a |
 | case99k | 99396 / 117860 | 84.27 ms | 94.88 ms | n/a |
 | case193k | 192768 / 228574 | 161.9 ms | 174.98 ms | n/a |
+<!-- BENCH:speed-julia END -->
 
 (PowerModels is skipped past case13659, where it takes minutes and the gap is
 already settled.)
@@ -65,12 +67,14 @@ pandapower reads MATPOWER `.m` through `matpowercaseframes` (a pandas reader) an
 then `from_mpc` builds its `net`. `benchmarks/bench_parse.py`, same machine,
 median wall time:
 
+<!-- BENCH:speed-pandapower START -->
 | case | powerio parse | matpowercaseframes (pandapower's `.m` reader) |
 | --- | --- | --- |
 | case2869pegase | 1.8 ms | 25.6 ms |
 | case9241pegase | 5.7 ms | 85.9 ms |
 | case13659pegase | 8.9 ms | 139.9 ms |
 | case193k | 165.4 ms | 2214.3 ms |
+<!-- BENCH:speed-pandapower END -->
 
 powerio's parse is ~14× faster than pandapower's `.m` reader, and that is before
 `from_mpc` builds the `net` (case30: `from_mpc` ≈ 59 ms vs powerio under 1 ms).

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -96,9 +96,13 @@ prints a pass/fail matrix. Latest run, all checks pass:
 | t_case9_dcline | ✓ | ✓ | ✓ | ✓ | ✓ |
 | t_case9_oos | ✓ | ✓ | ✓ | ✓ | ✓ |
 | pglib case5_pjm / case14_ieee | ✓ | ✓ | ✓ | ✓ | ✓ |
-| case2869pegase | ✓ | ✓ | ✓ | ✓ | ✓ |
+| case2869pegase | ✓ | ✓ | ✓ | ✓ | n/a† |
 | psse/case5, psse/case14 (read side) | n/a | n/a | ✓ | n/a | n/a |
 | egret/case9, case14, case30 (read side) | ✓ | n/a | n/a | n/a | n/a |
+
+† pandapower's reader (matpowercaseframes) does `int(float(tok))` and raises on the
+`Inf` limits MATPOWER uses for "unlimited", which case2869pegase carries; the pp
+validator reports n/a there (powerio, PowerModels, and ExaPowerIO all read the case).
 
 What each column checks:
 

--- a/benchmarks/asv/README.md
+++ b/benchmarks/asv/README.md
@@ -1,0 +1,23 @@
+# asv: powerio parse performance over time
+
+[airspeed velocity](https://asv.readthedocs.io) tracks powerio's own Python parse and
+matrix timings across git history and renders a dashboard. This answers "did we regress
+vs our past?", which the cross-tool table in [../RESULTS.md](../RESULTS.md) does not (it
+compares powerio against other parsers at one commit). It runs locally, not in CI —
+absolute timings need a quiet machine, the same reason the speed tables aren't gated in
+CI. For a noise-robust PR check, the Julia binding uses AirspeedVelocity.jl's
+same-runner PR-vs-base comparison instead.
+
+`asv.conf.json` builds the wheel with maturin per commit, so a Rust toolchain must be on
+PATH.
+
+```
+pip install asv
+cd benchmarks/asv
+asv run main^!          # benchmark the current commit
+asv run main~10..main   # or a range of history
+asv publish && asv preview
+```
+
+The first `asv run` is also what validates the maturin `build_command`; if the wheel
+build needs a tweak for your platform, it surfaces there.

--- a/benchmarks/asv/asv.conf.json
+++ b/benchmarks/asv/asv.conf.json
@@ -1,0 +1,24 @@
+{
+    "version": 1,
+    "project": "powerio",
+    "project_url": "https://github.com/eigenergy/powerio",
+    "repo": "../..",
+    "branches": ["main"],
+    "show_commit_url": "https://github.com/eigenergy/powerio/commit/",
+    "environment_type": "virtualenv",
+    "pythons": ["3.12"],
+    "matrix": {
+        "req": {
+            "numpy": [],
+            "scipy": []
+        }
+    },
+    "build_command": [
+        "python -m pip install maturin",
+        "maturin build --release --out {build_cache_dir}"
+    ],
+    "benchmark_dir": "benchmarks",
+    "env_dir": "env",
+    "results_dir": "results",
+    "html_dir": "html"
+}

--- a/benchmarks/asv/benchmarks/benchmarks.py
+++ b/benchmarks/asv/benchmarks/benchmarks.py
@@ -1,0 +1,34 @@
+"""asv suite: powerio's own parse and matrix performance across git history.
+
+This tracks self-regression over commits (does a change make powerio slower than its
+past?), which the cross-tool snapshot in benchmarks/RESULTS.md does not: that compares
+powerio against ExaPowerIO/PowerModels/pandapower at one commit. The Rust hot path also
+has criterion coverage (powerio/benches/parse.rs); this watches the user-facing Python
+wheel.
+
+Run from benchmarks/asv/ — see README.md. asv builds the wheel with maturin per commit
+(asv.conf.json build_command), so a Rust toolchain must be on PATH.
+"""
+
+from pathlib import Path
+
+import powerio
+
+# benchmarks/asv/benchmarks/benchmarks.py -> repo root is four parents up.
+CASE = str(Path(__file__).resolve().parents[3] / "tests" / "data" / "case2869pegase.m")
+
+
+class Parse:
+    def time_parse(self):
+        powerio.parse(CASE)
+
+
+class Matrices:
+    def setup(self):
+        self.case = powerio.parse_matpower(CASE)
+
+    def time_ybus(self):
+        self.case.ybus()
+
+    def time_bprime(self):
+        self.case.bprime()

--- a/benchmarks/bench_julia.jl
+++ b/benchmarks/bench_julia.jl
@@ -64,7 +64,10 @@ end
 println(rpad("case", 20), rpad("powerio", 13), rpad("ExaPowerIO", 13),
         rpad("PowerModels", 13), "buses (powerio / ExaPowerIO)")
 for (name, f, run_pm) in CASES
-    isfile(f) || continue
+    if !isfile(f)
+        @warn "bench_julia: fixture missing, dropping it from the run" case = name path = f
+        continue
+    end
 
     # powerio through the C ABI. Time only the parse (read + build the model) and
     # free in an untimed teardown — matching ExaPowerIO/PowerModels, whose returned

--- a/benchmarks/bench_julia.jl
+++ b/benchmarks/bench_julia.jl
@@ -37,6 +37,30 @@ const CASES = [
 
 ms(b) = round(median(b).time / 1e6, digits = 2)
 
+# `--json`: also write benchmarks/results/speed_julia.json for render_tables.py.
+# Case names are plain ASCII and values are numbers or null, so a hand-rolled
+# writer keeps the bench env free of a JSON dependency.
+const JSON_OUT = "--json" in ARGS
+jrows = NamedTuple[]
+
+function write_speed_julia(path, rows)
+    mkpath(dirname(path))
+    open(path, "w") do io
+        println(io, "{")
+        println(io, "  \"rows\": [")
+        for (i, r) in enumerate(rows)
+            pm = r.powermodels_ms === nothing ? "null" : string(r.powermodels_ms)
+            tail = i < length(rows) ? "," : ""
+            println(io, "    {\"case\": \"$(r.case)\", \"buses\": $(r.buses), \"branches\": $(r.branches), " *
+                        "\"powerio_ms\": $(r.powerio_ms), \"exapowerio_ms\": $(r.exapowerio_ms), " *
+                        "\"powermodels_ms\": $pm}$tail")
+        end
+        println(io, "  ]")
+        println(io, "}")
+    end
+    println("wrote $path ($(length(rows)) rows)")
+end
+
 println(rpad("case", 20), rpad("powerio", 13), rpad("ExaPowerIO", 13),
         rpad("PowerModels", 13), "buses (powerio / ExaPowerIO)")
 for (name, f, run_pm) in CASES
@@ -46,7 +70,7 @@ for (name, f, run_pm) in CASES
     # free in an untimed teardown — matching ExaPowerIO/PowerModels, whose returned
     # data is GC'd outside the @benchmark sample rather than freed inside it. The
     # handle reaches teardown through a Ref, so no sample leaks.
-    h = pio_parse(f); nbuses = pio_n_buses(h); pio_free(h)
+    h = pio_parse(f); nbuses = pio_n_buses(h); nbranch = pio_n_branches(h); pio_free(h)
     samples = nbuses > 30_000 ? 5 : 30
     href = Ref{Ptr{Cvoid}}(C_NULL)
     bc = @benchmark $href[] = pio_parse($f) teardown = (pio_free($href[])) samples = samples evals = 1
@@ -56,13 +80,19 @@ for (name, f, run_pm) in CASES
     be = @benchmark ExaPowerIO.parse_matpower($f) samples = samples evals = 1
     e = ms(be)
 
+    pm_ms = nothing
     p = "skip"
     if run_pm
         bp = @benchmark PowerModels.parse_file($f) samples = 5 evals = 1
-        p = string(round(median(bp).time / 1e6, digits = 1)) * " ms"
+        pm_ms = round(median(bp).time / 1e6, digits = 1)
+        p = "$(pm_ms) ms"
     end
 
     count = nbuses == length(ed.bus) ? string(nbuses) : "$nbuses / $(length(ed.bus))"
     println(rpad(name, 20), rpad("$(c) ms", 13), rpad("$(e) ms", 13),
             rpad(p, 13), count)
+    push!(jrows, (case = name, buses = nbuses, branches = nbranch,
+                  powerio_ms = c, exapowerio_ms = e, powermodels_ms = pm_ms))
 end
+
+JSON_OUT && write_speed_julia(joinpath(@__DIR__, "results", "speed_julia.json"), jrows)

--- a/benchmarks/bench_parse.py
+++ b/benchmarks/bench_parse.py
@@ -18,6 +18,7 @@ Run it with the venv that has the extensions built (`maturin develop --release`)
 Install the comparison baselines with `pip install 'powerio[bench]'`.
 """
 
+import json
 import logging
 import statistics
 import sys
@@ -115,11 +116,28 @@ def bench_case(path: Path):
         print(f"{name:<{width}}  {best:>10.1f}  {median:>12.1f}")
     print()
 
+    # The two rows render_tables.py needs for the RESULTS pandapower table; round to
+    # the 1 decimal the published table shows. matpowercaseframes is None when its
+    # baseline isn't installed.
+    medians = {name: median for name, _, median in rows}
+    return {
+        "case": path.stem,
+        "powerio_parse_ms": round(medians["powerio: parse"], 1),
+        "matpowercaseframes_ms": round(medians["matpowercaseframes: parse"], 1)
+        if "matpowercaseframes: parse" in medians else None,
+    }
+
 
 def main():
-    paths = [Path(a) for a in sys.argv[1:]] or DEFAULT_CASES
-    for path in paths:
-        bench_case(path)
+    args = sys.argv[1:]
+    json_out = "--json" in args
+    paths = [Path(a) for a in args if a != "--json"] or DEFAULT_CASES
+    results = [bench_case(path) for path in paths]
+    if json_out:
+        out = Path(__file__).resolve().parent / "results" / "speed_python.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"rows": results}, indent=2) + "\n")
+        print(f"wrote {out} ({len(results)} rows)")
 
 
 if __name__ == "__main__":

--- a/benchmarks/bench_parse.py
+++ b/benchmarks/bench_parse.py
@@ -107,7 +107,7 @@ def bench_case(path: Path):
             print("pandapower not installed; skipping the pandapower row.")
             print("  pip install pandapower matpowercaseframes")
         except Exception as exc:  # noqa: BLE001 - from_mpc raises on some cases (pp 3.2.2)
-            print(f"pandapower from_mpc failed on this case: {type(exc).__name__}")
+            print(f"pandapower from_mpc failed on this case: {type(exc).__name__}: {exc}")
 
     width = max(len(name) for name, *_ in rows)
     print(f"{'task':<{width}}  {'best (ms)':>10}  {'median (ms)':>12}")

--- a/benchmarks/convert_cases.py
+++ b/benchmarks/convert_cases.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Produce every powerio conversion the validation matrix compares against, in one
+process (import powerio once instead of per conversion). Writes outputs to <tmp>
+by the naming convention validate_oracles.jl expects:
+
+    <stem>.pmjson.json   <m>  -> PowerModels JSON   (PMjson writer leg)
+    <stem>.psse.raw      <m>  -> PSS/E .raw         (PSSE writer leg)
+    <stem>.reemit.json   <stem>.pmref.json -> PowerModels JSON  (PMread reader leg)
+    psse_<stem>.json     <raw> -> PowerModels JSON  (PSSE read side)
+    egret_<stem>.json    <egret.json> -> PowerModels JSON (EGRET read side)
+
+A failed or empty conversion is reported and the output left absent, so the
+matching comparison leg fails on a missing file rather than on stale data.
+
+    python benchmarks/convert_cases.py <tmp> --m <m>... --raw <r>... --egret <e>...
+"""
+
+import sys
+import warnings
+from pathlib import Path
+
+warnings.filterwarnings("ignore")
+import powerio
+
+
+def convert(inp, to, out):
+    try:
+        text = powerio.convert(str(inp), to).text
+    except Exception as exc:  # noqa: BLE001 — report any reader/writer failure, keep going
+        print(f"  convert FAIL {Path(inp).name} -> {to}: {exc}", file=sys.stderr)
+        return
+    if not text:
+        print(f"  convert EMPTY {Path(inp).name} -> {to}", file=sys.stderr)
+        return
+    Path(out).write_text(text)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: convert_cases.py <tmp> --m <m>... --raw <r>... --egret <e>...", file=sys.stderr)
+        return 2
+    tmp = Path(sys.argv[1])
+    groups = {"m": [], "raw": [], "egret": []}
+    cur = None
+    for arg in sys.argv[2:]:
+        if arg.startswith("--"):
+            cur = arg[2:]
+            if cur not in groups:
+                print(f"unknown group flag --{cur}", file=sys.stderr)
+                return 2
+        elif cur is None:
+            print(f"argument before any --group flag: {arg}", file=sys.stderr)
+            return 2
+        else:
+            groups[cur].append(arg)
+
+    for m in groups["m"]:
+        stem = Path(m).stem
+        convert(m, "powermodels-json", tmp / f"{stem}.pmjson.json")
+        convert(m, "psse", tmp / f"{stem}.psse.raw")
+        pmref = tmp / f"{stem}.pmref.json"
+        if pmref.is_file():
+            convert(pmref, "powermodels-json", tmp / f"{stem}.reemit.json")
+    for r in groups["raw"]:
+        convert(r, "powermodels-json", tmp / f"psse_{Path(r).stem}.json")
+    for e in groups["egret"]:
+        convert(e, "powermodels-json", tmp / f"egret_{Path(e).stem}.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/oracle_compare.jl
+++ b/benchmarks/oracle_compare.jl
@@ -101,13 +101,13 @@ function compare_psse(ref_path::AbstractString, test_path::AbstractString)
         isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σ$et.$f: ref=$r test=$t")
     end
     # When the shunt counts agree, the admittances must match too.
-    if _count(ref, "shunt") == _count(test, "shunt")
+    sref, stest = _count(ref, "shunt"), _count(test, "shunt")
+    if sref == stest
         for f in ("gs", "bs")
             r, t = _total(ref, "shunt", f), _total(test, "shunt", f)
             isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σshunt.$f: ref=$r test=$t")
         end
     end
-    sref, stest = _count(ref, "shunt"), _count(test, "shunt")
     note = sref == stest ? "" : "  (shunt: ref=$sref test=$stest — switched shunts not modeled)"
     return problems, note
 end

--- a/benchmarks/oracle_compare.jl
+++ b/benchmarks/oracle_compare.jl
@@ -1,0 +1,205 @@
+# Shared PowerModels / ExaPowerIO comparison kernels, factored out of the
+# individual validate_*.jl scripts. The batched driver (validate_oracles.jl)
+# includes this once so it can load PowerModels and ExaPowerIO a single time and
+# run every case in one process, instead of paying `using PowerModels` per case
+# (the bulk of the validation CI time). The standalone validate_*.jl wrappers
+# include it too, so one case can still be checked on its own.
+#
+# Every kernel returns a Vector{String} of problems (empty == match). The caller
+# provides `using PowerModels` (and `using ExaPowerIO` + powerio_ffi.jl for the
+# ExaPowerIO kernel) before including this file.
+
+const _SKIP_FIELDS = ("source_id", "index")
+
+_approx(a, b) =
+    (a isa Number && b isa Number) ? isapprox(float(a), float(b); atol = 1e-9, rtol = 1e-7) : a == b
+
+# JSON has no ±Inf/NaN, so an unbounded reference value (e.g. a pegase gen
+# qmax=Inf) arrives as `nothing` on the JSON side. Restore it from `ref` so the
+# two compare equal (both mean unbounded) and make_per_unit! doesn't trip.
+function _restore_inf!(data, ref)
+    for et in ("bus", "branch", "gen", "load", "shunt")
+        haskey(ref, et) || continue
+        for (k, dv) in get(data, et, Dict())
+            rv = get(ref[et], k, nothing)
+            rv === nothing && continue
+            for (f, val) in dv
+                if val === nothing && haskey(rv, f) && rv[f] isa Number && !isfinite(rv[f])
+                    dv[f] = rv[f]
+                end
+            end
+        end
+    end
+end
+
+_total(d, et, f) = round(sum(e[f] for e in values(get(d, et, Dict())); init = 0.0), digits = 4)
+_count(d, et) = length(get(d, et, Dict()))
+
+# powerio's PowerModels JSON vs PowerModels' own parse of the .m, value for value
+# over bus/branch/gen/load/shunt. Two checks: (1) the powerio JSON must load under
+# PowerModels' default validate=true (the interop property that motivates emitting
+# per_unit=true); (2) parse both with validate=false and per-unitize explicitly so
+# correct_network_data! can't rewrite both sides into agreement and hide a bug.
+function compare_powermodels(ref_m::AbstractString, our_json::AbstractString)
+    try
+        PowerModels.parse_file(our_json)
+    catch e
+        return ["powerio JSON rejected by PowerModels validate=true: $e"]
+    end
+
+    ref = PowerModels.parse_file(ref_m; validate = false)
+    ours = PowerModels.parse_file(our_json; validate = false)
+    PowerModels.make_per_unit!(ref)
+    PowerModels.make_per_unit!(ours)
+    _restore_inf!(ours, ref)
+
+    problems = String[]
+    for et in ("bus", "branch", "gen", "load", "shunt")
+        r = get(ref, et, Dict())
+        o = get(ours, et, Dict())
+        if length(r) != length(o)
+            push!(problems, "$et: count $(length(r)) (ref) vs $(length(o)) (ours)")
+            continue
+        end
+        for (k, rv) in r
+            haskey(o, k) || (push!(problems, "$et[$k]: missing in ours"); continue)
+            ov = o[k]
+            for (f, rfv) in rv
+                f in _SKIP_FIELDS && continue
+                if !haskey(ov, f)
+                    push!(problems, "$et[$k].$f: missing in ours (ref=$rfv)")
+                elseif !_approx(rfv, ov[f])
+                    push!(problems, "$et[$k].$f: ref=$rfv ours=$(ov[f])")
+                end
+            end
+            for f in keys(ov)
+                f in _SKIP_FIELDS && continue
+                haskey(rv, f) || push!(problems, "$et[$k].$f: extra in ours (=$(ov[f]))")
+            end
+        end
+    end
+    return problems
+end
+
+# Generic PowerModels electrical-core comparator: bus/branch/gen/load counts and
+# the demand/generation totals are strict, shunt count is informational (powerio
+# models fixed shunts but not PSS/E switched shunts). Returns (problems, note).
+function compare_psse(ref_path::AbstractString, test_path::AbstractString)
+    ref = PowerModels.parse_file(ref_path)
+    test = PowerModels.parse_file(test_path)
+    _restore_inf!(test, ref)
+    PowerModels.make_per_unit!(ref)
+    PowerModels.make_per_unit!(test)
+
+    problems = String[]
+    for et in ("bus", "branch", "gen", "load")
+        _count(ref, et) == _count(test, et) ||
+            push!(problems, "$et count: ref=$(_count(ref, et)) test=$(_count(test, et))")
+    end
+    for (et, f) in (("load", "pd"), ("load", "qd"), ("gen", "pg"))
+        r, t = _total(ref, et, f), _total(test, et, f)
+        isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σ$et.$f: ref=$r test=$t")
+    end
+    # When the shunt counts agree, the admittances must match too.
+    if _count(ref, "shunt") == _count(test, "shunt")
+        for f in ("gs", "bs")
+            r, t = _total(ref, "shunt", f), _total(test, "shunt", f)
+            isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σshunt.$f: ref=$r test=$t")
+        end
+    end
+    sref, stest = _count(ref, "shunt"), _count(test, "shunt")
+    note = sref == stest ? "" : "  (shunt: ref=$sref test=$stest — switched shunts not modeled)"
+    return problems, note
+end
+
+# Core comparator against a per-unitized reference, totals including shunt gs/bs
+# checked unconditionally so a dropped or mis-scaled element shows up regardless
+# of how each oracle buckets elements per bus.
+function compare_core(ref_path::AbstractString, test_path::AbstractString)
+    ref = PowerModels.parse_file(ref_path)
+    PowerModels.make_per_unit!(ref)
+    local test
+    try
+        test = PowerModels.parse_file(test_path)
+    catch e
+        return ["parse error $e"]
+    end
+    _restore_inf!(test, ref)
+    PowerModels.make_per_unit!(test)
+
+    problems = String[]
+    for et in ("bus", "branch", "gen", "load")
+        _count(ref, et) == _count(test, et) ||
+            push!(problems, "$et count ref=$(_count(ref, et)) test=$(_count(test, et))")
+    end
+    for (et, f) in (("load", "pd"), ("load", "qd"), ("gen", "pg"), ("shunt", "gs"), ("shunt", "bs"))
+        r, t = _total(ref, et, f), _total(test, et, f)
+        isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σ$et.$f ref=$r test=$t")
+    end
+    return problems
+end
+
+_eff_tap(t) = t == 0.0 ? 1.0 : float(t)
+_xa(a, b) = isapprox(float(a), float(b); atol = 1e-6, rtol = 1e-6)
+
+# powerio (through its C ABI, see powerio_ffi.jl) vs ExaPowerIO.jl, value for
+# value on the in-service rows ExaPowerIO keeps (default filtered=true). The
+# caller must `using ExaPowerIO` and include powerio_ffi.jl first.
+function compare_exapowerio(path::AbstractString)
+    c = powerio_load(path)
+    ed = ExaPowerIO.parse_matpower(path)   # default filtered=true
+    base = ed.baseMVA
+
+    # powerio's in-service survivors, in file order, to line up with ExaPowerIO's
+    # filtered, renumbered branch/gen lists.
+    kb = [k for k in 1:c.m if c.branch.in_service[k] != 0]
+    kg = [k for k in 1:c.ng if c.gen.in_service[k] != 0]
+
+    problems = String[]
+    pc(label, a, b) = a == b || push!(problems, "$label count: powerio=$a exapowerio=$b")
+    pc("bus", c.n, length(ed.bus))
+    pc("branch (in service)", length(kb), length(ed.branch))
+    pc("gen (in service)", length(kg), length(ed.gen))
+    isempty(problems) || return problems
+
+    abs(c.base_mva - base) > 1e-6 && push!(problems, "baseMVA: powerio=$(c.base_mva) exapowerio=$base")
+
+    exa_bus_id = [b.bus_i for b in ed.bus]
+    if exa_bus_id != c.bus_ids
+        push!(problems, "bus id order differs (powerio vs exapowerio)")
+        return problems
+    end
+
+    for (k, b) in enumerate(ed.bus)
+        _xa(c.demand.pd[k], b.pd * base) || push!(problems, "bus[$(b.bus_i)].pd: powerio=$(c.demand.pd[k]) exa=$(b.pd*base)")
+        _xa(c.demand.qd[k], b.qd * base) || push!(problems, "bus[$(b.bus_i)].qd: powerio=$(c.demand.qd[k]) exa=$(b.qd*base)")
+        _xa(c.shunt.gs[k], b.gs * base) || push!(problems, "bus[$(b.bus_i)].gs: powerio=$(c.shunt.gs[k]) exa=$(b.gs*base)")
+        _xa(c.shunt.bs[k], b.bs * base) || push!(problems, "bus[$(b.bus_i)].bs: powerio=$(c.shunt.bs[k]) exa=$(b.bs*base)")
+    end
+
+    for (j, k) in enumerate(kb)
+        br = ed.branch[j]
+        cf_id, ct_id = c.branch.from[k], c.branch.to[k]
+        ef_id, et_id = ed.bus[br.f_bus].bus_i, ed.bus[br.t_bus].bus_i
+        if (cf_id, ct_id) != (ef_id, et_id)
+            push!(problems, "branch[$k] endpoints: powerio=($cf_id,$ct_id) exa=($ef_id,$et_id)")
+            continue
+        end
+        _xa(c.branch.r[k], br.br_r) || push!(problems, "branch[$k].r: powerio=$(c.branch.r[k]) exa=$(br.br_r)")
+        _xa(c.branch.x[k], br.br_x) || push!(problems, "branch[$k].x: powerio=$(c.branch.x[k]) exa=$(br.br_x)")
+        _xa(c.branch.b[k], br.b_fr + br.b_to) || push!(problems, "branch[$k].b: powerio=$(c.branch.b[k]) exa=$(br.b_fr + br.b_to)")
+        _xa(_eff_tap(c.branch.tap[k]), _eff_tap(br.tap)) || push!(problems, "branch[$k].tap: powerio=$(c.branch.tap[k]) exa=$(br.tap)")
+        _xa(c.branch.shift[k], rad2deg(br.shift)) || push!(problems, "branch[$k].shift: powerio=$(c.branch.shift[k]) exa(deg)=$(rad2deg(br.shift))")
+    end
+
+    for (j, k) in enumerate(kg)
+        g = ed.gen[j]
+        cg_id, eg_id = c.gen.bus[k], ed.bus[g.bus].bus_i
+        cg_id == eg_id || push!(problems, "gen[$k] bus: powerio=$cg_id exa=$eg_id")
+        _xa(c.gen.pg[k], g.pg * base) || push!(problems, "gen[$k].pg: powerio=$(c.gen.pg[k]) exa=$(g.pg*base)")
+        _xa(c.gen.pmax[k], g.pmax * base) || push!(problems, "gen[$k].pmax: powerio=$(c.gen.pmax[k]) exa=$(g.pmax*base)")
+        _xa(c.gen.pmin[k], g.pmin * base) || push!(problems, "gen[$k].pmin: powerio=$(c.gen.pmin[k]) exa=$(g.pmin*base)")
+    end
+
+    return problems
+end

--- a/benchmarks/render_tables.py
+++ b/benchmarks/render_tables.py
@@ -76,6 +76,11 @@ def panda_rows(rows, cases):
     selected, missing = _select(rows, cases)
     if selected is None:
         return None, missing
+    # The published table always carries the matpowercaseframes baseline; if a run
+    # lacked it (None), fail closed rather than publish an `n/a` cell.
+    no_baseline = [r["case"] for r in selected if r["matpowercaseframes_ms"] is None]
+    if no_baseline:
+        return None, [f"{c} (matpowercaseframes baseline)" for c in no_baseline]
     lines = [
         f"| {r['case']} | {ms(r['powerio_parse_ms'])} | {ms(r['matpowercaseframes_ms'])} |"
         for r in selected

--- a/benchmarks/render_tables.py
+++ b/benchmarks/render_tables.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Regenerate the benchmark speed tables in README.md and benchmarks/RESULTS.md
+from the JSON the bench scripts emit, so the numbers stop being copy-pasted by hand.
+
+Reads benchmarks/results/{speed_julia,speed_python}.json (written by
+`bench_julia.jl --json` and `bench_parse.py --json`) and rewrites only the regions
+fenced by `<!-- BENCH:<id> START -->` / `<!-- BENCH:<id> END -->`. Prose outside the
+markers is never touched.
+
+Scope: the three speed tables only. The correctness matrix and the version block in
+RESULTS.md stay hand-written — correctness is a boolean gated in CI (run_validation.sh),
+not a table that drifts every run.
+
+    python benchmarks/render_tables.py            # rewrite the tables in place
+    python benchmarks/render_tables.py --check    # exit 1 if a table is out of date
+
+A region whose JSON is missing any of its canonical cases is left UNCHANGED with a
+warning (run `bash benchmarks/fetch_cases.sh` and re-bench), so a partial run never
+silently shrinks a published table. Stdlib only; does not import powerio.
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RESULTS_DIR = REPO / "benchmarks" / "results"
+
+SPEED_HEADER = (
+    "| case | buses / branches | powerio | ExaPowerIO.jl | PowerModels.jl |\n"
+    "| --- | --- | --- | --- | --- |"
+)
+PANDA_HEADER = (
+    "| case | powerio parse | matpowercaseframes (pandapower's `.m` reader) |\n"
+    "| --- | --- | --- |"
+)
+
+# Canonical case order per region. A region renders only when its JSON carries
+# every case listed here.
+SPEED_MAIN_CASES = [
+    "case2869pegase", "case_ACTIVSg2000", "case9241pegase", "case13659pegase", "case193k",
+]
+SPEED_JULIA_CASES = [
+    "case2869pegase", "case_ACTIVSg2000", "case9241pegase", "case13659pegase",
+    "case_ACTIVSg10k", "case_ACTIVSg25k", "case_ACTIVSg70k", "case_SyntheticUSA",
+    "case99k", "case193k",
+]
+PANDA_CASES = ["case2869pegase", "case9241pegase", "case13659pegase", "case193k"]
+
+
+def ms(value):
+    return "n/a" if value is None else f"{value} ms"
+
+
+def _select(rows, cases):
+    """Rows for `cases` in order, or (None, missing) when the JSON lacks any of them."""
+    by_case = {r["case"]: r for r in rows}
+    missing = [c for c in cases if c not in by_case]
+    return (None, missing) if missing else ([by_case[c] for c in cases], [])
+
+
+def julia_rows(rows, cases):
+    selected, missing = _select(rows, cases)
+    if selected is None:
+        return None, missing
+    lines = [
+        f"| {r['case']} | {r['buses']} / {r['branches']} | "
+        f"{ms(r['powerio_ms'])} | {ms(r['exapowerio_ms'])} | {ms(r['powermodels_ms'])} |"
+        for r in selected
+    ]
+    return "\n".join(lines), []
+
+
+def panda_rows(rows, cases):
+    selected, missing = _select(rows, cases)
+    if selected is None:
+        return None, missing
+    lines = [
+        f"| {r['case']} | {ms(r['powerio_parse_ms'])} | {ms(r['matpowercaseframes_ms'])} |"
+        for r in selected
+    ]
+    return "\n".join(lines), []
+
+
+def load(name):
+    path = RESULTS_DIR / name
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def splice(text, region_id, body):
+    pat = re.compile(
+        rf"(<!-- BENCH:{re.escape(region_id)} START -->\n).*?(\n<!-- BENCH:{re.escape(region_id)} END -->)",
+        re.DOTALL,
+    )
+    if not pat.search(text):
+        raise SystemExit(f"error: marker BENCH:{region_id} not found; refusing to write")
+    return pat.sub(lambda m: m.group(1) + body + m.group(2), text, count=1)
+
+
+def main():
+    check = "--check" in sys.argv[1:]
+    speed_julia = load("speed_julia.json")
+    speed_python = load("speed_python.json")
+
+    # (region id, target file, table body or None, list of missing cases)
+    plan = []
+    if speed_julia is not None:
+        for region, cases in (("speed-main", SPEED_MAIN_CASES), ("speed-julia", SPEED_JULIA_CASES)):
+            body, missing = julia_rows(speed_julia["rows"], cases)
+            target = "README.md" if region == "speed-main" else "benchmarks/RESULTS.md"
+            plan.append((region, target, SPEED_HEADER, body, missing))
+    if speed_python is not None:
+        body, missing = panda_rows(speed_python["rows"], PANDA_CASES)
+        plan.append(("speed-pandapower", "benchmarks/RESULTS.md", PANDA_HEADER, body, missing))
+
+    if not plan:
+        raise SystemExit(f"error: no JSON in {RESULTS_DIR} — run the bench scripts with --json first")
+
+    edits = {}  # file -> (original text, edited text); each file is read once
+    for region, target, header, body, missing in plan:
+        if body is None:
+            print(f"skip BENCH:{region}: JSON missing {', '.join(missing)} (fetch + re-bench); left unchanged")
+            continue
+        if target not in edits:
+            text = (REPO / target).read_text()
+            edits[target] = (text, text)
+        original, current = edits[target]
+        edits[target] = (original, splice(current, region, f"{header}\n{body}"))
+
+    changed = []
+    for target, (original, new_text) in edits.items():
+        if original != new_text:
+            changed.append(target)
+            if not check:
+                (REPO / target).write_text(new_text)
+
+    if check:
+        if changed:
+            print("out of date: " + ", ".join(changed))
+            return 1
+        print("benchmark tables up to date")
+        return 0
+    print("updated: " + (", ".join(changed) if changed else "nothing (already current)"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -7,4 +7,5 @@
 # (The Julia oracle, PowerModels.jl, is likewise benchmark-scoped in
 # benchmarks/Project.toml, not in any crate.)
 pandapower>=3       # validate_pandapower.py: parse + Y_bus cross-check
+matpowercaseframes  # pandapower's .m reader (from_mpc/_m2ppc), needed by validate_pandapower.py
 gridx-egret>=0.6    # validate_egret.py / validate_matrix.py: the EGRET oracle

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -6,6 +6,6 @@
 #
 # (The Julia oracle, PowerModels.jl, is likewise benchmark-scoped in
 # benchmarks/Project.toml, not in any crate.)
-pandapower>=3       # validate_pandapower.py: parse + Y_bus cross-check
-matpowercaseframes  # pandapower's .m reader (from_mpc/_m2ppc), needed by validate_pandapower.py
-gridx-egret>=0.6    # validate_egret.py / validate_matrix.py: the EGRET oracle
+pandapower>=3          # validate_pandapower.py: parse + Y_bus cross-check
+matpowercaseframes<2   # pandapower's .m reader; 2.x's reader is broken (loadcase bug), 1.x works
+gridx-egret>=0.6       # validate_egret.py / validate_matrix.py: the EGRET oracle

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -6,6 +6,6 @@
 #
 # (The Julia oracle, PowerModels.jl, is likewise benchmark-scoped in
 # benchmarks/Project.toml, not in any crate.)
-pandapower>=3          # validate_pandapower.py: parse + Y_bus cross-check
+pandapower==3.2.2      # validate_pandapower.py: parse + Y_bus cross-check (pinned; 3.4 needs the broken matpowercaseframes 2.x)
 matpowercaseframes<2   # pandapower's .m reader; 2.x's reader is broken (loadcase bug), 1.x works
 gridx-egret>=0.6       # validate_egret.py / validate_matrix.py: the EGRET oracle

--- a/benchmarks/run_validation.sh
+++ b/benchmarks/run_validation.sh
@@ -118,7 +118,8 @@ awk -F'\t' '
 # A FAIL mark is a real discrepancy; n/a and SKIP are not. A short results file
 # (fewer rows than legs run) means a phase crashed before recording — fail loudly.
 mark_fails=$(awk -F'\t' '$3 == "FAIL" { c++ } END { print c + 0 }' "$PIO_RESULTS_TSV")
-expected=$((${#MCASES[@]} * 4 + ${#RAWCASES[@]} + ${#EGCASES[@]} + ${#MCASES[@]} + 1))
+# 5 legs per .m case (PMjson, PMread, PSSE, Exa, pp) + 1 per raw + 1 per egret + 1 matrix.
+expected=$((${#MCASES[@]} * 5 + ${#RAWCASES[@]} + ${#EGCASES[@]} + 1))
 got=$(wc -l <"$PIO_RESULTS_TSV")
 short=0
 [ "$got" -lt "$expected" ] && short=1

--- a/benchmarks/run_validation.sh
+++ b/benchmarks/run_validation.sh
@@ -3,32 +3,33 @@
 # pass/fail matrix. Each MATPOWER fixture is checked against:
 #
 #   PMjson  — powerio's PowerModels JSON (writer) vs PowerModels.jl's own parse of
-#             the .m, field by field.              benchmarks/validate_powermodels.jl
+#             the .m, field by field.
 #   PMread  — powerio's PowerModels JSON reader: PowerModels exports the .m to JSON,
-#             powerio reads it and re-emits, the two are compared.  benchmarks/pm_export.jl
+#             powerio reads it and re-emits, the two are compared.
 #   PSSE    — powerio's PSS/E .raw vs PowerModels.jl (counts + demand/gen totals).
-#                                                   benchmarks/validate_psse.jl
 #   Exa     — powerio (via C ABI) vs ExaPowerIO.jl, value for value.
-#                                                   benchmarks/validate_exapowerio.jl
 #   pp      — powerio's parse + Y_bus vs pandapower (_m2ppc + makeYbus).
-#                                                   benchmarks/validate_pandapower.py
 #
 # Then the read sides and the full conversion matrix:
 #   PSSE-read   — powerio reads a real PSS/E .raw, emits PowerModels JSON, compared
 #                 against PowerModels.jl reading the same .raw.
-#   EGRET-read  — powerio reads a real EGRET .json (egret's own output), emits
-#                 PowerModels JSON, checked against the matching MATPOWER case.
+#   EGRET-read  — powerio reads a real EGRET .json, emits PowerModels JSON, checked
+#                 against the matching MATPOWER case.
 #   matrix(5x5) — every reader -> every writer over the fixtures, each output's
-#                 electrical core checked against the ground-truth MATPOWER case
-#                 (PowerModels.jl for MATPOWER/PowerModels/PSS-E/PowerWorld, the
-#                 egret package for EGRET), byte-exact on the diagonal.
-#                                                   benchmarks/validate_matrix.py
+#                 electrical core checked against the ground-truth MATPOWER case.
+#
+# To keep the wall time down the work is staged so each heavy interpreter starts
+# once, not once per case: PowerModels exports all references (one Julia process),
+# powerio runs all conversions (one Python process), PowerModels + ExaPowerIO run
+# every comparison (one Julia process), pandapower runs every case (one Python
+# process), and the 5x5 matrix runs its own batched process. Each leg appends a
+# `<case>\t<leg>\t<mark>` line to results.tsv, rendered into the matrix below.
 #
 # Prereqs: `cargo build --release -p powerio-capi`, the powerio Python extension
 # built into .venv (`maturin develop --release`), the Julia env instantiated
 # (`julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'`), and the Python
-# oracle tools (`pip install -r benchmarks/requirements.txt`, for the pandapower
-# and EGRET checks). All oracle tools are benchmark-scoped, not powerio deps.
+# oracle tools (`pip install -r benchmarks/requirements.txt`). All oracle tools are
+# benchmark-scoped, not powerio deps.
 #
 #   bash benchmarks/run_validation.sh
 #
@@ -41,10 +42,13 @@ PY="${PYTHON:-.venv/bin/python}"
 JL=(julia --project=benchmarks)
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
+export PIO_RESULTS_TSV="$TMP/results.tsv"
+: > "$PIO_RESULTS_TSV"
 
-# The full matrix needs the egret package (the EGRET oracle); it's a benchmark
-# dependency, not a powerio one (see benchmarks/requirements.txt). Skip that one
-# leg with a notice if it isn't installed, rather than failing the whole run.
+# The full 5x5 matrix needs the egret package (the EGRET oracle); it's a benchmark
+# dependency, not a powerio one. Skip that one leg with a notice if it isn't
+# installed, rather than failing the whole run. The EGRET *read-side* leg below
+# needs only powerio + PowerModels, so it runs regardless.
 HAVE_EGRET=1
 "$PY" -c "import egret" 2>/dev/null || HAVE_EGRET=0
 
@@ -61,131 +65,70 @@ MCASES=(
     tests/data/case2869pegase.m
 )
 RAWCASES=(tests/data/psse/case5.raw tests/data/psse/case14.raw)
+EGCASES=(tests/data/egret/case9.json tests/data/egret/case14.json tests/data/egret/case30.json)
 
-fails=0
-rows=()
-
-# Convert a case to another format via the powerio Python package (no CLI build).
-convert() { # <in> <to> <out>
-    "$PY" - "$@" <<'EOF'
-import sys, warnings
-warnings.filterwarnings("ignore")
-import powerio
-inp, to, out = sys.argv[1], sys.argv[2], sys.argv[3]
-open(out, "w").write(powerio.convert(inp, to).text)
-EOF
-    local rc=$?
-    # Guard against a silent success that wrote nothing — validating an empty file
-    # would otherwise look like a pass.
-    if [ "$rc" -eq 0 ] && [ ! -s "$3" ]; then
-        echo "convert: $1 → $2 produced empty output" >&2
-        return 1
-    fi
-    return "$rc"
+phase_fail=0
+run() { # <label> <command...>
+    echo "=== $1 ==="
+    shift
+    "$@" || phase_fail=$((phase_fail + 1))
 }
 
-# Run a check, echo its output, return a one-word mark for the summary row.
-mark() { # <command...> ; sets MARK
-    if "$@"; then MARK="ok"; else MARK="FAIL"; fails=$((fails + 1)); fi
-}
+# 1. PowerModels exports each .m to a per_unit reference JSON (one Julia process).
+#    Must precede the conversions: the PMread leg re-emits these references.
+run "PowerModels reference export (PMread)" \
+    "${JL[@]}" benchmarks/validate_oracles.jl export "$TMP" "${MCASES[@]}"
 
-echo "=== MATPOWER fixtures ==="
-for m in "${MCASES[@]}"; do
-    base="$(basename "$m" .m)"
-    echo "--- $base ---"
-    row="$(printf '%-26s' "$base")"
+# 2. powerio runs every conversion the comparisons read (one Python process).
+run "powerio conversions" \
+    "$PY" benchmarks/convert_cases.py "$TMP" --m "${MCASES[@]}" --raw "${RAWCASES[@]}" --egret "${EGCASES[@]}"
 
-    if convert "$m" powermodels-json "$TMP/$base.json" 2>"$TMP/err"; then
-        mark "${JL[@]}" benchmarks/validate_powermodels.jl "$m" "$TMP/$base.json"
-    else
-        echo "  PMjson: convert failed"; cat "$TMP/err"; MARK="FAIL"; fails=$((fails + 1))
-    fi
-    row+="  PMjson:$MARK"
+# 3. PowerModels + ExaPowerIO run every comparison leg (one Julia process). A
+#    nonzero exit here means a leg failed, which the results.tsv tally below counts;
+#    it is not a phase crash, so don't double-count it.
+echo "=== PowerModels + ExaPowerIO comparisons ==="
+"${JL[@]}" benchmarks/validate_oracles.jl compare "$TMP" \
+    --m "${MCASES[@]}" --raw "${RAWCASES[@]}" --egret "${EGCASES[@]}" || true
 
-    # PowerModels JSON reader: PowerModels exports the .m to JSON, powerio reads that
-    # and re-emits, and the two are compared — exercises powerio reading real
-    # PowerModels output, not only its own writer.
-    if "${JL[@]}" benchmarks/pm_export.jl "$m" "$TMP/$base.pmref.json" 2>"$TMP/err" \
-        && convert "$TMP/$base.pmref.json" powermodels-json "$TMP/$base.reemit.json" 2>>"$TMP/err"; then
-        mark "${JL[@]}" benchmarks/validate_powermodels.jl "$TMP/$base.pmref.json" "$TMP/$base.reemit.json"
-    else
-        echo "  PMread: setup failed"; cat "$TMP/err"; MARK="FAIL"; fails=$((fails + 1))
-    fi
-    row+="  PMread:$MARK"
+# 4. pandapower parse + Y_bus over every case (one Python process; n/a where its
+#    reader can't parse the case). Nonzero exit == a real mismatch, counted below.
+echo "=== pandapower (parse + Y_bus) ==="
+"$PY" benchmarks/validate_pandapower.py "${MCASES[@]}" || true
 
-    if convert "$m" psse "$TMP/$base.raw" 2>"$TMP/err"; then
-        mark "${JL[@]}" benchmarks/validate_psse.jl "$m" "$TMP/$base.raw"
-    else
-        echo "  PSSE: convert failed"; cat "$TMP/err"; MARK="FAIL"; fails=$((fails + 1))
-    fi
-    row+="  PSSE:$MARK"
-
-    mark "${JL[@]}" benchmarks/validate_exapowerio.jl "$m"
-    row+="  Exa:$MARK"
-
-    # The pp validator exits 77 when its oracle (matpowercaseframes) can't read the
-    # case — e.g. pegase's `Inf` branch limits; treat that as n/a, not a failure.
-    "$PY" benchmarks/validate_pandapower.py "$m"; pp_rc=$?
-    if [ "$pp_rc" -eq 0 ]; then MARK="ok"
-    elif [ "$pp_rc" -eq 77 ]; then MARK="n/a"
-    else MARK="FAIL"; fails=$((fails + 1)); fi
-    row+="  pp:$MARK"
-
-    rows+=("$row")
-done
-
-echo
-echo "=== PSS/E .raw fixtures (read side) ==="
-for r in "${RAWCASES[@]}"; do
-    base="$(basename "$r" .raw)"
-    echo "--- psse/$base ---"
-    row="$(printf '%-26s' "psse/$base")"
-    if convert "$r" powermodels-json "$TMP/psse_$base.json" 2>"$TMP/err"; then
-        mark "${JL[@]}" benchmarks/validate_psse.jl "$r" "$TMP/psse_$base.json"
-    else
-        echo "  PSSE-read: convert failed"; cat "$TMP/err"; MARK="FAIL"; fails=$((fails + 1))
-    fi
-    row+="  PSSE-read:$MARK"
-    rows+=("$row")
-done
-
-echo
-echo "=== EGRET .json fixtures (read side) ==="
-# Real EGRET files (egret's own serializer output) read by powerio, re-emitted as
-# PowerModels JSON, and checked against the matching MATPOWER case.
-for base in case9 case14 case30; do
-    echo "--- egret/$base ---"
-    row="$(printf '%-26s' "egret/$base")"
-    if convert "tests/data/egret/$base.json" powermodels-json "$TMP/egret_$base.json" 2>"$TMP/err"; then
-        mark "${JL[@]}" benchmarks/validate_core.jl "tests/data/$base.m" "$TMP/egret_$base.json"
-    else
-        echo "  EGRET-read: convert failed"; cat "$TMP/err"; MARK="FAIL"; fails=$((fails + 1))
-    fi
-    row+="  EGRET-read:$MARK"
-    rows+=("$row")
-done
-
-echo
+# 5. Full reader x writer matrix (its own batched process).
 echo "=== full reader x writer matrix (PowerModels + egret oracles) ==="
-# Every source format -> every target, each output's core checked against the
-# source's own core via an independent oracle; byte-exact on the diagonal. Real
-# native files where they exist (PSS/E .raw, EGRET .json). See validate_matrix.py.
 if [ "$HAVE_EGRET" -eq 0 ]; then
     echo "  skipped: egret not installed (pip install -r benchmarks/requirements.txt)"
-    rows+=("$(printf '%-26s' 'matrix(5x5)')  all-cells:SKIP(egret)")
+    printf 'matrix(5x5)\tall-cells\tSKIP(egret)\n' >>"$PIO_RESULTS_TSV"
 elif "$PY" benchmarks/validate_matrix.py; then
-    rows+=("$(printf '%-26s' 'matrix(5x5)')  all-cells:ok")
+    printf 'matrix(5x5)\tall-cells\tok\n' >>"$PIO_RESULTS_TSV"
 else
-    rows+=("$(printf '%-26s' 'matrix(5x5)')  all-cells:FAIL"); fails=$((fails + 1))
+    printf 'matrix(5x5)\tall-cells\tFAIL\n' >>"$PIO_RESULTS_TSV"
 fi
 
+# --- summary --------------------------------------------------------------
 echo
 echo "=== summary ==="
-for row in "${rows[@]}"; do echo "$row"; done
+awk -F'\t' '
+    !($1 in seen) { order[++n] = $1; seen[$1] = 1 }
+    { row[$1] = row[$1] sprintf("  %s:%s", $2, $3) }
+    END { for (i = 1; i <= n; i++) printf "%-26s%s\n", order[i], row[order[i]] }
+' "$PIO_RESULTS_TSV"
+
+# A FAIL mark is a real discrepancy; n/a and SKIP are not. A short results file
+# (fewer rows than legs run) means a phase crashed before recording — fail loudly.
+mark_fails=$(awk -F'\t' '$3 == "FAIL" { c++ } END { print c + 0 }' "$PIO_RESULTS_TSV")
+expected=$((${#MCASES[@]} * 4 + ${#RAWCASES[@]} + ${#EGCASES[@]} + ${#MCASES[@]} + 1))
+got=$(wc -l <"$PIO_RESULTS_TSV")
+short=0
+[ "$got" -lt "$expected" ] && short=1
+
 echo
-if [ "$fails" -eq 0 ]; then
+if [ "$mark_fails" -eq 0 ] && [ "$phase_fail" -eq 0 ] && [ "$short" -eq 0 ]; then
     echo "all checks passed"
-else
-    echo "$fails check(s) FAILED"
+    exit 0
 fi
-exit "$((fails > 0 ? 1 : 0))"
+[ "$short" -eq 1 ] && echo "incomplete: recorded $got of $expected legs (a phase crashed)"
+[ "$phase_fail" -ne 0 ] && echo "$phase_fail phase(s) failed to run"
+[ "$mark_fails" -ne 0 ] && echo "$mark_fails check(s) FAILED"
+exit 1

--- a/benchmarks/run_validation.sh
+++ b/benchmarks/run_validation.sh
@@ -123,7 +123,12 @@ for m in "${MCASES[@]}"; do
     mark "${JL[@]}" benchmarks/validate_exapowerio.jl "$m"
     row+="  Exa:$MARK"
 
-    mark "$PY" benchmarks/validate_pandapower.py "$m"
+    # The pp validator exits 77 when its oracle (matpowercaseframes) can't read the
+    # case — e.g. pegase's `Inf` branch limits; treat that as n/a, not a failure.
+    "$PY" benchmarks/validate_pandapower.py "$m"; pp_rc=$?
+    if [ "$pp_rc" -eq 0 ]; then MARK="ok"
+    elif [ "$pp_rc" -eq 77 ]; then MARK="n/a"
+    else MARK="FAIL"; fails=$((fails + 1)); fi
     row+="  pp:$MARK"
 
     rows+=("$row")

--- a/benchmarks/validate_core.jl
+++ b/benchmarks/validate_core.jl
@@ -1,67 +1,19 @@
-# Generic PowerModels core comparator, batched. Loads one reference and compares
-# the electrical core of each test file to it: bus/branch/gen/load counts and the
-# demand/generation/shunt totals after make_per_unit!. Used by validate_matrix.sh
-# to check every reader->writer output that PowerModels can read (MATPOWER,
-# PowerModels JSON, PSS/E, and PowerWorld via a powerio .aux -> JSON bridge)
-# against the ground-truth MATPOWER case, in a single Julia process.
+# Generic PowerModels electrical-core comparator: one reference, one or more test
+# files. bus/branch/gen/load counts and the demand/generation/shunt totals after
+# make_per_unit!. The comparison kernel is shared with the batched driver
+# (oracle_compare.jl); this is the standalone wrapper.
 #
 #   julia --project=benchmarks validate_core.jl <ref> <test1> [test2 ...]
 #
 # Prints "OK <test>" or "FAIL <test>: ..." per file; exits nonzero if any fail.
 using PowerModels
 PowerModels.silence()
-
-ref = PowerModels.parse_file(ARGS[1])
-# Inf survives per-unit unchanged, so per-unit the reference up front; each test
-# then restores its JSON-null (unbounded) fields from it before its own per-unit.
-PowerModels.make_per_unit!(ref)
-
-cnt(d, et) = length(get(d, et, Dict()))
-total(d, et, f) = round(sum(e[f] for e in values(get(d, et, Dict())); init = 0.0), digits = 4)
-
-function restore_inf!(test)
-    for et in ["bus", "branch", "gen", "load", "shunt"]
-        haskey(ref, et) || continue
-        for (k, tv) in get(test, et, Dict())
-            rv = get(ref[et], k, nothing)
-            rv === nothing && continue
-            for (f, val) in tv
-                if val === nothing && haskey(rv, f) && rv[f] isa Number && !isfinite(rv[f])
-                    tv[f] = rv[f]
-                end
-            end
-        end
-    end
-end
+include(joinpath(@__DIR__, "oracle_compare.jl"))
 
 fails = 0
+ref = ARGS[1]
 for test_path in ARGS[2:end]
-    local test
-    try
-        test = PowerModels.parse_file(test_path)
-    catch e
-        println("FAIL $test_path: parse error $e")
-        global fails += 1
-        continue
-    end
-    restore_inf!(test)
-    PowerModels.make_per_unit!(test)
-
-    problems = String[]
-    for et in ["bus", "branch", "gen", "load"]
-        if cnt(ref, et) != cnt(test, et)
-            push!(problems, "$et count ref=$(cnt(ref, et)) test=$(cnt(test, et))")
-        end
-    end
-    # Totals are checked unconditionally, including shunt gs/bs: a dropped or
-    # mis-scaled element shows up in the sum regardless of how each oracle buckets
-    # elements into per-bus entries, so this catches a loss even when the counts
-    # legitimately differ.
-    for (et, f) in [("load", "pd"), ("load", "qd"), ("gen", "pg"), ("shunt", "gs"), ("shunt", "bs")]
-        r, t = total(ref, et, f), total(test, et, f)
-        isapprox(r, t; atol = 1e-6, rtol = 1e-6) || push!(problems, "Σ$et.$f ref=$r test=$t")
-    end
-
+    problems = compare_core(ref, test_path)
     if isempty(problems)
         println("OK $test_path")
     else
@@ -69,5 +21,4 @@ for test_path in ARGS[2:end]
         global fails += 1
     end
 end
-
 exit(fails == 0 ? 0 : 1)

--- a/benchmarks/validate_exapowerio.jl
+++ b/benchmarks/validate_exapowerio.jl
@@ -1,117 +1,26 @@
 # Validate powerio's parse against ExaPowerIO.jl, value for value, on a MATPOWER
-# case. powerio's numbers come through its C ABI (see powerio_ffi.jl); ExaPowerIO is
-# the reference Julia reader, parsed with its default filtered=true. That default
-# drops out-of-service branches/gens and isolated (type-4) buses and renumbers the
-# survivors, so we filter powerio's tables to the in-service rows and compare those
-# — the genuine test that powerio reproduces ExaPowerIO's filtered view. Encodings
-# reconciled:
+# case. powerio's numbers come through its C ABI (see powerio_ffi.jl); ExaPowerIO
+# is the reference Julia reader, parsed with its default filtered=true (which drops
+# out-of-service rows and renumbers the survivors, so powerio's tables are filtered
+# to the in-service rows to match). The comparison kernel — including the unit and
+# encoding reconciliations (per-unit MW, b_fr+b_to split, radians vs degrees, tap
+# 0→1) — is shared with the batched driver (oracle_compare.jl); this is the
+# standalone one-case wrapper. Needs `cargo build --release -p powerio-capi`.
 #
-#   - ExaPowerIO returns per-unit MW/MVAr (÷baseMVA); powerio returns raw MW. ×base.
-#   - ExaPowerIO splits line charging into b_fr + b_to (each = b/2); powerio's b is
-#     the total. Compare powerio.b == b_fr + b_to.
-#   - ExaPowerIO stores shift / angle limits in radians; powerio in degrees.
-#   - ExaPowerIO normalizes tap 0→1; powerio keeps the raw 0, so normalize both.
-#   - ExaPowerIO rewrites bus types (PV/PQ/ref) from generator placement, so the
-#     bus `type` is deliberately not compared.
-#
-# Bus filtering on type 4 isn't exercised here (no fixture has isolated buses, and
-# the C ABI doesn't surface the bus type); the in-service branch/gen filtering is.
-#
-#   julia --project=benchmarks benchmarks/validate_exapowerio.jl tests/data/case14.m
-#
-# Exit 0 on a full match, 1 on any mismatch. Needs `cargo build --release -p powerio-capi`.
-
+#   julia --project=benchmarks validate_exapowerio.jl tests/data/case14.m
 using ExaPowerIO
+include(joinpath(@__DIR__, "oracle_compare.jl"))
 include(joinpath(@__DIR__, "powerio_ffi.jl"))
 
-const ATOL = 1e-6
-const RTOL = 1e-6
-
-approx(a, b) = isapprox(float(a), float(b); atol = ATOL, rtol = RTOL)
-eff_tap(t) = t == 0.0 ? 1.0 : float(t)
-
-function main(path)
-    name = basename(path)
-    c = powerio_load(path)
-    ed = ExaPowerIO.parse_matpower(path)   # default filtered=true
-    base = ed.baseMVA
-
-    # powerio's in-service survivors, in file order, to line up with ExaPowerIO's
-    # filtered, renumbered branch/gen lists.
-    kb = [k for k in 1:c.m if c.branch.in_service[k] != 0]
-    kg = [k for k in 1:c.ng if c.gen.in_service[k] != 0]
-
-    problems = String[]
-    push_count(label, a, b) = a == b || push!(problems, "$label count: powerio=$a exapowerio=$b")
-    push_count("bus", c.n, length(ed.bus))
-    push_count("branch (in service)", length(kb), length(ed.branch))
-    push_count("gen (in service)", length(kg), length(ed.gen))
-    isempty(problems) || return report(name, problems)
-
-    if abs(c.base_mva - base) > ATOL
-        push!(problems, "baseMVA: powerio=$(c.base_mva) exapowerio=$base")
+path = ARGS[1]
+problems = compare_exapowerio(path)
+name = basename(path)
+if isempty(problems)
+    println("MATCH: $name — bus/branch/gen counts and values identical")
+else
+    println("MISMATCH: $name ($(length(problems)))")
+    for p in first(problems, 40)
+        println("  ", p)
     end
-
-    # Buses aren't dropped here (no type-4 fixtures), so they stay in file order.
-    exa_bus_id = [b.bus_i for b in ed.bus]
-    if exa_bus_id != c.bus_ids
-        push!(problems, "bus id order differs (powerio vs exapowerio)")
-        return report(name, problems)
-    end
-
-    # Per-bus demand / shunt: ExaPowerIO per-unit → ×base to powerio's raw MW.
-    for (k, b) in enumerate(ed.bus)
-        approx(c.demand.pd[k], b.pd * base) || push!(problems, "bus[$(b.bus_i)].pd: powerio=$(c.demand.pd[k]) exa=$(b.pd*base)")
-        approx(c.demand.qd[k], b.qd * base) || push!(problems, "bus[$(b.bus_i)].qd: powerio=$(c.demand.qd[k]) exa=$(b.qd*base)")
-        approx(c.shunt.gs[k], b.gs * base)  || push!(problems, "bus[$(b.bus_i)].gs: powerio=$(c.shunt.gs[k]) exa=$(b.gs*base)")
-        approx(c.shunt.bs[k], b.bs * base)  || push!(problems, "bus[$(b.bus_i)].bs: powerio=$(c.shunt.bs[k]) exa=$(b.bs*base)")
-    end
-
-    # Per in-service branch. powerio from/to are 1-based bus ids (same id space as
-    # pio_bus_ids), so compare them to ExaPowerIO's bus ids directly.
-    for (j, k) in enumerate(kb)
-        br = ed.branch[j]
-        cf_id = c.branch.from[k]
-        ct_id = c.branch.to[k]
-        ef_id = ed.bus[br.f_bus].bus_i
-        et_id = ed.bus[br.t_bus].bus_i
-        if (cf_id, ct_id) != (ef_id, et_id)
-            push!(problems, "branch[$k] endpoints: powerio=($cf_id,$ct_id) exa=($ef_id,$et_id)")
-            continue
-        end
-        approx(c.branch.r[k], br.br_r) || push!(problems, "branch[$k].r: powerio=$(c.branch.r[k]) exa=$(br.br_r)")
-        approx(c.branch.x[k], br.br_x) || push!(problems, "branch[$k].x: powerio=$(c.branch.x[k]) exa=$(br.br_x)")
-        approx(c.branch.b[k], br.b_fr + br.b_to) || push!(problems, "branch[$k].b: powerio=$(c.branch.b[k]) exa=$(br.b_fr + br.b_to)")
-        approx(eff_tap(c.branch.tap[k]), eff_tap(br.tap)) || push!(problems, "branch[$k].tap: powerio=$(c.branch.tap[k]) exa=$(br.tap)")
-        approx(c.branch.shift[k], rad2deg(br.shift)) || push!(problems, "branch[$k].shift: powerio=$(c.branch.shift[k]) exa(deg)=$(rad2deg(br.shift))")
-    end
-
-    # Per in-service gen. powerio gen.bus is a 1-based bus id; ExaPowerIO g.bus is a
-    # dense 1-based index into ed.bus.
-    for (j, k) in enumerate(kg)
-        g = ed.gen[j]
-        cg_id = c.gen.bus[k]
-        eg_id = ed.bus[g.bus].bus_i
-        cg_id == eg_id || push!(problems, "gen[$k] bus: powerio=$cg_id exa=$eg_id")
-        approx(c.gen.pg[k], g.pg * base)     || push!(problems, "gen[$k].pg: powerio=$(c.gen.pg[k]) exa=$(g.pg*base)")
-        approx(c.gen.pmax[k], g.pmax * base) || push!(problems, "gen[$k].pmax: powerio=$(c.gen.pmax[k]) exa=$(g.pmax*base)")
-        approx(c.gen.pmin[k], g.pmin * base) || push!(problems, "gen[$k].pmin: powerio=$(c.gen.pmin[k]) exa=$(g.pmin*base)")
-    end
-
-    return report(name, problems)
+    exit(1)
 end
-
-function report(name, problems)
-    if isempty(problems)
-        println("MATCH: $name — bus/branch/gen counts and values identical")
-        return 0
-    else
-        println("MISMATCH: $name ($(length(problems)))")
-        for p in first(problems, 40)
-            println("  ", p)
-        end
-        return 1
-    end
-end
-
-exit(main(ARGS[1]))

--- a/benchmarks/validate_oracles.jl
+++ b/benchmarks/validate_oracles.jl
@@ -1,0 +1,122 @@
+# Batched cross-tool validation driver: load PowerModels and ExaPowerIO ONCE and
+# run every oracle leg for every fixture in a single process, instead of spawning
+# a fresh `julia` (and re-`using PowerModels`) per case — the bulk of the
+# validation CI wall time. The per-leg comparison kernels live in oracle_compare.jl;
+# the standalone validate_*.jl wrappers reuse the same kernels for one-off checks.
+#
+#   julia --project=benchmarks validate_oracles.jl export  <tmp> <case.m>...
+#   julia --project=benchmarks validate_oracles.jl compare <tmp> --m <m>... --raw <r>... --egret <e>...
+#
+# `export` writes <tmp>/<base>.pmref.json (PowerModels' own per_unit JSON) for the
+# PMread leg — it must run before powerio re-emits it. `compare` runs PMjson /
+# PMread / PSSE / Exa over the MATPOWER cases, PSSE-read over the .raw cases, and
+# EGRET-read over the EGRET cases, reading powerio's conversions from <tmp> (named
+# by convention, see run_validation.sh). It appends one `<case>\t<leg>\t<mark>`
+# line per leg to <tmp>/results.tsv and prints detail; exits nonzero on any FAIL.
+using PowerModels
+using ExaPowerIO
+PowerModels.silence()
+include(joinpath(@__DIR__, "oracle_compare.jl"))
+include(joinpath(@__DIR__, "powerio_ffi.jl"))
+
+stem(path) = first(splitext(basename(path)))
+
+# A leg that reads a powerio conversion fails cleanly if that conversion is
+# missing or empty (the Python convert phase reports the underlying error).
+present(path) = (isfile(path) && filesize(path) > 0) ? nothing : "missing or empty: $(basename(path))"
+
+# Run one leg: require `files` to exist, run `cmp` (caught so one leg can't abort
+# the driver), record the mark to results.tsv, print detail. `cmp` returns the
+# problems vector, or a (problems, note) tuple for an informational annotation.
+# Returns true on pass.
+function leg!(io, case, name, files, cmp)
+    miss = filter(!isnothing, present.(files))
+    problems, note = if !isempty(miss)
+        (String.(miss), "")
+    else
+        try
+            r = cmp()
+            r isa Tuple ? r : (r, "")
+        catch e
+            (["exception: $e"], "")
+        end
+    end
+    ok = isempty(problems)
+    println(io, "$case\t$name\t$(ok ? "ok" : "FAIL")")
+    if ok
+        println("MATCH: $case $name$note")
+    else
+        println("MISMATCH: $case $name$note ($(length(problems)))")
+        for p in first(problems, 40)
+            println("  ", p)
+        end
+    end
+    return ok
+end
+
+function do_export(tmp, mcases)
+    for m in mcases
+        PowerModels.export_file(joinpath(tmp, stem(m) * ".pmref.json"), PowerModels.parse_file(m))
+    end
+end
+
+function do_compare(tmp, groups)
+    fails = 0
+    open(joinpath(tmp, "results.tsv"), "a") do io
+        for m in groups["m"]
+            b = stem(m)
+            pmjson = joinpath(tmp, "$b.pmjson.json")
+            pmref, reemit = joinpath(tmp, "$b.pmref.json"), joinpath(tmp, "$b.reemit.json")
+            psse = joinpath(tmp, "$b.psse.raw")
+
+            leg!(io, b, "PMjson", [pmjson], () -> compare_powermodels(m, pmjson)) || (fails += 1)
+            leg!(io, b, "PMread", [pmref, reemit], () -> compare_powermodels(pmref, reemit)) || (fails += 1)
+            leg!(io, b, "PSSE", [psse], () -> compare_psse(m, psse)) || (fails += 1)
+            leg!(io, b, "Exa", String[], () -> compare_exapowerio(m)) || (fails += 1)
+        end
+
+        for r in groups["raw"]
+            b = stem(r)
+            json = joinpath(tmp, "psse_$b.json")
+            leg!(io, "psse/$b", "PSSE-read", [json], () -> compare_psse(r, json)) || (fails += 1)
+        end
+
+        for e in groups["egret"]
+            b = stem(e)
+            json = joinpath(tmp, "egret_$b.json")
+            mref = joinpath(@__DIR__, "..", "tests", "data", "$b.m")
+            leg!(io, "egret/$b", "EGRET-read", [json], () -> compare_core(mref, json)) || (fails += 1)
+        end
+    end
+    return fails
+end
+
+function parse_groups(args)
+    groups = Dict("m" => String[], "raw" => String[], "egret" => String[])
+    cur = nothing
+    for a in args
+        if startswith(a, "--")
+            cur = a[3:end]
+            haskey(groups, cur) || error("unknown group flag --$cur")
+        else
+            cur === nothing && error("argument before any --group flag: $a")
+            push!(groups[cur], a)
+        end
+    end
+    return groups
+end
+
+function main(args)
+    isempty(args) && error("usage: validate_oracles.jl export|compare <tmp> ...")
+    mode, tmp, rest = args[1], args[2], args[3:end]
+    if mode == "export"
+        do_export(tmp, rest)
+        return 0
+    elseif mode == "compare"
+        return do_compare(tmp, parse_groups(rest)) == 0 ? 0 : 1
+    else
+        error("unknown mode $mode (expected export or compare)")
+    end
+end
+
+exit(main(ARGS))

--- a/benchmarks/validate_pandapower.py
+++ b/benchmarks/validate_pandapower.py
@@ -71,7 +71,16 @@ def main():
     name = path.name
 
     case = powerio.parse_matpower(str(path))
-    ppc = _m2ppc(str(path), "mpc")
+    try:
+        ppc = _m2ppc(str(path), "mpc")
+    except OverflowError as exc:
+        # pandapower's reader (matpowercaseframes) does int(float(tok)) and raises on
+        # the `Inf` limit tokens MATPOWER uses for "unlimited" (e.g. pegase branch
+        # limits). That's an oracle limitation, not a powerio discrepancy — skip this
+        # case (exit 77 -> n/a) rather than report a false mismatch. powerio, PowerModels,
+        # and ExaPowerIO all read the case, so it stays covered by the other validators.
+        print(f"SKIP: {name} — pandapower's matpowercaseframes reader can't parse Inf limits ({exc})")
+        return 77
     bus, branch, gen = ppc["bus"], ppc["branch"], ppc["gen"]
     base_mva = float(ppc["baseMVA"])
 

--- a/benchmarks/validate_pandapower.py
+++ b/benchmarks/validate_pandapower.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate powerio's parse and Y_bus against pandapower on a MATPOWER case.
+"""Validate powerio's parse and Y_bus against pandapower on MATPOWER cases.
 
 pandapower is an independent MATPOWER reader (via matpowercaseframes) and carries
 PYPOWER's `makeYbus`, the same admittance kernel MATPOWER uses. We compare the two
@@ -16,13 +16,17 @@ auxiliary buses, and raises on dclines / parallel branches inside `from_ppc`.
 `_m2ppc` runs before any of that, so it works on every case (pegase included) and
 keeps the bus order aligned with powerio's file order.
 
-    python benchmarks/validate_pandapower.py tests/data/case14.m
+    python benchmarks/validate_pandapower.py tests/data/case14.m [case.m ...]
 
-Exit 0 on a full match, 1 on any mismatch. Needs the `powerio` package and
-pandapower (`pip install 'powerio[bench]'`).
+Imports pandapower once and loops every case (the validation matrix runs all
+fixtures in one process to amortize the import). Per case the mark is `ok`, `FAIL`,
+or `n/a` (pandapower's reader can't parse the case — an oracle limit, not a powerio
+discrepancy). Appends `<stem>\tpp\t<mark>` to $PIO_RESULTS_TSV when set. Exits
+nonzero only on a real mismatch. Needs the `powerio` package and pandapower.
 """
 
 import logging
+import os
 import sys
 import warnings
 from collections import defaultdict
@@ -63,24 +67,20 @@ def sum_by_bus(elems, ka, kb):
     return a, b
 
 
-def main():
-    if len(sys.argv) != 2:
-        print("usage: validate_pandapower.py <case.m>", file=sys.stderr)
-        return 2
-    path = Path(sys.argv[1])
+def check_case(path):
+    """Validate one case. Returns the mark: "ok", "FAIL", or "n/a"."""
     name = path.name
-
     case = powerio.parse_matpower(str(path))
     try:
         ppc = _m2ppc(str(path), "mpc")
     except OverflowError as exc:
         # pandapower's reader (matpowercaseframes) does int(float(tok)) and raises on
         # the `Inf` limit tokens MATPOWER uses for "unlimited" (e.g. pegase branch
-        # limits). That's an oracle limitation, not a powerio discrepancy — skip this
-        # case (exit 77 -> n/a) rather than report a false mismatch. powerio, PowerModels,
-        # and ExaPowerIO all read the case, so it stays covered by the other validators.
+        # limits). That's an oracle limitation, not a powerio discrepancy — mark it
+        # n/a rather than report a false mismatch. powerio, PowerModels, and
+        # ExaPowerIO all read the case, so it stays covered by the other validators.
         print(f"SKIP: {name} — pandapower's matpowercaseframes reader can't parse Inf limits ({exc})")
-        return 77
+        return "n/a"
     bus, branch, gen = ppc["bus"], ppc["branch"], ppc["gen"]
     base_mva = float(ppc["baseMVA"])
 
@@ -98,7 +98,7 @@ def main():
         problems.append(f"gen count: powerio={ng} pandapower={gen.shape[0]}")
     if problems:
         report(name, problems)
-        return 1
+        return "FAIL"
 
     # --- bus-id alignment (both should be file order) -------------------
     powerio_ids = [b["id"] for b in case.buses]
@@ -106,7 +106,7 @@ def main():
     if sorted(powerio_ids) != sorted(pp_ids):
         problems.append("bus id sets differ between powerio and pandapower")
         report(name, problems)
-        return 1
+        return "FAIL"
     pp_row_of_id = {bid: r for r, bid in enumerate(pp_ids)}
     order = np.array([pp_row_of_id[bid] for bid in powerio_ids])  # pp rows, powerio order
 
@@ -175,7 +175,7 @@ def main():
                 )
 
     report(name, problems)
-    return 1 if problems else 0
+    return "FAIL" if problems else "ok"
 
 
 def check_vec(problems, label, a, b, atol=ATOL, rtol=RTOL):
@@ -197,6 +197,25 @@ def report(name, problems):
         print(f"MISMATCH: {name} ({len(problems)})")
         for p in problems[:40]:
             print("  ", p)
+
+
+def main():
+    cases = sys.argv[1:]
+    if not cases:
+        print("usage: validate_pandapower.py <case.m> [case.m ...]", file=sys.stderr)
+        return 2
+    results = os.environ.get("PIO_RESULTS_TSV")
+    fails = 0
+    for arg in cases:
+        path = Path(arg)
+        print(f"--- pp {path.stem} ---")
+        mark = check_case(path)
+        if mark == "FAIL":
+            fails += 1
+        if results:
+            with open(results, "a") as fh:
+                fh.write(f"{path.stem}\tpp\t{mark}\n")
+    return 1 if fails else 0
 
 
 if __name__ == "__main__":

--- a/benchmarks/validate_powermodels.jl
+++ b/benchmarks/validate_powermodels.jl
@@ -1,87 +1,22 @@
 # Validate powerio's PowerModels JSON against PowerModels' own parse of the .m,
-# value for value over bus/branch/gen/load/shunt.
-# Usage: julia --project=benchmarks validate_powermodels.jl case.m our.json
+# value for value over bus/branch/gen/load/shunt. The comparison kernel is shared
+# with the batched driver (oracle_compare.jl); this is the standalone one-case
+# wrapper (validate_oracles.jl runs every case in one process to amortize the
+# PowerModels load).
 #
-# Two checks:
-#  1. Consumability — powerio writes idiomatic per_unit=true JSON, so PowerModels'
-#     default parse_file (validate=true, which runs correct_network_data! and the
-#     dcline correction) must load it without error. This is the interop property
-#     that motivated emitting per_unit=true.
-#  2. Value-for-value — parse both sides with validate=false and per-unitize them
-#     explicitly. validate=false matters: correct_network_data! clamps angmin/angmax
-#     to ±60° (default_pad) and normalizes branch direction / thermal limits, which
-#     would rewrite BOTH sides into agreement and hide a scaling bug. make_per_unit!
-#     is a no-op on data already flagged per_unit=true (powerio's JSON), so it only
-#     per-unitizes the native .m reference.
+#   julia --project=benchmarks validate_powermodels.jl case.m our.json
 using PowerModels
 PowerModels.silence()
+include(joinpath(@__DIR__, "oracle_compare.jl"))
 
 ref_m, our_json = ARGS[1], ARGS[2]
-
-# 1. Consumability: the powerio JSON must load under PowerModels' default validate=true.
-try
-    PowerModels.parse_file(our_json)
-catch e
-    println("MISMATCH: ", basename(ref_m), " — powerio JSON rejected by PowerModels validate=true: ", e)
-    exit(1)
-end
-
-# 2. Strict comparison on un-normalized, explicitly per-unitized data.
-ref  = PowerModels.parse_file(ref_m; validate=false)
-ours = PowerModels.parse_file(our_json; validate=false)
-PowerModels.make_per_unit!(ref)
-PowerModels.make_per_unit!(ours)
-
-# JSON has no ±Inf/NaN, so an unbounded ref value (e.g. a pegase gen qmax=Inf)
-# arrives as `nothing` on our side. Restore it from the reference so the two
-# compare equal (both mean unbounded).
-for et in ["bus", "branch", "gen", "load", "shunt"]
-    haskey(ref, et) || continue
-    for (k, ov) in get(ours, et, Dict())
-        rv = get(ref[et], k, nothing)
-        rv === nothing && continue
-        for (f, val) in ov
-            if val === nothing && haskey(rv, f) && rv[f] isa Number && !isfinite(rv[f])
-                ov[f] = rv[f]
-            end
-        end
-    end
-end
-
-approx(a, b) = (a isa Number && b isa Number) ? isapprox(float(a), float(b); atol=1e-9, rtol=1e-7) : a == b
-
-# source_id/index are bookkeeping, not network data.
-const SKIP = ("source_id", "index")
-
-mismatches = String[]
-for et in ["bus", "branch", "gen", "load", "shunt"]
-    r = get(ref, et, Dict()); o = get(ours, et, Dict())
-    if length(r) != length(o)
-        push!(mismatches, "$et: count $(length(r)) (ref) vs $(length(o)) (ours)")
-        continue
-    end
-    for (k, rv) in r
-        haskey(o, k) || (push!(mismatches, "$et[$k]: missing in ours"); continue)
-        ov = o[k]
-        for (f, rfv) in rv
-            f in SKIP && continue
-            if !haskey(ov, f)
-                push!(mismatches, "$et[$k].$f: missing in ours (ref=$rfv)")
-            elseif !approx(rfv, ov[f])
-                push!(mismatches, "$et[$k].$f: ref=$rfv ours=$(ov[f])")
-            end
-        end
-        for f in keys(ov)
-            f in SKIP && continue
-            haskey(rv, f) || push!(mismatches, "$et[$k].$f: extra in ours (=$(ov[f]))")
-        end
-    end
-end
-
-if isempty(mismatches)
+problems = compare_powermodels(ref_m, our_json)
+if isempty(problems)
     println("MATCH: ", basename(ref_m), " — loads under validate=true; bus/branch/gen/load/shunt identical per-unit")
 else
-    println("MISMATCH: ", basename(ref_m), " (", length(mismatches), ")")
-    for m in first(mismatches, 40); println("  ", m); end
+    println("MISMATCH: ", basename(ref_m), " (", length(problems), ")")
+    for m in first(problems, 40)
+        println("  ", m)
+    end
     exit(1)
 end

--- a/benchmarks/validate_psse.jl
+++ b/benchmarks/validate_psse.jl
@@ -1,75 +1,24 @@
 # Validate powerio's PSS/E support against PowerModels (which reads PSS/E `.raw`).
-# Generic comparator: parse two PowerModels-readable files, make_per_unit both,
-# and compare the electrical core. bus/branch/gen/load and the demand/generation
-# totals are strict; shunt count is informational (powerio models fixed shunts but
-# not PSS/E switched shunts).
+# Generic comparator: bus/branch/gen/load and the demand/generation totals are
+# strict, shunt count is informational. The comparison kernel is shared with the
+# batched driver (oracle_compare.jl); this is the standalone one-case wrapper.
 #
-# Two uses, driven by `powerio convert` (see the loop in the PR's validation run):
+# Two uses, driven by `powerio convert`:
 #   write side:  ref = case.m         test = powerio's case.raw
 #   read side:   ref = real.raw       test = powerio's PowerModels JSON of real.raw
 #
-#   julia --project=benchmarks benchmarks/validate_psse.jl <ref> <test>
+#   julia --project=benchmarks validate_psse.jl <ref> <test>
 using PowerModels
 PowerModels.silence()
+include(joinpath(@__DIR__, "oracle_compare.jl"))
 
 ref_path, test_path = ARGS[1], ARGS[2]
-ref  = PowerModels.parse_file(ref_path)
-test = PowerModels.parse_file(test_path)
-
-# JSON can't carry ±Inf; an unbounded value arrives as `nothing`. Restore it from
-# the reference so make_per_unit! (which divides by the base) doesn't trip.
-for et in ["bus", "branch", "gen", "load", "shunt"]
-    haskey(ref, et) || continue
-    for (k, tv) in get(test, et, Dict())
-        rv = get(ref[et], k, nothing)
-        rv === nothing && continue
-        for (f, val) in tv
-            if val === nothing && haskey(rv, f) && rv[f] isa Number && !isfinite(rv[f])
-                tv[f] = rv[f]
-            end
-        end
-    end
-end
-
-PowerModels.make_per_unit!(ref)
-PowerModels.make_per_unit!(test)
-
-total(d, et, f) = round(sum(e[f] for e in values(get(d, et, Dict())); init = 0.0), digits = 4)
-count(d, et) = length(get(d, et, Dict()))
-
-problems = String[]
-for et in ["bus", "branch", "gen", "load"]
-    if count(ref, et) != count(test, et)
-        push!(problems, "$et count: ref=$(count(ref, et)) test=$(count(test, et))")
-    end
-end
-for (et, f) in [("load", "pd"), ("load", "qd"), ("gen", "pg")]
-    r, t = total(ref, et, f), total(test, et, f)
-    if !isapprox(r, t; atol = 1e-6, rtol = 1e-6)
-        push!(problems, "Σ$et.$f: ref=$r test=$t")
-    end
-end
-
-# When the shunt counts agree (no switched-shunt discrepancy), the shunt
-# admittances must match too — a dropped or mis-scaled fixed shunt would otherwise
-# slip past the count-only check.
-if count(ref, "shunt") == count(test, "shunt")
-    for f in ["gs", "bs"]
-        r, t = total(ref, "shunt", f), total(test, "shunt", f)
-        if !isapprox(r, t; atol = 1e-6, rtol = 1e-6)
-            push!(problems, "Σshunt.$f: ref=$r test=$t")
-        end
-    end
-end
-
+problems, note = compare_psse(ref_path, test_path)
 name = basename(ref_path)
-sref, stest = count(ref, "shunt"), count(test, "shunt")
-shunt_note = sref == stest ? "" : "  (shunt: ref=$sref test=$stest — switched shunts not modeled)"
-
 if isempty(problems)
-    println("MATCH: $name — bus/branch/gen/load + totals identical after per-unit$shunt_note")
+    println("MATCH: $name — bus/branch/gen/load + totals identical after per-unit$note")
 else
-    println("MISMATCH: $name$shunt_note")
+    println("MISMATCH: $name$note")
     for p in problems
         println("  ", p)
     end

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+# powerio docs
+
+Reference material that doesn't fit in the top-level [README](../README.md) or a
+crate doc comment.
+
+- [format-fidelity.md](format-fidelity.md) — the numeric conventions every reader
+  and writer follows, how they're validated against four independent tools, and the
+  per-format limits reported in `Conversion::warnings`.
+- [matrices.md](matrices.md) — the matrix family `powerio-matrix` builds and the
+  sign, tap, per unit, and DC conventions across them.
+- [dcopf-bundle.md](dcopf-bundle.md) — the Matrix Market + manifest schema the
+  `dcopf` subcommand writes for a downstream solver.
+
+Rendered API docs (rustdoc) for all crates:
+<https://eigenergy.github.io/powerio/>.
+
+## Architecture
+
+`Network` is the one canonical model: format neutral, with loads, shunts, branches,
+and generators as first-class records. Every reader produces a `Network` and every
+writer consumes one, so a format is one reader/writer at the hub rather than a
+pairwise converter, and adding one touches a single module. `IndexedNetwork` is the
+dense `[0, n)` analysis view derived from a `Network`; the matrix builders work from
+it. The parser, the hub, the lossless writer, and the converters live in the
+`powerio` crate (light dependencies); the matrices and graph views live in
+`powerio-matrix`, which re-exports `powerio` so one import pulls in both layers.

--- a/docs/matrices.md
+++ b/docs/matrices.md
@@ -1,6 +1,6 @@
 # Matrix outputs and conventions
 
-`powerio-matrix` builds sparse matrices and graph views from a [`Network`]. The
+`powerio-matrix` builds sparse matrices and graph views from a `Network`. The
 builders take the dense-indexed `IndexedNetwork`, which maps MATPOWER bus ids to a
 contiguous `[0, n)`. This document is the convention reference; the DC-OPF bundle
 has its own schema in [dcopf-bundle.md](dcopf-bundle.md), and per-builder API
@@ -41,8 +41,9 @@ dense `m×n`; sparse large-scale PTDF is future work. The DC-OPF instance bundle
 - **`BR_B` is already per unit.** Line charging susceptance is per unit on `baseMVA`
   in MATPOWER; never divide by `base_mva` again.
 - **DC susceptance.** The default is `b = 1/x` (`DcConvention::PaperPure`, taps and
-  shifts ignored), which makes `L = A diag(b) Aᵀ` equal `build_bprime`.
-  `DcConvention::Matpower` uses `b = 1/(x·τ)` plus a phase-shift injection `p_shift`.
+  shifts ignored), which makes `L = A diag(b) Aᵀ` equal `build_bprime` in the XB
+  scheme. `DcConvention::Matpower` uses `b = 1/(x·τ)` plus a phase shift injection
+  `p_shift`.
 
 ## Output
 

--- a/docs/matrices.md
+++ b/docs/matrices.md
@@ -1,0 +1,57 @@
+# Matrix outputs and conventions
+
+`powerio-matrix` builds sparse matrices and graph views from a [`Network`]. The
+builders take the dense-indexed `IndexedNetwork`, which maps MATPOWER bus ids to a
+contiguous `[0, n)`. This document is the convention reference; the DC-OPF bundle
+has its own schema in [dcopf-bundle.md](dcopf-bundle.md), and per-builder API
+detail is in the [crate docs](https://eigenergy.github.io/powerio/powerio_matrix/).
+
+## What it builds
+
+| matrix | shape | builder | notes |
+| --- | --- | --- | --- |
+| B' (FDPF) | n×n | `build_bprime` | singular positive Laplacian, rank n−1, shuntless |
+| B'' (FDPF) | n×n | `build_bdoubleprime` | SDDM when bus shunts are present |
+| `Re(Y_bus)`, `-Im(Y_bus)` | n×n | `build_ybus` | full admittance, keeps taps and shifts |
+| LACPF block | 2n×2n | `build_lacpf` | `[[G, −B], [−B, −G]]`, flat start, indefinite |
+| signed incidence `A` | n×m | `build_incidence` | column `e`: `+1` at from-bus, `−1` at to-bus |
+| weighted Laplacian `L` | n×n | `build_weighted_laplacian` | `L = A diag(w) Aᵀ`, `ground_at` removes a row/col |
+| flow map `B Aᵀ` | m×n | `build_flow_map` | `f = B Aᵀ θ` |
+| PTDF | m×n | `build_ptdf` | dense; factors the Laplacian grounded at the slack |
+| LODF | m×m | `build_lodf` | dense DC line-outage factors |
+| adjacency | n×n | `build_adjacency` | `MatrixKind::Adjacency` |
+| petgraph view | — | `IndexedNetwork::to_petgraph` | `UnGraph<bus_idx, branch_idx>` |
+
+PTDF and LODF need a linear solve; both factor `ground_at(L, r)` (SPD) with the
+self-contained dense Cholesky in `matrix::sensitivity`, no external solver. PTDF is
+dense `m×n`; sparse large-scale PTDF is future work. The DC-OPF instance bundle (`A`,
+`b`, `L`, costs, bounds, thermal limits, `C_g`) is documented in
+[dcopf-bundle.md](dcopf-bundle.md).
+
+## Conventions
+
+- **Positive Laplacian.** Off-diagonal `< 0`, diagonal `> 0`, with `diag = Σ|off-diag|`
+  for B'. This is the M-matrix form an SDDM or Cholesky solver expects; a consumer
+  recovers an edge weight as `−L[i,j] > 0`.
+- **Bus indexing.** MATPOWER bus ids are 1-based and preserved on the model.
+  `IndexedNetwork::bus_index(id)` is the only mapping into the dense `[0, n)`; an id
+  out of range is an `Error::UnknownBus`, never clamped.
+- **Taps and shifts.** `tap == 0` means `tap = 1` (`Branch::effective_tap`). B'
+  ignores taps and shifts; B'' keeps taps and zeros only shifts; Y_bus keeps both.
+- **`BR_B` is already per unit.** Line charging susceptance is per unit on `baseMVA`
+  in MATPOWER; never divide by `base_mva` again.
+- **DC susceptance.** The default is `b = 1/x` (`DcConvention::PaperPure`, taps and
+  shifts ignored), which makes `L = A diag(b) Aᵀ` equal `build_bprime`.
+  `DcConvention::Matpower` uses `b = 1/(x·τ)` plus a phase-shift injection `p_shift`.
+
+## Output
+
+Matrices write as Matrix Market or stay in memory. A symmetric matrix writes the
+lower triangle with the `symmetric` header, 1-based indices, via `io::mtx::write_mtx`
+(sprs writes the upper triangle, so powerio ships its own spec-compliant writer).
+The `sensitivities` and `dcopf` CLI subcommands bundle the relevant family with a
+JSON manifest.
+
+The petgraph view (`UnGraph<usize, usize>`, node weight = dense bus index, edge
+weight = branch index) backs the connectivity and radial diagnostics and is the
+substrate for spanning-tree work (LinDist3Flow).

--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -34,6 +34,11 @@ int main(int argc, char **argv) {
         return 2;
     }
 
+    /* ABI handshake: a consumer refuses a library whose ABI version differs from
+     * the header it compiled against. pio_version() is a static, non-owned string. */
+    CHECK(pio_abi_version() == PIO_ABI_VERSION, "ABI version mismatch");
+    printf("powerio %s (ABI %u)\n", pio_version(), pio_abi_version());
+
     char err[PIO_ERRBUF_MIN];
     PioCase *c = pio_parse(argv[1], NULL, err, sizeof err);
     CHECK(c != NULL, err);

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -31,6 +31,16 @@
 extern "C" {
 #endif
 
+/* ABI version of this interface. pio_abi_version() returns the value the library
+ * was built with; compare it against PIO_ABI_VERSION (the value you compiled
+ * against) and refuse a mismatched library. Bump on any breaking change to an
+ * existing pio_* signature or the JSON transport schema (additive symbols don't
+ * bump it). pio_version() is the informational crate version string ("0.1.0"):
+ * 'static and NUL-terminated, do NOT free it. */
+#define PIO_ABI_VERSION 1
+uint32_t pio_abi_version(void);
+const char *pio_version(void);
+
 typedef struct PioCase PioCase;
 
 /* Parse `path`; format from the file extension, or forced by `from`

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -71,6 +71,33 @@ unsafe fn guard<R>(fallback: R, f: impl FnOnce() -> R) -> R {
     catch_unwind(AssertUnwindSafe(f)).unwrap_or(fallback)
 }
 
+/// ABI version of this C interface. Bump on any breaking change to an existing
+/// `pio_*` signature or to the JSON transport schema (new additive symbols don't
+/// require a bump). A consumer compares [`pio_abi_version`] against the value it
+/// was built against (the `PIO_ABI_VERSION` macro in `powerio.h`) and refuses a
+/// mismatched library instead of calling in blind.
+pub const PIO_ABI_VERSION: u32 = 1;
+
+/// The ABI version the library was built with (see [`PIO_ABI_VERSION`]). Lets a
+/// consumer detect a stale or incompatible library at load time. Infallible.
+#[unsafe(no_mangle)]
+pub extern "C" fn pio_abi_version() -> u32 {
+    PIO_ABI_VERSION
+}
+
+/// The crate version string (e.g. `"0.1.0"`), `'static` and NUL-terminated — do
+/// NOT free it. Informational; pair it with [`pio_abi_version`] for the actual
+/// compatibility check.
+#[unsafe(no_mangle)]
+pub extern "C" fn pio_version() -> *const c_char {
+    // env! is resolved at compile time; the trailing NUL makes it a valid C
+    // string and the 'static lifetime means the pointer is always valid and
+    // never owned by the caller.
+    concat!(env!("CARGO_PKG_VERSION"), "\0")
+        .as_ptr()
+        .cast::<c_char>()
+}
+
 /// Parse `path` (format from extension, or `from` if non-NULL) into a case
 /// handle. Returns `NULL` on error and writes the message into `errbuf`.
 #[unsafe(no_mangle)]
@@ -513,6 +540,16 @@ mod tests {
         let c = unsafe { pio_parse(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len()) };
         assert!(!c.is_null(), "parse returned null");
         c
+    }
+
+    #[test]
+    fn version_surface() {
+        // The ABI version is the compatibility contract a consumer checks at
+        // load; the version string is static, NUL-terminated, and non-empty.
+        assert_eq!(pio_abi_version(), PIO_ABI_VERSION);
+        let v = unsafe { CStr::from_ptr(pio_version()) }.to_str().unwrap();
+        assert_eq!(v, env!("CARGO_PKG_VERSION"));
+        assert!(!v.is_empty());
     }
 
     #[test]

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -9,6 +9,11 @@ repository = "https://github.com/eigenergy/powerio"
 keywords = ["matpower", "sparse", "ptdf", "dc-opf"]
 categories = ["science", "mathematics"]
 
+# Render the feature-gated surface (gridfm Parquet export, the kkt operators) on
+# docs.rs when this crate is published.
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 # Experimental DC-OPF interior point operators (optional).
 kkt = []

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -20,17 +20,15 @@
 //!
 //! # Conventions
 //!
-//! - **Positive Laplacian.** Off-diagonal negative, diagonal positive, with
-//!   `diag = sum |off-diag|` for B' — the M-matrix form SDDM/Cholesky solvers
-//!   expect.
-//! - **Bus indexing.** MATPOWER 1-based bus ids are preserved on the model;
-//!   [`IndexedNetwork`] maps them to a dense `[0, n)` for the builders.
-//! - **Taps and shifts.** `tap == 0` means `tap = 1`. B' ignores taps and
-//!   shifts; B'' keeps taps and zeros only shifts; Y_bus keeps both.
-//! - **`BR_B` is already per unit** — never divide by `base_mva` again.
-//! - **DC-OPF is bus-indexed** (`p_g ∈ ℝⁿ`); the default susceptance is
-//!   `b = 1/x` (paper-pure), and [`DcConvention::Matpower`] uses `1/(x·τ)` plus
-//!   a phase-shift injection.
+//! B' and the Laplacians use the positive (M-matrix) form: off-diagonal `< 0`,
+//! diagonal `> 0`, `diag = Σ|off-diag|`. Bus ids are MATPOWER 1-based on the
+//! model; [`IndexedNetwork`] maps them to a dense `[0, n)`. `tap == 0` means
+//! `tap = 1`; B' ignores taps and shifts, B'' keeps taps and zeros shifts,
+//! Y_bus keeps both. `BR_B` is already per unit. DC-OPF is bus-indexed
+//! (`p_g ∈ ℝⁿ`), default susceptance `b = 1/x`, with [`DcConvention::Matpower`]
+//! the `1/(x·τ)` plus phase-shift variant. The full reference across every
+//! matrix is in
+//! [docs/matrices.md](https://github.com/eigenergy/powerio/blob/main/docs/matrices.md).
 
 // Re-export the powerio data layer so this crate is a one-stop import, and so
 // the matrix modules' `crate::Error` / `crate::network` / `crate::format` paths

--- a/powerio/Cargo.toml
+++ b/powerio/Cargo.toml
@@ -9,6 +9,12 @@ repository = "https://github.com/eigenergy/powerio"
 keywords = ["matpower", "parser", "lossless"]
 categories = ["science", "parsing"]
 
+# powerio has no features, so this just pins the docs.rs build to the same flags
+# the Pages build uses; the block is here so a future `cargo publish` renders
+# identically on docs.rs.
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 thiserror = "2"
 num-complex = "0.4"

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -89,7 +89,7 @@ pub fn target_format_from_name(name: &str) -> Option<TargetFormat> {
 /// Read the case at `path` into a [`Network`], choosing the reader from `from`
 /// (a format name, see [`target_format_from_name`]) or, when `None`, from the
 /// file extension (`m`/`json`/`raw`/`aux`). A `.json` file is sniffed for the
-/// EGRET vs PowerModels shape (see [`sniff_json`]); pass `from` to force one.
+/// EGRET vs PowerModels shape; pass `from` to force one.
 /// The one reader the CLI and the Python/C bindings share, so adding a source
 /// format is one edit here, not one per binding.
 ///

--- a/scripts/dev-capi.sh
+++ b/scripts/dev-capi.sh
@@ -7,7 +7,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-cargo build -p powerio-capi --release >&2
+# --features arrow so the sibling PowerIO.jl build gets the zero-copy
+# pio_export_arrow symbol; the base ABI is identical with or without it.
+cargo build -p powerio-capi --release --features arrow >&2
 
 case "$(uname -s)" in
   Darwin) ext=dylib ;;

--- a/scripts/dev-capi.sh
+++ b/scripts/dev-capi.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build the C ABI and print the env line that points a consumer at it.
+#
+# With a sibling ../PowerIO.jl checkout, PowerIO.jl auto-discovers this build and
+# needs nothing further. This script is for non-sibling layouts and for the wider
+# C/C++/Julia FFI: run it, then `eval "$(scripts/dev-capi.sh)"` to export the path.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cargo build -p powerio-capi --release >&2
+
+case "$(uname -s)" in
+  Darwin) ext=dylib ;;
+  *)      ext=so ;;
+esac
+lib="$PWD/target/release/libpowerio_capi.$ext"
+
+echo "built $lib" >&2
+echo "export POWERIO_CAPI=$lib"


### PR DESCRIPTION
## Summary

Three threads, all on the `Network` hub.

**Tandem dev (powerio ↔ PowerIO.jl).** `julia-binding.yml` builds `powerio-capi` and runs the separate [PowerIO.jl](https://github.com/eigenergy/PowerIO.jl) test suite against it (path-filtered to code dirs), so a change to the `pio_*` surface or the `Network` JSON schema that breaks the Julia binding fails here, at the source. `scripts/dev-capi.sh` builds the cdylib and prints the `POWERIO_CAPI` line. The companion PowerIO.jl PR adds sibling auto-discovery so local tandem dev needs no env var.

**Docs.**
- `docs.yml` builds `cargo doc --no-deps --all-features` for all four crates and deploys to GitHub Pages, with `RUSTDOCFLAGS=-D warnings` so a broken intra-doc link fails the build. `[package.metadata.docs.rs]` on `powerio` + `powerio-matrix` readies a future crates.io publish. No crate is published here.
- README rewritten to terse notes; the dead `docs.rs/...` links now point at the Pages URL.
- `docs/matrices.md` lifts the sign/tap/per-unit/DC conventions out of the crate `//!` + CLAUDE.md into a browsable reference; `docs/README.md` adds an index + architecture note. Two public docs that linked to private items are fixed (would have failed `-D warnings`).

**Benchmark + correctness automation.**
- `bench_julia.jl` and `bench_parse.py` gain `--json`; `render_tables.py` rewrites only the `<!-- BENCH:* -->` speed-table regions in README + RESULTS from it. The `/refresh-benchmarks` skill drives the local refresh.
- `validation.yml` gates correctness (`run_validation.sh`) on PRs, path-filtered. Speed stays local (per-machine, not CI).
- `benchmarks/asv/` adds an airspeed velocity suite for self-regression tracking over commits.

**Hooks** (`.claude/settings.json`): `rustfmt` on `.rs` edits; cbindgen header regen on `powerio-capi/src/lib.rs` edits.

## Verification
- `cargo fmt --all --check`, `cargo clippy -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -- -D warnings`, `cargo test -p powerio -p powerio-matrix`: pass.
- `cargo doc --no-deps --all-features` for all four crates with `-D warnings`: clean.
- `render_tables.py --check` against the current published numbers: no-op (formatting matches byte for byte).
- PowerIO.jl suite against a locally built capi via the sibling probe: 47/47 pass.

## One-time setup / follow-ups
- Enable Pages: Settings → Pages → Source = GitHub Actions, so `docs.yml` can deploy.
- The `asv` maturin `build_command` and the AirspeedVelocity.jl action want a live run to confirm on CI hardware; both are off the default build path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
