### PR TITLE
feat(mcp): expose powerio as an MCP convert/validate tool (#26)

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,11 +39,13 @@ jobs:
           python-version: ${{ matrix.python }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      # `pip install .[all]` builds the extension via the maturin backend and
-      # pulls scipy/numpy/networkx so the matrix and graph tests run. Quote the
-      # extras so the shell doesn't glob `[all]`.
+      # `pip install .[all,mcp]` builds the extension via the maturin backend and
+      # pulls scipy/numpy/networkx (matrix + graph tests) plus the MCP SDK. The
+      # `mcp` extra carries a `python_version >= '3.10'` marker, so it installs
+      # the SDK on 3.12 (test_mcp runs) and resolves to nothing on 3.9 (test_mcp
+      # skips). Quote the extras so the shell doesn't glob `[all,mcp]`.
       - name: Install powerio + test deps
-        run: pip install '.[all]' pytest
+        run: pip install '.[all,mcp]' pytest
       - name: Run tests
         run: pytest python/tests -q
       # The zero-dep promise: parse/convert/write import nothing but the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,9 @@ cargo build -p powerio-py    # plain cargo build of the extension
 maturin develop              # build + install the `powerio` wheel into the active venv
 maturin develop -E all       # also pull scipy/numpy/networkx for the matrix + graph paths
 pytest python/tests
+
+# MCP server (optional; the `mcp` SDK needs Python 3.10+):
+pip install '.[mcp]' && powerio-mcp    # serve convert_case + case_summary over stdio
 ```
 
 ## Layout
@@ -117,6 +120,7 @@ powerio-cli/                  # the `powerio` binary (CLI + TUI)
 
 powerio-py/src/lib.rs        # PyO3 extension → COO triplets (module `_powerio`)
 python/powerio/              # importable package (scipy/networkx assembly, lazy)
+python/powerio/mcp/          # optional FastMCP server (convert_case + case_summary)
 python/tests/test_powerio.py
 powerio-capi/                # C ABI (pio_*, include/powerio.h, examples/smoke.c)
 │                            #   src/arrow_export.rs: pio_export_arrow (feature = "arrow")
@@ -142,6 +146,15 @@ benchmarks/                  # parse benchmarks + Julia validation harnesses
   raises a clear ImportError. `maturin develop` drops the `.so` into
   `python/powerio/`. One package surfaces both halves: parse/convert and the
   matrices.
+- **MCP server is optional and isolated.** `python/powerio/mcp/` is a FastMCP
+  server wrapping `parse`/`convert` as two tools (`convert_case`,
+  `case_summary`); entry point `powerio-mcp`. It is gated behind the
+  `powerio[mcp]` extra, which carries a `python_version >= '3.10'` marker (the
+  `mcp` SDK needs 3.10+, the core stays 3.9). It reuses the existing
+  parser/converter — don't reimplement parsing there — and **must never be
+  imported from `powerio/__init__.py`**, so `import powerio` stays zero-dep
+  (the subprocess test in `test_powerio.py` enforces this). `convert` is
+  path-only, so `convert_case` stages inline content to a temp file.
 - **Lossless round-trip.** Every reader retains the original source text and the
   same-format writer echoes it, so `parse → write → parse` is byte-for-byte for
   all five formats (`write_as` returns the retained source when the target

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ gen, load, shunt) over the [Arrow C Data Interface](https://arrow.apache.org/doc
 pyarrow, Arrow.jl, Arrow C++, polars, and DuckDB read a table in process without a
 copy or a temp file. It is the in memory form of `pio_to_json`.
 
+## MCP server
+
+powerio ships an optional [MCP](https://modelcontextprotocol.io) server so
+LLM-agent tooling gets a fast, lossless converter over the case-file family. It
+exposes two tools over stdio — `convert_case` (to a target format, with fidelity
+warnings) and `case_summary` (counts, base MVA, source format, connectivity) —
+each accepting either a file `path` or inline `content`.
+
+```
+pip install 'powerio[mcp]'   # the MCP extra (needs Python 3.10+; the core is 3.9+)
+powerio-mcp                  # serve the two tools over stdio
+```
+
 ## Benchmark
 
 Median parse time, one Apple M-series laptop, release build. Every parser runs in

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ copy or a temp file. It is the in memory form of `pio_to_json`.
 ## MCP server
 
 powerio ships an optional [MCP](https://modelcontextprotocol.io) server so
-LLM-agent tooling gets a fast, lossless converter over the case-file family. It
-exposes two tools over stdio — `convert_case` (to a target format, with fidelity
-warnings) and `case_summary` (counts, base MVA, source format, connectivity) —
-each accepting either a file `path` or inline `content`.
+LLM agent tooling gets a lossless converter and a case summary over the case
+file family. It exposes two tools over stdio — `convert_case` (to a target
+format, with fidelity warnings) and `case_summary` (counts, base MVA, source
+format, connectivity) — each accepting either a file `path` or inline `content`.
 
 ```
 pip install 'powerio[mcp]'   # the MCP extra (needs Python 3.10+; the core is 3.9+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,14 @@ bench = ["matpowercaseframes", "pandapower"]
 # with the Rust `gridfm` feature (`maturin develop -E gridfm --features gridfm`),
 # so the default wheel stays interpreter-only.
 gridfm = ["pandas>=2", "pyarrow>=14"]
+# The MCP server (powerio.mcp) wraps parse/convert as two MCP tools. The
+# official `mcp` SDK (FastMCP) requires Python >=3.10; the env marker keeps this
+# extra a no-op on 3.9 so `import powerio` stays zero-dep and 3.9-compatible.
+mcp = ["mcp>=1.2; python_version >= '3.10'"]
+
+[project.scripts]
+# Serves the convert_case + case_summary tools over stdio. Needs the `mcp` extra.
+powerio-mcp = "powerio.mcp.server:main"
 
 [project.urls]
 Repository = "https://github.com/eigenergy/powerio"

--- a/python/powerio/mcp/__init__.py
+++ b/python/powerio/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""MCP (Model Context Protocol) server for powerio.
+
+Optional: install with ``pip install 'powerio[mcp]'`` (needs Python 3.10+).
+This submodule is never imported by ``powerio/__init__.py``, so ``import
+powerio`` stays zero-dependency; the MCP SDK is pulled in only here.
+"""
+
+from .server import main
+
+__all__ = ["main"]

--- a/python/powerio/mcp/__init__.py
+++ b/python/powerio/mcp/__init__.py
@@ -2,7 +2,7 @@
 
 Optional: install with ``pip install 'powerio[mcp]'`` (needs Python 3.10+).
 This submodule is never imported by ``powerio/__init__.py``, so ``import
-powerio`` stays zero-dependency; the MCP SDK is pulled in only here.
+powerio`` stays zero-dep; the MCP SDK is pulled in only here.
 """
 
 from .server import main

--- a/python/powerio/mcp/__main__.py
+++ b/python/powerio/mcp/__main__.py
@@ -1,0 +1,3 @@
+from .server import main
+
+main()

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -27,7 +27,10 @@ mcp = FastMCP("powerio")
 # Format name (and alias) → file extension, for staging inline content to a temp
 # file. ``convert`` is path-only, so inline conversion writes the text to disk
 # first; a matching extension keeps the format obvious even though we always
-# pass ``from_`` explicitly for inline input.
+# pass ``from_`` explicitly for inline input. Mirrors the canonical Rust tables
+# (`target_format_from_name` + `TargetFormat::extension` in
+# `powerio/src/format/mod.rs`); the temp file goes away once powerio grows an
+# in-memory `convert_str` (see issue tracker) and this map with it.
 _EXT = {
     "matpower": ".m",
     "m": ".m",
@@ -45,12 +48,21 @@ _EXT = {
 def _stage(content: str, fmt: str) -> str:
     """Write ``content`` to a temp file whose extension matches ``fmt``.
 
-    Returns the path; the caller is responsible for deleting it.
+    Returns the path; the caller is responsible for deleting it. Writes UTF-8
+    regardless of the platform's default text encoding, because the case
+    readers decode as UTF-8 (a non-UTF-8 locale would otherwise corrupt
+    non-ASCII content or fail the parse). If the write fails, the temp file
+    `mkstemp` already created on disk is removed before re-raising — the caller
+    only learns the path on success, so it can't clean up after a failed stage.
     """
     suffix = _EXT.get(fmt.strip().lower(), ".txt")
     fd, path = tempfile.mkstemp(suffix=suffix)
-    with os.fdopen(fd, "w") as fh:
-        fh.write(content)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    except Exception:
+        os.unlink(path)
+        raise
     return path
 
 

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -1,6 +1,6 @@
 """A FastMCP server exposing powerio's lossless converter and case summary.
 
-Two tools for LLM-agent tooling, both accepting either a filesystem ``path`` or
+Two tools for LLM agent tooling, both accepting either a filesystem ``path`` or
 inline ``content``:
 
 - ``convert_case`` — convert a case file between formats, returning the text and
@@ -30,7 +30,7 @@ mcp = FastMCP("powerio")
 # pass ``from_`` explicitly for inline input. Mirrors the canonical Rust tables
 # (`target_format_from_name` + `TargetFormat::extension` in
 # `powerio/src/format/mod.rs`); the temp file goes away once powerio grows an
-# in-memory `convert_str` (see issue tracker) and this map with it.
+# in-memory `convert_str` (issue #66) and this map with it.
 _EXT = {
     "matpower": ".m",
     "m": ".m",
@@ -44,6 +44,16 @@ _EXT = {
     "powerworld": ".aux",
     "aux": ".aux",
 }
+
+
+def _unlink_quietly(path: str) -> None:
+    """Remove ``path``, ignoring a missing or locked file. Cleanup runs next to
+    an in-flight exception (a failed write, a conversion error), so it must
+    never raise and mask the error the caller actually cares about."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
 
 
 def _stage(content: str, fmt: str) -> str:
@@ -62,7 +72,7 @@ def _stage(content: str, fmt: str) -> str:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
     except Exception:
-        os.unlink(path)
+        _unlink_quietly(path)
         raise
     return path
 
@@ -79,7 +89,7 @@ def convert_case(
     content: Optional[str] = None,
     from_: Optional[str] = None,
 ) -> dict:
-    """Convert a power-system case file to another format, losslessly where the
+    """Convert a power system case file to another format, losslessly where the
     target allows.
 
     Provide exactly one of ``path`` (a file on disk) or ``content`` (inline file
@@ -103,7 +113,7 @@ def convert_case(
             try:
                 conv = powerio.convert(tmp, to, from_)
             finally:
-                os.unlink(tmp)
+                _unlink_quietly(tmp)
     except powerio.PowerIOError as exc:
         raise ValueError(f"conversion failed: {exc}") from exc
     except FileNotFoundError as exc:
@@ -117,7 +127,7 @@ def case_summary(
     content: Optional[str] = None,
     format: str = "matpower",
 ) -> dict:
-    """Summarize a power-system case: name, base MVA, source format, element
+    """Summarize a power system case: name, base MVA, source format, element
     counts, and connectivity.
 
     Provide exactly one of ``path`` or ``content``. For inline ``content``,

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -35,6 +35,7 @@ _EXT = {
     "matpower": ".m",
     "m": ".m",
     "powermodels-json": ".json",
+    "powermodels": ".json",
     "pm": ".json",
     "egret-json": ".json",
     "egret": ".json",
@@ -87,8 +88,9 @@ def convert_case(
     (``raw``), ``powerworld`` (``aux``). The input format is inferred from the
     file extension for ``path``; ``from_`` is REQUIRED with inline ``content``.
 
-    Returns ``{"text": <converted file>, "warnings": [<fields the target could
-    not represent>]}``.
+    Returns ``{"text": <converted file>, "warnings": [<fidelity notes: data the
+    target can't represent, defaults synthesized, or blocks mapped
+    best-effort>]}`` (empty for a faithful conversion).
     """
     _one_input(path, content)
     if content is not None and not from_:

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -1,0 +1,139 @@
+"""A FastMCP server exposing powerio's lossless converter and case summary.
+
+Two tools for LLM-agent tooling, both accepting either a filesystem ``path`` or
+inline ``content``:
+
+- ``convert_case`` — convert a case file between formats, returning the text and
+  any fidelity warnings.
+- ``case_summary`` — counts, base MVA, source format, and connectivity, with no
+  scipy/numpy in the loop.
+
+Run over stdio with the ``powerio-mcp`` console script (or ``python -m
+powerio.mcp``). The server reuses ``powerio.convert``/``parse``/``parse_str`` —
+it never reimplements parsing.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Optional
+
+import powerio
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("powerio")
+
+# Format name (and alias) → file extension, for staging inline content to a temp
+# file. ``convert`` is path-only, so inline conversion writes the text to disk
+# first; a matching extension keeps the format obvious even though we always
+# pass ``from_`` explicitly for inline input.
+_EXT = {
+    "matpower": ".m",
+    "m": ".m",
+    "powermodels-json": ".json",
+    "pm": ".json",
+    "egret-json": ".json",
+    "egret": ".json",
+    "psse": ".raw",
+    "raw": ".raw",
+    "powerworld": ".aux",
+    "aux": ".aux",
+}
+
+
+def _stage(content: str, fmt: str) -> str:
+    """Write ``content`` to a temp file whose extension matches ``fmt``.
+
+    Returns the path; the caller is responsible for deleting it.
+    """
+    suffix = _EXT.get(fmt.strip().lower(), ".txt")
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(content)
+    return path
+
+
+def _one_input(path: Optional[str], content: Optional[str]) -> None:
+    if (path is None) == (content is None):
+        raise ValueError("provide exactly one of `path` or `content`")
+
+
+@mcp.tool()
+def convert_case(
+    to: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    from_: Optional[str] = None,
+) -> dict:
+    """Convert a power-system case file to another format, losslessly where the
+    target allows.
+
+    Provide exactly one of ``path`` (a file on disk) or ``content`` (inline file
+    text). ``to``/``from_`` are format names or aliases: ``matpower`` (``m``),
+    ``powermodels-json`` (``pm``), ``egret-json`` (``egret``), ``psse``
+    (``raw``), ``powerworld`` (``aux``). The input format is inferred from the
+    file extension for ``path``; ``from_`` is REQUIRED with inline ``content``.
+
+    Returns ``{"text": <converted file>, "warnings": [<fields the target could
+    not represent>]}``.
+    """
+    _one_input(path, content)
+    if content is not None and not from_:
+        raise ValueError("`from_` is required when converting inline `content`")
+    try:
+        if path is not None:
+            conv = powerio.convert(path, to, from_)
+        else:
+            tmp = _stage(content, from_)
+            try:
+                conv = powerio.convert(tmp, to, from_)
+            finally:
+                os.unlink(tmp)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+    return {"text": conv.text, "warnings": list(conv.warnings)}
+
+
+@mcp.tool()
+def case_summary(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> dict:
+    """Summarize a power-system case: name, base MVA, source format, element
+    counts, and connectivity.
+
+    Provide exactly one of ``path`` or ``content``. For inline ``content``,
+    ``format`` names the input format (default ``matpower``). Pulls in no
+    scipy/numpy.
+    """
+    _one_input(path, content)
+    try:
+        case = (
+            powerio.parse(path) if path is not None else powerio.parse_str(content, format)
+        )
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+    return {
+        "name": case.name,
+        "base_mva": case.base_mva,
+        "source_format": case.source_format,
+        "n_buses": case.n,
+        "n_branches": case.n_branches,
+        "n_gens": case.n_gens,
+        "n_loads": case.n_loads,
+        "n_shunts": case.n_shunts,
+        "is_radial": case.is_radial,
+        "n_connected_components": case.n_connected_components,
+        "connectivity_report": case.connectivity_report(),
+    }
+
+
+def main() -> None:
+    """Console-script entry point: serve the two tools over stdio."""
+    mcp.run()

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -1,0 +1,70 @@
+"""Tests for the optional MCP server (``powerio.mcp``).
+
+Run with ``pytest python/tests`` after ``maturin develop`` and ``pip install
+'.[mcp]'``. The whole module skips cleanly when the ``mcp`` extra is absent
+(e.g. on Python 3.9, where the SDK is unavailable). The FastMCP-decorated tools
+stay ordinary callables, so we exercise them in-process without a transport.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="powerio[mcp] not installed (needs Python 3.10+)")
+
+from powerio.mcp.server import case_summary, convert_case  # noqa: E402
+
+DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
+
+
+def test_case_summary_path():
+    s = case_summary(path=str(DATA / "case9.m"))
+    assert s["n_buses"] == 9
+    assert s["source_format"] == "Matpower"
+    assert s["base_mva"] == 100.0
+    assert s["n_connected_components"] == 1
+    assert s["connectivity_report"]["n_buses"] == 9
+
+
+def test_case_summary_inline():
+    text = (DATA / "case9.m").read_text()
+    s = case_summary(content=text, format="matpower")
+    assert s["n_buses"] == 9
+    assert s["source_format"] == "Matpower"
+
+
+def test_convert_case_path():
+    r = convert_case(to="powermodels-json", path=str(DATA / "case30.m"))
+    assert isinstance(r["text"], str) and r["text"]
+    assert isinstance(r["warnings"], list)
+    assert len(json.loads(r["text"])["bus"]) == 30
+
+
+def test_convert_case_inline_requires_from():
+    text = (DATA / "case30.m").read_text()
+    with pytest.raises(ValueError):
+        convert_case(to="psse", content=text)  # missing from_
+    r = convert_case(to="psse", content=text, from_="matpower")
+    assert r["text"]
+
+
+def test_convert_case_exactly_one_input():
+    with pytest.raises(ValueError):
+        convert_case(to="matpower")  # neither path nor content
+    with pytest.raises(ValueError):
+        convert_case(to="matpower", path="x", content="y")  # both
+
+
+def test_case_summary_exactly_one_input():
+    with pytest.raises(ValueError):
+        case_summary()  # neither
+    with pytest.raises(ValueError):
+        case_summary(path="x", content="y")  # both
+
+
+def test_errors_map_cleanly():
+    with pytest.raises(ValueError):  # FileNotFoundError → ValueError
+        case_summary(path=str(DATA / "does_not_exist.m"))
+    with pytest.raises(ValueError):  # PowerIOError → ValueError
+        case_summary(content="not a case", format="matpower")

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -7,12 +7,15 @@ stay ordinary callables, so we exercise them in-process without a transport.
 """
 
 import json
+import os
 from pathlib import Path
 
 import pytest
 
 pytest.importorskip("mcp", reason="powerio[mcp] not installed (needs Python 3.10+)")
 
+import powerio  # noqa: E402
+from powerio.mcp import server  # noqa: E402
 from powerio.mcp.server import case_summary, convert_case  # noqa: E402
 
 DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
@@ -68,3 +71,53 @@ def test_errors_map_cleanly():
         case_summary(path=str(DATA / "does_not_exist.m"))
     with pytest.raises(ValueError):  # PowerIOError → ValueError
         case_summary(content="not a case", format="matpower")
+
+
+def test_convert_case_errors_map_cleanly():
+    # convert_case has its own except arms, separate from case_summary's.
+    with pytest.raises(ValueError):  # FileNotFoundError → ValueError
+        convert_case(to="psse", path=str(DATA / "does_not_exist.m"))
+    with pytest.raises(ValueError):  # PowerIOError → ValueError
+        convert_case(to="psse", content="not a case", from_="matpower")
+
+
+def test_convert_case_reports_lossy_warnings():
+    # PSS/E has no cost curves, so case30 (which carries gencost) drops them and
+    # the warning rides through conv.warnings → the tool's "warnings" list;
+    # PowerModels JSON represents everything, so its conversion is warning-free.
+    text = (DATA / "case30.m").read_text()
+    lossy = convert_case(to="psse", content=text, from_="matpower")
+    assert lossy["warnings"]
+    assert any("cost" in w.lower() for w in lossy["warnings"])
+    faithful = convert_case(to="powermodels-json", content=text, from_="matpower")
+    assert faithful["warnings"] == []
+
+
+def test_inline_convert_removes_temp_file(monkeypatch):
+    # The inline path stages content to a temp file and unlinks it in a finally.
+    # Capture the staged path and assert it's gone on both the success and the
+    # failure path — the finally is the only guard against leaking temp files.
+    staged = []
+    real_mkstemp = server.tempfile.mkstemp
+
+    def spy_mkstemp(*args, **kwargs):
+        fd, path = real_mkstemp(*args, **kwargs)
+        staged.append(path)
+        return fd, path
+
+    monkeypatch.setattr(server.tempfile, "mkstemp", spy_mkstemp)
+    text = (DATA / "case30.m").read_text()
+
+    r = convert_case(to="psse", content=text, from_="matpower")
+    assert r["text"]
+    assert staged and not os.path.exists(staged[-1])
+
+    staged.clear()
+
+    def boom(*args, **kwargs):
+        raise powerio.PowerIOError("boom")
+
+    monkeypatch.setattr(powerio, "convert", boom)
+    with pytest.raises(ValueError):
+        convert_case(to="psse", content=text, from_="matpower")
+    assert staged and not os.path.exists(staged[-1])

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -199,16 +199,19 @@ def test_delegated_surface_resolves(case9):
         case9.does_not_exist
 
 
-def test_import_and_parse_pull_in_no_numpy_or_scipy():
+def test_import_and_parse_pull_in_no_optional_deps():
     # The zero-dep promise: parse/convert/write need nothing but the
     # interpreter. Run in a fresh process so another test importing scipy can't
     # pollute it, and parse + write a real case so the whole IO path is covered.
+    # `mcp` is checked too: the powerio.mcp submodule must never be imported from
+    # powerio/__init__.py, so the optional MCP SDK stays out of `import powerio`.
     code = (
         "import sys, powerio\n"
         f"c = powerio.parse_matpower(r'{DATA / 'case9.m'}')\n"
         "assert c.write()\n"
         "assert 'numpy' not in sys.modules, 'powerio dragged in numpy'\n"
         "assert 'scipy' not in sys.modules, 'powerio dragged in scipy'\n"
+        "assert 'mcp' not in sys.modules, 'powerio dragged in the mcp SDK'\n"
     )
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     assert r.returncode == 0, r.stderr


### PR DESCRIPTION
Closes #26.

Wraps the existing `powerio` Python package as a small [MCP](https://modelcontextprotocol.io) (FastMCP) server, so LLM-agent tooling gets a fast, lossless converter and a case summary over the case-file family. **No new Rust** — it reuses `powerio.convert`/`parse`/`parse_str`.

## Tools (over stdio)

Both accept either a filesystem `path` or inline `content`:

- **`convert_case(to, path|content, from_)` → `{text, warnings}`** — convert between formats with fidelity warnings. Since `convert()` is path-only, inline content is staged to a temp file (removed in a `finally`); `from_` is required for inline input.
- **`case_summary(path|content, format)`** — name, base MVA, source format, element counts, and connectivity. Stays scipy/numpy-free.

`PowerIOError`/`FileNotFoundError` map to clean `ValueError`s (FastMCP turns these into clean MCP tool errors rather than a transport crash).

## Packaging

- New `python/powerio/mcp/` submodule (`server.py`, `__init__.py`, `__main__.py`) + a `powerio-mcp` console script.
- Gated behind a `powerio[mcp]` optional extra. The `mcp` SDK needs **Python ≥3.10**, so the extra carries a `python_version >= '3.10'` marker — the core stays 3.9-compatible (abi3-py39 wheel unaffected).
- The submodule is **never imported from `powerio/__init__.py`**, so `import powerio` stays zero-dependency (enforced by the existing subprocess test).

## Verification

- **Full Python suite: 46 passed, 1 skipped** (the skip is an unrelated `gridfm`-extra test), including the new `test_mcp.py` (7 tests: path + inline for both tools, input/error guards) and the zero-dep contract test.
- Confirmed `import powerio` pulls in no `mcp`/`numpy`/`scipy`.
- `powerio-mcp` console script installs and registers both tools.
- End-to-end stdio JSON-RPC handshake against the live `powerio-mcp` process returns a correct `case_summary` for `case9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)