### PR TITLE
fix(docs): disambiguate Error intra-doc link; build docs on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,8 +4,12 @@ name: Docs
 # four library crates, including powerio-capi and powerio-py (publish = false),
 # whose //! docs docs.rs would never host. docs.rs takes over for powerio and
 # powerio-matrix once those are published to crates.io.
+# PRs build the docs too (so a broken intra-doc link fails review, not main),
+# but only push-to-main / dispatch deploys to Pages — see the `deploy` gate.
 on:
   push:
+    branches: [ "main" ]
+  pull_request:
     branches: [ "main" ]
   workflow_dispatch:
 
@@ -14,9 +18,10 @@ permissions:
   pages: write
   id-token: write
 
-# One Pages deploy at a time; a newer push supersedes an in-flight build.
+# Serialize per ref: main's Pages deploys supersede each other, and a PR's doc
+# build can't cancel main's in-flight deploy.
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -44,6 +49,8 @@ jobs:
 
   deploy:
     needs: build
+    # PR runs build to catch doc breakage but never publish; only main / dispatch deploy.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -120,13 +120,13 @@ pub enum Error {
     UnknownFormat(String),
 }
 
-/// Coarse classification of an [`Error`], for callers that map onto their own
+/// Coarse classification of an [`enum@Error`], for callers that map onto their own
 /// taxonomy (the Python layer's exception subclasses, C ABI status codes, a
 /// CLI exit code). Distinguishing "the input file is bad" from "the operation
 /// can't run on this otherwise-valid case" is the split callers actually branch
 /// on, and it's a property of the error, not of the binding that surfaces it.
 ///
-/// Deliberately *not* `#[non_exhaustive]` (unlike [`Error`]): a category-mapping
+/// Deliberately *not* `#[non_exhaustive]` (unlike [`enum@Error`]): a category-mapping
 /// match should fail to compile when a category is added, so every binding is
 /// forced to decide how to surface it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

The `Docs` workflow is red on `main` (run on `49b43b0`): the `build` job fails with

```
error: `Error` is both an enum and a derive macro
  --> powerio/src/error.rs:123:35
   = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
error: could not document `powerio`
```

`powerio/src/error.rs` does `use thiserror::Error;`, so inside that file `Error`
names both the enum and the `thiserror::Error` derive macro. The `ErrorCategory`
doc comment links ``[`Error`]``, which rustdoc can't disambiguate, and the Docs
job's `RUSTDOCFLAGS: -D warnings` turns that into a hard failure. (The two
``[`Error`]`` links in `format/mod.rs` are fine — that file doesn't import the
derive macro, so the name is unambiguous there.)

## Fix

- Prefix the two links with `enum@` (`[`enum@Error`]`), exactly as rustdoc's own
  diagnostic suggests. It renders as plain `Error` and resolves to the enum.

## Prevent recurrence

The regression reached `main` because `Docs` ran only on push-to-`main` and
manual dispatch — never on PRs — so the loop that landed it never built the docs.

- Add a `pull_request` trigger so the `build` job runs on PRs; a `-D warnings`
  doc break now fails review instead of `main`.
- Gate `deploy` to non-PR runs (`if: github.event_name != 'pull_request'`) so
  Pages still publishes only from `main` / dispatch.
- Scope concurrency per ref (`group: pages-${{ github.ref }}`) so a PR's doc
  build can't cancel `main`'s in-flight Pages deploy.

Verified locally: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
-p powerio -p powerio-matrix -p powerio-capi -p powerio-py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)