### PR TITLE
fix(tests): pin vendored case fixtures to their committed bytes (Windows CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,13 @@ tests/data/**/*.m linguist-vendored
 
 # Julia appears here only as a validation harness, not as the package language.
 benchmarks/**/*.jl linguist-vendored
+
+# Vendored case fixtures are byte-exact round-trip references: the `parse → write`
+# tests (e.g. powerio/tests/roundtrip.rs) compare the writer output to the file
+# verbatim. `-text` checks them out byte-identical to the committed blob on every
+# platform (no CRLF/LF conversion), so the comparison holds on Windows
+# (`core.autocrlf=true`) too — where the `.m` fixtures (LF in the repo) would
+# otherwise materialize as CRLF while the lossless writer echoes that CRLF and the
+# test (which normalizes only the read side) fails. The PSS/E `.raw` fixtures are
+# intentionally CRLF (the format's native DOS line ending) and stay CRLF. #72.
+tests/data/** -text


### PR DESCRIPTION
Fixes the Windows-only byte-exact roundtrip test failure in #72.

## Problem

On a Windows checkout with `core.autocrlf=true`, git materializes the LF-stored `.m` fixtures as CRLF. The MATPOWER writer is a lossless byte-exact echo of the retained source, so it reproduces the CRLF; but `powerio/tests/roundtrip.rs::writer_reproduces_source_modulo_trailing_newline` normalizes CRLF→LF **only on the read side**, so `written` (CRLF) ≠ `original`-normalized (LF) and it fails. The loop panics on the first fixture in walk order (`case118.m`); every `.m` fixture would fail the same way. CI (Linux, no autocrlf) is unaffected — this is a local dev papercut.

## Fix

Mark `tests/data/** -text` so the vendored fixtures check out **byte-identical to their committed blobs** on every platform — no CRLF/LF conversion:
- `.m` / `.json` fixtures are LF in the repo → stay LF.
- PSS/E `.raw` fixtures are CRLF in the repo (the format's native DOS line ending) → stay CRLF.

`-text` (rather than `text eol=lf`) is deliberate: `eol=lf` would rewrite the `.raw` fixtures to LF, changing vendored content and their native format. `-text` preserves each fixture exactly — **no repo content changes**, the diff is `.gitattributes` only.

## Verification (Windows, git 2.37, `core.autocrlf=true`)

- **Before:** `writer_reproduces_source_modulo_trailing_newline` failed on `case118.m`.
- **After** (re-checkout under the new attribute): `od -c` confirms `.m` are LF and `.raw` keep CRLF; `git status` clean; **`cargo test -p powerio` all green** — the roundtrip test and the PSS/E `.raw` roundtrip both pass.

Existing Windows working copies keep stale CRLF `.m` until re-checked out (delete `tests/data` and `git checkout -- tests/data`, or re-clone); CI and fresh clones are correct automatically.

