### PR TITLE
docs: CONTRIBUTING, SECURITY, CHANGELOG for the public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## 0.0.1
+
+First release.
+
+- Parsers and writers for MATPOWER `.m`, PSS/E RAW, PowerWorld AUX,
+  PowerModels JSON, and egret JSON; byte-exact same-format round trips,
+  maximal-fidelity conversion between formats.
+- `Network`, the one canonical model, with `to_normalized` deriving a
+  per-unit / radian / filtered / reindexed view.
+- C ABI (`powerio-capi`, ABI version 3): parse, query, convert, JSON
+  transport, and Arrow C Data Interface export behind `--features arrow`;
+  cbindgen-generated header, version handshake, panic-safe boundary.
+- Python bindings (`pip install powerio`) with `matrix`, `graph`, and
+  `gridfm` extras, plus an MCP convert/validate server.
+- `powerio-matrix`: admittance and Laplacian builders over the parsed
+  tables; gridfm Parquet export behind `--features gridfm`.
+- `powerio-cli`: convert and validate from the shell.
+
+The C ABI history (versions 1 through 3) is tracked in
+[powerio-capi/README.md](powerio-capi/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+## Build and test
+
+```
+cargo build
+cargo test -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi
+cargo fmt --all --check
+cargo clippy --all-targets -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -- -D warnings
+```
+
+CI denies clippy warnings and requires rustfmt-clean code (edition 2024 style).
+The gridfm Parquet export is feature gated; exercise it with
+`cargo test -p powerio-matrix --features gridfm`.
+
+Python bindings: `maturin develop` against `powerio-py`, then
+`pytest python/tests`. See [docs/python.md](docs/python.md).
+
+## C ABI changes
+
+`powerio-capi/include/powerio.h` is generated; never hand-edit it. After any
+change to the `powerio-capi` surface:
+
+```
+cbindgen --config powerio-capi/cbindgen.toml --crate powerio-capi --output powerio-capi/include/powerio.h
+```
+
+CI checks header/source symbol parity and runs a C smoke test against the
+built library. A breaking change to an existing `pio_*` signature bumps
+`PIO_ABI_VERSION` (in `powerio-capi/src/lib.rs`; the header `#define` follows
+from regeneration) and requires a lockstep PowerIO.jl release targeting the new
+version. Additive symbols don't bump it. The history is in
+[powerio-capi/README.md](powerio-capi/README.md).
+
+## Naming
+
+The cross-language verb taxonomy lives in [docs/languages.md](docs/languages.md):
+`parse_file` / `parse_str` / `from_json` produce a `Network`, `to_*` derive from
+it, `convert_file` goes file to text in one call. A Network is the parsed model;
+a case is the file it came from.
+
+## Text encoding
+
+UTF-8 with LF line endings, no BOM. CI rejects BOM and cp1252 mojibake outside
+`tests/data`; vendored fixtures keep their committed bytes exactly. Configure
+Windows editors accordingly.
+
+## Test fixtures
+
+Vendor real cases from the upstream projects (MATPOWER, pglib) rather than
+writing bespoke fixtures; pin their bytes.
+
+## PRs
+
+Conventional commit subjects (`feat:`, `fix:`, `refactor:`); squash merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+Report vulnerabilities through GitHub's private vulnerability reporting on this
+repository (Security tab → Report a vulnerability). Do not open a public issue
+for anything exploitable.
+
+In scope: memory safety defects reachable through the C ABI or the Python
+bindings, and parser behavior on untrusted case files (the parsers are written
+to reject malformed input with an error, never to crash or corrupt memory).
+
+Only the latest release is supported.


### PR DESCRIPTION
Community files ahead of going public: build/test/C ABI workflow and the encoding rules in CONTRIBUTING.md, GitHub private vulnerability reporting in SECURITY.md, and a 0.0.1 CHANGELOG. CODE_OF_CONDUCT and issue/PR templates deliberately left out for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)