### PR TITLE
fix(py): pack license files into the sdist; dispatchable publish; draft releases

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -152,7 +152,10 @@ jobs:
 
   publish:
     name: publish to PyPI
-    if: github.event_name == 'release'
+    # Releases created by workflows (the GITHUB_TOKEN recursion guard) never
+    # fire the release event, so manual dispatch is the recovery path; the
+    # pypi environment's deployment rules still gate both.
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: [ lint, test, test-gridfm, wheels, sdist ]
     runs-on: ubuntu-latest
     # Protect this environment with required reviewers before launch.
@@ -174,3 +177,6 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+          # A partially failed upload (e.g. wheels in, sdist rejected) is
+          # recovered by re-running; already-uploaded files are skipped.
+          skip-existing: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -104,3 +104,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: libpowerio_capi.${{ matrix.triplet }}.tar.gz
+          # Stage the release as a draft a human publishes: the release event
+          # then has a user actor, so it actually triggers python.yml (the
+          # GITHUB_TOKEN recursion guard swallows bot-published events), and
+          # nothing ships until the maintainer clicks publish.
+          draft: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,11 @@ module-name = "powerio._powerio"
 python-source = "python"
 features = ["extension-module", "gridfm"]
 strip = true
+# maturin resolves the workspace-root license files into the wheel and the
+# package metadata, but does not copy them into the sdist on its own (the
+# manifest lives in the powerio-py subcrate); without these, PyPI rejects the
+# sdist for declaring a License-File it doesn't carry.
+include = [
+    { path = "LICENSE-APACHE", format = "sdist" },
+    { path = "LICENSE-MIT", format = "sdist" },
+]


### PR DESCRIPTION
PyPI accepted all 5 wheels but rejected the sdist: `License-File: LICENSE-APACHE does not exist in distribution file powerio-0.0.1.tar.gz`. maturin resolves the workspace-root license files into the wheel and metadata but not into the sdist when `manifest-path` points into a subcrate, so the sdist declared files it didn't carry.

- `[tool.maturin] include` ships both LICENSE files in the sdist. Verified locally: the tarball packs `LICENSE-APACHE`/`LICENSE-MIT` and `twine`-visible metadata matches.
- The publish job also accepts `workflow_dispatch` with `skip-existing: true`: recovery from a partial upload is one dispatch + environment approval; already-published wheels are skipped.
- release-binaries stages releases as drafts a human publishes, so the release event has a user actor and triggers python.yml natively (workflow-token events never trigger workflows), and nothing ships until the maintainer clicks publish.

After merge: add `main` to the pypi environment's deployment branch rules, then `gh workflow run python.yml --ref main` and approve; the fixed sdist uploads, wheels skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)