### PR TITLE
ci: bump actions off Node 20

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - uses: dtolnay/rust-toolchain@stable
@@ -67,7 +67,7 @@ jobs:
         <li><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl (Julia API docs)</a></li>
         </ul>
         HTML
-    - uses: actions/upload-pages-artifact@v3
+    - uses: actions/upload-pages-artifact@v5
       with:
         path: target/doc
 
@@ -81,4 +81,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -35,7 +35,7 @@ jobs:
           echo "available=false" >> "$GITHUB_OUTPUT"
           echo "eigenergy/PowerIO.jl is unreachable (no POWERIO_JL_REPO_TOKEN secret, and the repo is not public); skipping the contract test."
         fi
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       if: steps.powerio-jl.outputs.available == 'true'
     - uses: dtolnay/rust-toolchain@stable
       if: steps.powerio-jl.outputs.available == 'true'
@@ -48,17 +48,17 @@ jobs:
       run: cargo build -p powerio-capi --release --features arrow
     - name: Check out PowerIO.jl
       if: steps.powerio-jl.outputs.available == 'true'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: eigenergy/PowerIO.jl
         path: PowerIO.jl
         # Falls back to the workflow token, which suffices once the repo is public.
         token: ${{ secrets.POWERIO_JL_REPO_TOKEN || github.token }}
-    - uses: julia-actions/setup-julia@v2
+    - uses: julia-actions/setup-julia@v3
       if: steps.powerio-jl.outputs.available == 'true'
       with:
         version: '1'
-    - uses: julia-actions/cache@v2
+    - uses: julia-actions/cache@v3
       if: steps.powerio-jl.outputs.available == 'true'
     # PowerIO.jl's ccall tests skip themselves when the cdylib is absent.
     # POWERIO_CAPI points them at the library just built.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - uses: dtolnay/rust-toolchain@stable
@@ -33,8 +33,8 @@ jobs:
       matrix:
         python: [ "3.9", "3.12" ]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - uses: dtolnay/rust-toolchain@stable
@@ -82,8 +82,8 @@ jobs:
     name: test (gridfm extra)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - uses: dtolnay/rust-toolchain@stable
@@ -119,8 +119,8 @@ jobs:
           - { runner: macos-14,       target: aarch64 }
           - { runner: windows-latest, target: x64 }
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       # abi3-py39 → one wheel per platform covers Python 3.9+.
@@ -130,7 +130,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           manylinux: auto
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
           path: dist
@@ -139,13 +139,13 @@ jobs:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build powerio sdist
         uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist
@@ -163,11 +163,11 @@ jobs:
     permissions:
       id-token: write  # PyPI trusted publishing; no stored token
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
       - name: Check distributions

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -55,7 +55,7 @@ jobs:
             triplet: x86_64-w64-mingw32
             lib: powerio_capi.dll
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.rust_target }}
@@ -95,13 +95,13 @@ jobs:
           # informational; gen/update_artifacts.jl recomputes from the release assets
           shasum -a 256 "libpowerio_capi.${{ matrix.triplet }}.tar.gz" \
             || sha256sum "libpowerio_capi.${{ matrix.triplet }}.tar.gz"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: libpowerio_capi.${{ matrix.triplet }}
           path: libpowerio_capi.${{ matrix.triplet }}.tar.gz
       - name: Attach to release
         if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: libpowerio_capi.${{ matrix.triplet }}.tar.gz
           # Stage the release as a draft a human publishes: the release event

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Encoding (no BOM, no mojibake)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     # Windows editors have twice corrupted text files in PRs: CRLF in vendored
     # fixtures (#73, now pinned via .gitattributes) and UTF-8 re-encoded as
     # cp1252 plus a BOM (#77). .gitattributes can't catch the latter two, so
@@ -35,7 +35,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt
@@ -46,7 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
@@ -72,7 +72,7 @@ jobs:
     name: C ABI (header parity + C smoke test)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Build powerio-capi (cdylib + staticlib)
@@ -100,7 +100,7 @@ jobs:
     name: C ABI (arrow feature)
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,24 +27,24 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
     - name: Build powerio-capi
       run: cargo build --release -p powerio-capi
-    - uses: julia-actions/setup-julia@v2
+    - uses: julia-actions/setup-julia@v3
       with:
         version: '1'
-    - uses: julia-actions/cache@v2
+    - uses: julia-actions/cache@v3
     - name: Instantiate the Julia oracle env
       run: julia --project=benchmarks -e 'using Pkg; Pkg.instantiate()'
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.12'
     # Cache the pip wheels (pandapower + scipy/numpy, egret + pyomo, matpowercaseframes);
     # setup-python's own cache only covers the interpreter, not site-packages. Keyed on
     # the requirements file so a dependency bump re-resolves.
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: pip-validate-${{ runner.os }}-${{ hashFiles('benchmarks/requirements.txt') }}


### PR DESCRIPTION
Every job currently carries "Node.js 20 actions are deprecated" annotations (one per node20 action; node24 is the forced default on June 16, 2026). Bumps each pinned major to its current node24 release. Floating tags checked at their resolved refs: Swatinem/rust-cache@v2 and PyO3/maturin-action@v1 already run node24; pypa/gh-action-pypi-publish and dtolnay/rust-toolchain are composites.

Verification: this PR's own runs exercise checkout/setup-python/rust-cache/julia actions in every job and should carry zero Node annotations. A release-binaries dispatch off this branch exercises upload-artifact@v7. download-artifact@v8 in the publish job runs at the next release; v4-uploaded artifacts are cross-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)