### PR TITLE
ci: publish the library crates to crates.io on release

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,54 @@
+name: crates.io
+
+# Releases created by workflows (the GITHUB_TOKEN recursion guard) never fire
+# the release event, so manual dispatch is the recovery path; the crates-io
+# environment's deployment rules gate both.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: publish to crates.io
+    runs-on: ubuntu-latest
+    # Protect this environment with required reviewers before launch.
+    environment: crates-io
+    permissions:
+      id-token: write  # crates.io trusted publishing; no stored token
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Read the workspace version
+        run: |
+          version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "powerio") | .version')"
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+      - name: Check the release tag against the workspace version
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ "v$VERSION" != "$TAG" ]; then
+            echo "release tag $TAG does not match workspace version $VERSION" >&2
+            exit 1
+          fi
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Publish in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        # `cargo publish` blocks until the published crate is live in the
+        # index, so each dependent resolves its predecessor. Already-published
+        # versions are skipped (the analog of pypi-publish's skip-existing),
+        # which makes a re-run after a partial publish safe. The list is every
+        # workspace member without `publish = false`, in dependency order.
+        run: |
+          for crate in powerio powerio-matrix powerio-cli; do
+            if curl -fsS "https://crates.io/api/v1/crates/$crate/$VERSION" >/dev/null 2>&1; then
+              echo "$crate $VERSION is already on crates.io; skipping"
+              continue
+            fi
+            cargo publish -p "$crate"
+          done

--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,8 +1,9 @@
 name: crates.io
 
-# Releases created by workflows (the GITHUB_TOKEN recursion guard) never fire
-# the release event, so manual dispatch is the recovery path; the crates-io
-# environment's deployment rules gate both.
+# release-binaries.yml stages each release as a draft a human publishes, so the
+# release event fires with a user actor (events from a workflow's GITHUB_TOKEN
+# are swallowed by the recursion guard). Manual dispatch is the recovery path
+# for a missed event; both paths deploy through the crates-io environment.
 on:
   release:
     types: [ published ]
@@ -12,7 +13,8 @@ jobs:
   publish:
     name: publish to crates.io
     runs-on: ubuntu-latest
-    # Protect this environment with required reviewers before launch.
+    # Deployment protection (required reviewers, branch/tag rules) lives on the
+    # crates-io environment in the repo settings, not in this file.
     environment: crates-io
     permissions:
       id-token: write  # crates.io trusted publishing; no stored token
@@ -23,32 +25,70 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Read the workspace version
         run: |
-          version="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "powerio") | .version')"
+          set -o pipefail
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -er '.packages[] | select(.name == "powerio") | .version')" \
+            || { echo "could not read the powerio version from cargo metadata" >&2; exit 1; }
           echo "VERSION=$version" >> "$GITHUB_ENV"
-      - name: Check the release tag against the workspace version
-        if: github.event_name == 'release'
-        env:
-          TAG: ${{ github.event.release.tag_name }}
+      - name: Check the publish list against the workspace
+        # A publishable crate added to the workspace without updating the list
+        # in the publish step would silently never ship; fail here instead.
         run: |
-          if [ "v$VERSION" != "$TAG" ]; then
-            echo "release tag $TAG does not match workspace version $VERSION" >&2
+          set -o pipefail
+          actual="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '[.packages[] | select(.publish == null) | .name] | sort | join(" ")')"
+          if [ "$actual" != "powerio powerio-cli powerio-matrix" ]; then
+            echo "publishable workspace members ($actual) do not match the publish list in crates.yml" >&2
             exit 1
+          fi
+      - name: Check the ref against the workspace version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        # On a release event the tag must match the workspace version. On
+        # dispatch the version must at least be tagged, so a stray version bump
+        # on a branch cannot publish an untagged version; content drift between
+        # the dispatched ref and the tag is what the environment reviewer is
+        # approving.
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+            if [ "v$VERSION" != "$RELEASE_TAG" ]; then
+              echo "release tag $RELEASE_TAG does not match workspace version $VERSION" >&2
+              exit 1
+            fi
+          else
+            git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null \
+              || { echo "v$VERSION is not a tag; tag the release before dispatching" >&2; exit 1; }
           fi
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Publish in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          # crates.io's data access policy 403s requests without an
+          # identifying User-Agent (curl's default is blocked).
+          UA: powerio release workflow (https://github.com/eigenergy/powerio)
         # `cargo publish` blocks until the published crate is live in the
-        # index, so each dependent resolves its predecessor. Already-published
-        # versions are skipped (the analog of pypi-publish's skip-existing),
-        # which makes a re-run after a partial publish safe. The list is every
-        # workspace member without `publish = false`, in dependency order.
+        # index, so each dependent resolves its predecessor. Versions already
+        # in the index are skipped (the analog of pypi-publish's
+        # skip-existing), so a re-run after a partial publish only publishes
+        # what's missing.
         run: |
           for crate in powerio powerio-matrix powerio-cli; do
-            if curl -fsS "https://crates.io/api/v1/crates/$crate/$VERSION" >/dev/null 2>&1; then
-              echo "$crate $VERSION is already on crates.io; skipping"
-              continue
-            fi
+            resp="$RUNNER_TEMP/$crate.json"
+            code="$(curl -sS -A "$UA" --max-time 30 -o "$resp" -w '%{http_code}' \
+              "https://crates.io/api/v1/crates/$crate/$VERSION")" || code=unreachable
+            case "$code" in
+              200)
+                if jq -e '.version.yanked' "$resp" >/dev/null; then
+                  echo "$crate $VERSION is on crates.io but yanked; un-yank it or bump the version" >&2
+                  exit 1
+                fi
+                echo "$crate $VERSION is already on crates.io; skipping"
+                continue ;;
+              404) ;;  # not published; fall through to cargo publish
+              *)
+                echo "crates.io returned $code for $crate $VERSION; re-run once it is reachable" >&2
+                exit 1 ;;
+            esac
             cargo publish -p "$crate"
           done

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -152,13 +152,15 @@ jobs:
 
   publish:
     name: publish to PyPI
-    # Releases created by workflows (the GITHUB_TOKEN recursion guard) never
-    # fire the release event, so manual dispatch is the recovery path; the
-    # pypi environment's deployment rules still gate both.
+    # release-binaries.yml stages each release as a draft a human publishes, so
+    # the release event fires with a user actor (events from a workflow's
+    # GITHUB_TOKEN are swallowed by the recursion guard). Manual dispatch is the
+    # recovery path for a missed event.
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     needs: [ lint, test, test-gridfm, wheels, sdist ]
     runs-on: ubuntu-latest
-    # Protect this environment with required reviewers before launch.
+    # Deployment protection (required reviewers, tag rules) lives on the pypi
+    # environment in the repo settings, not in this file.
     environment: pypi
     permissions:
       id-token: write  # PyPI trusted publishing; no stored token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,23 @@ from regeneration) and requires a lockstep PowerIO.jl release targeting the new
 version. Additive symbols don't bump it. The history is in
 [powerio-capi/README.md](powerio-capi/README.md).
 
+## Releasing
+
+The release version lives in `[workspace.package]` plus the two intra-workspace
+dependency pins in `[workspace.dependencies]`; a bump touches exactly those
+three lines of the root Cargo.toml. Then:
+
+1. Merge the bump, tag the commit `vX.Y.Z`, push the tag. The release-binaries
+   workflow builds the C ABI tarballs and stages a draft GitHub release.
+2. Publish the draft release. The release event fires the PyPI publish
+   (python.yml) and the crates.io publish (crates.yml: powerio, powerio-matrix,
+   powerio-cli, in dependency order). Both run behind protected environments
+   and skip already-uploaded files, so a partial failure is recovered by
+   re-running.
+3. Follow up in PowerIO.jl: regenerate Artifacts.toml from the new tag and
+   register the new version (see its CONTRIBUTING.md). A breaking C ABI change
+   bumps `PIO_ABI_VERSION` first; see "C ABI changes" above.
+
 ## Naming
 
 The cross-language verb taxonomy lives in [docs/languages.md](docs/languages.md):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,15 +36,16 @@ version. Additive symbols don't bump it. The history is in
 
 The release version lives in `[workspace.package]` plus the two intra-workspace
 dependency pins in `[workspace.dependencies]`; a bump touches exactly those
-three lines of the root Cargo.toml. Then:
+three lines of the root Cargo.toml (Cargo.lock follows on the next build). Then:
 
 1. Merge the bump, tag the commit `vX.Y.Z`, push the tag. The release-binaries
    workflow builds the C ABI tarballs and stages a draft GitHub release.
 2. Publish the draft release. The release event fires the PyPI publish
    (python.yml) and the crates.io publish (crates.yml: powerio, powerio-matrix,
-   powerio-cli, in dependency order). Both run behind protected environments
-   and skip already-uploaded files, so a partial failure is recovered by
-   re-running.
+   powerio-cli, in dependency order). Both deploy through reviewer-protected
+   environments (`pypi`, `crates-io`; the protection lives in the repo
+   settings). PyPI skips already-uploaded files and crates.io skips versions
+   already in the index, so a partial failure is recovered by re-running.
 3. Follow up in PowerIO.jl: regenerate Artifacts.toml from the new tag and
    register the new version (see its CONTRIBUTING.md). A breaking C ABI change
    bumps `PIO_ABI_VERSION` first; see "C ABI changes" above.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ default-members = ["powerio", "powerio-matrix", "powerio-cli"]
 resolver = "2"
 
 # Single source for the release version and shared metadata; the crates inherit
-# via `key.workspace = true`, so a release bump touches exactly this block.
+# via `key.workspace = true`, so a release bump touches this version and the
+# two dependency pins below.
 [workspace.package]
 version = "0.0.1"
 edition = "2024"


### PR DESCRIPTION
Adds `crates.yml`: on `release: published` (or manual dispatch as the recovery path), publishes `powerio`, `powerio-matrix`, and `powerio-cli` in dependency order via crates.io trusted publishing — OIDC through `rust-lang/crates-io-auth-action`, no stored token, gated by the new `crates-io` environment (already created; add required reviewers if desired). Already-published versions are skipped, so a re-run after a partial publish is safe, and a release-event guard fails the job if the tag doesn't match the workspace version. CONTRIBUTING gains a Releasing section documenting the whole flow.

`powerio-py` and `powerio-capi` stay `publish = false` (PyPI wheels and release binaries respectively).

## One-time setup before this can run

crates.io requires the first publish of each crate to be manual with an API token; trusted publishing is configured per crate afterwards.

1. crates.io account (GitHub login), verified email under Account Settings.
2. API token at https://crates.io/settings/tokens with publish-new + publish-update scopes.
3. From the v0.0.1 tag checkout: `cargo publish -p powerio -p powerio-matrix -p powerio-cli` (cargo ≥ 1.90 orders them; `--dry-run` already passes).
4. For each crate: Settings → Trusted Publishing → GitHub: owner `eigenergy`, repo `powerio`, workflow `crates.yml`, environment `crates-io`.
5. Revoke the token. Optionally enable "require trusted publishing" per crate.

Undo window, for the record: a crate is deletable self-service within 72 hours of first publish, and after that while it has a single owner, under 500 downloads per month published, and no crates.io reverse deps (so reverse order: powerio-cli, powerio-matrix, powerio). Individual versions can only ever be yanked.

## Verification

- `actionlint` clean.
- After step 4 above, a `workflow_dispatch` run should no-op with three "already on crates.io; skipping" lines — that proves the trusted publishing handshake and the idempotency path without a new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)