### PR TITLE
ci: pin crates-io-auth-action to v1.0.4 for Node 24

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -59,7 +59,7 @@ jobs:
             git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null \
               || { echo "v$VERSION is not a tag; tag the release before dispatching" >&2; exit 1; }
           fi
-      - uses: rust-lang/crates-io-auth-action@v1
+      - uses: rust-lang/crates-io-auth-action@v1.0.4
         id: auth
       - name: Publish in dependency order
         env:


### PR DESCRIPTION
The proof run logged the Node 20 deprecation warning for `rust-lang/crates-io-auth-action@v1`: upstream's `v1` is a branch that lags at a node20 commit, while the `v1.0.4` tag already declares node24. Runners force Node 24 on June 16, 2026, likely before the next release, so pin the tag. Revisit when upstream moves the major ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)