### PR TITLE
feat: upstream the full PowerMCP tool surface into powerio.mcp.server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,12 @@ gridfm = ["polars>=1"]
 # pyarrow fixes current advisories in 23.0.1, which does not publish Python 3.9
 # wheels; use the Polars gridfm extra on Python 3.9.
 pandas = ["pandas>=2; python_version >= '3.10'", "pyarrow>=23.0.1; python_version >= '3.10'"]
-# The MCP server wraps parse/convert as two MCP tools. The official `mcp` SDK
+# The MCP server exposes the powerio.mcp tool surface. The official `mcp` SDK
 # requires Python >=3.10; the env marker keeps this extra empty on 3.9.
 mcp = ["mcp>=1.2; python_version >= '3.10'"]
 
 [project.scripts]
-# Serves the convert_case + case_summary tools over stdio. Needs the `mcp` extra.
+# Serves the powerio.mcp tool surface over stdio. Needs the `mcp` extra.
 powerio-mcp = "powerio.mcp.server:main"
 
 [project.urls]

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -158,7 +158,11 @@ def save_case(
     except powerio.PowerIOError as exc:
         raise ValueError(f"conversion failed: {exc}") from exc
     try:
-        with open(out_path, "w" if overwrite else "x", encoding="utf-8") as fh:
+        # newline="" disables newline translation so the file is byte-identical
+        # to the converter output (and to the CLI) on every platform, and
+        # bytes_written below is exact on Windows.
+        mode = "w" if overwrite else "x"
+        with open(out_path, mode, encoding="utf-8", newline="") as fh:
             fh.write(conv.text)
     except FileExistsError:
         raise ValueError(

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -1,32 +1,94 @@
-"""A FastMCP server exposing powerio's lossless converter and case summary.
+"""A FastMCP server exposing powerio: case conversion, summaries, the JSON
+transport, and sparse matrix views.
 
-Two tools for LLM agent tooling, both accepting either a filesystem ``path`` or
-inline ``content``:
+Tools for LLM agents, accepting a filesystem ``path``, inline ``content``, or
+(for ``save_case``, ``compute_matrix``, and ``dense_view``) the JSON transport
+string:
 
-- ``convert_case``: convert a case file between formats, returning the text and
-  any fidelity warnings.
+- ``convert_case``: convert a case between formats, returning the text and any
+  fidelity warnings.
+- ``save_case``: convert and write the result to a file on disk, staging input
+  for path-only consumers.
 - ``case_summary``: counts, base MVA, source format, and connectivity, with no
   scipy/numpy in the loop.
+- ``parse_case`` / ``normalize_case`` / ``case_to_json``: emit the JSON
+  transport (``Network.to_json``), the cheap handoff between tool calls.
+- ``compute_matrix``: the sparse matrix views in COO form as plain lists.
+- ``dense_view``: the dense table view as plain lists and dicts.
 
 Run over stdio with the ``powerio-mcp`` console script (or ``python -m
-powerio.mcp``). The server reuses ``powerio.convert_file``/``convert_str``/
-``parse_file``/``parse_str``; it never reimplements parsing, and inline
-content converts in memory with no temp file staging.
+powerio.mcp``). The server is a thin wrapper over the powerio Python API; it
+never reimplements parsing or math, and inline content converts in memory with
+no temp file staging.
+
+This file is canonical for the tool surface. The PowerMCP bundle ships a
+standalone copy (``powerio/powerio_mcp.py`` in Power-Agent/PowerMCP); land
+changes here first and sync that copy.
 """
 
 from __future__ import annotations
 
-from typing import Optional
+import os
+from typing import Any, Dict, Optional
 
 import powerio
 from mcp.server.fastmcp import FastMCP
 
 mcp = FastMCP("powerio")
 
+_MATRIX_KINDS = (
+    "bprime", "bdoubleprime", "ybus_real", "ybus_imag",
+    "adjacency", "ptdf", "lodf", "laplacian", "lacpf",
+)
+
 
 def _one_input(path: Optional[str], content: Optional[str]) -> None:
     if (path is None) == (content is None):
         raise ValueError("provide exactly one of `path` or `content`")
+
+
+def _parse(path: Optional[str], content: Optional[str], format: str) -> "powerio.Network":
+    """Parse from exactly one of ``path`` or inline ``content``, mapping powerio
+    and filesystem errors to ValueError so MCP clients see one error shape."""
+    _one_input(path, content)
+    try:
+        if path is not None:
+            return powerio.parse_file(path)
+        return powerio.parse_str(content, format)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+
+
+def _load(
+    path: Optional[str], content: Optional[str], json: Optional[str], format: str
+) -> "powerio.Network":
+    """Like ``_parse`` but also accepts the JSON transport string."""
+    if sum(v is not None for v in (path, content, json)) != 1:
+        raise ValueError("provide exactly one of `path`, `content`, or `json`")
+    if json is None:
+        return _parse(path, content, format)
+    try:
+        return powerio.from_json(json)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+
+
+def _summary(case: "powerio.Network") -> Dict[str, Any]:
+    return {
+        "name": case.name,
+        "base_mva": case.base_mva,
+        "source_format": case.source_format,
+        "n_buses": case.n_buses,
+        "n_branches": case.n_branches,
+        "n_gens": case.n_gens,
+        "n_loads": case.n_loads,
+        "n_shunts": case.n_shunts,
+        "is_radial": case.is_radial,
+        "n_connected_components": case.n_connected_components,
+        "connectivity_report": case.connectivity_report(),
+    }
 
 
 @mcp.tool()
@@ -65,6 +127,53 @@ def convert_case(
 
 
 @mcp.tool()
+def save_case(
+    to: str,
+    out_path: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+    overwrite: bool = False,
+) -> dict:
+    """Convert a case and write the result to a file on disk.
+
+    Use this to stage input for consumers that only accept file paths: convert
+    any case (or the JSON transport from ``parse_case``) to the target format
+    and point the other program at ``out_path``. Pick an ``out_path`` extension
+    matching ``to`` (``.m``, ``.json``, ``.raw``, ``.aux``).
+
+    ``to`` is a format name or alias: ``matpower`` (``m``), ``powermodels-json``
+    (``pm``), ``egret-json`` (``egret``), ``psse`` (``raw``), ``powerworld``
+    (``aux``). Provide exactly one of ``path``, ``content`` (with ``format``),
+    or ``json`` (the transport string). An existing ``out_path`` is not
+    overwritten unless ``overwrite`` is true.
+
+    Returns ``{"path": <absolute path written>, "bytes_written": <count>,
+    "warnings": [<fidelity notes>]}``.
+    """
+    case = _load(path, content, json, format)
+    try:
+        conv = case.to_format(to)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    try:
+        with open(out_path, "w" if overwrite else "x", encoding="utf-8") as fh:
+            fh.write(conv.text)
+    except FileExistsError:
+        raise ValueError(
+            f"refusing to overwrite existing file: {out_path}; pass overwrite=true"
+        ) from None
+    except OSError as exc:
+        raise ValueError(f"write failed: {exc}") from exc
+    return {
+        "path": os.path.abspath(out_path),
+        "bytes_written": len(conv.text.encode("utf-8")),
+        "warnings": list(conv.warnings),
+    }
+
+
+@mcp.tool()
 def case_summary(
     path: Optional[str] = None,
     content: Optional[str] = None,
@@ -77,32 +186,201 @@ def case_summary(
     ``format`` names the input format (default ``matpower``). Pulls in no
     scipy/numpy.
     """
-    _one_input(path, content)
+    return _summary(_parse(path, content, format))
+
+
+@mcp.tool()
+def parse_case(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> dict:
+    """Parse a power system case once and return its JSON transport plus a
+    summary.
+
+    Provide exactly one of ``path`` or ``content``. For inline ``content``,
+    ``format`` names the input format (default ``matpower``); formats:
+    ``matpower``, ``powermodels-json``, ``egret-json``, ``psse``,
+    ``powerworld``.
+
+    The returned ``json`` string is the exchange format between tool calls:
+    pass it to ``compute_matrix``, ``dense_view``, and ``save_case`` here, or
+    to any downstream tool that ingests the transport (e.g. PowerMCP's
+    pandapower, egret, and PyPSA bridges), instead of parsing the file again
+    on every call.
+
+    Returns ``{"json": <transport string>, "summary": <case_summary fields>}``.
+    """
+    case = _parse(path, content, format)
+    return {"json": case.to_json(), "summary": _summary(case)}
+
+
+@mcp.tool()
+def normalize_case(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> dict:
+    """Parse a case and return the JSON transport of its normalized form: per
+    unit, radians, out of service elements filtered, buses densely reindexed
+    (1-based), bus types canonicalized.
+
+    Use this instead of ``parse_case`` when downstream math wants a computation
+    ready case rather than the verbatim source tables. Provide exactly one of
+    ``path`` or ``content`` (with ``format``).
+
+    Returns ``{"json": <transport string>, "summary": <fields of the normalized
+    case>}``; the ``json`` is accepted everywhere the ``parse_case`` transport
+    is.
+    """
+    case = _parse(path, content, format)
     try:
-        case = (
-            powerio.parse_file(path)
-            if path is not None
-            else powerio.parse_str(content, format)
-        )
+        norm = case.to_normalized()
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
-    except FileNotFoundError as exc:
-        raise ValueError(f"file not found: {exc}") from exc
+        raise ValueError(f"normalization failed: {exc}") from exc
+    return {"json": norm.to_json(), "summary": _summary(norm)}
+
+
+@mcp.tool()
+def case_to_json(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    format: str = "matpower",
+) -> dict:
+    """Convert a case file (or inline text) to the powerio JSON transport
+    string.
+
+    Provide exactly one of ``path`` or ``content`` (with ``format``). The
+    returned ``json`` is accepted by ``compute_matrix``, ``dense_view``,
+    ``save_case``, and any downstream tool that ingests the transport. Use
+    ``parse_case`` instead if you also want the summary.
+
+    Returns ``{"json": <transport string>}``.
+    """
+    return {"json": _parse(path, content, format).to_json()}
+
+
+@mcp.tool()
+def compute_matrix(
+    kind: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+    scheme: str = "bx",
+    convention: str = "paper",
+) -> dict:
+    """Build a sparse matrix view of a case and return it in COO form.
+
+    ``kind`` is one of: ``bprime`` (FDPF B', shuntless), ``bdoubleprime`` (FDPF
+    B'' with shunts and taps), ``ybus_real`` / ``ybus_imag`` (Re/Im of Y_bus),
+    ``adjacency`` (0/1 bus adjacency), ``ptdf`` (DC PTDF, m×n), ``lodf`` (DC
+    LODF, m×m), ``laplacian`` (weighted Laplacian L = A diag(b) Aᵀ), ``lacpf``
+    (linearized AC 2n×2n block [[G, -B], [-B, -G]], taps and shifts included).
+    ``scheme`` ("bx"|"xb") applies to bprime/bdoubleprime; ``convention``
+    ("paper"|"matpower") to ptdf/lodf/laplacian.
+
+    Provide exactly one of ``path``, ``content`` (with ``format``), or
+    ``json``, the transport string from ``parse_case`` / ``normalize_case`` /
+    ``case_to_json``; passing it skips parsing again.
+
+    Returns ``{"format": "coo", "shape": [rows, cols], "nnz": <count>,
+    "data": [...], "row": [...], "col": [...]}`` with plain Python lists.
+    Requires scipy (``pip install 'powerio[matrix]'``).
+    """
+    if kind not in _MATRIX_KINDS:
+        raise ValueError(
+            f"unknown matrix kind {kind!r}; expected one of: {', '.join(_MATRIX_KINDS)}"
+        )
+    case = _load(path, content, json, format)
+    try:
+        if kind == "bprime":
+            m = case.bprime(scheme)
+        elif kind == "bdoubleprime":
+            m = case.bdoubleprime(scheme)
+        elif kind in ("ybus_real", "ybus_imag"):
+            parts = case.ybus_parts()
+            m = parts.g if kind == "ybus_real" else parts.b
+        elif kind == "adjacency":
+            m = case.adjacency()
+        elif kind == "ptdf":
+            m = case.ptdf(convention)
+        elif kind == "lodf":
+            m = case.lodf(convention)
+        elif kind == "lacpf":
+            m = case.lacpf()
+        else:
+            m = case.weighted_laplacian(convention)
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"matrix build failed: {exc}") from exc
+    coo = m.tocoo()
     return {
-        "name": case.name,
-        "base_mva": case.base_mva,
-        "source_format": case.source_format,
-        "n_buses": case.n_buses,
-        "n_branches": case.n_branches,
-        "n_gens": case.n_gens,
-        "n_loads": case.n_loads,
-        "n_shunts": case.n_shunts,
-        "is_radial": case.is_radial,
-        "n_connected_components": case.n_connected_components,
-        "connectivity_report": case.connectivity_report(),
+        "format": "coo",
+        "shape": [int(coo.shape[0]), int(coo.shape[1])],
+        "nnz": int(coo.nnz),
+        "data": coo.data.tolist(),
+        "row": coo.row.tolist(),
+        "col": coo.col.tolist(),
+    }
+
+
+@mcp.tool()
+def dense_view(
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: str = "matpower",
+) -> dict:
+    """Dense table view of a case as plain lists and dicts: counts, base MVA,
+    bus ids, branch arrays (from_id, to_id, r, x, b, tap, shift, in_service),
+    generator arrays (bus, pg, pmax, pmin, in_service), nodal demand and shunt
+    arrays, the reference bus index, connected component count, and radial
+    flag.
+
+    Provide exactly one of ``path``, ``content`` (with ``format``), or ``json``
+    (the transport string from ``parse_case`` / ``normalize_case`` /
+    ``case_to_json``). Requires numpy (``pip install 'powerio[matrix]'``).
+    """
+    case = _load(path, content, json, format)
+    try:
+        d = case.to_dense()
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"dense view failed: {exc}") from exc
+    return {
+        "n": int(d.n),
+        "m": int(d.m),
+        "ng": int(d.ng),
+        "base_mva": float(d.base_mva),
+        "bus_ids": d.bus_ids.tolist(),
+        "branch": {
+            "from_id": d.branch.from_id.tolist(),
+            "to_id": d.branch.to_id.tolist(),
+            "r": d.branch.r.tolist(),
+            "x": d.branch.x.tolist(),
+            "b": d.branch.b.tolist(),
+            "tap": d.branch.tap.tolist(),
+            "shift": d.branch.shift.tolist(),
+            "in_service": d.branch.in_service.tolist(),
+        },
+        "gen": {
+            "bus": d.gen.bus.tolist(),
+            "pg": d.gen.pg.tolist(),
+            "pmax": d.gen.pmax.tolist(),
+            "pmin": d.gen.pmin.tolist(),
+            "in_service": d.gen.in_service.tolist(),
+        },
+        "demand": {"pd": d.demand.pd.tolist(), "qd": d.demand.qd.tolist()},
+        "shunt": {"gs": d.shunt.gs.tolist(), "bs": d.shunt.bs.tolist()},
+        "reference_bus": None if d.reference_bus is None else int(d.reference_bus),
+        "n_components": int(d.n_components),
+        "is_radial": bool(d.is_radial),
     }
 
 
 def main() -> None:
-    """Console-script entry point: serve the two tools over stdio."""
+    """Console-script entry point: serve the tools over stdio."""
     mcp.run()

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -112,3 +112,104 @@ def test_inline_convert_str_error_maps_cleanly(monkeypatch):
     monkeypatch.setattr(powerio, "convert_str", boom)
     with pytest.raises(ValueError):
         convert_case(to="psse", content="whatever", from_="matpower")
+
+
+# --- the full tool surface (parse_case .. save_case) -----------------------
+
+
+def test_parse_case_json_round_trips():
+    from powerio.mcp.server import parse_case
+
+    r = parse_case(path=str(DATA / "case9.m"))
+    assert r["summary"]["n_buses"] == 9
+    assert powerio.from_json(r["json"]).n_buses == 9
+
+
+def test_normalize_case_returns_dense_one_based_ids():
+    from powerio.mcp.server import normalize_case
+
+    r = normalize_case(path=str(DATA / "case9.m"))
+    case = powerio.from_json(r["json"])
+    assert [b["id"] for b in case.buses] == list(range(1, 10))
+
+
+def test_case_to_json_accepted_downstream():
+    from powerio.mcp.server import case_to_json, compute_matrix
+
+    transport = case_to_json(path=str(DATA / "case9.m"))["json"]
+    m = compute_matrix("bprime", json=transport)
+    assert m["shape"] == [9, 9]
+
+
+def test_compute_matrix_kinds_and_plain_types():
+    from powerio.mcp.server import compute_matrix
+
+    m = compute_matrix("bprime", path=str(DATA / "case9.m"))
+    assert m["format"] == "coo"
+    assert m["shape"] == [9, 9]
+    assert m["nnz"] > 0 and isinstance(m["nnz"], int)
+    assert type(m["data"][0]) is float
+    assert type(m["row"][0]) is int
+    lacpf = compute_matrix("lacpf", path=str(DATA / "case9.m"))
+    assert lacpf["shape"] == [18, 18]
+    for kind in ("bdoubleprime", "ybus_real", "ybus_imag", "adjacency",
+                 "ptdf", "lodf", "laplacian"):
+        assert compute_matrix(kind, path=str(DATA / "case9.m"))["nnz"] > 0
+    with pytest.raises(ValueError):
+        compute_matrix("nope", path=str(DATA / "case9.m"))
+
+
+def test_dense_view_counts():
+    from powerio.mcp.server import dense_view
+
+    d = dense_view(path=str(DATA / "case9.m"))
+    assert d["n"] == 9 and d["m"] == 9
+    assert d["base_mva"] == 100.0
+    assert type(d["bus_ids"][0]) is int
+    assert type(d["branch"]["r"][0]) is float
+    assert type(d["is_radial"]) is bool
+
+
+def test_save_case_writes_and_refuses_overwrite(tmp_path):
+    from powerio.mcp.server import save_case
+
+    out = tmp_path / "case9.json"
+    r = save_case(to="powermodels-json", out_path=str(out), path=str(DATA / "case9.m"))
+    assert r["path"] == str(out)
+    assert r["bytes_written"] == out.stat().st_size
+    assert len(json.loads(out.read_text())["bus"]) == 9
+    with pytest.raises(ValueError):
+        save_case(to="powermodels-json", out_path=str(out), path=str(DATA / "case9.m"))
+    r2 = save_case(
+        to="matpower", out_path=str(out), path=str(DATA / "case9.m"), overwrite=True
+    )
+    assert r2["bytes_written"] == out.stat().st_size
+
+
+def test_exactly_one_of_path_content_json():
+    from powerio.mcp.server import compute_matrix, dense_view, parse_case
+
+    with pytest.raises(ValueError):
+        parse_case()
+    with pytest.raises(ValueError):
+        compute_matrix("bprime")
+    with pytest.raises(ValueError):
+        compute_matrix("bprime", path="x", json="{}")
+    with pytest.raises(ValueError):
+        dense_view(path="x", content="y")
+
+
+def test_tool_surface_parity():
+    # The PowerMCP bundle ships a standalone copy of this server
+    # (powerio/powerio_mcp.py in Power-Agent/PowerMCP); powerio.mcp.server is
+    # canonical. The set below is the shared surface; a tool added or removed
+    # here fails this test until the set, and the PowerMCP copy, move with it.
+    import asyncio
+
+    from powerio.mcp import server
+
+    names = {t.name for t in asyncio.run(server.mcp.list_tools())}
+    assert names == {
+        "convert_case", "save_case", "case_summary", "parse_case",
+        "normalize_case", "case_to_json", "compute_matrix", "dense_view",
+    }


### PR DESCRIPTION
Closes #87.

`powerio.mcp.server` grows from two tools to eight, matching the standalone copy the PowerMCP bundle ships (Power-Agent/PowerMCP#28):

- `parse_case` / `normalize_case` / `case_to_json` emit the JSON transport (`Network.to_json`), the cheap handoff between tool calls
- `compute_matrix` returns nine COO kinds (`bprime`, `bdoubleprime`, `ybus_real`, `ybus_imag`, `adjacency`, `ptdf`, `lodf`, `laplacian`, `lacpf`) as plain Python lists
- `dense_view` returns the dense table view as plain lists and dicts
- `save_case` converts and writes to disk, staging input for path-only consumers
- `case_summary` output is unchanged (now via a shared `_summary` helper)

The module docstring declares this file canonical: changes land here first and are synced to the PowerMCP copy. `test_tool_surface_parity` asserts the tool name set exactly, so adding or removing a tool fails the test until the set (and the copy) move with it. Eight new tests cover the transport round trip, normalization, all matrix kinds with plain Python types, the dense view, save_case write/overwrite, and input validation. Stale pyproject comments describing a two tool server are updated.

Reviewed before push: a correctness pass (error mapping, the `json=""` edge in exactly-one-of validation, `save_case`'s `"w"`/`"x"` overwrite modes, kind dispatch) found no defects, and a documentation pass tightened the docstrings (accurate `json=` acceptance lists everywhere, no em dashes, `dense_view` says reference bus index).

`pytest python/tests`: 86 passed, 2 skipped on top of current main (gridfm + convert_str included). The synth `generate_case` tool is NOT part of this surface; #89 is parked as a draft pending #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)