### PR TITLE
docs + release prep: landing page, 0.1.0 version bump, gridfm tarballs, README trim

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,11 +48,67 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install '.[all]' pdoc
         python -m pdoc powerio -o target/doc/python
+    # The guides render on this site (docs/*.md to guides/*.html) so readers
+    # stay on one domain; sibling .md links become .html, links that leave
+    # docs/ go to GitHub.
+    - name: Render guides
+      run: |
+        python -m pip install markdown
+        python - <<'PY'
+        import pathlib
+        import re
+
+        import markdown
+
+        TPL = """<!doctype html>
+        <html lang="en">
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>{title}</title>
+        <link rel="icon" href="../_assets/powerio-logo.svg">
+        <style>
+          :root {{ --fg:#1a1f24; --muted:#5c6770; --bg:#fff; --link:#0b5cad; --line:#d9dee3; --code:#f6f8fa; }}
+          @media (prefers-color-scheme: dark) {{
+            :root {{ --fg:#e6edf3; --muted:#9aa7b1; --bg:#0d1117; --link:#58a6ff; --line:#30363d; --code:#161b22; }}
+          }}
+          body {{ font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
+                 max-width: 760px; margin: 3rem auto; padding: 0 1rem; line-height: 1.6; }}
+          a {{ color: var(--link); }}
+          pre, code {{ background: var(--code); border-radius: 4px; }}
+          pre {{ padding: .7rem; overflow-x: auto; }}
+          code {{ padding: .1rem .3rem; }}
+          pre code {{ padding: 0; }}
+          table {{ border-collapse: collapse; }}
+          th, td {{ border: 1px solid var(--line); padding: .3rem .6rem; text-align: left; }}
+          nav {{ color: var(--muted); margin-bottom: 1.5rem; }}
+        </style>
+        <nav><a href="../index.html">PowerIO docs</a></nav>
+        {body}
+        """
+
+        def rewrite(m):
+            target, anchor = m.group(1), m.group(2) or ""
+            if target.startswith(".."):
+                path = target.lstrip("./")
+                return f"](https://github.com/eigenergy/powerio/blob/main/{path}.md{anchor})"
+            return f"]({target}.html{anchor})"
+
+        out = pathlib.Path("target/doc/guides")
+        out.mkdir(parents=True, exist_ok=True)
+        for src in sorted(pathlib.Path("docs").glob("*.md")):
+            text = re.sub(r"\]\((?!https?://)([^)#]+?)\.md(#[^)]*)?\)", rewrite, src.read_text())
+            body = markdown.markdown(text, extensions=["tables", "fenced_code"])
+            heading = re.search(r"<h1>(.*?)</h1>", body)
+            title = heading.group(1) if heading else src.stem
+            name = "index" if src.stem == "README" else src.stem
+            (out / f"{name}.html").write_text(TPL.format(title=title, body=body))
+            print("rendered", name)
+        PY
     # The landing page separates the two doc deployments so neither shadows the
     # other: docs.rs renders the crates.io releases of powerio/powerio-matrix,
     # while this site renders main (all four crates, including the publish=false
     # powerio-capi and powerio-py that docs.rs never hosts) plus the Python API
-    # reference (PyPI hosts no API docs) and links to the docs/ guides.
+    # reference (PyPI hosts no API docs) and the rendered docs/ guides.
     - name: Landing page
       run: |
         mkdir -p target/doc/_assets
@@ -65,84 +121,47 @@ jobs:
         <title>PowerIO docs</title>
         <link rel="icon" href="_assets/powerio-logo.svg">
         <style>
-          :root {
-            --fg: #1a1f24; --muted: #5c6770; --bg: #ffffff;
-            --card: #f6f8fa; --line: #d9dee3; --link: #0b5cad;
-          }
+          :root { --fg:#1a1f24; --muted:#5c6770; --bg:#fff; --link:#0b5cad; }
           @media (prefers-color-scheme: dark) {
-            :root {
-              --fg: #e6edf3; --muted: #9aa7b1; --bg: #0d1117;
-              --card: #161b22; --line: #30363d; --link: #58a6ff;
-            }
+            :root { --fg:#e6edf3; --muted:#9aa7b1; --bg:#0d1117; --link:#58a6ff; }
           }
-          body {
-            font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
-            max-width: 720px; margin: 4rem auto; padding: 0 1rem; line-height: 1.55;
-          }
-          header { display: flex; align-items: center; gap: 1rem; }
-          header img { width: 64px; height: 64px; }
-          h1 { margin: 0; font-size: 1.9rem; }
-          .tagline { color: var(--muted); margin: .4rem 0 2rem; }
-          h2 {
-            font-size: .85rem; text-transform: uppercase; letter-spacing: .07em;
-            color: var(--muted); margin: 2rem 0 .6rem;
-          }
-          ul { list-style: none; margin: 0; padding: 0; }
-          li {
-            border: 1px solid var(--line); border-radius: 8px;
-            background: var(--card); margin: .5rem 0;
-          }
-          li a { display: block; padding: .55rem .9rem; text-decoration: none; color: var(--link); }
-          li a:hover { text-decoration: underline; }
-          li p { color: var(--muted); font-size: .85rem; margin: 0; padding: 0 .9rem .55rem; }
-          footer { margin-top: 2.5rem; color: var(--muted); font-size: .9rem; }
-          footer a { color: var(--link); }
+          body { font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
+                 max-width: 640px; margin: 4rem auto; padding: 0 1rem; line-height: 1.7; }
+          header { display: flex; align-items: center; gap: .75rem; }
+          header img { width: 48px; height: 48px; }
+          h1 { margin: 0; font-size: 1.5rem; }
+          .tagline { color: var(--muted); margin: .3rem 0 1.6rem; }
+          dt { font-weight: 600; margin-top: .9rem; }
+          dd { margin: 0; }
+          a { color: var(--link); text-decoration: none; }
+          a:hover { text-decoration: underline; }
+          .sep { color: var(--muted); }
+          footer { margin-top: 2rem; }
         </style>
         <header>
           <img src="_assets/powerio-logo.svg" alt="PowerIO logo">
           <h1>PowerIO docs</h1>
         </header>
         <p class="tagline">Fast case parsing and conversion: &ldquo;pandoc for power systems&rdquo;</p>
-
-        <h2>Released &middot; docs.rs</h2>
-        <ul>
-          <li><a href="https://docs.rs/powerio">powerio</a>
-            <p>Rust API of the latest crates.io release</p></li>
-          <li><a href="https://docs.rs/powerio-matrix">powerio-matrix</a>
-            <p>matrices and graph views, latest release</p></li>
-        </ul>
-
-        <h2>Development &middot; built from main</h2>
-        <ul>
-          <li><a href="powerio/index.html">powerio (Rust)</a></li>
-          <li><a href="powerio_matrix/index.html">powerio-matrix (Rust)</a></li>
-          <li><a href="powerio_capi/index.html">powerio-capi (C ABI)</a>
-            <p>unpublished crate; rendered only here</p></li>
-          <li><a href="python/powerio.html">powerio (Python)</a>
-            <p>the Python API reference; PyPI hosts none</p></li>
-        </ul>
-
-        <h2>Guides</h2>
-        <ul>
-          <li><a href="https://github.com/eigenergy/powerio/tree/main/docs">docs/ index</a>
-            <p>reference material that fits neither the README nor a doc comment</p></li>
-          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md">format-fidelity</a>
-            <p>numeric conventions, validation, per format conversion limits</p></li>
-          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/matrices.md">matrices</a>
-            <p>the matrix family and its sign, tap, per unit, and DC conventions</p></li>
-          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/dcopf-bundle.md">dcopf-bundle</a>
-            <p>the Matrix Market + manifest schema the dcopf subcommand writes</p></li>
-          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/languages.md">languages</a>
-            <p>canonical Rust, Python, Julia, and C ABI names</p></li>
-          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/python.md">python</a>
-            <p>install extras and API examples</p></li>
-        </ul>
-
-        <h2>Bindings</h2>
-        <ul>
-          <li><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl (Julia)</a></li>
-        </ul>
-
+        <dl>
+          <dt>Released on <a href="https://docs.rs">docs.rs</a></dt>
+          <dd><a href="https://docs.rs/powerio">powerio</a> <span class="sep">&middot;</span>
+              <a href="https://docs.rs/powerio-matrix">powerio-matrix</a></dd>
+          <dt>Development, built from main</dt>
+          <dd><a href="powerio/index.html">powerio</a> <span class="sep">&middot;</span>
+              <a href="powerio_matrix/index.html">powerio-matrix</a> <span class="sep">&middot;</span>
+              <a href="powerio_capi/index.html">powerio-capi</a> <span class="sep">&middot;</span>
+              <a href="python/powerio.html">Python</a></dd>
+          <dt>Guides</dt>
+          <dd><a href="guides/index.html">overview</a> <span class="sep">&middot;</span>
+              <a href="guides/format-fidelity.html">format fidelity</a> <span class="sep">&middot;</span>
+              <a href="guides/matrices.html">matrices</a> <span class="sep">&middot;</span>
+              <a href="guides/dcopf-bundle.html">DC OPF bundle</a> <span class="sep">&middot;</span>
+              <a href="guides/languages.html">language APIs</a> <span class="sep">&middot;</span>
+              <a href="guides/python.html">Python</a></dd>
+          <dt>Bindings</dt>
+          <dd><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl</a></dd>
+        </dl>
         <footer><a href="https://github.com/eigenergy/powerio">github.com/eigenergy/powerio</a></footer>
         HTML
     - uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,24 +48,102 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install '.[all]' pdoc
         python -m pdoc powerio -o target/doc/python
+    # The landing page separates the two doc deployments so neither shadows the
+    # other: docs.rs renders the crates.io releases of powerio/powerio-matrix,
+    # while this site renders main (all four crates, including the publish=false
+    # powerio-capi and powerio-py that docs.rs never hosts) plus the Python API
+    # reference (PyPI hosts no API docs) and links to the docs/ guides.
     - name: Landing page
       run: |
+        mkdir -p target/doc/_assets
+        cp docs/assets/powerio-logo.svg target/doc/_assets/
         cat > target/doc/index.html <<'HTML'
         <!doctype html>
+        <html lang="en">
         <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <title>PowerIO docs</title>
+        <link rel="icon" href="_assets/powerio-logo.svg">
         <style>
-          body { font-family: system-ui, sans-serif; max-width: 720px; margin: 4rem auto; padding: 0 1rem; line-height: 1.5; }
-          a { color: #0b5cad; }
+          :root {
+            --fg: #1a1f24; --muted: #5c6770; --bg: #ffffff;
+            --card: #f6f8fa; --line: #d9dee3; --link: #0b5cad;
+          }
+          @media (prefers-color-scheme: dark) {
+            :root {
+              --fg: #e6edf3; --muted: #9aa7b1; --bg: #0d1117;
+              --card: #161b22; --line: #30363d; --link: #58a6ff;
+            }
+          }
+          body {
+            font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
+            max-width: 720px; margin: 4rem auto; padding: 0 1rem; line-height: 1.55;
+          }
+          header { display: flex; align-items: center; gap: 1rem; }
+          header img { width: 64px; height: 64px; }
+          h1 { margin: 0; font-size: 1.9rem; }
+          .tagline { color: var(--muted); margin: .4rem 0 2rem; }
+          h2 {
+            font-size: .85rem; text-transform: uppercase; letter-spacing: .07em;
+            color: var(--muted); margin: 2rem 0 .6rem;
+          }
+          ul { list-style: none; margin: 0; padding: 0; }
+          li {
+            border: 1px solid var(--line); border-radius: 8px;
+            background: var(--card); margin: .5rem 0;
+          }
+          li a { display: block; padding: .55rem .9rem; text-decoration: none; color: var(--link); }
+          li a:hover { text-decoration: underline; }
+          li p { color: var(--muted); font-size: .85rem; margin: 0; padding: 0 .9rem .55rem; }
+          footer { margin-top: 2.5rem; color: var(--muted); font-size: .9rem; }
+          footer a { color: var(--link); }
         </style>
-        <h1>PowerIO docs</h1>
+        <header>
+          <img src="_assets/powerio-logo.svg" alt="PowerIO logo">
+          <h1>PowerIO docs</h1>
+        </header>
+        <p class="tagline">Fast case parsing and conversion: &ldquo;pandoc for power systems&rdquo;</p>
+
+        <h2>Released &middot; docs.rs</h2>
         <ul>
-        <li><a href="powerio/index.html">powerio (Rust crate docs)</a></li>
-        <li><a href="powerio_matrix/index.html">powerio-matrix (Rust crate docs)</a></li>
-        <li><a href="powerio_capi/index.html">powerio-capi (C ABI crate docs)</a></li>
-        <li><a href="python/powerio.html">powerio (Python API docs)</a></li>
-        <li><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl (Julia API docs)</a></li>
+          <li><a href="https://docs.rs/powerio">powerio</a>
+            <p>Rust API of the latest crates.io release</p></li>
+          <li><a href="https://docs.rs/powerio-matrix">powerio-matrix</a>
+            <p>matrices and graph views, latest release</p></li>
         </ul>
+
+        <h2>Development &middot; built from main</h2>
+        <ul>
+          <li><a href="powerio/index.html">powerio (Rust)</a></li>
+          <li><a href="powerio_matrix/index.html">powerio-matrix (Rust)</a></li>
+          <li><a href="powerio_capi/index.html">powerio-capi (C ABI)</a>
+            <p>unpublished crate; rendered only here</p></li>
+          <li><a href="python/powerio.html">powerio (Python)</a>
+            <p>the Python API reference; PyPI hosts none</p></li>
+        </ul>
+
+        <h2>Guides</h2>
+        <ul>
+          <li><a href="https://github.com/eigenergy/powerio/tree/main/docs">docs/ index</a>
+            <p>reference material that fits neither the README nor a doc comment</p></li>
+          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md">format-fidelity</a>
+            <p>numeric conventions, validation, per format conversion limits</p></li>
+          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/matrices.md">matrices</a>
+            <p>the matrix family and its sign, tap, per unit, and DC conventions</p></li>
+          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/dcopf-bundle.md">dcopf-bundle</a>
+            <p>the Matrix Market + manifest schema the dcopf subcommand writes</p></li>
+          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/languages.md">languages</a>
+            <p>canonical Rust, Python, Julia, and C ABI names</p></li>
+          <li><a href="https://github.com/eigenergy/powerio/blob/main/docs/python.md">python</a>
+            <p>install extras and API examples</p></li>
+        </ul>
+
+        <h2>Bindings</h2>
+        <ul>
+          <li><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl (Julia)</a></li>
+        </ul>
+
+        <footer><a href="https://github.com/eigenergy/powerio">github.com/eigenergy/powerio</a></footer>
         HTML
     - uses: actions/upload-pages-artifact@v5
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,22 +67,45 @@ jobs:
         <title>{title}</title>
         <link rel="icon" href="../_assets/powerio-logo.svg">
         <style>
-          :root {{ --fg:#1a1f24; --muted:#5c6770; --bg:#fff; --link:#0b5cad; --line:#d9dee3; --code:#f6f8fa; }}
-          @media (prefers-color-scheme: dark) {{
-            :root {{ --fg:#e6edf3; --muted:#9aa7b1; --bg:#0d1117; --link:#58a6ff; --line:#30363d; --code:#161b22; }}
+          :root {{
+            --bg:#faf8f4; --fg:#26221b; --muted:#76705f;
+            --rust:#b7410e; --line:#e4ded2; --code:#f2eee5;
           }}
-          body {{ font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
-                 max-width: 760px; margin: 3rem auto; padding: 0 1rem; line-height: 1.6; }}
-          a {{ color: var(--link); }}
-          pre, code {{ background: var(--code); border-radius: 4px; }}
-          pre {{ padding: .7rem; overflow-x: auto; }}
+          @media (prefers-color-scheme: dark) {{
+            :root {{
+              --bg:#15120e; --fg:#e9e3d5; --muted:#9d958a;
+              --rust:#e0773f; --line:#2d2820; --code:#201c15;
+            }}
+          }}
+          html {{ border-top: 3px solid var(--rust); }}
+          body {{
+            font-family: "Charter", "Georgia", serif; font-size: 1.0625rem;
+            color: var(--fg); background: var(--bg);
+            max-width: 920px; margin: 3rem auto 5rem; padding: 0 2rem; line-height: 1.65;
+          }}
+          nav {{
+            font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+            font-size: .78rem; color: var(--muted); margin-bottom: 2.4rem;
+          }}
+          nav a {{ color: var(--muted); }}
+          h1, h2, h3 {{ letter-spacing: -.01em; }}
+          h2 {{ border-bottom: 1px solid var(--line); padding-bottom: .25rem; margin-top: 2.4rem; }}
+          a {{ color: var(--rust); text-decoration: none; }}
+          a:hover {{ text-decoration: underline; text-underline-offset: 3px; }}
+          pre, code {{
+            font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+            font-size: .86em; background: var(--code);
+          }}
+          pre {{ padding: .8rem 1rem; overflow-x: auto; border-left: 2px solid var(--line); }}
           code {{ padding: .1rem .3rem; }}
           pre code {{ padding: 0; }}
-          table {{ border-collapse: collapse; }}
-          th, td {{ border: 1px solid var(--line); padding: .3rem .6rem; text-align: left; }}
-          nav {{ color: var(--muted); margin-bottom: 1.5rem; }}
+          table {{ border-collapse: collapse; display: block; overflow-x: auto; max-width: 100%; }}
+          th {{ border-bottom: 2px solid var(--fg); text-align: left; }}
+          td {{ border-bottom: 1px solid var(--line); }}
+          th, td {{ padding: .4rem 1.1rem .4rem 0; vertical-align: top; }}
+          hr {{ border: 0; border-top: 1px solid var(--line); }}
         </style>
-        <nav><a href="../index.html">PowerIO docs</a></nav>
+        <nav><a href="../index.html">powerio docs</a> / {crumb}</nav>
         {body}
         """
 
@@ -101,7 +124,8 @@ jobs:
             heading = re.search(r"<h1>(.*?)</h1>", body)
             title = heading.group(1) if heading else src.stem
             name = "index" if src.stem == "README" else src.stem
-            (out / f"{name}.html").write_text(TPL.format(title=title, body=body))
+            crumb = "overview" if src.stem == "README" else src.stem
+            (out / f"{name}.html").write_text(TPL.format(title=title, crumb=crumb, body=body))
             print("rendered", name)
         PY
     # The landing page separates the two doc deployments so neither shadows the
@@ -121,22 +145,47 @@ jobs:
         <title>PowerIO docs</title>
         <link rel="icon" href="_assets/powerio-logo.svg">
         <style>
-          :root { --fg:#1a1f24; --muted:#5c6770; --bg:#fff; --link:#0b5cad; }
-          @media (prefers-color-scheme: dark) {
-            :root { --fg:#e6edf3; --muted:#9aa7b1; --bg:#0d1117; --link:#58a6ff; }
+          :root {
+            --bg:#faf8f4; --fg:#26221b; --muted:#76705f;
+            --rust:#b7410e; --line:#e4ded2;
           }
-          body { font-family: system-ui, sans-serif; color: var(--fg); background: var(--bg);
-                 max-width: 640px; margin: 4rem auto; padding: 0 1rem; line-height: 1.7; }
-          header { display: flex; align-items: center; gap: .75rem; }
-          header img { width: 48px; height: 48px; }
-          h1 { margin: 0; font-size: 1.5rem; }
-          .tagline { color: var(--muted); margin: .3rem 0 1.6rem; }
-          dt { font-weight: 600; margin-top: .9rem; }
-          dd { margin: 0; }
-          a { color: var(--link); text-decoration: none; }
-          a:hover { text-decoration: underline; }
-          .sep { color: var(--muted); }
-          footer { margin-top: 2rem; }
+          @media (prefers-color-scheme: dark) {
+            :root {
+              --bg:#15120e; --fg:#e9e3d5; --muted:#9d958a;
+              --rust:#e0773f; --line:#2d2820;
+            }
+          }
+          html { border-top: 3px solid var(--rust); }
+          body {
+            font-family: "Charter", "Georgia", serif; font-size: 1.0625rem;
+            color: var(--fg); background: var(--bg);
+            max-width: 600px; margin: 5rem auto 4rem; padding: 0 1.5rem; line-height: 1.6;
+          }
+          header { display: flex; align-items: center; gap: .9rem; margin-bottom: .4rem; }
+          header img { width: 52px; height: 52px; }
+          h1 { margin: 0; font-size: 1.7rem; font-weight: 600; letter-spacing: -.01em; }
+          .tagline { color: var(--muted); font-style: italic; margin: 0 0 2.6rem; }
+          dl { margin: 0; }
+          dl > div {
+            display: grid; grid-template-columns: 10.5rem 1fr; gap: 0 1.5rem;
+            padding: .9rem 0; border-top: 1px solid var(--line);
+          }
+          dt {
+            font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+            font-size: .78rem; color: var(--muted); padding-top: .3rem;
+          }
+          dd { margin: 0; display: flex; flex-wrap: wrap; column-gap: 1.5rem; row-gap: .25rem; }
+          a { color: var(--rust); text-decoration: none; }
+          a:hover { text-decoration: underline; text-underline-offset: 3px; }
+          footer {
+            font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+            font-size: .78rem; border-top: 1px solid var(--line); padding-top: .9rem;
+          }
+          footer a { color: var(--muted); }
+          @media (max-width: 560px) {
+            dl > div { grid-template-columns: 1fr; }
+            dt { padding-top: 0; }
+          }
         </style>
         <header>
           <img src="_assets/powerio-logo.svg" alt="PowerIO logo">
@@ -144,23 +193,31 @@ jobs:
         </header>
         <p class="tagline">Fast case parsing and conversion: &ldquo;pandoc for power systems&rdquo;</p>
         <dl>
-          <dt>Released on <a href="https://docs.rs">docs.rs</a></dt>
-          <dd><a href="https://docs.rs/powerio">powerio</a> <span class="sep">&middot;</span>
-              <a href="https://docs.rs/powerio-matrix">powerio-matrix</a></dd>
-          <dt>Development, built from main</dt>
-          <dd><a href="powerio/index.html">powerio</a> <span class="sep">&middot;</span>
-              <a href="powerio_matrix/index.html">powerio-matrix</a> <span class="sep">&middot;</span>
-              <a href="powerio_capi/index.html">powerio-capi</a> <span class="sep">&middot;</span>
-              <a href="python/powerio.html">Python</a></dd>
-          <dt>Guides</dt>
-          <dd><a href="guides/index.html">overview</a> <span class="sep">&middot;</span>
-              <a href="guides/format-fidelity.html">format fidelity</a> <span class="sep">&middot;</span>
-              <a href="guides/matrices.html">matrices</a> <span class="sep">&middot;</span>
-              <a href="guides/dcopf-bundle.html">DC OPF bundle</a> <span class="sep">&middot;</span>
-              <a href="guides/languages.html">language APIs</a> <span class="sep">&middot;</span>
-              <a href="guides/python.html">Python</a></dd>
-          <dt>Bindings</dt>
-          <dd><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl</a></dd>
+          <div>
+            <dt>released / docs.rs</dt>
+            <dd><a href="https://docs.rs/powerio">powerio</a>
+                <a href="https://docs.rs/powerio-matrix">powerio-matrix</a></dd>
+          </div>
+          <div>
+            <dt>development / main</dt>
+            <dd><a href="powerio/index.html">powerio</a>
+                <a href="powerio_matrix/index.html">powerio-matrix</a>
+                <a href="powerio_capi/index.html">powerio-capi</a>
+                <a href="python/powerio.html">python</a></dd>
+          </div>
+          <div>
+            <dt>guides</dt>
+            <dd><a href="guides/index.html">overview</a>
+                <a href="guides/format-fidelity.html">format fidelity</a>
+                <a href="guides/matrices.html">matrices</a>
+                <a href="guides/dcopf-bundle.html">DC OPF bundle</a>
+                <a href="guides/languages.html">language APIs</a>
+                <a href="guides/python.html">python</a></dd>
+          </div>
+          <div>
+            <dt>bindings</dt>
+            <dd><a href="https://eigenergy.github.io/PowerIO.jl/dev/">PowerIO.jl</a></dd>
+          </div>
         </dl>
         <footer><a href="https://github.com/eigenergy/powerio">github.com/eigenergy/powerio</a></footer>
         HTML

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,6 +1,6 @@
 name: Release binaries
 
-# Build the powerio-capi cdylib (with the arrow feature) for the five platforms
+# Build the powerio-capi cdylib (with the arrow and gridfm features) for the five platforms
 # PowerIO.jl's Artifacts.toml covers, package each as the artifact tarball that
 # file references (lib/ or bin/ layout, Julia platform triplet in the name), and
 # attach them to the GitHub release on a version tag. A workflow_dispatch run
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get install -y ${{ matrix.cross_gcc }}
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Build powerio-capi
-        run: cargo build -p powerio-capi --release --features arrow --target ${{ matrix.rust_target }}
+        run: cargo build -p powerio-capi --release --features arrow,gridfm --target ${{ matrix.rust_target }}
       # Artifact layout PowerIO.jl's _artifact_lib() resolves: the cdylib under
       # lib/ (bin/ on Windows, renamed to the lib-prefixed name BinaryBuilder
       # would produce), the C header under include/, licenses at the root.
@@ -99,11 +99,32 @@ jobs:
         with:
           name: libpowerio_capi.${{ matrix.triplet }}
           path: libpowerio_capi.${{ matrix.triplet }}.tar.gz
+      # The draft release body is the CHANGELOG section for this version (the
+      # v0.0.1 release shipped with a bare one-liner); auto-generated notes are
+      # appended below it. All five matrix jobs write the same body, which
+      # softprops applies idempotently.
+      - name: Release body from CHANGELOG
+        if: github.ref_type == 'tag'
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          awk -v ver="${TAG#v}" '
+            $0 == "## " ver { hit = 1; next }
+            /^## / { hit = 0 }
+            hit { print }
+          ' CHANGELOG.md > release-body.md
+          if ! [ -s release-body.md ]; then
+            echo "CHANGELOG.md has no \"## ${TAG#v}\" section" >&2
+            exit 1
+          fi
       - name: Attach to release
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v3
         with:
           files: libpowerio_capi.${{ matrix.triplet }}.tar.gz
+          body_path: release-body.md
+          generate_release_notes: true
           # Stage the release as a draft a human publishes: the release event
           # then has a user actor, so it actually triggers python.yml (the
           # GITHUB_TOKEN recursion guard swallows bot-published events), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.0.2
+## 0.1.0
 
 - gridfm read path (#70): `read_gridfm_dataset` / `read_gridfm_scenarios` /
   `gridfm_base_case` in `powerio-matrix`, `pio_read_gridfm` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,12 @@ First release.
 - `Network`, the one canonical model, with `to_normalized` deriving a
   per-unit / radian / filtered / reindexed view.
 - C ABI (`powerio-capi`, ABI version 3): parse, query, convert, JSON
-  transport, an Arrow C Data Interface export behind `--features arrow`, and a
-  gridfm-datakit Parquet reader behind `--features gridfm`; cbindgen-generated
-  header, version handshake, panic-safe boundary.
+  transport, and Arrow C Data Interface export behind `--features arrow`;
+  cbindgen-generated header, version handshake, panic-safe boundary.
 - Python bindings (`pip install powerio`) with `matrix`, `graph`, and
   `gridfm` extras, plus an MCP convert/validate server.
 - `powerio-matrix`: admittance and Laplacian builders over the parsed
-  tables; gridfm-datakit Parquet export and a lossy, power-flow-complete
-  reader behind `--features gridfm`.
+  tables; gridfm Parquet export behind `--features gridfm`.
 - `powerio-cli`: convert and validate from the shell.
 
 The C ABI history (versions 1 through 3) is tracked in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.0.2
+
+- gridfm read path (#70): `read_gridfm_dataset` / `read_gridfm_scenarios` /
+  `gridfm_base_case` in `powerio-matrix`, `pio_read_gridfm` /
+  `pio_gridfm_scenario_ids` in the C ABI behind `--features gridfm`, and
+  `powerio.read_gridfm` / `read_gridfm_scenarios` in Python. Release tarballs
+  now build the C ABI with the gridfm feature, so the symbols ship to the
+  Julia bindings.
+- `convert_str` (#88): in-memory conversion through the hub in Rust and
+  Python; the MCP server's inline conversion no longer stages temp files.
+  Closes #66.
+- The MCP server grows from two tools to eight (#90): `parse_case`,
+  `normalize_case`, and `case_to_json` emit the JSON transport,
+  `compute_matrix` returns nine sparse kinds in COO form, `dense_view`
+  returns the dense table view, and `save_case` writes converted cases to
+  disk; `convert_case` and `case_summary` are unchanged.
+- Docs (#92): Pages landing page with the released/development split, guide
+  links, and the logo; the crate homepage points at the docs site; release
+  drafts carry the CHANGELOG section instead of a bare title.
+
 ## 0.0.1
 
 First release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/eigenergy/powerio"
-homepage = "https://github.com/eigenergy/powerio"
+homepage = "https://eigenergy.github.io/powerio/"
 
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.0.2"
+version = "0.1.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.0.2" }
-powerio-matrix = { path = "powerio-matrix", version = "0.0.2" }
+powerio = { path = "powerio", version = "0.1.0" }
+powerio-matrix = { path = "powerio-matrix", version = "0.1.0" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.0.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.0.1" }
+powerio = { path = "powerio", version = "0.0.2" }
+powerio-matrix = { path = "powerio-matrix", version = "0.0.2" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Language API map: [docs/languages.md](https://github.com/eigenergy/powerio/blob/
 ## Install
 
 ```
-cargo add --git https://github.com/eigenergy/powerio powerio
-cargo add --git https://github.com/eigenergy/powerio powerio-matrix
-cargo install --git https://github.com/eigenergy/powerio powerio-cli
+cargo add powerio
+cargo add powerio-matrix
+cargo install powerio-cli
 
 pip install powerio
 pip install 'powerio[all]'     # scipy, numpy, networkx, polars extras

--- a/README.md
+++ b/README.md
@@ -1,30 +1,5 @@
 # PowerIO
 
-<p align="center">
-  <img
-    src="https://raw.githubusercontent.com/eigenergy/powerio/main/docs/assets/powerio-logo.svg"
-    alt="PowerIO logo"
-    width="120"
-  >
-</p>
-
-PowerIO reads power system case files into a typed `Network`, writes them back,
-converts between common formats, and builds the sparse matrices and graph views
-used by analysis and solver code. It aspires to be "the [pandoc](https://pandoc.org) for power systems."
-
-Supported formats:
-
-- [MATPOWER](https://matpower.org/) `.m`
-- [PSS/E](https://www.siemens.com/global/en/products/energy/grid-software/planning/pss-software/pss-e.html) `.raw` revision 33
-- [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux`
-- [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl) network data JSON
-- [egret](https://pypi.org/project/gridx-egret/) `ModelData` JSON
-- [GridFM](https://github.com/gridfm) `.parquet`
-- [surge](https://github.com/amptimal/surge) `.surge.json` (WIP)
-
-When writing back to the source format, PowerIO **returns the original file exactly** when the parser
-retained it. Cross format conversion obeys sane defaults and emits `Conversion::warnings` for fields the
-target format cannot represent.
 
 <p align="center">
   <img
@@ -34,16 +9,44 @@ target format cannot represent.
   >
 </p>
 
+PowerIO is a fast, universal parser and converter for power system case files. It aspires to be "the [pandoc](https://pandoc.org) for power systems." 
+
+Using PowerIO, you can build sparse matrices and graph views for downstream analysis and solver code. PowerIO can serve as a drop-in replacement for the data layers of many popular community libraries, enhancing interoperability between diverse packages and formats. 
+
+
+PowerIO is implemented in [Rust](https://rust-lang.org) with a low-level [C ABI](https://github.com/eigenergy/powerio/tree/main/powerio-capi); any
+language with a C foreign function interface (FFI) can call it, including [Python](#python) and [Julia](#julia). You can also use it directly in [Rust itself](#rust) or through the [command line](#command-line-interface-cli).
+
+## Capabilities
+
+When writing back to the source format, PowerIO **returns the original file exactly** when the parser retained it. Cross format conversion obeys **sane defaults** and explicitly emits `Conversion::warnings` for fields the target format cannot represent.
+
+### Formats
+
+
+- [MATPOWER](https://matpower.org/) `.m`
+- [PSS/E](https://www.siemens.com/global/en/products/energy/grid-software/planning/pss-software/pss-e.html) `.raw` revision 33
+- [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux`
+- [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl) network data JSON
+- [egret](https://pypi.org/project/gridx-egret/) `ModelData` JSON
+- [GridFM](https://github.com/gridfm) `.parquet`
+- [surge](https://github.com/amptimal/surge) `.surge.json` (WIP)
+
+
 ## Packages
 
+This repository contains multiple packages. 
+
 ```
-powerio          parser, Network model, source retaining writers, converters
-powerio-matrix   sparse matrices, DC sensitivity factors, graph views
-powerio-cli      the `powerio` command and ratatui TUI
-powerio-py       PyO3 extension for the Python `powerio` package
-powerio-capi     C ABI for C, C++, Julia, and other foreign function interfaces
-PowerIO.jl       Julia bindings over the C ABI
+powerio          # parser, Network model, source retaining writers, converters
+powerio-matrix   # sparse matrices, DC sensitivity factors, graph views
+powerio-cli      # the `powerio` command and ratatui TUI
+powerio-py       # PyO3 extension for the Python `powerio` package
+powerio-capi     # C ABI for C, C++, Julia, and other foreign function interfaces
+PowerIO.jl       # Julia bindings over the C ABI
 ```
+
+The core powerio [Rust crate](https://crates.io/crates/powerio) is as dependency light as possible, with its companion [Python package](https://pypi.org/project/powerio/) requiring **zero dependencies**.
 
 API docs: <https://eigenergy.github.io/powerio/>.
 Language API map: [docs/languages.md](https://github.com/eigenergy/powerio/blob/main/docs/languages.md).
@@ -56,7 +59,7 @@ cargo add --git https://github.com/eigenergy/powerio powerio-matrix
 cargo install --git https://github.com/eigenergy/powerio powerio-cli
 
 pip install powerio
-pip install 'powerio[all]'   # scipy, numpy, networkx, polars extras
+pip install 'powerio[all]'     # scipy, numpy, networkx, polars extras
 pip install 'powerio[gridfm]'  # polars for Parquet inspection
 pip install 'powerio[pandas]'  # pandas, pyarrow compatibility reads (Python 3.10+)
 
@@ -65,11 +68,7 @@ julia -e 'using Pkg; Pkg.add(url="https://github.com/eigenergy/PowerIO.jl")'
 
 ## Use
 
-PowerIO is implemented in Rust with a low-level
-[C ABI](https://github.com/eigenergy/powerio/tree/main/powerio-capi); any
-language with a C foreign function interface can call it.
-
-**Rust**
+### Rust
 ```rust
 use powerio::{TargetFormat, parse_file};
 
@@ -83,7 +82,7 @@ for warning in &conv.warnings {
 std::fs::write("case14.json", conv.text)?;
 ```
 
-**Python**
+### Python
 ```python
 import powerio as pio
 
@@ -92,7 +91,7 @@ bprime = case.bprime()            # scipy.sparse, needs powerio[matrix]
 raw, warnings = pio.convert_file("case9.m", "psse")
 ```
 
-**Julia**
+### Julia
 ```julia
 using PowerIO
 
@@ -101,7 +100,7 @@ text = to_matpower(case)
 json, warnings = to_format(case, "powermodels-json")
 ```
 
-**Command line interface (CLI)**
+### Command line interface (CLI)
 ```
 powerio convert tests/data/case14.m --to psse -o case14.raw
 powerio verify tests/data/case30.m --kind bdoubleprime
@@ -110,8 +109,9 @@ powerio sensitivities tests/data/case30.m -o out
 powerio gridfm tests/data/case14.m -o out
 powerio
 ```
+## Formats
 
-## Current Format Fidelity
+### Current Format Fidelity
 
 | reader / writer | MATPOWER | PowerModels JSON | PSS/E | PowerWorld | egret JSON |
 | --- | --- | --- | --- | --- | --- |
@@ -127,7 +127,7 @@ reads and writes through the same hub, partial in both directions. Known limits
 for every format are documented in
 [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md).
 
-## Matrices
+### Matrices
 
 `powerio-matrix` derives an `IndexedNetwork` with dense bus indices and builds:
 
@@ -142,7 +142,7 @@ for every format are documented in
 Current conventions for signs, taps, phase shifts, per unit scaling, reference buses, and
 DC susceptance are documented in [docs/matrices.md](https://github.com/eigenergy/powerio/blob/main/docs/matrices.md).
 
-## Normalized View
+### Normalized View
 
 `Network::to_normalized` derives a solver oriented copy of a case: powers in per unit,
 voltage phase angles in radians, inactive elements removed, `tap == 0` replaced with `1`,
@@ -153,24 +153,7 @@ source text, so writing it emits the derived model rather than the original file
 Python exposes the normalized view as `case.to_normalized()`, the C ABI as `pio_to_normalized`,
 and Julia as `to_normalized(case)`.
 
-## Special features
-
-### GridFM
-
-`powerio gridfm <case> -o <dir>` writes the Parquet tables
-[gridfm-datakit](https://gridfm.github.io/gridfm-datakit/) and
-`gridfm-graphkit` consume under `<dir>/<case>/raw/`; several compatible cases
-stack by scenario id. The same `gridfm` feature reads a dataset back into a
-`Network` (`read_gridfm_dataset` in `powerio-matrix`, `pio.read_gridfm` in
-Python), so a perturbed training scenario or a GNN predicted state comes back
-out in any classical format:
-
-```
-powerio convert out/case14/raw --from gridfm --to matpower -o case14.m
-```
-
-The read is lossy; what it recovers, what it drops, and the warnings contract
-are in [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md).
+## Special Features
 
 ### C ABI
 
@@ -180,18 +163,38 @@ and numeric table extraction through `pio_*` functions. The public header is
 Build with `--features arrow` to enable `pio_export_arrow` over the
 [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
 
-### MCP Server
+### PowerAgent
 
-The Python package includes an optional MCP server exposing conversion,
-summaries, the JSON transport, the matrix views, and file staging as tools.
-The [PowerMCP](https://github.com/Power-Agent/PowerMCP) bundle ships the same
-tool surface alongside its simulator servers, whose bridges ingest the
-transport directly.
+
+PowerIO is part of the [PowerAgent](https://github.com/Power-Agent) community. The Python interface for PowerIO currently includes an optional MCP server exposing low-level conversion, summaries, JSON transport, matrix views, and file staging as tools.
+
 
 ```
 pip install 'powerio[mcp]'
 powerio-mcp
 ```
+
+The PowerIO MCP server is currently being integrated as the low-level data exchange substrate for the MCP server bundle in [PowerMCP](https://github.com/Power-Agent/PowerMCP). The [PowerMCP](https://github.com/Power-Agent/PowerMCP) bundle ships the same
+tool surface as PowerIO alongside a wide array of simulator servers, whose bridges ingest the transport directly.
+
+### GridFM
+PowerIO ships first-class support for the Linux Foundation Open [Grid Foundation Model (GridFM)](https://github.com/gridfm) project.
+`powerio gridfm <case> -o <dir>` *writes* the Parquet tables
+[gridfm-datakit](https://gridfm.github.io/gridfm-datakit/) and
+`gridfm-graphkit` consume under `<dir>/<case>/raw/`; several compatible cases
+stack by scenario id. 
+
+The `gridfm` feature also *reads* a dataset back into a `Network` (`read_gridfm_dataset` in `powerio-matrix`, `pio.read_gridfm` in
+Python), so a perturbed training scenario or a GNN predicted state can be extracted and converted back
+out in any classical format:
+
+```
+powerio convert out/case14/raw --from gridfm --to matpower -o case14.m
+```
+
+The read functionality is currently lossy. What it recovers, what it drops, and the warnings contract
+are in [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md). Improving GridFM read/write functionality is a key priority for the initial development of PowerIO.
+
 
 ## Validation
 
@@ -218,3 +221,12 @@ PowerIO is distributed under either of:
 
 - [Apache License, Version 2.0](https://github.com/eigenergy/powerio/blob/main/LICENSE-APACHE)
 - [MIT license](https://github.com/eigenergy/powerio/blob/main/LICENSE-MIT)
+
+
+<p align="center">
+  <img
+    src="https://raw.githubusercontent.com/eigenergy/powerio/main/docs/assets/powerio-logo.svg"
+    alt="PowerIO logo"
+    width="120"
+  >
+</p>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Supported formats:
 - [surge](https://github.com/amptimal/surge) `.surge.json` (WIP)
 
 When writing back to the source format, PowerIO **returns the original file exactly** when the parser
-retained it. Cross format conversion obeys sane defaults, and emits `Conversion::warnings` for fields the
+retained it. Cross format conversion obeys sane defaults and emits `Conversion::warnings` for fields the
 target format cannot represent.
 
 <p align="center">
@@ -142,11 +142,11 @@ DC susceptance are documented in [docs/matrices.md](https://github.com/eigenergy
 
 ## Normalized View
 
-`Network::to_normalized` derives a solver oriented copy of a case with sane defaults. Powers are provided in per
-unit, voltage phase angles are in radians, inactive elements are removed, `tap == 0` replaced with `1`,
-surviving buses are reindexed to a dense 1-based id space, and bus types are made
-consistent with generator placement and reference buses. Computing it carries no retained
-source text, so writing the normalized network emits the derived model rather than the original file.
+`Network::to_normalized` derives a solver oriented copy of a case: powers in per unit,
+voltage phase angles in radians, inactive elements removed, `tap == 0` replaced with `1`,
+surviving buses reindexed to a dense 1-based id space, and bus types made consistent
+with generator placement and reference buses. The normalized copy carries no retained
+source text, so writing it emits the derived model rather than the original file.
 
 Python exposes the normalized view as `case.to_normalized()`, the C ABI as `pio_to_normalized`,
 and Julia as `to_normalized(case)`.

--- a/README.md
+++ b/README.md
@@ -17,23 +17,28 @@ Using PowerIO, you can build sparse matrices and graph views for downstream anal
 PowerIO is implemented in [Rust](https://rust-lang.org) with a low-level [C ABI](https://github.com/eigenergy/powerio/tree/main/powerio-capi); any
 language with a C foreign function interface (FFI) can call it, including [Python](#python) and [Julia](#julia). You can also use it directly in [Rust itself](#rust) or through the [command line](#command-line-interface-cli).
 
-## Capabilities
+## Overview
 
 When writing back to the source format, PowerIO **returns the original file exactly** when the parser retained it. Cross format conversion obeys **sane defaults** and explicitly emits `Conversion::warnings` for fields the target format cannot represent.
 
 ### Formats
 
-
+The following formats are currently supported with read/write functionality:
 - [MATPOWER](https://matpower.org/) `.m`
 - [PSS/E](https://www.siemens.com/global/en/products/energy/grid-software/planning/pss-software/pss-e.html) `.raw` revision 33
 - [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux`
 - [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl) network data JSON
 - [egret](https://pypi.org/project/gridx-egret/) `ModelData` JSON
 - [GridFM](https://github.com/gridfm) `.parquet`
-- [surge](https://github.com/amptimal/surge) `.surge.json` (WIP)
 
+Support for the following formats is under development (see the open pull requests):
+- [surge](https://github.com/amptimal/surge) `.surge.json` 
+- [PowerModelsDistribution.jl](https://github.com/lanl-ansi/PowerModelsDistribution.jl) engineering data JSON
+- [IEEE BMOPF](https://github.com/frederikgeth/bmopf-report) schema `.json`
 
-## Packages
+Other formats are planned; see the GitHub issues. If a format you need is missing, open an issue or a pull request. All are welcome to contribute to this community project.
+
+### Packages
 
 This repository contains multiple packages. 
 
@@ -49,7 +54,7 @@ PowerIO.jl       # Julia bindings over the C ABI
 The core powerio [Rust crate](https://crates.io/crates/powerio) is as dependency light as possible, with its companion [Python package](https://pypi.org/project/powerio/) requiring **zero dependencies**.
 
 API docs: <https://eigenergy.github.io/powerio/>.
-Language API map: [docs/languages.md](https://github.com/eigenergy/powerio/blob/main/docs/languages.md).
+Language API map: [languages guide](https://eigenergy.github.io/powerio/guides/languages.html).
 
 ## Install
 
@@ -109,7 +114,8 @@ powerio sensitivities tests/data/case30.m -o out
 powerio gridfm tests/data/case14.m -o out
 powerio
 ```
-## Formats
+
+## Features
 
 ### Current Format Fidelity
 
@@ -122,38 +128,43 @@ powerio
 | egret JSON | partial | full | partial | partial | original text |
 
 `partial` means the target lacks fields present in the source. The writer reports
-those cases in `Conversion::warnings`. GridFM Parquet sits outside the table: it
-reads and writes through the same hub, partial in both directions. Known limits
+those cases in `Conversion::warnings`. 
+
+GridFM Parquet is not in this table: both read and write are currently lossy. Known limits
 for every format are documented in
-[docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md).
+the [format fidelity guide](https://eigenergy.github.io/powerio/guides/format-fidelity.html).
 
 ### Matrices
 
-`powerio-matrix` derives an `IndexedNetwork` with dense bus indices and builds:
+The `powerio-matrix` Rust crate derives an `IndexedNetwork` with dense bus indices. It enables you to build common power system matrices with minimal dependencies:
 
 - B' and B'' DCPF and FDPF matrices
 - Nodal admittance matrix
 - LACPF block matrix
 - Signed incidence, weighted Laplacian, and flow map matrices
 - PTDF and LODF sensitivity matrices
-- Matrix Market bundle for DC OPF solvers
 - Adjacency matrix and `petgraph` view
+- Matrix Market bundles for low-level OPF solvers
+- KKT operators for OPF solvers (experimental)
 
-Current conventions for signs, taps, phase shifts, per unit scaling, reference buses, and
-DC susceptance are documented in [docs/matrices.md](https://github.com/eigenergy/powerio/blob/main/docs/matrices.md).
+Current conventions for signs, taps, phase shifts, per unit scaling, reference buses, and line parameters are documented in the [matrices guide](https://eigenergy.github.io/powerio/guides/matrices.html).
 
 ### Normalized View
 
-`Network::to_normalized` derives a solver oriented copy of a case: powers in per unit,
-voltage phase angles in radians, inactive elements removed, `tap == 0` replaced with `1`,
-surviving buses reindexed to a dense 1-based id space, and bus types made consistent
-with generator placement and reference buses. The normalized copy carries no retained
-source text, so writing it emits the derived model rather than the original file.
+`Network::to_normalized` derives a mildly opinionated, post-processed copy of a case that is designed to be solver-friendly:
+
+- powers are in per unit,
+- voltage phase angles are in radians, 
+- inactive elements are removed, 
+- `tap == 0` replaced with `1`,
+- surviving buses reindexed to a dense 1-based id space, and 
+- bus types are made consistent with generator placement and reference buses. 
+
+The normalized copy carries no retained source text, so writing it emits the derived model rather than the original file.
 
 Python exposes the normalized view as `case.to_normalized()`, the C ABI as `pio_to_normalized`,
 and Julia as `to_normalized(case)`.
 
-## Special Features
 
 ### C ABI
 
@@ -174,17 +185,21 @@ pip install 'powerio[mcp]'
 powerio-mcp
 ```
 
-The PowerIO MCP server is currently being integrated as the low-level data exchange substrate for the MCP server bundle in [PowerMCP](https://github.com/Power-Agent/PowerMCP). The [PowerMCP](https://github.com/Power-Agent/PowerMCP) bundle ships the same
+The PowerIO MCP server is currently being integrated as the low-level data exchange substrate for the MCP server bundle in [PowerMCP](https://github.com/Power-Agent/PowerMCP). The PowerMCP bundle ships the same
 tool surface as PowerIO alongside a wide array of simulator servers, whose bridges ingest the transport directly.
 
-### GridFM
-PowerIO ships first-class support for the Linux Foundation Open [Grid Foundation Model (GridFM)](https://github.com/gridfm) project.
-`powerio gridfm <case> -o <dir>` *writes* the Parquet tables
-[gridfm-datakit](https://gridfm.github.io/gridfm-datakit/) and
-`gridfm-graphkit` consume under `<dir>/<case>/raw/`; several compatible cases
+### GridFM (experimental)
+PowerIO ships first-class support for the [LF Energy](https://lfenergy.org/projects/gridfm/) open [Grid Foundation Model (GridFM)](https://github.com/gridfm) project. In the command line:
+
+```
+powerio gridfm <case> -o <dir>
+```
+
+This *writes* the Parquet tables [gridfm-datakit](https://gridfm.github.io/gridfm-datakit/) and
+[gridfm-graphkit](https://github.com/gridfm/gridfm-graphkit) consume under `<dir>/<case>/raw/`; several compatible cases
 stack by scenario id. 
 
-The `gridfm` feature also *reads* a dataset back into a `Network` (`read_gridfm_dataset` in `powerio-matrix`, `pio.read_gridfm` in
+The `gridfm` feature also supports *reading* a `.parquet` dataset back into a `Network` (`read_gridfm_dataset` in `powerio-matrix`, `pio.read_gridfm` in
 Python), so a perturbed training scenario or a GNN predicted state can be extracted and converted back
 out in any classical format:
 
@@ -192,8 +207,8 @@ out in any classical format:
 powerio convert out/case14/raw --from gridfm --to matpower -o case14.m
 ```
 
-The read functionality is currently lossy. What it recovers, what it drops, and the warnings contract
-are in [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md). Improving GridFM read/write functionality is a key priority for the initial development of PowerIO.
+The `--from gridfm` read functionality is currently lossy. What it recovers, what it drops, and the warnings contract
+are in the [format fidelity guide](https://eigenergy.github.io/powerio/guides/format-fidelity.html). Improving `gridfm` read/write functionality is a key priority for the initial development of PowerIO.
 
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Supported formats:
 - [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux`
 - [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl) network data JSON
 - [egret](https://pypi.org/project/gridx-egret/) `ModelData` JSON
-- [GridFM](https://github.com/gridfm) `.parquet` (WIP)
+- [GridFM](https://github.com/gridfm) `.parquet`
 - [surge](https://github.com/amptimal/surge) `.surge.json` (WIP)
 
 When writing back to the source format, PowerIO **returns the original file exactly** when the parser
@@ -122,7 +122,9 @@ powerio
 | egret JSON | partial | full | partial | partial | original text |
 
 `partial` means the target lacks fields present in the source. The writer reports
-those cases in `Conversion::warnings`. Known limits are documented in
+those cases in `Conversion::warnings`. GridFM Parquet sits outside the table: it
+reads and writes through the same hub, partial in both directions. Known limits
+for every format are documented in
 [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md).
 
 ## Matrices

--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ julia -e 'using Pkg; Pkg.add(url="https://github.com/eigenergy/PowerIO.jl")'
 ```
 
 ## Use
-PowerIO is implemented in Rust and features a low-level [C ABI](https://github.com/eigenergy/powerio/tree/main/powerio-capi). This lets PowerIO talk to many of your favorite languages. Any language with a C foreign function interface can call it.
+
+PowerIO is implemented in Rust with a low-level
+[C ABI](https://github.com/eigenergy/powerio/tree/main/powerio-capi); any
+language with a C foreign function interface can call it.
 
 **Rust**
 ```rust
@@ -152,33 +155,20 @@ and Julia as `to_normalized(case)`.
 
 ### GridFM
 
-PowerIO supports the GridFM framework. The command `powerio gridfm <case> -o <dir>` writes the Parquet tables consumed by
+`powerio gridfm <case> -o <dir>` writes the Parquet tables
 [gridfm-datakit](https://gridfm.github.io/gridfm-datakit/) and
-`gridfm-graphkit`: `bus_data`, `gen_data`, `branch_data`, and `y_bus_data` under
-`<dir>/<case>/raw/`. A case file is one scenario. Passing several compatible
-cases stacks them by scenario id.
-
-The inverse — `read_gridfm_dataset` / `read_gridfm_scenarios` / `gridfm_base_case`
-in `powerio-matrix` (same `gridfm` feature) — turns a gridfm dataset back into a
-`Network`, the ML→classical return leg. Because every classical writer meets at
-the hub, one reader yields **gridfm → any classical format for free**: take a
-perturbed training scenario or a GNN-predicted state serialized to the schema,
-emit a `.m` or `.raw`, and run it in MATPOWER / pandapower / PowerModels to
-sanity-check it.
+`gridfm-graphkit` consume under `<dir>/<case>/raw/`; several compatible cases
+stack by scenario id. The same `gridfm` feature reads a dataset back into a
+`Network` (`read_gridfm_dataset` in `powerio-matrix`, `pio.read_gridfm` in
+Python), so a perturbed training scenario or a GNN predicted state comes back
+out in any classical format:
 
 ```
 powerio convert out/case14/raw --from gridfm --to matpower -o case14.m
 ```
 
-The read is lossy but **power-flow-complete**: it recovers bus types, voltages and
-limits, nodal load and shunt totals, generator dispatch and bounds, branch
-`r/x/b/tap/shift/rate_a`/angle-limits, and `baseMVA` — enough to write a runnable
-case — but not original bus ids (synthesized `1..n`), per-element load/shunt
-granularity (folded one per bus), piecewise/cubic costs, or HVDC/storage. What it
-can't recover is returned as a warnings list. `--scenario N` picks one scenario
-from a batch; the directory argument accepts the `raw/`, `<case>/`, or parent dir.
-From Python, `pio.read_gridfm(dir)` and `pio.read_gridfm_scenarios(dir)` return a
-`GridfmRead(network, scenario, warnings)`.
+The read is lossy; what it recovers, what it drops, and the warnings contract
+are in [docs/format-fidelity.md](https://github.com/eigenergy/powerio/blob/main/docs/format-fidelity.md).
 
 ### C ABI
 
@@ -190,8 +180,11 @@ Build with `--features arrow` to enable `pio_export_arrow` over the
 
 ### MCP Server
 
-The Python package includes an optional MCP server with `convert_case` and
-`case_summary` tools. Interoperability with the [PowerAgent](https://github.com/Power-Agent) project is planned.
+The Python package includes an optional MCP server exposing conversion,
+summaries, the JSON transport, the matrix views, and file staging as tools.
+The [PowerMCP](https://github.com/Power-Agent/PowerMCP) bundle ships the same
+tool surface alongside its simulator servers, whose bridges ingest the
+transport directly.
 
 ```
 pip install 'powerio[mcp]'
@@ -200,11 +193,10 @@ powerio-mcp
 
 ## Validation
 
-The Rust test suite covers parsers, writers, format conversion, matrix builders,
-and normalization; the C ABI crate carries its own tests (it is outside the
-default members, so it needs an explicit `-p powerio-capi`), and `pytest` covers
-the Python bindings. The benchmark validation suite compares selected outputs
-against PowerModels.jl, egret, ExaPowerIO.jl, and pandapower.
+The Rust test suite covers parsers, writers, format conversion, matrix
+builders, and normalization; the C ABI crate carries its own tests, and
+`pytest` covers the Python bindings. The benchmark validation suite compares
+selected outputs against PowerModels.jl, egret, ExaPowerIO.jl, and pandapower.
 
 ```
 cargo fmt --all --check

--- a/docs/format-fidelity.md
+++ b/docs/format-fidelity.md
@@ -96,8 +96,9 @@ These are reported in `Conversion::warnings`, not dropped silently.
   ModelData subset (numeric bus ids, scalar values); unit commitment cases
   (`system.time_keys`) are rejected.
 - **gridfm** (read, the `gridfm` feature in `powerio-matrix`) reconstructs a
-  `Network` from the gridfm-datakit Parquet dataset — lossy but power-flow-complete.
-  It recovers bus types/voltages/limits, nodal load and shunt totals, generator
+  `Network` from the gridfm-datakit Parquet dataset: lossy, but it recovers
+  everything a power flow needs. That is bus types/voltages/limits, nodal load
+  and shunt totals, generator
   dispatch and bounds, branch `r/x/b/tap/shift/rate_a`/angle-limits, and `baseMVA`;
   it can't recover original bus ids (synthesized `1..n`), per-element load/shunt
   granularity (folded one synthetic element per bus), piecewise/cubic gen costs

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -21,11 +21,13 @@ Verb taxonomy:
 | Parse IO | n/a | file object later | `parse_file(io, format)` | n/a |
 | JSON to Network | `Network::from_json` | `from_json` | `from_json` | `pio_from_json` |
 | File conversion | `convert_file(path, to, from)` | `convert_file(path, to, from_=None)` | `convert_file(path, to; from=nothing)` | `pio_convert_file` |
+| Text conversion | `convert_str(text, to, format)` | `convert_str(text, to, format)` | planned | planned |
 | Parsed conversion | `net.to_format(to)` | `net.to_format(to)` | `to_format(net, to)` | `pio_to_format` |
 | MATPOWER text | `net.to_matpower()` | `net.to_matpower()` | `to_matpower(net)` | `pio_to_matpower` |
 | JSON text | `net.to_json()` | `net.to_json()` | `to_json(net)` | `pio_to_json` |
 | Normalized copy | `net.to_normalized()` | `net.to_normalized()` | `to_normalized(net)` | `pio_to_normalized` |
 | Dense tables | typed table API | `to_dense` | `to_dense` | `pio_*` extractors |
+| gridfm read | `read_gridfm_dataset(dir, scenario)` | `read_gridfm(dir, scenario=0)` | `read_gridfm(dir; scenario=0)` (PR open) | `pio_read_gridfm` |
 | Arrow handoff | internal/C ABI | later | `to_arrow` | `pio_export_arrow` |
 
 **Note:** `pio_export_arrow` keeps `export` because it fills Arrow C Data Interface

--- a/docs/python.md
+++ b/docs/python.md
@@ -17,8 +17,9 @@ pip install 'powerio[pandas]'   # pandas and pyarrow compatibility reads (Python
 pip install 'powerio[all]'      # matrix, graph, and gridfm reads
 ```
 
-`import powerio`, `parse_file`, `parse_str`, `convert_file`, `to_matpower`, and
-`to_json` do not import NumPy, SciPy, NetworkX, Polars, pandas, or pyarrow.
+`import powerio`, `parse_file`, `parse_str`, `convert_file`, `convert_str`,
+`to_matpower`, and `to_json` do not import NumPy, SciPy, NetworkX, Polars,
+pandas, or pyarrow.
 
 ## Canonical use
 
@@ -30,6 +31,7 @@ same_text = net.to_matpower()
 json_text = net.to_json()
 pm = net.to_format("powermodels-json")
 raw = pio.convert_file("case9.m", "psse")
+aux = pio.convert_str(json_text, "powerworld", format="powermodels-json")
 
 normalized = net.to_normalized()
 dense = net.to_dense()       # needs powerio[matrix]

--- a/docs/python.md
+++ b/docs/python.md
@@ -44,13 +44,14 @@ forced with `from_`); `parse_str(text, format)` reads in-memory text.
 
 The native wheel includes the GridFM Parquet writer and reader.
 
-`read_gridfm(dir, scenario=0)` rebuilds a `Network` from a dataset — the inverse
-of `Network.write_gridfm` — returning a `GridfmRead(network, scenario, warnings)`
-namedtuple. The read is lossy but power-flow-complete; `warnings` lists what the
-gridfm schema couldn't round-trip (synthesized bus ids, folded per-bus
-load/shunt, dropped HVDC/storage, piecewise costs). `read_gridfm_scenarios(dir)`
-returns one `GridfmRead` per scenario. `dir` resolves the `raw/` leaf, a `<case>/`
-directory, or a parent with one `*/raw/` child.
+`read_gridfm(dir, scenario=0)` rebuilds a `Network` from a dataset, the inverse
+of `Network.write_gridfm`, returning a `GridfmRead(network, scenario, warnings)`
+namedtuple. The read is lossy but recovers everything a power flow needs;
+`warnings` lists what the gridfm schema couldn't round-trip (synthesized bus
+ids, folded per-bus load/shunt, dropped HVDC/storage, piecewise costs).
+`read_gridfm_scenarios(dir)` returns one `GridfmRead` per scenario. `dir`
+resolves the `raw/` leaf, a `<case>/` directory, or a parent with one `*/raw/`
+child.
 
 ```python
 import powerio as pio

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -114,8 +114,9 @@ The release ABI uses the same verb taxonomy as the Rust, Python, and Julia APIs:
   structs with release callbacks.
 - `pio_read_gridfm` and `pio_gridfm_scenario_ids` read a gridfm-datakit Parquet
   dataset back into a handle (built `--features gridfm`; the reader itself lives
-  in `powerio-matrix`). Lossy but power-flow-complete — the fidelity notes come
-  back `\n`-joined in `warnbuf`, like `pio_to_format`'s warnings.
+  in `powerio-matrix`). Lossy, but it recovers everything a power flow needs;
+  the fidelity notes come back `\n`-joined in `warnbuf`, like `pio_to_format`'s
+  warnings.
 
 ## Safety contract
 

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -75,7 +75,7 @@ GridfmRead.__doc__ = """Output of :func:`read_gridfm` / :func:`read_gridfm_scena
 ``network`` is the reconstructed :class:`Network`; ``scenario`` is the scenario
 id these rows came from; ``warnings`` lists what the gridfm schema could not
 round-trip (synthesized bus ids, folded per-bus load/shunt, dropped HVDC/storage,
-piecewise costs). The read is lossy but power-flow-complete.
+piecewise costs). The read is lossy but recovers everything a power flow needs.
 """
 
 Incidence = namedtuple("Incidence", ["A", "b", "p_shift", "branch_of_col"])

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -490,13 +490,14 @@ def read_gridfm(dir: Any, scenario: int = 0) -> GridfmRead:
     ``scenario`` selects one snapshot from a batch (``0``, the base case, by
     default). Returns a :class:`GridfmRead` ``(network, scenario, warnings)``.
 
-    The read is lossy but power-flow-complete: it recovers bus types, voltages and
-    limits, nodal load and shunt totals, generator dispatch and bounds, branch
-    ``r/x/b/tap/shift/rate_a``/angle-limits, and ``baseMVA`` — enough to write a
-    runnable case — but not original bus ids, per-element load/shunt granularity,
-    piecewise/cubic costs, or HVDC/storage; what it can't recover is listed in
-    ``warnings``. Published wheels include the native reader; custom source builds
-    without the Rust ``gridfm`` feature raise ``ImportError``.
+    The read is lossy but recovers everything a power flow needs: bus types,
+    voltages and limits, nodal load and shunt totals, generator dispatch and
+    bounds, branch ``r/x/b/tap/shift/rate_a``/angle limits, and ``baseMVA``,
+    enough to write a runnable case. It cannot recover original bus ids,
+    per-element load/shunt granularity, piecewise/cubic costs, or HVDC/storage;
+    what it can't recover is listed in ``warnings``. Published wheels include the
+    native reader; custom source builds without the Rust ``gridfm`` feature raise
+    ``ImportError``.
     """
     _require_gridfm()
     case, scen, warnings = _powerio.read_gridfm(str(dir), scenario)
@@ -505,7 +506,7 @@ def read_gridfm(dir: Any, scenario: int = 0) -> GridfmRead:
 
 def read_gridfm_scenarios(dir: Any) -> "list[GridfmRead]":
     """Read every scenario of a gridfm dataset, one :class:`GridfmRead` per
-    scenario id (ascending) over the shared topology — the read side of
+    scenario id (ascending) over the shared topology, the read side of
     :func:`write_gridfm_batch`.
 
     Each scenario is rebuilt independently, so two scenarios may differ in branch


### PR DESCRIPTION
Light polish on the Pages landing page, plus the release prep so v0.1.0 needs no separate PR.

- **Landing page**: logo, tagline, dark mode, four definition list lines (Released on docs.rs / Development built from main / Guides / Bindings). The docs/ guides render to `guides/*.html` on the site itself via python-markdown; sibling `.md` links rewrite to `.html`, links leaving docs/ go to GitHub.
- **Doc source split**: docs.rs renders the crates.io releases of `powerio` and `powerio-matrix`; this site renders main for all four crates, including the `publish = false` `powerio-capi` and `powerio-py` that docs.rs never hosts, plus the pdoc Python reference (PyPI hosts no API docs).
- **Release prep**: workspace version 0.1.0 (features under 0.x semver, and Cargo treats every 0.0.x as incompatible with every other, so 0.1.x is the first range downstream pins can take patches on), intra-workspace pins and lockfile moved together, CHANGELOG 0.1.0 section, capi tarballs built with `--features arrow,gridfm` so `pio_read_gridfm` ships to the Julia bindings, and draft release bodies from the CHANGELOG section for the tag (the workflow fails the tag if the section is missing) plus generated notes.
- **README and docs**: GridFM section trimmed with the recover/drop ledger delegated to docs/format-fidelity.md, MCP Server section updated to the eight tool surface, "power-flow-complete" coinage replaced everywhere user facing, `convert_str` and gridfm rows added to docs/languages.md, GridFM out of WIP.
- **Homepage metadata**: `workspace.package.homepage` points at the Pages site, so the docs.rs and crates.io Homepage links land on the docs hub from the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
