### PR TITLE
fix(mcp): unreadable files keep the ValueError shape; harden error mapping

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -12,6 +12,9 @@ Verb taxonomy:
   hub also keeps `write_as` and per-format `write_*` text builders, the
   internals behind `to_format` and the `to_*` writers, which the bindings do
   not mirror
+- `read_*`: filesystem dataset inputs (`read_gridfm`), the inverse of
+  `write_*`. Datasets are multi-file directories, so they read and write;
+  single documents parse and serialize (`parse_*`/`to_*`)
 - `export_*`: handoff to external memory or interface protocols
 
 | Concept | Rust | Python | Julia | C ABI |

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -59,6 +59,9 @@ def _parse(path: Optional[str], content: Optional[str], format: str) -> "powerio
         raise ValueError(f"parse failed: {exc}") from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
+    except OSError as exc:
+        # e.g. an unreadable file (permissions); keep the one error shape.
+        raise ValueError(f"cannot read file: {exc}") from exc
 
 
 def _load(
@@ -72,6 +75,11 @@ def _load(
     try:
         return powerio.from_json(json)
     except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except (ValueError, KeyError, TypeError) as exc:
+        # The Rust layer already maps malformed and wrong-schema JSON to
+        # PowerIOParseError; this guards future Python-side paths so the tool
+        # keeps its one error shape.
         raise ValueError(f"parse failed: {exc}") from exc
 
 
@@ -123,6 +131,9 @@ def convert_case(
         raise ValueError(f"conversion failed: {exc}") from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
+    except OSError as exc:
+        # e.g. an unreadable file (permissions); keep the one error shape.
+        raise ValueError(f"cannot read file: {exc}") from exc
     return {"text": conv.text, "warnings": list(conv.warnings)}
 
 
@@ -313,8 +324,10 @@ def compute_matrix(
             m = case.lodf(convention)
         elif kind == "lacpf":
             m = case.lacpf()
-        else:
+        elif kind == "laplacian":
             m = case.weighted_laplacian(convention)
+        else:  # pragma: no cover - unreachable; _MATRIX_KINDS is checked above
+            raise ValueError(f"unhandled matrix kind {kind!r}")
     except ImportError as exc:
         raise ValueError(str(exc)) from exc
     except powerio.PowerIOError as exc:

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -213,3 +213,31 @@ def test_tool_surface_parity():
         "convert_case", "save_case", "case_summary", "parse_case",
         "normalize_case", "case_to_json", "compute_matrix", "dense_view",
     }
+
+
+def test_unreadable_file_maps_cleanly(tmp_path):
+    # PermissionError must surface as the documented ValueError shape, like
+    # FileNotFoundError, not leak raw through the tool.
+    import os
+    import sys
+
+    if sys.platform == "win32" or os.geteuid() == 0:
+        pytest.skip("permission bits are not enforceable here")
+    locked = tmp_path / "locked.m"
+    locked.write_text("function mpc = x\n")
+    locked.chmod(0o000)
+    try:
+        with pytest.raises(ValueError, match="cannot read file"):
+            convert_case(to="psse", path=str(locked))
+        with pytest.raises(ValueError, match="cannot read file"):
+            case_summary(path=str(locked))
+    finally:
+        locked.chmod(0o644)
+
+
+def test_wrong_schema_json_maps_cleanly():
+    from powerio.mcp.server import compute_matrix
+
+    for bad in ("{}", "[]", "null", '{"buses": "nope"}'):
+        with pytest.raises(ValueError, match="parse failed"):
+            compute_matrix("bprime", json=bad)


### PR DESCRIPTION
Follow-through from Qian's review of the PowerMCP copy (Power-Agent/PowerMCP#34) — porting the shareable parts here, since this file is canonical.

Validated against released 0.1.0 before porting:

- **Real fix**: `convert_case(path=<unreadable file>)` leaked a raw `PermissionError` through the tool instead of the documented ValueError shape (reproduced on the released wheel). An `OSError` arm in `convert_case` and `_parse` now maps it; covered by a test that chmods a fixture to 0o000 (skipped where permission bits don't bite).
- **Defensive only** (verified unreachable today): every wrong-schema JSON probe (`{}`, `[]`, `null`, wrong field types) already raises `PowerIOParseError` from the Rust layer, so `_load`'s new arm guards future Python-side paths and says so in its comment. `compute_matrix` names the `laplacian` branch explicitly with an unreachable-else guard.
- **Not ported**: the import-shadow guard from #34 — this file lives inside the package and cannot be shadowed; that guard stays a documented divergence in the PowerMCP copy.
- `docs/languages.md` codifies the `read_*` verb alongside the existing `write_*` rule: datasets (multi-file directories) read and write; single documents parse and serialize.

`pytest python/tests`: 88 passed, 2 skipped. Milestoned 0.1.1; no release needed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)