### PR TITLE
fix: make file extension detection case-insensitive

### DIFF
--- a/benchmarks/validate_egret.py
+++ b/benchmarks/validate_egret.py
@@ -26,7 +26,7 @@ from egret.parsers.matpower_parser import create_ModelData
 
 
 def load(path):
-    if path.endswith(".m"):
+    if path.lower().endswith(".m"):
         return create_ModelData(path)
     return ModelData(path)
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -400,7 +400,11 @@ fn run_batch(
             .into_iter()
             .filter_map(std::result::Result::ok)
             .filter(|e| e.file_type().is_file())
-            .filter(|e| e.path().extension().is_some_and(|x| x == "m"))
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|x| x.eq_ignore_ascii_case("m"))
+            })
             .map(|e| e.path().to_path_buf())
             .collect()
     };

--- a/powerio-cli/src/tui/app.rs
+++ b/powerio-cli/src/tui/app.rs
@@ -212,7 +212,11 @@ impl App {
             .into_iter()
             .filter_map(std::result::Result::ok)
             .filter(|e| e.file_type().is_file())
-            .filter(|e| e.path().extension().is_some_and(|x| x == "m"))
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .is_some_and(|x| x.eq_ignore_ascii_case("m"))
+            })
             .map(|e| {
                 let path = e.path().to_path_buf();
                 let display_name = path

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -153,24 +153,30 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
     let text = std::fs::read_to_string(path)?;
     let fmt = match from {
         Some(f) => target_format_from_name(f).ok_or_else(|| Error::UnknownFormat(f.to_string()))?,
-        None => {
-            let ext = path.extension().and_then(|e| e.to_str());
-            match ext.map(str::to_ascii_lowercase).as_deref() {
-                Some("m") => TargetFormat::Matpower,
-                Some("json") => sniff_json(&text),
-                Some("raw") => TargetFormat::Psse,
-                Some("aux") => TargetFormat::PowerWorld,
-                _ => {
-                    return Err(Error::UnknownFormat(format!(
-                        "cannot infer from file extension {ext:?}; pass an explicit source format"
-                    )));
-                }
-            }
-        }
+        None => format_from_extension(path, &text)?,
     };
     // The file stem is the name hint for formats that don't carry their own name.
     let stem = path.file_stem().and_then(|s| s.to_str());
     read_source(Arc::new(text), fmt, stem)
+}
+
+/// Map a file extension to a [`TargetFormat`], case-insensitively (issue #97:
+/// `.RAW` is as common as `.raw` in the wild). A `.json` is sniffed for the
+/// egret vs PowerModels shape. The error keeps the extension as the user wrote
+/// it.
+fn format_from_extension(path: &std::path::Path, text: &str) -> Result<TargetFormat> {
+    let ext = path.extension().and_then(|e| e.to_str());
+    Ok(match ext.map(str::to_ascii_lowercase).as_deref() {
+        Some("m") => TargetFormat::Matpower,
+        Some("json") => sniff_json(text),
+        Some("raw") => TargetFormat::Psse,
+        Some("aux") => TargetFormat::PowerWorld,
+        _ => {
+            return Err(Error::UnknownFormat(format!(
+                "cannot infer from file extension {ext:?}; pass an explicit source format"
+            )));
+        }
+    })
 }
 
 /// Read an owned `source` buffer as `fmt`, using `name_hint` (e.g. the file

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -153,17 +153,20 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
     let text = std::fs::read_to_string(path)?;
     let fmt = match from {
         Some(f) => target_format_from_name(f).ok_or_else(|| Error::UnknownFormat(f.to_string()))?,
-        None => match path.extension().and_then(|e| e.to_str()) {
-            Some("m") => TargetFormat::Matpower,
-            Some("json") => sniff_json(&text),
-            Some("raw") => TargetFormat::Psse,
-            Some("aux") => TargetFormat::PowerWorld,
-            other => {
-                return Err(Error::UnknownFormat(format!(
-                    "cannot infer from file extension {other:?}; pass an explicit source format"
-                )));
+        None => {
+            let ext = path.extension().and_then(|e| e.to_str());
+            match ext.map(str::to_ascii_lowercase).as_deref() {
+                Some("m") => TargetFormat::Matpower,
+                Some("json") => sniff_json(&text),
+                Some("raw") => TargetFormat::Psse,
+                Some("aux") => TargetFormat::PowerWorld,
+                _ => {
+                    return Err(Error::UnknownFormat(format!(
+                        "cannot infer from file extension {ext:?}; pass an explicit source format"
+                    )));
+                }
             }
-        },
+        }
     };
     // The file stem is the name hint for formats that don't carry their own name.
     let stem = path.file_stem().and_then(|s| s.to_str());

--- a/powerio/tests/convert.rs
+++ b/powerio/tests/convert.rs
@@ -421,8 +421,8 @@ fn powermodels_unbounded_limit_round_trips_as_infinity() {
 
 #[test]
 fn parse_file_accepts_uppercase_and_mixed_case_extensions() {
-    // Issue #97: .RAW / .Raw / .M should work identically to their lowercase forms.
-    // Extension detection must be case-insensitive.
+    // Issue #97: .RAW / .Raw / .M / .JSON / .AUX must work identically to their
+    // lowercase forms; extension detection is case-insensitive.
     let dir = std::env::temp_dir();
 
     let raw_src = std::fs::read_to_string(data("psse/case14.raw")).unwrap();
@@ -435,12 +435,22 @@ fn parse_file_accepts_uppercase_and_mixed_case_extensions() {
         assert_eq!(net.buses.len(), 14, ".{ext}: wrong bus count");
     }
 
+    // One uppercase probe per remaining extension; the JSON goes through the
+    // egret-vs-PowerModels sniff, the AUX through the PowerWorld reader.
+    let net = parse_matpower_file(data("case14.m")).unwrap();
     let m_src = std::fs::read_to_string(data("case14.m")).unwrap();
-    let path = dir.join("powerio_test_issue97.M");
-    std::fs::write(&path, &m_src).unwrap();
-    let result = parse_file(&path, None);
-    let _ = std::fs::remove_file(&path);
-    result.unwrap_or_else(|e| panic!(".M extension should be accepted: {e}"));
+    for (ext, src) in [
+        ("M", m_src),
+        ("JSON", write_powermodels_json(&net).text),
+        ("AUX", write_powerworld(&net).text),
+    ] {
+        let path = dir.join(format!("powerio_test_issue97.{ext}"));
+        std::fs::write(&path, &src).unwrap();
+        let result = parse_file(&path, None);
+        let _ = std::fs::remove_file(&path);
+        let parsed = result.unwrap_or_else(|e| panic!(".{ext} extension should be accepted: {e}"));
+        assert_eq!(parsed.buses.len(), 14, ".{ext}: wrong bus count");
+    }
 }
 
 #[test]

--- a/powerio/tests/convert.rs
+++ b/powerio/tests/convert.rs
@@ -420,6 +420,30 @@ fn powermodels_unbounded_limit_round_trips_as_infinity() {
 }
 
 #[test]
+fn parse_file_accepts_uppercase_and_mixed_case_extensions() {
+    // Issue #97: .RAW / .Raw / .M should work identically to their lowercase forms.
+    // Extension detection must be case-insensitive.
+    let dir = std::env::temp_dir();
+
+    let raw_src = std::fs::read_to_string(data("psse/case14.raw")).unwrap();
+    for ext in ["RAW", "Raw", "rAw"] {
+        let path = dir.join(format!("powerio_test_issue97.{ext}"));
+        std::fs::write(&path, &raw_src).unwrap();
+        let result = parse_file(&path, None);
+        let _ = std::fs::remove_file(&path);
+        let net = result.unwrap_or_else(|e| panic!(".{ext} extension should be accepted: {e}"));
+        assert_eq!(net.buses.len(), 14, ".{ext}: wrong bus count");
+    }
+
+    let m_src = std::fs::read_to_string(data("case14.m")).unwrap();
+    let path = dir.join("powerio_test_issue97.M");
+    std::fs::write(&path, &m_src).unwrap();
+    let result = parse_file(&path, None);
+    let _ = std::fs::remove_file(&path);
+    result.unwrap_or_else(|e| panic!(".M extension should be accepted: {e}"));
+}
+
+#[test]
 fn oos_fixture_marks_out_of_service_elements() {
     // t_case9_oos.m turns gen 2 and branch 5-6 out of service; the parse must carry
     // those in_service=false flags.

--- a/powerio/tests/roundtrip.rs
+++ b/powerio/tests/roundtrip.rs
@@ -18,7 +18,10 @@ fn cases() -> Vec<PathBuf> {
             let path = entry.unwrap().path();
             if path.is_dir() {
                 walk(&path, out);
-            } else if path.extension().is_some_and(|x| x == "m") {
+            } else if path
+                .extension()
+                .is_some_and(|x| x.eq_ignore_ascii_case("m"))
+            {
                 out.push(path);
             }
         }


### PR DESCRIPTION
Fixes #97: capitalised file suffixes like .RAW were rejected by parse_file because extension matching was case-sensitive.

The fix lowercases the extension before matching, so .RAW/.Raw/.rAw/.M/.JSON/.AUX all work alongside their lowercase forms. A regression test is included.

Generated with [Claude Code](https://claude.ai/code)