### PR TITLE
release: 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.1.1
+
+- File extension detection is case-insensitive (#97, #101): `parse_file`
+  accepts `.RAW`/`.M`/`.JSON`/`.AUX` and any mixed case alongside the
+  lowercase forms, and the CLI batch discovery and TUI file browser find
+  such files too. Reported by @jd-foster.
+- MCP server error hardening (#93): an unreadable input file surfaces as
+  the documented ValueError shape instead of a raw `PermissionError`, with
+  defensive guards on the JSON load and matrix dispatch paths.
+
 ## 0.1.0
 
 - gridfm read path (#70): `read_gridfm_dataset` / `read_gridfm_scenarios` /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.1.0" }
-powerio-matrix = { path = "powerio-matrix", version = "0.1.0" }
+powerio = { path = "powerio", version = "0.1.1" }
+powerio-matrix = { path = "powerio-matrix", version = "0.1.1" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }


### PR DESCRIPTION
Version bump and CHANGELOG for v0.1.1: the case-insensitive extension fix (#97 via #101, including CLI/TUI discovery) and the MCP error-shape hardening (#93). ABI unchanged (3), so no PowerIO.jl lockstep. After merge: tag v0.1.1, publish the draft release, and PyPI + crates.io ship automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)