### PR TITLE
release: 0.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,11 @@
-# Vendored MATPOWER cases (BSD-3, verbatim from github.com/MATPOWER/matpower).
-# They're MATLAB syntax, so GitHub Linguist counts them as MATLAB and drowns
-# out the Rust source in the language bar. Mark them vendored to drop them from
-# the language stats and collapse them in diffs. The files stay in the repo so
-# the test suite stays hermetic.
-tests/data/**/*.m linguist-vendored
+# Vendored case fixtures (MATPOWER cases verbatim from
+# github.com/MATPOWER/matpower, PSS/E, egret, PowerWorld exports). GitHub
+# Linguist misclassifies them — the `.m` MATPOWER cases as MATLAB, the
+# PowerWorld `.aux` exports as TeX (ACTIVSg200.aux alone showed as 32% of the
+# repo) — and drowns out the Rust source in the language bar. Mark the whole
+# fixture tree vendored to drop it from the language stats and collapse it in
+# diffs. The files stay in the repo so the test suite stays hermetic.
+tests/data/** linguist-vendored
 
 # Julia appears here only as a validation harness, not as the package language.
 benchmarks/**/*.jl linguist-vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.2.0
+
+The PowerWorld compatibility release.
+
+- Full `.aux` fidelity (#95): the reader covers the complete aux grammar
+  (legacy and concise headers, multiline field lists, SUBDATA and SCRIPT
+  blocks retained verbatim) and all three field naming generations through
+  Simulator 21+, merging the DATA sections real exports spread one object
+  over; byte-exact echo, parity tested against sibling MATPOWER and PSS/E
+  exports of the same cases.
+- Read-only `.pwb` binary reader (#95, #102, #105): 2016 through 2022 era
+  exports under the six decoded header constants 425, 483, 508, 537, 550,
+  and 551 — every Texas7k save decodes — with the table search running
+  faster than the aux text reader on every sibling pair; unsupported writer
+  vintages are detected and rejected with the format constant named.
+- Read-only `.pwd` display reader (#102): `powerworld::parse_pwd` extracts
+  substation diagram coordinates, matched 1-1 against the aux substations
+  on every probed save with a same-vintage aux (the v19 resave matches
+  1248/1250 against the published case, a vintage skew).
+- The decoded vintages and the per-field evidence behind the parity claims
+  are documented in [docs/powerworld.md](docs/powerworld.md).
+
 ## 0.1.1
 
 - File extension detection is case-insensitive (#97, #101): `parse_file`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.1.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.1.1" }
+powerio = { path = "powerio", version = "0.2.0" }
+powerio-matrix = { path = "powerio-matrix", version = "0.2.0" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When writing back to the source format, PowerIO **returns the original file exac
 The following formats are currently supported with read/write functionality:
 - [MATPOWER](https://matpower.org/) `.m`
 - [PSS/E](https://www.siemens.com/global/en/products/energy/grid-software/planning/pss-software/pss-e.html) `.raw` revision 33
-- [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux` (all three field naming generations through Simulator 21+), plus a read only `.pwb` binary reader (2016 through 2022 era exports under the six decoded header constants 425, 483, 508, 537, 550, and 551, parity tested against sibling formats up to the 6717 bus Texas7k; unsupported writer vintages are detected and rejected with the format constant named), and a read only `.pwd` display reader for substation diagram coordinates (matched 1-1 against the aux substations on every probed save with a same vintage aux; the v19 resave matches 1248/1250 against the published case, a vintage skew)
+- [PowerWorld](https://www.powerworld.com/WebHelp/Content/MainDocumentation_HTML/Case_Formats.htm) `.aux`, plus read only `.pwb` (binary case) and `.pwd` (substation coordinates) readers; the supported vintages and parity evidence are in [docs/powerworld.md](docs/powerworld.md)
 - [PowerModels.jl](https://github.com/lanl-ansi/PowerModels.jl) network data JSON
 - [egret](https://pypi.org/project/gridx-egret/) `ModelData` JSON
 - [GridFM](https://github.com/gridfm) `.parquet`


### PR DESCRIPTION
Release prep for v0.2.0, the PowerWorld compatibility release (#95, #102, #105).

- Workspace version and intra-workspace dependency pins 0.1.1 → 0.2.0; Cargo.lock refreshed (same shape as the 0.1.1 release commit).
- CHANGELOG entry for 0.2.0: full `.aux` fidelity, the `.pwb` reader vintages and parity, `.pwd` substation coordinates, and the docs/powerworld.md pointer.
- README: the PowerWorld formats bullet shrinks to a pointer. Every detail it carried (the field naming generations, the six header constants, Texas7k parity, the pwd 1-1 match and the v19 1248/1250 vintage skew) is already recorded in docs/powerworld.md, and the changelog entry now carries the release-level summary.
- .gitattributes: all of `tests/data/` is linguist-vendored — Linguist classifies the PowerWorld ACTIVSg200.aux fixture as TeX and was showing TeX as 32% of the repo.

If #106 (pandapower/PyPSA converters) merges before this does, its changelog entry gets added here first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)