### PR TITLE
release: 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.2.1
+
+Hardening fixes only; no API or ABI change (`PIO_ABI_VERSION` stays 3).
+
+- MATPOWER: a crafted `gencost` NCOST (e.g. `1e20`) overflowed the row
+  width arithmetic and panicked on every build profile, a denial of
+  service on untrusted input through the Rust API and the CLI. The width
+  now saturates and the row is rejected as a `ShortRow` parse error.
+  Found by malformed input fuzzing.
+- C ABI: error and warning messages were clipped at a raw byte count,
+  which could split a multibyte UTF-8 character and hand the caller an
+  invalid string. Truncation now lands on a character boundary.
+- PowerWorld `.pwd`: the reader's byte accessors return `Option` instead
+  of indexing, so an out of range offset from a corrupt file rejects the
+  record instead of panicking. A corruption sweep test pins the
+  invariant; the differential oracle tests pass unchanged.
+- `powerio.h`: a doc comment contained a literal `*/` that terminated
+  the generated block comment, so compiling with `-DPIO_GRIDFM` against
+  the shipped 0.2.0 header failed with `unknown type name 'raw'`.
+
 ## 0.2.0
 
 - PowerWorld `.pwb` binary reader (#95, #102, #105): read only, covering

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.2.0" }
-powerio-matrix = { path = "powerio-matrix", version = "0.2.0" }
+powerio = { path = "powerio", version = "0.2.1" }
+powerio-matrix = { path = "powerio-matrix", version = "0.2.1" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -240,7 +240,7 @@ int32_t pio_write_pypsa_csv_folder(const PioNetwork *net,
  * Read one scenario of a gridfm-datakit Parquet dataset into a network handle —
  * the inverse of the gridfm writer. `dir` resolves leniently: the `raw/` leaf
  * holding the parquet files, a `<case>/` directory with a `raw/` child, or a
- * parent with one `*/raw/` child. Returns `NULL` on error and writes the message
+ * parent holding exactly one such case. Returns `NULL` on error and writes the message
  * into `errbuf`; the lossy read's fidelity warnings (what the gridfm schema
  * couldn't round-trip) are written `\n`-joined into `warnbuf`. Free the handle
  * with [`pio_network_free`]. Built `--features gridfm`.

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn pio_write_pypsa_csv_folder(
 /// Read one scenario of a gridfm-datakit Parquet dataset into a network handle —
 /// the inverse of the gridfm writer. `dir` resolves leniently: the `raw/` leaf
 /// holding the parquet files, a `<case>/` directory with a `raw/` child, or a
-/// parent with one `*/raw/` child. Returns `NULL` on error and writes the message
+/// parent holding exactly one such case. Returns `NULL` on error and writes the message
 /// into `errbuf`; the lossy read's fidelity warnings (what the gridfm schema
 /// couldn't round-trip) are written `\n`-joined into `warnbuf`. Free the handle
 /// with [`pio_network_free`]. Built `--features gridfm`.

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -36,7 +36,9 @@ pub struct PioNetwork {
 }
 
 /// Copy `msg` (truncated to fit) into a caller `char[len]` buffer, always
-/// NUL-terminated. Shared by the error and warning outputs.
+/// NUL-terminated. Truncation backs up to a UTF-8 character boundary so a
+/// clipped message is still valid UTF-8. Shared by the error and warning
+/// outputs.
 ///
 /// # Safety
 /// A non-NULL `buf` must point to at least `len` writable bytes; the write
@@ -48,7 +50,10 @@ unsafe fn copy_to_buf(buf: *mut c_char, len: usize, msg: &str) {
             return;
         }
         let bytes = msg.as_bytes();
-        let n = bytes.len().min(len - 1);
+        let mut n = bytes.len().min(len - 1);
+        while n > 0 && !msg.is_char_boundary(n) {
+            n -= 1;
+        }
         std::ptr::copy_nonoverlapping(bytes.as_ptr().cast::<c_char>(), buf, n);
         *buf.add(n) = 0;
     }
@@ -1307,6 +1312,25 @@ mpc.branch = [
             .position(|&b| b == 0)
             .expect("buffer must be NUL-terminated");
         assert!(nul <= 15);
+    }
+
+    #[test]
+    fn truncation_lands_on_a_utf8_char_boundary() {
+        // "aé€" is 1+2+3 bytes; a 6-byte buffer fits 5 message bytes, which
+        // would split '€'. The copy must back up to "aé" instead of emitting a
+        // dangling partial codepoint.
+        let mut buf = [0x7f as c_char; 6];
+        unsafe { copy_to_buf(buf.as_mut_ptr(), buf.len(), "aé€") };
+        let s = unsafe { CStr::from_ptr(buf.as_ptr()) }
+            .to_str()
+            .expect("truncated message must be valid UTF-8");
+        assert_eq!(s, "aé");
+
+        // A message that fits is copied whole.
+        let mut buf = [0x7f as c_char; 8];
+        unsafe { copy_to_buf(buf.as_mut_ptr(), buf.len(), "aé€") };
+        let s = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+        assert_eq!(s, "aé€");
     }
 
     #[cfg(feature = "arrow")]

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -238,9 +238,19 @@ pub(super) fn gencost_row(row: &[f64], i: usize) -> Result<GenCost> {
     // only this row's values, not the padding. Require the row to actually hold
     // them: a NCOST larger than the row is malformed, and silently truncating it
     // would misrepresent the cost curve.
-    let want = if model == 1 { 2 * ncost } else { ncost };
+    // `ncost` is an untrusted file field truncated from an f64, so a huge or
+    // non-finite NCOST saturates near `usize::MAX`. Size the requirement with
+    // saturating arithmetic: an implausible NCOST is then rejected by the length
+    // check below (a loud `ShortRow`), instead of overflowing the add (a panic
+    // under debug overflow checks) or wrapping into a reversed `start..start+want`
+    // slice range at `coeffs` (a slice-index panic in release).
+    let want = if model == 1 {
+        ncost.saturating_mul(2)
+    } else {
+        ncost
+    };
     let start = gencost_col::REQUIRED;
-    require("gencost", row, i, start + want)?;
+    require("gencost", row, i, start.saturating_add(want))?;
     Ok(GenCost {
         model,
         startup: row[gencost_col::STARTUP],

--- a/powerio/src/format/matpower/tests.rs
+++ b/powerio/src/format/matpower/tests.rs
@@ -153,6 +153,31 @@ mpc.storage = [
 }
 
 #[test]
+fn rejects_oversized_gencost_ncost_without_panicking() {
+    // NCOST is read from the file as an f64 truncated to usize, so a huge value
+    // saturates near usize::MAX. The row-width requirement (`start + 2*ncost` for
+    // model 1, `start + ncost` for model 2) must be computed without overflowing:
+    // a malformed NCOST has to surface as a loud `ShortRow`, not an add-overflow
+    // panic (debug) or a reversed-slice panic (release). Both cost models exercise
+    // a distinct saturating op (`saturating_mul` vs `saturating_add`).
+    let case = |gencost: &str| {
+        format!(
+            "mpc.baseMVA = 100;\n\
+             mpc.bus = [\n1 3 0 0 0 0 1 1 0 345 1 1.1 0.9;\n];\n\
+             mpc.gen = [\n1 0 0 100 -100 1 100 1 100 0 0 0 0 0 0 0 0 0 0 0 0;\n];\n\
+             mpc.branch = [\n1 1 0.01 0.05 0.02 0 0 0 0 0 1 -360 360;\n];\n\
+             mpc.gencost = [\n{gencost}\n];\n"
+        )
+    };
+    // model 2 (polynomial): want = ncost
+    let err = parse_mpc(&case("2 0 0 1e20 500 300 200;")).expect_err("huge model-2 ncost");
+    assert!(err.to_string().contains("gencost"), "got: {err}");
+    // model 1 (piecewise): want = 2 * ncost, the saturating_mul path
+    let err = parse_mpc(&case("1 0 0 1e19 0 0 1 1;")).expect_err("huge model-1 ncost");
+    assert!(err.to_string().contains("gencost"), "got: {err}");
+}
+
+#[test]
 fn rejects_unterminated_matrix() {
     // A `mpc.bus = [ … ` truncated at EOF with no closing `];`. The streaming
     // row parser must reject this (old `find_matrix` returned UnbalancedBrackets)

--- a/powerio/src/format/powerworld/pwd.rs
+++ b/powerio/src/format/powerworld/pwd.rs
@@ -68,21 +68,17 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
         format: FMT,
         message,
     };
-    if bytes.len() < 0x40 || u32_at(bytes, 0) != 50 {
+    if bytes.len() < 0x40 || u32_at(bytes, 0) != Some(50) {
         return Err(err(format!(
             "not a recognized PowerWorld display file (header word {}; the probed saves all \
              carry 50)",
-            if bytes.len() >= 4 {
-                u32_at(bytes, 0)
-            } else {
-                0
-            },
+            u32_at(bytes, 0).unwrap_or(0),
         )));
     }
-    if u16_at(bytes, 4) == 0 || u16_at(bytes, 6) == 0 {
+    if u16_at(bytes, 4) == Some(0) || u16_at(bytes, 6) == Some(0) {
         return Err(err("display header canvas dimensions are zero".into()));
     }
-    let stamp = u32_at(bytes, 22);
+    let stamp = u32_at(bytes, 22).unwrap_or(0);
     if stamp == 0 {
         return Err(err(
             "display header stamp is zero; every validated save carries a nonzero stamp the \
@@ -96,13 +92,14 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
     // Every drawing object record repeats the header stamp at +18 and dual
     // encodes its position (f64 at +22/+30, f32 echo at +2/+6); the scan
     // collects every offset with that shape and groups by the u16 type tag.
-    let mut groups: Vec<(u16, Vec<usize>)> = Vec::new();
+    let mut groups: Vec<(u16, Vec<DrawRecord>)> = Vec::new();
     for i in 0..bytes.len().saturating_sub(38) {
-        if u32_at(bytes, i + 18) != stamp {
+        if u32_at(bytes, i + 18) != Some(stamp) {
             continue;
         }
-        let x = f64_at(bytes, i + 22);
-        let y = f64_at(bytes, i + 30);
+        let (Some(x), Some(y)) = (f64_at(bytes, i + 22), f64_at(bytes, i + 30)) else {
+            continue;
+        };
         if !x.is_finite() || !y.is_finite() {
             continue;
         }
@@ -110,8 +107,8 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
         let (rx, ry) = (x as f32, y as f32);
         // Bit equality: the magnitude gate below excludes zero, so the only
         // value the echo can hold is the rounded f64 itself.
-        if f32_at(bytes, i + 2).to_bits() != rx.to_bits()
-            || f32_at(bytes, i + 6).to_bits() != ry.to_bits()
+        if f32_at(bytes, i + 2).map(f32::to_bits) != Some(rx.to_bits())
+            || f32_at(bytes, i + 6).map(f32::to_bits) != Some(ry.to_bits())
         {
             continue;
         }
@@ -119,10 +116,13 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
         if !(1.0..1.0e7).contains(&magnitude) {
             continue;
         }
-        let tag = u16_at(bytes, i);
+        let Some(tag) = u16_at(bytes, i) else {
+            continue;
+        };
+        let rec = DrawRecord { at: i, x, y };
         match groups.iter_mut().find(|(t, _)| *t == tag) {
-            Some((_, v)) => v.push(i),
-            None => groups.push((tag, vec![i])),
+            Some((_, v)) => v.push(rec),
+            None => groups.push((tag, vec![rec])),
         }
     }
 
@@ -131,17 +131,17 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
     // era) followed by the row's u32 number, somewhere in the style tail.
     // Field label decoys carry other markers (0x05 observed) or another
     // order and fail; ambiguity is a loud error, never a pick.
-    let matches: Vec<&(u16, Vec<usize>)> = groups
+    let matches: Vec<&(u16, Vec<DrawRecord>)> = groups
         .iter()
-        .filter(|(_, offsets)| {
-            offsets.len() == identity.len()
-                && offsets
+        .filter(|(_, records)| {
+            records.len() == identity.len()
+                && records
                     .iter()
                     .zip(&identity)
-                    .all(|(&i, (number, _))| links_number(bytes, i, *number))
+                    .all(|(rec, (number, _))| links_number(bytes, rec.at, *number))
         })
         .collect();
-    let (_, offsets) = match matches.as_slice() {
+    let (_, records) = match matches.as_slice() {
         [one] => *one,
         [] => {
             return Err(err(format!(
@@ -159,16 +159,25 @@ pub fn parse_pwd(bytes: &[u8]) -> Result<Vec<PwdSubstation>> {
         }
     };
 
-    Ok(offsets
+    Ok(records
         .iter()
         .zip(identity)
-        .map(|(&i, (number, name))| PwdSubstation {
+        .map(|(rec, (number, name))| PwdSubstation {
             number,
             name,
-            x: f64_at(bytes, i + 22),
-            y: f64_at(bytes, i + 30),
+            x: rec.x,
+            y: rec.y,
         })
         .collect())
+}
+
+/// A drawing record that passed the shape gate: its stream offset (for the
+/// identity link check) and the decoded coordinates, kept so the final mapping
+/// never re-reads the bytes.
+struct DrawRecord {
+    at: usize,
+    x: f64,
+    y: f64,
 }
 
 /// The substation identity table: exactly one valid walk behind a
@@ -207,22 +216,19 @@ fn identity_walk(b: &[u8], mut at: usize) -> Option<Vec<(u32, String)>> {
     let mut rows = Vec::new();
     let mut seen = HashSet::new();
     loop {
-        if at + 4 <= b.len() && b[at..at + 4] == [0xff; 4] {
+        if b.get(at..at + 4) == Some([0xff; 4].as_slice()) {
             return (!rows.is_empty()).then_some(rows);
         }
-        if at + 13 > b.len() {
+        let number = u32_at(b, at)?;
+        if number == 0 || number > 99_999_999 || u32_at(b, at + 4) != Some(number) {
             return None;
         }
-        let number = u32_at(b, at);
-        if number == 0 || number > 99_999_999 || u32_at(b, at + 4) != number {
+        let len = u32_at(b, at + 8)? as usize;
+        if len == 0 || len >= 64 {
             return None;
         }
-        let len = u32_at(b, at + 8) as usize;
-        if len == 0 || len >= 64 || at + 12 + len + 1 > b.len() {
-            return None;
-        }
-        let name = &b[at + 12..at + 12 + len];
-        if !name.iter().all(|&c| (0x20..0x7f).contains(&c)) || b[at + 12 + len] != 0x02 {
+        let name = b.get(at + 12..at + 12 + len)?;
+        if !name.iter().all(|&c| (0x20..0x7f).contains(&c)) || b.get(at + 12 + len) != Some(&0x02) {
             return None;
         }
         if !seen.insert(number) {
@@ -239,11 +245,8 @@ fn identity_walk(b: &[u8], mut at: usize) -> Option<Vec<(u32, String)>> {
 /// variable because a digit string of 1 to 4 characters precedes the link
 /// in some saves.
 fn links_number(b: &[u8], i: usize, number: u32) -> bool {
-    (40..140).any(|d| {
-        i + d + 5 <= b.len()
-            && (b[i + d] == 0x03 || b[i + d] == 0x07)
-            && u32_at(b, i + d + 1) == number
-    })
+    (40..140)
+        .any(|d| matches!(b.get(i + d), Some(0x03 | 0x07)) && u32_at(b, i + d + 1) == Some(number))
 }
 
 /// Every start of `needle` in `haystack`.
@@ -254,18 +257,22 @@ fn memmem<'a>(haystack: &'a [u8], needle: &'a [u8]) -> impl Iterator<Item = usiz
         .filter_map(move |(i, w)| (w == needle).then_some(i))
 }
 
-fn u16_at(b: &[u8], i: usize) -> u16 {
-    u16::from_le_bytes(b[i..i + 2].try_into().unwrap())
+// Total little endian reads: `None` past the end of the buffer, no index
+// arithmetic that can panic or wrap. Every offset in this reader derives
+// from untrusted file bytes, so the accessors carry the bounds check.
+
+fn u16_at(b: &[u8], i: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(*b.get(i..)?.first_chunk()?))
 }
 
-fn u32_at(b: &[u8], i: usize) -> u32 {
-    u32::from_le_bytes(b[i..i + 4].try_into().unwrap())
+fn u32_at(b: &[u8], i: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(*b.get(i..)?.first_chunk()?))
 }
 
-fn f32_at(b: &[u8], i: usize) -> f32 {
-    f32::from_le_bytes(b[i..i + 4].try_into().unwrap())
+fn f32_at(b: &[u8], i: usize) -> Option<f32> {
+    Some(f32::from_le_bytes(*b.get(i..)?.first_chunk()?))
 }
 
-fn f64_at(b: &[u8], i: usize) -> f64 {
-    f64::from_le_bytes(b[i..i + 8].try_into().unwrap())
+fn f64_at(b: &[u8], i: usize) -> Option<f64> {
+    Some(f64::from_le_bytes(*b.get(i..)?.first_chunk()?))
 }

--- a/powerio/tests/powerworld_pwd.rs
+++ b/powerio/tests/powerworld_pwd.rs
@@ -208,7 +208,7 @@ fn corrupt_display_files_never_panic() {
     let stride = 9973;
     for len in (0..pwd.len())
         .step_by(stride)
-        .chain(pwd.len() - 48..pwd.len())
+        .chain(pwd.len().saturating_sub(48)..pwd.len())
     {
         let _ = parse_pwd(&pwd[..len]);
     }

--- a/powerio/tests/powerworld_pwd.rs
+++ b/powerio/tests/powerworld_pwd.rs
@@ -197,6 +197,31 @@ fn local_corpus_pwd_siblings_match_their_auxes() {
     }
 }
 
+/// The malformed input invariant the fuzz harness asserts: every truncation
+/// or byte corruption of a real display file parses to Ok or a structured
+/// Err, never a panic. Every offset the reader follows derives from file
+/// bytes, so the sweep walks the whole file at a stride plus the tail,
+/// where a clipped record leaves reads dangling past the end.
+#[test]
+fn corrupt_display_files_never_panic() {
+    let pwd = fs::read(common::powerworld_vendored("ACTIVSg200.pwd")).unwrap();
+    let stride = 9973;
+    for len in (0..pwd.len())
+        .step_by(stride)
+        .chain(pwd.len() - 48..pwd.len())
+    {
+        let _ = parse_pwd(&pwd[..len]);
+    }
+    let mut copy = pwd.clone();
+    for i in (0..pwd.len()).step_by(stride) {
+        for byte in [0x00, 0xff] {
+            copy[i] = byte;
+            let _ = parse_pwd(&copy);
+        }
+        copy[i] = pwd[i];
+    }
+}
+
 /// Loud rejections: a binary case is not a display file, garbage is not a
 /// display file, and a display header with no substation identity table
 /// names what is missing.


### PR DESCRIPTION
Patch release: the nonbreaking hardening fixes from the v0.3.0 candidate (#116), shippable now. No API or ABI change; `PIO_ABI_VERSION` stays 3, so the binaries are drop in for PowerIO.jl.

- MATPOWER: crafted gencost NCOST overflowed the row width arithmetic and panicked on every profile; now a `ShortRow` parse error (cherry-pick of 57269e9).
- C ABI: message truncation lands on a UTF-8 character boundary instead of splitting a codepoint (cherry-pick of f76149d).
- `.pwd` reader: byte accessors are total (`Option`, no direct indexing), with a corruption sweep test; extracted from the v4 commits, `parse_pwd` unchanged.
- `powerio.h`: the 0.2.0 header fails to compile under `-DPIO_GRIDFM` — the gridfm doc's `*/raw/` example terminated the block comment (`unknown type name 'raw'` at line 243). The feature guard kept the default build and the CI smoke test green, which is how it shipped.

Excluded by design: ABI v4, the fuzz harnesses (not a shipped artifact; one target needs the v4 format), and the snapshot fix (v4 only code). All stay in #116, which takes a main merge back after this lands (clean: identical patches, identical pwd.rs).

Release runbook after merge: `git tag v0.2.1 && git push origin v0.2.1` → release-binaries stages the draft release → publish → crates.io and PyPI fire on the release event → PowerIO.jl `gen/update_artifacts.jl v0.2.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)