### PR TITLE
ci: notify PowerIO.jl on release publish

### DIFF
--- a/.github/workflows/notify-powerio-jl.yml
+++ b/.github/workflows/notify-powerio-jl.yml
@@ -1,0 +1,37 @@
+name: Notify PowerIO.jl
+
+# After a release is published, nudge PowerIO.jl's Update artifacts workflow so
+# its Artifacts.toml repins to the new binaries immediately. PowerIO.jl's daily
+# schedule is the no-secret backstop, so a missing token only costs latency.
+#
+# POWERIO_JL_DISPATCH_TOKEN: a fine-grained PAT for eigenergy/PowerIO.jl with
+# Contents read/write (the repository_dispatch endpoint requires write on the
+# target repo). The receiving workflow validates the tag shape and refuses
+# binaries whose ABI the binding does not target.
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository_dispatch powerio-release
+        env:
+          TOKEN: ${{ secrets.POWERIO_JL_DISPATCH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "POWERIO_JL_DISPATCH_TOKEN not set; PowerIO.jl's daily schedule will pick up $TAG" \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -n --arg tag "$TAG" '{event_type: "powerio-release", client_payload: {tag: $tag}}' \
+            | curl -sf -X POST \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                https://api.github.com/repos/eigenergy/PowerIO.jl/dispatches \
+                --data-binary @-
+          echo "dispatched powerio-release ($TAG) to eigenergy/PowerIO.jl" \
+            | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Companion to eigenergy/PowerIO.jl#27. On `release: published`, sends `repository_dispatch` (`powerio-release`, tag in the payload) to PowerIO.jl, whose Update artifacts workflow repins Artifacts.toml, gated on tag shape and ABI match.

Needs `POWERIO_JL_DISPATCH_TOKEN` (fine-grained PAT, Contents read/write on PowerIO.jl) in this repo's secrets for immediacy; without it the step exits 0 with a summary note and PowerIO.jl's daily schedule picks the release up within a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)