### PR TITLE
feat(mcp): add PyPSA CSV folder and gridfm Parquet read/write tools

### DIFF
--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -15,6 +15,9 @@ string:
   transport (``Network.to_json``), the cheap handoff between tool calls.
 - ``compute_matrix``: the sparse matrix views in COO form as plain lists.
 - ``dense_view``: the dense table view as plain lists and dicts.
+- ``read_pypsa_csv_folder`` / ``write_pypsa_csv_folder``: the PyPSA static CSV
+  folder format, which has no single-file text form.
+- ``read_gridfm`` / ``write_gridfm``: the gridfm-datakit Parquet datasets.
 
 Run over stdio with the ``powerio-mcp`` console script (or ``python -m
 powerio.mcp``). The server is a thin wrapper over the powerio Python API; it
@@ -419,6 +422,144 @@ def dense_view(
         "n_components": int(d.n_components),
         "is_radial": bool(d.is_radial),
     }
+
+
+@mcp.tool()
+def read_pypsa_csv_folder(folder: str) -> dict:
+    """Read a PyPSA static CSV folder into the JSON transport plus a summary.
+
+    ``folder`` is a directory of PyPSA component CSVs (``buses.csv``,
+    ``generators.csv``, ``lines.csv``, ...). PyPSA CSV is a folder format with
+    no single-file text form; ``convert_case`` / ``case_summary`` accept such a
+    folder as a ``path`` input, but this tool returns the JSON transport in one
+    call so the case can be handed to ``compute_matrix`` / ``dense_view`` or any
+    downstream consumer without re-reading the folder.
+
+    Returns ``{"json": <transport string>, "summary": <case_summary fields>,
+    "warnings": [<read fidelity notes>]}``.
+    """
+    try:
+        case = powerio.read_pypsa_csv_folder(folder)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"cannot read folder: {exc}") from exc
+    return {
+        "json": case.to_json(),
+        "summary": _summary(case),
+        "warnings": list(getattr(case, "read_warnings", []) or []),
+    }
+
+
+@mcp.tool()
+def write_pypsa_csv_folder(
+    out_dir: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: Optional[str] = None,
+) -> dict:
+    """Write a case out as a PyPSA static CSV folder.
+
+    Converts any case — a file ``path``, inline ``content`` (with ``format``),
+    or the ``json`` transport from ``parse_case`` — to PyPSA's CSV component
+    tables under ``out_dir`` (created if needed). The PyPSA-CSV counterpart of
+    ``save_case`` for the folder format. ``format`` is the source format name;
+    default: inferred from the path extension, or ``matpower`` for inline
+    ``content``.
+
+    Returns ``{"dir": <folder written>, "files": [<csv paths>],
+    "warnings": [<fidelity notes>]}``.
+    """
+    case = _load(path, content, json, format)
+    try:
+        result = case.write_pypsa_csv_folder(out_dir)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"write failed: {exc}") from exc
+    return {
+        "dir": result.get("dir", out_dir),
+        "files": list(result.get("files", [])),
+        "warnings": list(result.get("warnings", [])),
+    }
+
+
+@mcp.tool()
+def read_gridfm(dir: str, scenario: int = 0) -> dict:
+    """Read one scenario of a gridfm-datakit Parquet dataset into the transport.
+
+    ``dir`` is resolved leniently: the ``raw/`` directory holding the parquet
+    files, a ``<case>/`` directory with a ``raw/`` child, or a parent with one
+    ``*/raw/`` child all work. ``scenario`` selects one snapshot from a batch
+    (``0``, the base case, by default). The read is lossy but recovers
+    everything a power flow needs; what it can't recover is in ``warnings``.
+
+    Returns ``{"json": <transport string>, "summary": <case_summary fields>,
+    "scenario": <int>, "warnings": [<fidelity notes>]}``. Requires a powerio
+    build with the native gridfm reader (published wheels include it).
+    """
+    try:
+        result = powerio.read_gridfm(dir, scenario)
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"parse failed: {exc}") from exc
+    except FileNotFoundError as exc:
+        raise ValueError(f"file not found: {exc}") from exc
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except OSError as exc:
+        raise ValueError(f"cannot read dataset: {exc}") from exc
+    case = result.network
+    return {
+        "json": case.to_json(),
+        "summary": _summary(case),
+        "scenario": int(result.scenario),
+        "warnings": list(result.warnings),
+    }
+
+
+@mcp.tool()
+def write_gridfm(
+    out_dir: str,
+    path: Optional[str] = None,
+    content: Optional[str] = None,
+    json: Optional[str] = None,
+    format: Optional[str] = None,
+    scenario: int = 0,
+    include_y_bus: bool = True,
+    include_taps: bool = True,
+    include_shifts: bool = True,
+) -> dict:
+    """Write a case as a gridfm-datakit Parquet dataset under ``out_dir``.
+
+    Converts any case — a file ``path``, inline ``content`` (with ``format``),
+    or the ``json`` transport — and writes the gridfm layout
+    (``<case>/raw/*.parquet`` plus ``gridfm_meta.json``). ``scenario`` tags the
+    snapshot id; the ``include_*`` flags toggle the Y-bus, tap, and shift
+    columns. ``format`` is the source format name; default: inferred from the
+    path extension, or ``matpower`` for inline ``content``.
+
+    Returns the writer's report ``{"dir": ..., "files": [...], ...}``. Requires
+    a powerio build with the native gridfm writer (published wheels include it).
+    """
+    case = _load(path, content, json, format)
+    try:
+        result = case.write_gridfm(
+            out_dir,
+            scenario,
+            include_y_bus=include_y_bus,
+            include_taps=include_taps,
+            include_shifts=include_shifts,
+        )
+    except powerio.PowerIOError as exc:
+        raise ValueError(f"conversion failed: {exc}") from exc
+    except ImportError as exc:
+        raise ValueError(str(exc)) from exc
+    except OSError as exc:
+        raise ValueError(f"write failed: {exc}") from exc
+    return dict(result)
 
 
 def main() -> None:

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -19,6 +19,13 @@ from powerio.mcp.server import case_summary, convert_case  # noqa: E402
 
 DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
 
+# The gridfm Parquet surface is a compile-time feature; skip its tools when the
+# extension was built without it (mirrors test_powerio.py).
+HAS_GRIDFM = bool(getattr(powerio._powerio, "_has_gridfm", False))
+gridfm_only = pytest.mark.skipif(
+    not HAS_GRIDFM, reason="extension built without the gridfm feature"
+)
+
 
 def test_case_summary_path():
     s = case_summary(path=str(DATA / "case9.m"))
@@ -341,6 +348,7 @@ def test_read_pypsa_csv_missing_folder_maps_cleanly(tmp_path):
         read_pypsa_csv_folder(str(tmp_path / "nope"))
 
 
+@gridfm_only
 def test_gridfm_round_trip(tmp_path):
     from powerio.mcp.server import read_gridfm, write_gridfm
 
@@ -353,6 +361,7 @@ def test_gridfm_round_trip(tmp_path):
     assert json.loads(r["json"])
 
 
+@gridfm_only
 def test_read_gridfm_missing_dir_maps_cleanly(tmp_path):
     from powerio.mcp.server import read_gridfm
 

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -275,6 +275,8 @@ def test_tool_surface_parity():
     assert names == {
         "convert_case", "save_case", "case_summary", "parse_case",
         "normalize_case", "case_to_json", "compute_matrix", "dense_view",
+        "read_pypsa_csv_folder", "write_pypsa_csv_folder",
+        "read_gridfm", "write_gridfm",
     }
 
 
@@ -304,3 +306,55 @@ def test_wrong_schema_json_maps_cleanly():
     for bad in ("{}", "[]", "null", '{"buses": "nope"}'):
         with pytest.raises(ValueError, match="parse failed"):
             compute_matrix("bprime", json=bad)
+
+
+# ---------------------------------------------------------------------------
+# Folder / Parquet tools: PyPSA static CSV folders and gridfm Parquet datasets,
+# which have no single-file text form and so get dedicated read/write tools.
+# ---------------------------------------------------------------------------
+
+def test_pypsa_csv_folder_round_trip(tmp_path):
+    from powerio.mcp.server import read_pypsa_csv_folder, write_pypsa_csv_folder
+
+    out_dir = tmp_path / "pypsa_csv"
+    w = write_pypsa_csv_folder(str(out_dir), path=str(DATA / "case9.m"))
+    assert w["files"], w
+    assert (out_dir / "buses.csv").exists()
+    r = read_pypsa_csv_folder(str(out_dir))
+    assert r["summary"]["n_buses"] == 9
+    assert json.loads(r["json"])
+
+
+def test_pypsa_csv_folder_accepts_transport(tmp_path):
+    from powerio.mcp.server import parse_case, write_pypsa_csv_folder
+
+    transport = parse_case(path=str(DATA / "case9.m"))["json"]
+    out_dir = tmp_path / "from_json"
+    write_pypsa_csv_folder(str(out_dir), json=transport)
+    assert (out_dir / "generators.csv").exists()
+
+
+def test_read_pypsa_csv_missing_folder_maps_cleanly(tmp_path):
+    from powerio.mcp.server import read_pypsa_csv_folder
+
+    with pytest.raises(ValueError):
+        read_pypsa_csv_folder(str(tmp_path / "nope"))
+
+
+def test_gridfm_round_trip(tmp_path):
+    from powerio.mcp.server import read_gridfm, write_gridfm
+
+    out_dir = tmp_path / "gfm"
+    w = write_gridfm(str(out_dir), path=str(DATA / "case9.m"))
+    assert w["files"], w
+    r = read_gridfm(str(out_dir))
+    assert r["summary"]["n_buses"] == 9
+    assert r["scenario"] == 0
+    assert json.loads(r["json"])
+
+
+def test_read_gridfm_missing_dir_maps_cleanly(tmp_path):
+    from powerio.mcp.server import read_gridfm
+
+    with pytest.raises(ValueError):
+        read_gridfm(str(tmp_path / "nope"))


### PR DESCRIPTION
## What

The MCP server (`powerio.mcp.server`) exposed only the single-file/text formats as tools. The **PyPSA static CSV folder** and **gridfm-datakit Parquet** formats were reachable only via the library API (or, for PyPSA, a folder `path` into `convert_case`/`case_summary`). This adds dedicated tools so agents can move those formats to/from the JSON transport in one call:

- `read_pypsa_csv_folder` / `write_pypsa_csv_folder`
- `read_gridfm` / `write_gridfm`

They reuse `_load`/`_summary`, so input resolution and the summary shape match the existing tools. The `test_tool_surface_parity` set is updated, and each tool has round-trip + error-mapping tests.

## Why

These were prototyped in the PowerMCP standalone copy (`powerio/powerio_mcp.py` in Power-Agent/PowerMCP), which now re-exports this canonical server. Landing them here lets that copy drop its local overlay and become a pure re-export — restoring the "canonical here, sync the copy" invariant this file documents.

## Tests

`pytest python/tests/test_mcp.py` → 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)