### PR TITLE
Preserve source bus IDs in normalized networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Normalization: `Network::to_normalized` preserves source bus ids instead of
+  renumbering surviving buses to dense 1-based ids. Dense row mapping remains
+  available through `IndexedNetwork` and the C ABI table order.
+
 ## 0.2.2
 
 - Display API: `parse_display_file` / `parse_display_bytes` read display

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Current conventions for signs, taps, phase shifts, per unit scaling, reference b
 - voltage phase angles are in radians, 
 - inactive elements are removed, 
 - `tap == 0` replaced with `1`,
-- surviving buses reindexed to a dense 1-based id space, and 
+- surviving buses keep their source bus ids, and
 - bus types are made consistent with generator placement and reference buses. 
 
 The normalized copy carries no retained source text, so writing it emits the derived model rather than the original file.

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -141,10 +141,10 @@ void pio_network_free(PioNetwork *net);
 
 /**
  * Normalize `net` into a NEW per-unit network handle: per unit, radians,
- * out-of-service filtered, densely reindexed, bus types canonicalized (see
- * `Network::to_normalized`). The result is independent of `net`; free both
- * with [`pio_network_free`]. Every extractor and [`pio_to_json`] works on it
- * unchanged (the handle is per unit, not MW). Returns `NULL` on error (no
+ * out-of-service filtered, source bus ids preserved, bus types canonicalized
+ * (see `Network::to_normalized`). The result is independent of `net`; free
+ * both with [`pio_network_free`]. Every extractor and [`pio_to_json`] works on
+ * it unchanged (the handle is per unit, not MW). Returns `NULL` on error (no
  * reference bus can be chosen, or a non-positive base MVA) and writes the
  * message into `errbuf`.
  */

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -270,10 +270,10 @@ unsafe fn view<'a>(net: *const PioNetwork) -> Option<IndexedNetwork<'a>> {
 }
 
 /// Normalize `net` into a NEW per-unit network handle: per unit, radians,
-/// out-of-service filtered, densely reindexed, bus types canonicalized (see
-/// `Network::to_normalized`). The result is independent of `net`; free both
-/// with [`pio_network_free`]. Every extractor and [`pio_to_json`] works on it
-/// unchanged (the handle is per unit, not MW). Returns `NULL` on error (no
+/// out-of-service filtered, source bus ids preserved, bus types canonicalized
+/// (see `Network::to_normalized`). The result is independent of `net`; free
+/// both with [`pio_network_free`]. Every extractor and [`pio_to_json`] works on
+/// it unchanged (the handle is per unit, not MW). Returns `NULL` on error (no
 /// reference bus can be chosen, or a non-positive base MVA) and writes the
 /// message into `errbuf`.
 #[unsafe(no_mangle)]
@@ -1212,6 +1212,62 @@ mpc.branch = [
             let mut refs = vec![0i64; pio_n_reference_buses(cn)];
             pio_reference_buses(cn, refs.as_mut_ptr());
             assert_eq!(refs, vec![0, 1]);
+
+            pio_network_free(cn);
+            pio_network_free(cs);
+        }
+    }
+
+    #[test]
+    fn normalized_preserves_source_bus_ids() {
+        let src = "\
+function mpc = sparseids
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t3\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t4\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t10\t1\t50\t10\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t0\t0\t100\t-100\t1\t100\t1\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t2\t3\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t3\t4\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t4\t10\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+        let text = CString::new(src).unwrap();
+        let fmt = CString::new("matpower").unwrap();
+        let mut err = [0 as c_char; 256];
+        unsafe {
+            let cs = pio_parse_str(text.as_ptr(), fmt.as_ptr(), err.as_mut_ptr(), err.len());
+            assert!(!cs.is_null(), "parse_str returned null");
+            let cn = pio_to_normalized(cs, err.as_mut_ptr(), err.len());
+            assert!(!cn.is_null(), "to_normalized returned null");
+
+            let mut ids = vec![0i64; pio_n_buses(cn)];
+            pio_bus_ids(cn, ids.as_mut_ptr());
+            assert_eq!(ids, vec![1, 2, 3, 4, 10]);
+
+            let mut from = vec![0i64; pio_n_branches(cn)];
+            let mut to = vec![0i64; pio_n_branches(cn)];
+            pio_branches(
+                cn,
+                from.as_mut_ptr(),
+                to.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            );
+            assert_eq!((from[3], to[3]), (4, 10));
 
             pio_network_free(cn);
             pio_network_free(cs);

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -143,9 +143,10 @@ pub enum SourceFormat {
     /// Built in memory (e.g. from synth or an edited case); no source text.
     InMemory,
     /// A normalized derived view ([`Network::to_normalized`]): per unit, radians,
-    /// filtered, densely reindexed. Distinct from [`InMemory`](SourceFormat::InMemory)
-    /// so consumers can tell a per-unit product from a raw in-memory network; it
-    /// has no source text and a different unit basis than a parsed network.
+    /// filtered, source bus ids preserved. Distinct from
+    /// [`InMemory`](SourceFormat::InMemory) so consumers can tell a per-unit
+    /// product from a raw in-memory network; it has no source text and a different
+    /// unit basis than a parsed network.
     Normalized,
     /// Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,
     /// `powerio-matrix`'s `read_gridfm_dataset`). A lossy, power-flow-complete
@@ -442,7 +443,7 @@ impl Network {
         Ok(net)
     }
 
-    /// Whether this is a normalized (per-unit, radian, filtered, reindexed)
+    /// Whether this is a normalized (per-unit, radian, filtered)
     /// derived product from [`to_normalized`](Network::to_normalized), rather
     /// than a raw network at the file's unit basis. Unit-sensitive code that
     /// takes a `&Network` can check this instead of silently assuming MW.

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -9,8 +9,8 @@
 //!   reader inverts it; [`Network::to_normalized`] scales the same way into a new
 //!   `Network`. The cost rescale is the one piece subtle enough that a second copy
 //!   would drift, so it has a single home.
-//! - **[`Network::to_normalized`]**: a derived, computation-ready view — per unit,
-//!   radians, out-of-service filtered, densely reindexed, bus types canonicalized.
+//! - **[`Network::to_normalized`]**: a derived, computation-ready view, per unit,
+//!   radians, out-of-service filtered, source id preserving, bus types canonicalized.
 
 use std::collections::{HashMap, HashSet};
 
@@ -96,7 +96,7 @@ pub(crate) fn cost_from_pu(coeffs: &[f64], model: u8, base: f64) -> Vec<f64> {
     }
 }
 
-/// Map an old bus id to its new dense id, or `None` if the bus was dropped.
+/// Map a source bus id to its surviving normalized id, or `None` if the bus was dropped.
 fn remap(map: &HashMap<BusId, BusId>, id: BusId) -> Option<BusId> {
     map.get(&id).copied()
 }
@@ -252,8 +252,10 @@ impl Network {
     ///   bus. A bus orphaned by the out-of-service filter (no in-service branch,
     ///   but not typed isolated) is kept — its load is real — and surfaces as its
     ///   own island, which the grounding check reports if it has no reference.
-    /// - **Reindexed**: kept buses get a dense 1-based id (their position among the
-    ///   survivors), and every endpoint is remapped to match.
+    /// - **IDs**: kept buses retain their source bus ids, and every surviving
+    ///   endpoint stays in the same id space. Consumers that need dense rows should
+    ///   use [`IndexedNetwork`](crate::IndexedNetwork), which derives `[0, n)`
+    ///   indices without destroying source ids.
     /// - **Bus types**: a bus hosting a surviving generator keeps `REF` if the file
     ///   marked it `REF`, otherwise becomes `PV`; a generator-less bus is `PQ` (so a
     ///   generator-less `REF` is demoted). The file's `REF` buses are kept, several
@@ -282,18 +284,15 @@ impl Network {
         let base = self.base_mva;
 
         // Kept buses keep their original `kind` for now (the reference scan below
-        // reads it); the new id is the 1-based position among survivors. Isolated
-        // buses are dropped.
+        // reads it) and their source ids. Isolated buses are dropped.
         let mut id_map: HashMap<BusId, BusId> = HashMap::with_capacity(self.buses.len());
         let mut buses: Vec<Bus> = Vec::with_capacity(self.buses.len());
         for b in &self.buses {
             if b.kind == BusType::Isolated {
                 continue;
             }
-            let new_id = BusId(buses.len() + 1);
-            id_map.insert(b.id, new_id);
+            id_map.insert(b.id, b.id);
             buses.push(Bus {
-                id: new_id,
                 va: b.va * DEG_TO_RAD,
                 ..b.clone()
             });
@@ -349,9 +348,9 @@ impl Network {
             source_format: SourceFormat::Normalized,
             source: None,
         };
-        // The filter+remap drops every reference to a dropped bus by
+        // The filter drops every reference to a dropped bus by
         // construction, so the result is reference-consistent. Assert it in
-        // debug builds to catch a future regression in the remap logic.
+        // debug builds to catch a future regression in the filtering logic.
         debug_assert!(
             net.validate().is_ok(),
             "to_normalized produced a dangling reference"

--- a/powerio/tests/normalize.rs
+++ b/powerio/tests/normalize.rs
@@ -1,4 +1,4 @@
-//! `Network::to_normalized`: per-unit / radians / tap / filter / reindex / bus
+//! `Network::to_normalized`: per-unit / radians / tap / filter / source ids / bus
 //! types, plus the no-false-write-back contract and `parse_str == parse`.
 
 use std::path::{Path, PathBuf};
@@ -161,7 +161,7 @@ fn filters_and_retypes_out_of_service_case() {
     let n = raw.to_normalized().unwrap();
 
     // The fixture marks the bus-2 generator and branch 5-6 out of service; no
-    // isolated buses, so all 9 buses survive with dense 1-based ids.
+    // isolated buses, so all 9 buses survive with their source ids.
     assert_eq!(n.generators.len(), raw.generators.len() - 1);
     assert_eq!(n.branches.len(), raw.branches.len() - 1);
     assert_eq!(n.buses.len(), 9);
@@ -183,7 +183,7 @@ fn filters_and_retypes_out_of_service_case() {
 #[test]
 fn drops_isolated_bus_and_remaps_endpoints() {
     // Bus 2 is isolated (type 4); branch 2-3 references it (dropped), branch 1-3
-    // survives and is remapped, the load on bus 3 follows the reindex.
+    // survives, and the load on bus 3 keeps that source id.
     let src = "\
 function mpc = iso
 mpc.version = '2';
@@ -205,13 +205,56 @@ mpc.branch = [
     let n = raw.to_normalized().unwrap();
 
     assert_eq!(n.buses.len(), 2, "isolated bus dropped");
-    assert_eq!(n.buses.iter().map(|b| b.id.0).collect::<Vec<_>>(), [1, 2]);
+    assert_eq!(n.buses.iter().map(|b| b.id.0).collect::<Vec<_>>(), [1, 3]);
     assert_eq!(n.branches.len(), 1, "branch on the isolated bus dropped");
-    assert_eq!((n.branches[0].from.0, n.branches[0].to.0), (1, 2));
+    assert_eq!((n.branches[0].from.0, n.branches[0].to.0), (1, 3));
     assert_eq!(n.loads.len(), 1);
-    assert_eq!(n.loads[0].bus.0, 2, "load remapped to the dense id");
+    assert_eq!(n.loads[0].bus.0, 3, "load keeps the source id");
     assert_eq!(n.buses[0].kind, BusType::Ref);
     assert_eq!(n.buses[1].kind, BusType::Pq);
+}
+
+#[test]
+fn preserves_sparse_source_bus_ids() {
+    let src = "\
+function mpc = sparseids
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t3\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t4\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t10\t1\t50\t10\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t0\t0\t100\t-100\t1\t100\t1\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t2\t3\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t3\t4\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t4\t10\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+    let n = parse_str(src, "matpower")
+        .unwrap()
+        .network
+        .to_normalized()
+        .unwrap();
+
+    assert_eq!(
+        n.buses.iter().map(|b| b.id.0).collect::<Vec<_>>(),
+        [1, 2, 3, 4, 10]
+    );
+    assert_eq!(n.loads.len(), 1);
+    assert_eq!(n.loads[0].bus.0, 10);
+    assert_eq!(n.branches.len(), 4);
+    assert_eq!((n.branches[3].from.0, n.branches[3].to.0), (4, 10));
+
+    let view = IndexedNetwork::new(&n);
+    assert_eq!(view.bus_index(BusId(10)), Some(4));
+    assert_eq!(view.bus_id(4), BusId(10));
 }
 
 #[test]

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -423,7 +423,7 @@ class Network:
 
     def to_normalized(self) -> "Network":
         """A normalized, computation-ready copy of this case: per unit, radians,
-        out-of-service filtered, densely reindexed (1-based), bus types
+        out-of-service filtered, source bus ids preserved, bus types
         canonicalized. The original case is unchanged; the result carries no
         retained source, so :meth:`write` serializes the per-unit model rather
         than echoing it. Raises :class:`PowerIODataError` if the case can't be

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -257,8 +257,8 @@ def normalize_case(
     format: Optional[str] = None,
 ) -> dict:
     """Parse a case and return the JSON transport of its normalized form: per
-    unit, radians, out of service elements filtered, buses densely reindexed
-    (1-based), bus types canonicalized.
+    unit, radians, out of service elements filtered, source bus ids preserved,
+    bus types canonicalized.
 
     Use this instead of ``parse_case`` when downstream math wants a computation
     ready case rather than the verbatim source tables. Provide exactly one of

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -218,6 +218,34 @@ def test_to_normalized_filters_out_of_service():
     assert n.source_format == "Normalized"
 
 
+def test_to_normalized_preserves_source_bus_ids():
+    src = """function mpc = sparseids
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t3\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t4\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t10\t1\t50\t10\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t0\t0\t100\t-100\t1\t100\t1\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t2\t3\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t3\t4\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t4\t10\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+"""
+    n = powerio.parse_str(src).to_normalized()
+    assert [bus["id"] for bus in n.buses] == [1, 2, 3, 4, 10]
+    assert n.loads[0]["bus"] == 10
+    assert n.branches[-1]["from_id"] == 4
+    assert n.branches[-1]["to_id"] == 10
+
+
 def test_parse_bad_path_raises():
     # I/O failures map to the standard OSError subclass, not PowerIOError.
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Summary

- Preserve source bus ids in `Network::to_normalized` while still filtering isolated buses and out of service elements.
- Keep dense row mapping in `IndexedNetwork` and C ABI table ordering rather than rewriting `Bus.id`.
- Add Rust, C ABI, and Python regressions for a sparse MATPOWER bus id case.

Closes #121.

## Tests

- `cargo fmt --all --check`
- `cargo test -p powerio --test normalize`
- `cargo test -p powerio-capi normalized_preserves_source_bus_ids`
- `cargo test -p powerio-capi`
- `uv run --no-project --cache-dir /private/tmp/powerio-uv-cache --with pytest --with numpy --with scipy --with-editable . pytest python/tests/test_powerio.py -q -k to_normalized`
- `cargo test -p powerio -p powerio-capi`
- `cargo clippy -p powerio -p powerio-capi --all-targets -- -D warnings`