### PR TITLE
release: v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.4
+
+- PSLF `.epc`: read support for GE PSLF power flow cases, including `.epc`
+  extension inference and `pslf` / `epc` input aliases. The reader is read only
+  and keeps source text plus warnings for sections outside `Network`.
+- PowerWorld `.pwb`: expanded binary reader coverage across older and newer
+  header constants, with stricter record probes, companion format parity checks,
+  and clearer rejection of unsupported vintages.
+- PowerWorld `.pwd`: display parsing keeps the separate display API path and
+  retains the malformed input invariant: corrupt or truncated display files
+  return a structured error or a parsed display, not a panic.
+- No C ABI break; `PIO_ABI_VERSION` stays 3.
+
 ## 0.2.3
 
 - Normalization: `Network::to_normalized` preserves source bus ids instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,7 +1721,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "arrow",
  "powerio",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "approx",
  "arrow",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "powerio-matrix",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -20,8 +20,8 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.2.3" }
-powerio-matrix = { path = "powerio-matrix", version = "0.2.3" }
+powerio = { path = "powerio", version = "0.2.4" }
+powerio-matrix = { path = "powerio-matrix", version = "0.2.4" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -578,11 +578,17 @@ pub unsafe extern "C" fn pio_gridfm_scenario_ids(
         }));
         match r {
             Ok(Ok(ids)) => {
+                let Ok(total) = isize::try_from(ids.len()) else {
+                    copy_to_buf(errbuf, errlen, "gridfm scenario count exceeds isize");
+                    return -1;
+                };
                 if !out.is_null() {
                     let n = ids.len().min(cap);
-                    std::ptr::copy_nonoverlapping(ids.as_ptr(), out, n);
+                    if n > 0 {
+                        std::ptr::copy_nonoverlapping(ids.as_ptr(), out, n);
+                    }
                 }
-                ids.len() as isize
+                total
             }
             Ok(Err(msg)) => {
                 copy_to_buf(errbuf, errlen, &msg);

--- a/powerio/src/format/powerworld/pwb.rs
+++ b/powerio/src/format/powerworld/pwb.rs
@@ -573,7 +573,7 @@ fn resync_end(b: &[u8], after: usize, prev_bit4: bool) -> usize {
     if prev_bit4 {
         after.saturating_add(BLOB_WINDOW).min(b.len())
     } else {
-        after.saturating_add(RESYNC_WINDOW)
+        after.saturating_add(RESYNC_WINDOW).min(b.len())
     }
 }
 

--- a/powerio/src/format/powerworld/pwd.rs
+++ b/powerio/src/format/powerworld/pwd.rs
@@ -278,26 +278,30 @@ fn identity_walk(b: &[u8], mut at: usize) -> Option<Vec<(u32, String)>> {
     let mut rows = Vec::new();
     let mut seen = HashSet::new();
     loop {
-        if b.get(at..at + 4) == Some([0xff; 4].as_slice()) {
+        if b.get(at..).and_then(|s| s.get(..4)) == Some([0xff; 4].as_slice()) {
             return (!rows.is_empty()).then_some(rows);
         }
         let number = u32_at(b, at)?;
-        if number == 0 || number > 99_999_999 || u32_at(b, at + 4) != Some(number) {
+        let duplicate_at = at.checked_add(4)?;
+        if number == 0 || number > 99_999_999 || u32_at(b, duplicate_at) != Some(number) {
             return None;
         }
-        let len = u32_at(b, at + 8)? as usize;
+        let len_at = at.checked_add(8)?;
+        let len = u32_at(b, len_at)? as usize;
         if len == 0 || len >= 64 {
             return None;
         }
-        let name = b.get(at + 12..at + 12 + len)?;
-        if !name.iter().all(|&c| (0x20..0x7f).contains(&c)) || b.get(at + 12 + len) != Some(&0x02) {
+        let name_start = at.checked_add(12)?;
+        let name_end = name_start.checked_add(len)?;
+        let name = b.get(name_start..name_end)?;
+        if !name.iter().all(|&c| (0x20..0x7f).contains(&c)) || b.get(name_end) != Some(&0x02) {
             return None;
         }
         if !seen.insert(number) {
             return None;
         }
         rows.push((number, String::from_utf8_lossy(name).into_owned()));
-        at += 12 + len + 1;
+        at = name_end.checked_add(1)?;
     }
 }
 
@@ -307,8 +311,15 @@ fn identity_walk(b: &[u8], mut at: usize) -> Option<Vec<(u32, String)>> {
 /// variable because a digit string of 1 to 4 characters precedes the link
 /// in some saves.
 fn links_number(b: &[u8], i: usize, number: u32) -> bool {
-    (40..140)
-        .any(|d| matches!(b.get(i + d), Some(0x03 | 0x07)) && u32_at(b, i + d + 1) == Some(number))
+    (40..140).any(|d| {
+        let Some(marker_at) = i.checked_add(d) else {
+            return false;
+        };
+        let Some(number_at) = marker_at.checked_add(1) else {
+            return false;
+        };
+        matches!(b.get(marker_at), Some(0x03 | 0x07)) && u32_at(b, number_at) == Some(number)
+    })
 }
 
 /// Every start of `needle` in `haystack`.

--- a/powerio/tests/pslf.rs
+++ b/powerio/tests/pslf.rs
@@ -61,6 +61,26 @@ fn pslf_is_not_a_write_target() {
     assert_eq!(target_format_from_name("epc"), None);
 }
 
+#[test]
+fn malformed_pslf_input_returns_errors_without_panics() {
+    for text in [
+        "",
+        "title\nunterminated\n",
+        "bus data [1]\nnot-a-bus\nend\n",
+        "bus data [1]\n1 \"A\" 230 : bad 1 1 0 1 1 1.1 0.9\nend\n",
+        "bus data [1]\n1 \"A\" 230 : 0 1 1 0 1 1 1.1 0.9 /\n",
+    ] {
+        let outcome = std::panic::catch_unwind(|| parse_str(text, "pslf"));
+        assert!(outcome.is_ok(), "PSLF parser panicked on {text:?}");
+    }
+
+    let err = parse_str("bus data [1]\nnot-a-bus\nend\n", "pslf").expect_err("bad bus must fail");
+    assert!(
+        err.to_string().contains("bus id missing or invalid"),
+        "{err}"
+    );
+}
+
 fn temp_path(name: &str) -> PathBuf {
     let mut path = std::env::temp_dir();
     path.push(format!(

--- a/powerio/tests/pslf.rs
+++ b/powerio/tests/pslf.rs
@@ -63,21 +63,46 @@ fn pslf_is_not_a_write_target() {
 
 #[test]
 fn malformed_pslf_input_returns_errors_without_panics() {
-    for text in [
-        "",
-        "title\nunterminated\n",
-        "bus data [1]\nnot-a-bus\nend\n",
-        "bus data [1]\n1 \"A\" 230 : bad 1 1 0 1 1 1.1 0.9\nend\n",
-        "bus data [1]\n1 \"A\" 230 : 0 1 1 0 1 1 1.1 0.9 /\n",
+    for (text, expected) in [
+        ("", "no buses"),
+        ("title\nunterminated\n", "no buses"),
+        (
+            "bus data [1]\nnot-a-bus\nend\n",
+            "bus id missing or invalid",
+        ),
+        (
+            "bus data [1]\n1 \"A\" 230 : bad 1 1 0 1 1 1.1 0.9\nend\n",
+            "bus type field 0 value",
+        ),
     ] {
         let outcome = std::panic::catch_unwind(|| parse_str(text, "pslf"));
         assert!(outcome.is_ok(), "PSLF parser panicked on {text:?}");
+        let err = outcome
+            .unwrap()
+            .expect_err("malformed PSLF input parsed successfully");
+        assert!(
+            err.to_string().contains(expected),
+            "expected {expected:?} in {err}"
+        );
     }
+}
 
-    let err = parse_str("bus data [1]\nnot-a-bus\nend\n", "pslf").expect_err("bad bus must fail");
+#[test]
+fn pslf_missing_end_marker_warns_without_panic() {
+    let text = "bus data [1]\n1 \"A\" 230 : 0 1 1 0 1 1 1.1 0.9 /\n";
+    let outcome = std::panic::catch_unwind(|| parse_str(text, "pslf"));
     assert!(
-        err.to_string().contains("bus id missing or invalid"),
-        "{err}"
+        outcome.is_ok(),
+        "PSLF parser panicked on missing end marker"
+    );
+    let parsed = outcome.unwrap().expect("single bus PSLF case should parse");
+    assert!(
+        parsed
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("no end marker")),
+        "expected no end marker warning, got {:?}",
+        parsed.warnings
     );
 }
 


### PR DESCRIPTION
## Summary

Prepares the merged PSLF/PWB/PWD work as the v0.2.4 release.

- Bumps the workspace version and intra-workspace publish pins to 0.2.4.
- Adds the 0.2.4 changelog entry.
- Includes memory safety hardening found during the release audit: bounded PWB resync scans, checked PWD offset arithmetic, and a guarded gridfm C ABI zero-length copy path.
- Adds a PSLF malformed input non-panic test.

`PIO_ABI_VERSION` remains 3.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets`
- `cargo test`
- `cargo test -p powerio-capi`
- `cargo test -p powerio-capi --features arrow`
- `cargo test -p powerio-capi --features gridfm`
- Targeted checks: `powerio --test pslf`, PWB truncation guard, PWD corruption guard, and C ABI null handle/null out guard.

## Release Notes

Do not merge or tag from this PR until explicitly approved. When approved, squash merge only, then tag the resulting main commit as `v0.2.4`.

PowerIO.jl does not need binding source changes for this release because the C ABI stays at version 3 and the existing binding contract still works. After the native v0.2.4 tarballs are published, PowerIO.jl should receive a separate artifact repin and, if registered users should get those tarballs, a PowerIO.jl patch release such as v0.1.4.