### PR TITLE
feat(dist): typed grounding reactor support

### DIFF
--- a/powerio-dist/src/dss/defaults.rs
+++ b/powerio-dist/src/dss/defaults.rs
@@ -65,6 +65,15 @@ pub mod capacitor {
     pub const KV: f64 = 12.47;
 }
 
+pub mod reactor {
+    //! `TReactorObj.Create` (Reactor.pas): 3 phases, 100 kvar, 12.47 kV,
+    //! wye. Unlike the capacitor's 1200 kvar bank, the reactor constructor
+    //! seeds a 100 kvar rating.
+    pub const PHASES: usize = 3;
+    pub const KVAR: f64 = 100.0;
+    pub const KV: f64 = 12.47;
+}
+
 pub mod generator {
     pub const PHASES: usize = 3;
     pub const KV: f64 = 12.47;

--- a/powerio-dist/src/dss/prop.rs
+++ b/powerio-dist/src/dss/prop.rs
@@ -290,6 +290,41 @@ class!(
 );
 
 class!(
+    REACTOR,
+    "reactor",
+    [
+        "bus1",
+        "bus2",
+        "phases",
+        "kvar",
+        "kv",
+        "conn",
+        "rmatrix",
+        "xmatrix",
+        "parallel",
+        "r",
+        "x",
+        "rp",
+        "z1",
+        "z2",
+        "z0",
+        "z",
+        "rcurve",
+        "lcurve",
+        "lmh",
+        // inherited
+        "normamps",
+        "emergamps",
+        "faultrate",
+        "pctperm",
+        "repair",
+        "basefreq",
+        "enabled",
+        "like",
+    ]
+);
+
+class!(
     GENERATOR,
     "generator",
     [
@@ -418,6 +453,7 @@ static CLASSES: &[&DssClass] = &[
     &TRANSFORMER,
     &VSOURCE,
     &CAPACITOR,
+    &REACTOR,
     &GENERATOR,
     &SWTCONTROL,
     &REGCONTROL,
@@ -488,7 +524,21 @@ mod tests {
     fn class_lookup() {
         assert!(class_by_name("Line").is_some());
         assert!(class_by_name("LINECODE").is_some());
-        assert!(class_by_name("reactor").is_none());
+        assert!(class_by_name("reactor").is_some());
+        assert!(class_by_name("xfmrcode").is_none());
+    }
+
+    #[test]
+    fn reactor_positions_match_the_engine() {
+        // Reactor.pas DefineProperties: 19 own properties (bus1..lmh) plus the
+        // PD-element inherited tail. A missing slot would shift positional
+        // assignment of every later property.
+        assert_eq!(REACTOR.prop_index("bus1"), Some(0));
+        assert_eq!(REACTOR.prop_index("kvar"), Some(3));
+        assert_eq!(REACTOR.prop_index("lmh"), Some(18));
+        // "normamps" opens the inherited PD tail right after lmh.
+        assert_eq!(REACTOR.prop_index("normamps"), Some(19));
+        assert_eq!(REACTOR.props.len(), 19 + 8);
     }
 
     #[test]

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -103,6 +103,9 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
     for obj in raw.of_class("capacitor") {
         rd.capacitor(obj);
     }
+    for obj in raw.of_class("reactor") {
+        rd.reactor(obj);
+    }
     for obj in raw.of_class("generator") {
         let g = rd.generator(obj);
         rd.net.generators.push(g);
@@ -122,6 +125,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
                 | "transformer"
                 | "load"
                 | "capacitor"
+                | "reactor"
                 | "generator"
                 | "swtcontrol"
                 | "regcontrol"
@@ -294,6 +298,14 @@ impl<'a> Props<'a> {
             .collect()
     }
 }
+
+/// Reactor properties that define the impedance directly. When any is
+/// present the engine ignores `kvar`/`kv`, so the kvar-shunt typing does not
+/// apply and the object stays untyped.
+const REACTOR_IMPEDANCE_FORMS: &[&str] = &[
+    "rmatrix", "xmatrix", "parallel", "r", "x", "rp", "z1", "z2", "z0", "z", "rcurve", "lcurve",
+    "lmh",
+];
 
 impl Reader<'_> {
     fn warn(&mut self, msg: impl Into<String>) {
@@ -1166,6 +1178,90 @@ impl Reader<'_> {
         }
         // The written pair regenerates verbatim in the dss writer; the b
         // matrix is the model truth either way.
+        let mut extras = extras_from_leftovers(&props);
+        self.stash_kv_and_phases(&props, &mut extras, kv, phases);
+        extras.insert("kvar".into(), kvar.into());
+        self.net.shunts.push(DistShunt {
+            name: obj.name.clone(),
+            bus: spec.name,
+            terminal_map: map,
+            g: vec![vec![0.0; n]; n],
+            b,
+            extras,
+        });
+    }
+
+    // ----- reactor → shunt -----------------------------------------------
+
+    /// A grounding (shunt) reactor specified by `kvar`/`kv` maps to a shunt
+    /// with inductive (negative) susceptance, the sign mirror of a
+    /// capacitor. Series reactors (`bus2`), delta banks, and the
+    /// impedance-defined forms (`r`/`x`, `z*`, the matrices, `lmh`, the
+    /// curves) override the kvar interpretation in the engine, so they stay
+    /// untyped with a precise warning rather than emit a wrong admittance.
+    fn reactor(&mut self, obj: &RawObject) {
+        let props = Props::new(obj);
+        if props.by_name.contains_key("bus2") {
+            self.warn(format!(
+                "reactor {}: series reactors (bus2) are not typed yet; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        // Any of these defines the impedance directly; kvar/kv is then
+        // ignored by the engine, so typing it as a kvar shunt would invent
+        // an admittance the source never asked for.
+        if let Some(form) = REACTOR_IMPEDANCE_FORMS
+            .iter()
+            .find(|k| props.by_name.contains_key(**k))
+        {
+            self.warn(format!(
+                "reactor {}: impedance form (`{form}`) is not typed yet; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        let phases = self.usize_or(&props, "phases", "reactor", &obj.name, dd::reactor::PHASES);
+        // InterpretConnection (Reactor.pas): `d*` and `ll` are delta.
+        let conn_delta = props.get("conn").is_some_and(|v| {
+            v.text.to_ascii_lowercase().starts_with('d') || v.text.eq_ignore_ascii_case("ll")
+        });
+        if conn_delta {
+            self.warn(format!(
+                "reactor {}: delta connection is not typed yet; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        let kvar = props
+            .get("kvar")
+            .and_then(|v| self.f64_prop(Some(v)))
+            .unwrap_or_else(|| {
+                self.defaulted("reactor", &obj.name, "kvar");
+                dd::reactor::KVAR
+            });
+        let kv = self.f64_or(&props, "kv", "reactor", &obj.name, dd::reactor::KV);
+        // Reactor.pas mirrors the capacitor: a wye bank's kv is line to line
+        // for 2 or 3 phases, line to neutral otherwise.
+        let v_phase = if phases == 2 || phases == 3 {
+            kv * 1e3 / 3f64.sqrt()
+        } else {
+            kv * 1e3
+        };
+        // Inductive: the susceptance is negative, the sign opposite the
+        // capacitor's. b = -Q / V^2 per phase.
+        let b_phase = -kvar * 1e3 / phases as f64 / (v_phase * v_phase);
+
+        let spec = bus_spec(props.get("bus1"), "");
+        let map = self.terminals(&spec, phases, phases + 1, phases);
+        let n = map.len();
+        let mut b = vec![vec![0.0; n]; n];
+        for (i, row) in b.iter_mut().enumerate().take(phases) {
+            row[i] = b_phase;
+        }
         let mut extras = extras_from_leftovers(&props);
         self.stash_kv_and_phases(&props, &mut extras, kv, phases);
         extras.insert("kvar".into(), kvar.into());

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -299,12 +299,14 @@ impl<'a> Props<'a> {
     }
 }
 
-/// Reactor properties that define the impedance directly. When any is
-/// present the engine ignores `kvar`/`kv`, so the kvar-shunt typing does not
-/// apply and the object stays untyped.
+/// Reactor properties that set the impedance directly. When any is present
+/// the engine takes its SpecType from the impedance and ignores `kvar`/`kv`,
+/// so the kvar-shunt typing does not apply and the object stays untyped.
+/// `parallel` (series vs parallel R-X) and `rp` (a parallel damping
+/// resistance) are modifiers, not a SpecType of their own: a `kvar` reactor
+/// that also sets them is still a kvar shunt, so they are not listed here.
 const REACTOR_IMPEDANCE_FORMS: &[&str] = &[
-    "rmatrix", "xmatrix", "parallel", "r", "x", "rp", "z1", "z2", "z0", "z", "rcurve", "lcurve",
-    "lmh",
+    "rmatrix", "xmatrix", "r", "x", "z1", "z2", "z0", "z", "rcurve", "lcurve", "lmh",
 ];
 
 impl Reader<'_> {
@@ -1236,9 +1238,12 @@ impl Reader<'_> {
             self.net.untyped.push(UntypedObject::from(obj));
             return;
         }
+        // Read kvar the way the capacitor does, so an array token (kvar=[..])
+        // is interpreted identically by both shunt readers.
         let kvar = props
             .get("kvar")
-            .and_then(|v| self.f64_prop(Some(v)))
+            .and_then(|v| v.to_vector(Some(self.vars)).ok())
+            .and_then(|v| v.first().copied())
             .unwrap_or_else(|| {
                 self.defaulted("reactor", &obj.name, "kvar");
                 dd::reactor::KVAR

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -920,9 +920,10 @@ impl DssWriter {
             // inductive (negative) sign and regenerates as a Reactor. The
             // sign is the class discriminator, the mirror of the reader.
             let phases = extras_usize(&sh.extras, "phases").unwrap_or(sh.terminal_map.len());
-            let diag: Vec<f64> = (0..phases.min(sh.b.len())).map(|i| sh.b[i][i]).collect();
-            let b_max = diag.iter().copied().fold(0.0_f64, f64::max);
-            let b_min = diag.iter().copied().fold(0.0_f64, f64::min);
+            // One pass over the diagonal for both extremes.
+            let (b_max, b_min) = (0..phases.min(sh.b.len()))
+                .map(|i| sh.b[i][i])
+                .fold((0.0_f64, 0.0_f64), |(mx, mn), v| (mx.max(v), mn.min(v)));
             let (class, b_phase) = if b_max > 0.0 {
                 ("capacitor", b_max)
             } else if b_min < 0.0 {
@@ -934,6 +935,15 @@ impl DssWriter {
                 ));
                 continue;
             };
+            if b_max > 0.0 && b_min < 0.0 {
+                // Both signs on the diagonal: only the dominant class is
+                // emitted; the opposite-sign phases are not regenerated.
+                self.warn(format!(
+                    "shunt {}: diagonal mixes capacitive and inductive phases; only the \
+                     {class} phases are regenerated",
+                    sh.name
+                ));
+            }
             self.check_name(class, &sh.name);
             let off_diag =
                 sh.b.iter()

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -915,30 +915,38 @@ impl DssWriter {
 
     fn shunts(&mut self, net: &DistNetwork) {
         for sh in &net.shunts {
-            self.check_name("capacitor", &sh.name);
+            // A purely capacitive shunt has positive diagonal susceptance and
+            // regenerates as a Capacitor; a grounding reactor carries the
+            // inductive (negative) sign and regenerates as a Reactor. The
+            // sign is the class discriminator, the mirror of the reader.
             let phases = extras_usize(&sh.extras, "phases").unwrap_or(sh.terminal_map.len());
-            let b_phase = (0..phases.min(sh.b.len()))
-                .map(|i| sh.b[i][i])
-                .fold(0.0_f64, f64::max);
-            if b_phase <= 0.0 {
+            let diag: Vec<f64> = (0..phases.min(sh.b.len())).map(|i| sh.b[i][i]).collect();
+            let b_max = diag.iter().copied().fold(0.0_f64, f64::max);
+            let b_min = diag.iter().copied().fold(0.0_f64, f64::min);
+            let (class, b_phase) = if b_max > 0.0 {
+                ("capacitor", b_max)
+            } else if b_min < 0.0 {
+                ("reactor", b_min)
+            } else {
                 self.warn(format!(
-                    "shunt {}: no positive susceptance; dropped from the output",
+                    "shunt {}: no nonzero susceptance; dropped from the output",
                     sh.name
                 ));
                 continue;
-            }
+            };
+            self.check_name(class, &sh.name);
             let off_diag =
                 sh.b.iter()
                     .enumerate()
                     .any(|(i, row)| row.iter().enumerate().any(|(j, &v)| i != j && v != 0.0));
             if off_diag {
                 self.warn(format!(
-                    "shunt {}: off diagonal susceptance has no capacitor expression; \
+                    "shunt {}: off diagonal susceptance has no {class} expression; \
                      only the diagonal is regenerated",
                     sh.name
                 ));
             }
-            // Any (kv, kvar) pair with kvar = b v^2 reproduces the same
+            // Any (kv, kvar) pair with |kvar| = |b| v^2 reproduces the same
             // admittance; the recorded pair (when the source carried one)
             // emits verbatim, keeping the text stable across round trips.
             let kv = self.element_kv(
@@ -947,31 +955,37 @@ impl DssWriter {
                 phases,
                 Configuration::Wye,
                 &sh.name,
-                "capacitor",
+                class,
             );
             let kvar = extras_f64(&sh.extras, "kvar").unwrap_or_else(|| {
-                // The reader's wye capacitor convention: line to line kv
-                // for 2 and 3 phase, line to neutral for single phase.
+                // The reader's wye convention: line to line kv for 2 and 3
+                // phase, line to neutral for single phase. kvar is the
+                // positive rating; the inductive sign lives in the model's b.
                 let v_phase = if matches!(phases, 2 | 3) {
                     kv * 1e3 / 3f64.sqrt()
                 } else {
                     kv * 1e3
                 };
-                b_phase * v_phase * v_phase * phases as f64 / 1e3
+                b_phase.abs() * v_phase * v_phase * phases as f64 / 1e3
             });
             let mut extras = sh.extras.clone();
             extras.remove("kv");
             extras.remove("kvar");
             extras.remove("phases");
             extras.remove("conn");
+            let decl = if class == "reactor" {
+                "Reactor"
+            } else {
+                "Capacitor"
+            };
             let mut s = format!(
-                "New Capacitor.{} bus1={} phases={phases} conn=wye kv={} kvar={}",
+                "New {decl}.{} bus1={} phases={phases} conn=wye kv={} kvar={}",
                 sh.name,
                 self.bus_ref(&sh.bus, &sh.terminal_map),
                 num(kv),
                 num(kvar),
             );
-            s.push_str(&self.extras_tail("capacitor", &sh.name, &extras));
+            s.push_str(&self.extras_tail(class, &sh.name, &extras));
             self.line_out(&s);
         }
         self.out.push('\n');
@@ -1467,6 +1481,45 @@ mod tests {
             .lines()
             .find(|l| l.contains("Capacitor.c1"))
             .unwrap();
+        assert!(line.contains(&format!("kvar={}", num(expected))), "{line}");
+    }
+
+    #[test]
+    fn inductive_shunt_regenerates_as_a_reactor() {
+        // A negative diagonal susceptance is the grounding-reactor sign; it
+        // must emit `New Reactor`, not a capacitor, with the positive kvar
+        // rating recovered from |b| v^2.
+        let (b, vs) = three_phase_source(2400.0);
+        let b_phase = -1e-3;
+        let sh = DistShunt {
+            name: "rx".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3"]),
+            g: vec![vec![0.0; 3]; 3],
+            b: vec![
+                vec![b_phase, 0.0, 0.0],
+                vec![0.0, b_phase, 0.0],
+                vec![0.0, 0.0, b_phase],
+            ],
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            shunts: vec![sh],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("Reactor.rx"))
+            .unwrap_or_else(|| panic!("no reactor emitted in:\n{}", out.text));
+        assert!(!out.text.contains("Capacitor.rx"), "{}", out.text);
+        let kv = 2400.0 * 3f64.sqrt() / 1e3;
+        let v_phase = kv * 1e3 / 3f64.sqrt();
+        let expected = b_phase.abs() * v_phase * v_phase * 3.0 / 1e3;
         assert!(line.contains(&format!("kvar={}", num(expected))), "{line}");
     }
 

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -335,6 +335,14 @@ fn series_and_impedance_reactors_stay_untyped() {
             .iter()
             .any(|w| w.contains("reactor rz") && w.contains("impedance form"))
     );
+    // `parallel` and `rp` are modifiers, not an impedance SpecType: a kvar
+    // reactor that also sets them still types as an inductive shunt.
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Reactor.rmod bus1=b2 phases=3 kvar=900 kv=4.16 parallel=yes rp=1000\n",
+    );
+    assert!(net.shunts.iter().any(|s| s.name == "rmod"));
+    assert!(net.untyped.iter().all(|o| o.name != "rmod"));
 }
 
 #[test]

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -275,6 +275,69 @@ fn ten_conductor_linecode_types() {
 }
 
 #[test]
+#[allow(clippy::float_cmp)]
+fn grounding_reactor_types_as_an_inductive_shunt() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Reactor.rx bus1=b2 phases=3 kvar=900 kv=4.16\n",
+    );
+    let sh = net
+        .shunts
+        .iter()
+        .find(|s| s.name.eq_ignore_ascii_case("rx"))
+        .expect("reactor typed as a shunt");
+    // Inductive: the diagonal susceptance is negative, the capacitor's mirror.
+    let v_phase = 4.16e3 / 3f64.sqrt();
+    let expected = -900e3 / 3.0 / (v_phase * v_phase);
+    assert!((sh.b[0][0] - expected).abs() < 1e-12, "{}", sh.b[0][0]);
+    assert_eq!(sh.g[0][0], 0.0);
+    // No silent loss: nothing falls through to the untyped layer.
+    assert!(net.untyped.is_empty(), "{:?}", net.untyped);
+}
+
+#[test]
+fn reactor_defaults_are_materialized_and_recorded() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str("New Circuit.c basekv=12.47\nNew Reactor.rd bus1=b2\n");
+    assert!(net.shunts.iter().any(|s| s.name.eq_ignore_ascii_case("rd")));
+    let recorded = net
+        .defaulted
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("reactor.rd"))
+        .map(|(_, v)| v)
+        .expect("defaults recorded for the reactor");
+    assert!(recorded.contains(&"kvar"), "{recorded:?}");
+    assert!(recorded.contains(&"kv"), "{recorded:?}");
+}
+
+#[test]
+fn series_and_impedance_reactors_stay_untyped() {
+    use powerio_dist::parse_dss_str;
+    // Series reactor (bus2): deferred, like the series capacitor.
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\nNew Reactor.rs bus1=b2 bus2=b3 phases=3 kvar=900 kv=4.16\n",
+    );
+    assert!(net.untyped.iter().any(|o| o.name == "rs"));
+    assert!(net.shunts.iter().all(|s| s.name != "rs"));
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("reactor rs") && w.contains("series"))
+    );
+    // Impedance form (r/x): kvar is ignored by the engine, so we refuse to
+    // invent a susceptance and keep it untyped instead.
+    let net =
+        parse_dss_str("New Circuit.c basekv=4.16\nNew Reactor.rz bus1=b2 phases=3 r=0.1 x=5\n");
+    assert!(net.untyped.iter().any(|o| o.name == "rz"));
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("reactor rz") && w.contains("impedance form"))
+    );
+}
+
+#[test]
 fn regcontrol_warns_and_keeps_taps() {
     let net = parse("opendss/ieee13/IEEE13Nodeckt.dss");
     assert!(


### PR DESCRIPTION
Stacked on #82 (`worktree-powerio-dist`). Addresses the `reactor` class from #84.

## What
Adds typed support for **grounding (shunt) reactors** in the OpenDSS reader/writer, following the crate's established typed-class pattern.

- **Reader**: a `kvar`/`kv` shunt reactor maps to a `DistShunt` with **inductive (negative) susceptance** — the sign mirror of a capacitor.
- **Writer**: `shunts()` uses the susceptance sign as the class discriminator — positive → `Capacitor` (unchanged), negative → `Reactor`, with the positive kvar rating recovered from `|b|·v²`. (Previously negative-susceptance shunts were silently dropped.)
- **Property table** (`prop.rs`): `REACTOR` with all 19 properties in `Reactor.pas` `DefineProperties` order plus the inherited PD tail.
- **Defaults** (`defaults.rs`): from `TReactorObj.Create` — 100 kvar, 12.47 kV, 3 phases, wye.

## Deliberately deferred (kept untyped, with precise warnings)
- **series reactors** (`bus2`) — needs a series two-terminal impedance element the model doesn't have yet (`DistLine` requires a linecode); mirrors the existing series-capacitor deferral
- **delta banks**
- **impedance-defined forms** (`r`/`x`, `z*`, matrices, `lmh`, curves) where the engine ignores `kvar` — refusing to invent an admittance

This is a first increment of #84's `reactor` item; series reactors are the documented follow-up.

## Tests
5 new (reader: inductive shunt typing, defaults+provenance, series/impedance deferral; writer: reactor regeneration; prop: position parity). `cargo test -p powerio-dist`, `clippy -D warnings`, and `fmt --all --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
