### PR TITLE
Fix DSS shunts in BMOPF conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.3.2
+
+- `powerio-dist` OpenDSS: grounding reactors written from a bus terminal to the
+  same bus's node 0 now type as shunts in BMOPF instead of staying untyped.
+  Impedance form reactors use the equivalent admittance matrix, so neutral
+  grounding resistors survive DSS to BMOPF conversion.
+- `powerio-dist` OpenDSS: delta capacitor and reactor banks now type as shunt
+  admittance matrices, including off diagonal branch terms, instead of being
+  dropped as untyped objects.
+- DSS writing now regenerates conductance bearing shunts as grounding reactors
+  and preserves delta shunts as `conn=delta` where the typed model identifies
+  them.
+- No core or distribution C ABI break; `PIO_ABI_VERSION` stays 4 and
+  `PIO_DIST_ABI_VERSION` stays 1.
+
 ## 0.3.1
 
 - Parser warnings: PSS/E and PowerWorld `.aux` parse warnings now surface

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "powerio",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "approx",
  "arrow",
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # two dependency pins below.
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -23,9 +23,9 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.3.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.3.1" }
-powerio-dist = { path = "powerio-dist", version = "0.3.1" }
+powerio = { path = "powerio", version = "0.3.2" }
+powerio-matrix = { path = "powerio-matrix", version = "0.3.2" }
+powerio-dist = { path = "powerio-dist", version = "0.3.2" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -1180,7 +1180,7 @@ impl Reader<'_> {
         let bus2 = props.get("bus2").map(super::lex::Value::to_bus_spec);
         let grounding_return = bus2
             .as_ref()
-            .is_some_and(|return_bus| same_bus_ground_return(&bus, return_bus));
+            .is_some_and(|return_bus| same_bus_ground_return(&bus, return_bus, phases));
 
         if bus2.is_some() && !grounding_return {
             self.warn(format!(
@@ -1291,7 +1291,7 @@ impl Reader<'_> {
         });
         let bus = bus_spec(props.get("bus1"), "");
         if let Some(return_bus) = props.get("bus2").map(super::lex::Value::to_bus_spec) {
-            if !same_bus_ground_return(&bus, &return_bus) {
+            if !same_bus_ground_return(&bus, &return_bus, phases) {
                 self.warn(format!(
                     "{} {}: series {} (bus2) are not typed yet; kept untyped",
                     spec.class, obj.name, spec.series_name
@@ -1544,10 +1544,20 @@ fn scale_mat(m: &Mat, k: f64) -> Mat {
         .collect()
 }
 
-fn same_bus_ground_return(bus: &BusSpec, return_bus: &BusSpec) -> bool {
+fn filled_phase_nodes(spec: &BusSpec, phases: usize) -> Vec<i32> {
+    let mut nodes: Vec<i32> = (1..=i32::try_from(phases).unwrap_or(i32::MAX)).collect();
+    for (idx, &node) in spec.nodes.iter().enumerate().take(phases) {
+        nodes[idx] = node.max(0);
+    }
+    nodes
+}
+
+fn same_bus_ground_return(bus: &BusSpec, return_bus: &BusSpec, phases: usize) -> bool {
     bus.name.eq_ignore_ascii_case(&return_bus.name)
         && !return_bus.nodes.is_empty()
-        && return_bus.nodes.iter().all(|&n| n <= 0)
+        && filled_phase_nodes(return_bus, phases)
+            .iter()
+            .all(|&n| n <= 0)
 }
 
 fn delta_edges(n: usize, phases: usize) -> Vec<(usize, usize)> {

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -1161,19 +1161,39 @@ impl Reader<'_> {
     // ----- reactor → shunt -----------------------------------------------
 
     /// A grounding (shunt) reactor specified by `kvar`/`kv` maps to a shunt
-    /// with inductive (negative) susceptance, the sign mirror of a
-    /// capacitor. Series reactors (`bus2`), delta banks, and the
-    /// impedance-defined forms (`r`/`x`, `z*`, the matrices, `lmh`, the
-    /// curves) override the kvar interpretation in the engine, so they stay
-    /// untyped with a precise warning rather than emit a wrong admittance.
+    /// with inductive (negative) susceptance, the sign mirror of a capacitor.
+    /// A reactor from a bus terminal to the same bus's node 0 is also a shunt;
+    /// when it uses `r`/`x`, store the equivalent conductance and susceptance.
+    /// Other `bus2` reactors are series elements and stay untyped.
     fn reactor(&mut self, obj: &RawObject) {
         let props = Props::new(obj);
-        // Any of these defines the impedance directly; kvar/kv is then
-        // ignored by the engine, so typing it as a kvar shunt would invent
-        // an admittance the source never asked for.
+        let phases = self.usize_or(&props, "phases", "reactor", &obj.name, dd::reactor::PHASES);
+        if phases == 0 {
+            self.warn(format!(
+                "reactor {}: nonpositive `phases` value is not a typed shunt; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        let bus = bus_spec(props.get("bus1"), "");
+        let bus2 = props.get("bus2").map(super::lex::Value::to_bus_spec);
+        let grounding_return = bus2
+            .as_ref()
+            .is_some_and(|return_bus| same_bus_ground_return(&bus, return_bus));
+
+        if bus2.is_some() && !grounding_return {
+            self.warn(format!(
+                "reactor {}: series reactors (bus2) are not typed yet; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+
         if let Some(form) = REACTOR_IMPEDANCE_FORMS
             .iter()
-            .find(|k| props.by_name.contains_key(**k))
+            .find(|k| !matches!(**k, "r" | "x") && props.by_name.contains_key(**k))
         {
             self.warn(format!(
                 "reactor {}: impedance form (`{form}`) is not typed yet; kept untyped",
@@ -1182,7 +1202,70 @@ impl Reader<'_> {
             self.net.untyped.push(UntypedObject::from(obj));
             return;
         }
+        let has_rx = props.by_name.contains_key("r") || props.by_name.contains_key("x");
+        if has_rx {
+            if grounding_return {
+                self.grounding_impedance_reactor(obj, &props, &bus, phases);
+            } else {
+                let form = if props.by_name.contains_key("r") {
+                    "r"
+                } else {
+                    "x"
+                };
+                self.warn(format!(
+                    "reactor {}: impedance form (`{form}`) is not typed yet; kept untyped",
+                    obj.name
+                ));
+                self.net.untyped.push(UntypedObject::from(obj));
+            }
+            return;
+        }
+
         self.kvar_shunt_with_props(obj, &props, REACTOR_KVAR_SHUNT);
+    }
+
+    fn grounding_impedance_reactor(
+        &mut self,
+        obj: &RawObject,
+        props: &Props<'_>,
+        bus: &BusSpec,
+        phases: usize,
+    ) {
+        let resistance = props
+            .get("r")
+            .and_then(|v| v.to_f64(Some(self.vars)).ok())
+            .unwrap_or(0.0);
+        let reactance = props
+            .get("x")
+            .and_then(|v| v.to_f64(Some(self.vars)).ok())
+            .unwrap_or(0.0);
+        let denom = resistance * resistance + reactance * reactance;
+        if !denom.is_finite() || denom <= 0.0 {
+            self.warn(format!(
+                "reactor {}: zero impedance grounding reactor is not a typed shunt; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        let map = self.terminals(bus, phases, phases + 1, phases);
+        let dim = map.len();
+        let mut conductance = vec![vec![0.0; dim]; dim];
+        let mut susceptance = vec![vec![0.0; dim]; dim];
+        let y_g = resistance / denom;
+        let y_b = -reactance / denom;
+        for idx in 0..dim {
+            conductance[idx][idx] = y_g;
+            susceptance[idx][idx] = y_b;
+        }
+        self.net.shunts.push(DistShunt {
+            name: obj.name.clone(),
+            bus: bus.name.clone(),
+            terminal_map: map,
+            g: conductance,
+            b: susceptance,
+            extras: extras_from_leftovers(props),
+        });
     }
 
     fn kvar_shunt(&mut self, obj: &RawObject, spec: KvarShuntSpec) {
@@ -1191,14 +1274,6 @@ impl Reader<'_> {
     }
 
     fn kvar_shunt_with_props(&mut self, obj: &RawObject, props: &Props<'_>, spec: KvarShuntSpec) {
-        if props.by_name.contains_key("bus2") {
-            self.warn(format!(
-                "{} {}: series {} (bus2) are not typed yet; kept untyped",
-                spec.class, obj.name, spec.series_name
-            ));
-            self.net.untyped.push(UntypedObject::from(obj));
-            return;
-        }
         let phases = self.usize_or(props, "phases", spec.class, &obj.name, spec.default_phases);
         if phases == 0 {
             self.warn(format!(
@@ -1209,13 +1284,26 @@ impl Reader<'_> {
             return;
         }
         // InterpretConnection: `d*` and `ll` are delta for both Capacitor and
-        // Reactor, and delta banks are not a shunt-to-ground matrix.
+        // Reactor. Delta banks are line to line shunts represented by a nodal
+        // admittance matrix.
         let conn_delta = props.get("conn").is_some_and(|v| {
             v.text.to_ascii_lowercase().starts_with('d') || v.text.eq_ignore_ascii_case("ll")
         });
-        if conn_delta {
+        let bus = bus_spec(props.get("bus1"), "");
+        if let Some(return_bus) = props.get("bus2").map(super::lex::Value::to_bus_spec) {
+            if !same_bus_ground_return(&bus, &return_bus) {
+                self.warn(format!(
+                    "{} {}: series {} (bus2) are not typed yet; kept untyped",
+                    spec.class, obj.name, spec.series_name
+                ));
+                self.net.untyped.push(UntypedObject::from(obj));
+                return;
+            }
+        }
+
+        if conn_delta && phases == 1 && bus.nodes.len() < 2 {
             self.warn(format!(
-                "{} {}: delta connection is not typed yet; kept untyped",
+                "{} {}: single phase delta shunt needs two bus nodes; kept untyped",
                 spec.class, obj.name
             ));
             self.net.untyped.push(UntypedObject::from(obj));
@@ -1233,13 +1321,15 @@ impl Reader<'_> {
             });
         let kv = self.f64_or(props, "kv", spec.class, &obj.name, spec.default_kv);
         // A wye bank's kv is line to line for 2 or 3 phases, line to neutral
-        // otherwise.
-        let v_phase = if phases == 2 || phases == 3 {
+        // otherwise. A delta bank's kv is line to line across each branch.
+        let v_ref = if conn_delta {
+            kv * 1e3
+        } else if phases == 2 || phases == 3 {
             kv * 1e3 / 3f64.sqrt()
         } else {
             kv * 1e3
         };
-        if !v_phase.is_finite() || v_phase <= 0.0 {
+        if !v_ref.is_finite() || v_ref <= 0.0 {
             self.warn(format!(
                 "{} {}: invalid `kv` value is not a typed shunt; kept untyped",
                 spec.class, obj.name
@@ -1247,27 +1337,43 @@ impl Reader<'_> {
             self.net.untyped.push(UntypedObject::from(obj));
             return;
         }
-        let b_phase = spec.b_sign * kvar * 1e3 / phases as f64 / (v_phase * v_phase);
 
-        let bus = bus_spec(props.get("bus1"), "");
-        // The default return (bus2) is the same bus's ground; register the
-        // ground connection but keep the map and matrices phase only, the
-        // shape a shunt-to-ground admittance has downstream.
-        let map = self.terminals(&bus, phases, phases + 1, phases);
-        let n = map.len();
-        let mut b = vec![vec![0.0; n]; n];
-        for (i, row) in b.iter_mut().enumerate().take(phases) {
-            row[i] = b_phase;
-        }
+        let (nconds, keep) = if conn_delta {
+            let keep = match phases {
+                1 => 2,
+                2 => 3,
+                _ => phases,
+            };
+            (keep, keep)
+        } else {
+            // The default return is the same bus's ground; register the ground
+            // connection but keep the map and matrices phase only, the shape a
+            // shunt-to-ground admittance has downstream.
+            (phases + 1, phases)
+        };
+        let map = self.terminals(&bus, phases, nconds, keep);
+        let Some(susceptance) =
+            kvar_shunt_matrix(&map, phases, conn_delta, kvar, v_ref, spec.b_sign)
+        else {
+            self.warn(format!(
+                "{} {}: delta shunt terminal map is not typed; kept untyped",
+                spec.class, obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        };
         let mut extras = extras_from_leftovers(props);
         self.stash_kv_and_phases(props, &mut extras, kv, phases);
         extras.insert("kvar".into(), kvar.into());
+        if conn_delta {
+            extras.insert("conn".into(), "delta".into());
+        }
         self.net.shunts.push(DistShunt {
             name: obj.name.clone(),
             bus: bus.name,
             terminal_map: map,
-            g: vec![vec![0.0; n]; n],
-            b,
+            g: vec![vec![0.0; susceptance.len()]; susceptance.len()],
+            b: susceptance,
             extras,
         });
     }
@@ -1436,6 +1542,54 @@ fn scale_mat(m: &Mat, k: f64) -> Mat {
     m.iter()
         .map(|row| row.iter().map(|v| v * k).collect())
         .collect()
+}
+
+fn same_bus_ground_return(bus: &BusSpec, return_bus: &BusSpec) -> bool {
+    bus.name.eq_ignore_ascii_case(&return_bus.name)
+        && !return_bus.nodes.is_empty()
+        && return_bus.nodes.iter().all(|&n| n <= 0)
+}
+
+fn delta_edges(n: usize, phases: usize) -> Vec<(usize, usize)> {
+    if n < 2 {
+        Vec::new()
+    } else if phases >= 3 && n >= 3 {
+        (0..n).map(|i| (i, (i + 1) % n)).collect()
+    } else {
+        let branches = phases.max(1).min(n - 1);
+        (0..branches).map(|i| (i, i + 1)).collect()
+    }
+}
+
+fn kvar_shunt_matrix(
+    map: &[String],
+    phases: usize,
+    conn_delta: bool,
+    kvar: f64,
+    v_ref: f64,
+    b_sign: f64,
+) -> Option<Mat> {
+    let dim = map.len();
+    let mut susceptance = vec![vec![0.0; dim]; dim];
+    if conn_delta {
+        let edges = delta_edges(dim, phases);
+        if edges.is_empty() || map.iter().any(|t| t == "0") {
+            return None;
+        }
+        let b_branch = b_sign * kvar * 1e3 / edges.len() as f64 / (v_ref * v_ref);
+        for (from, to) in edges {
+            susceptance[from][from] += b_branch;
+            susceptance[to][to] += b_branch;
+            susceptance[from][to] -= b_branch;
+            susceptance[to][from] -= b_branch;
+        }
+    } else {
+        let b_phase = b_sign * kvar * 1e3 / phases as f64 / (v_ref * v_ref);
+        for (idx, row) in susceptance.iter_mut().enumerate().take(phases) {
+            row[idx] = b_phase;
+        }
+    }
+    Some(susceptance)
 }
 
 fn bus_spec(v: Option<&Value>, fallback: &str) -> BusSpec {
@@ -1702,12 +1856,15 @@ mod tests {
              New Capacitor.cap bus1=b.1.2.3 phases=3 conn=ll kvar=600 kv=4.16",
         );
         assert_eq!(net.generators[0].configuration, Configuration::Delta);
-        // Delta capacitors stay untyped, same as conn=delta.
-        assert!(net.shunts.is_empty());
+        // `ll` capacitor banks use the delta shunt path.
+        assert_eq!(net.shunts.len(), 1);
+        let sh = &net.shunts[0];
+        assert!(sh.b[0][1] < 0.0, "{:?}", sh.b);
+        assert_eq!(sh.terminal_map, vec!["1", "2", "3"]);
         assert!(
             net.untyped
                 .iter()
-                .any(|u| u.class.eq_ignore_ascii_case("capacitor") && u.name == "cap")
+                .all(|u| !(u.class.eq_ignore_ascii_case("capacitor") && u.name == "cap"))
         );
     }
 

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -1060,6 +1060,13 @@ impl DssWriter {
             ));
             return;
         }
+        if conn_delta && delta_branch_susceptance(&sh.b, &edges, sh.terminal_map.len()).is_none() {
+            self.warn(format!(
+                "shunt {}: delta susceptance matrix has no scalar {class} expression; \
+                 only the average branch susceptance is regenerated",
+                sh.name
+            ));
+        }
         let configuration = if conn_delta {
             Configuration::Delta
         } else {
@@ -1095,7 +1102,8 @@ impl DssWriter {
             let stashed_delta = shunt_stashed_delta(sh);
             let inferred_phases =
                 extras_usize(&sh.extras, "phases").unwrap_or_else(|| sh.terminal_map.len().max(1));
-            let conn_delta = stashed_delta || looks_like_delta_shunt(&sh.b, inferred_phases);
+            let conn_delta = stashed_delta
+                || looks_like_delta_shunt(&sh.b, sh.terminal_map.len(), inferred_phases);
             let phases = self.shunt_phases(sh, conn_delta, inferred_phases);
             if has_nonzero(&sh.g) {
                 self.write_impedance_shunt(sh, phases);
@@ -1223,19 +1231,16 @@ fn shunt_stashed_delta(sh: &crate::model::DistShunt) -> bool {
         .is_some_and(|t| t.to_ascii_lowercase().starts_with('d') || t.eq_ignore_ascii_case("ll"))
 }
 
-fn looks_like_delta_shunt(b: &Mat, phases: usize) -> bool {
-    if b.len() < 2 || !has_off_diagonal(b) {
+fn mat_at(m: &Mat, i: usize, j: usize) -> f64 {
+    m.get(i).and_then(|row| row.get(j)).copied().unwrap_or(0.0)
+}
+
+fn looks_like_delta_shunt(b: &Mat, terminals: usize, phases: usize) -> bool {
+    if terminals < 2 || !has_off_diagonal(b) {
         return false;
     }
-    let scale = matrix_scale(b);
-    if scale == 0.0 {
-        return false;
-    }
-    let n = b.len().min(phases.max(2));
-    b.iter().take(n).all(|row| {
-        let sum: f64 = row.iter().take(n).sum();
-        close(sum, 0.0, scale)
-    })
+    let edges = delta_edges(terminals, phases);
+    delta_branch_susceptance(b, &edges, terminals).is_some()
 }
 
 fn delta_edges(n: usize, phases: usize) -> Vec<(usize, usize)> {
@@ -1263,6 +1268,51 @@ fn delta_branch_abs(b: &Mat, edges: &[(usize, usize)]) -> Option<f64> {
         count += 1;
     }
     (count > 0).then_some(total / count as f64)
+}
+
+fn delta_branch_susceptance(b: &Mat, edges: &[(usize, usize)], terminals: usize) -> Option<f64> {
+    if terminals < 2 || edges.is_empty() {
+        return None;
+    }
+    let scale = matrix_scale(b);
+    if scale == 0.0 {
+        return None;
+    }
+    let first = edges[0];
+    let branch = -mat_at(b, first.0, first.1);
+    if branch == 0.0 {
+        return None;
+    }
+    let scale = scale.max(branch.abs());
+    for (i, row) in b.iter().enumerate() {
+        for (j, &value) in row.iter().enumerate() {
+            if (i >= terminals || j >= terminals) && !close(value, 0.0, scale) {
+                return None;
+            }
+        }
+    }
+    for i in 0..terminals {
+        let incident = edges
+            .iter()
+            .filter(|&&(from, to)| from == i || to == i)
+            .count() as f64;
+        for j in 0..terminals {
+            let linked = edges
+                .iter()
+                .any(|&(from, to)| (from == i && to == j) || (from == j && to == i));
+            let expected = if i == j {
+                incident * branch
+            } else if linked {
+                -branch
+            } else {
+                0.0
+            };
+            if !close(mat_at(b, i, j), expected, scale) {
+                return None;
+            }
+        }
+    }
+    Some(branch)
 }
 
 fn shunt_kvar(
@@ -1814,6 +1864,85 @@ mod tests {
         assert!(line.contains("phases=3 conn=delta"), "{line}");
         assert!(
             !out.warnings.iter().any(|w| w.contains("off diagonal")),
+            "{:?}",
+            out.warnings
+        );
+    }
+
+    #[test]
+    fn non_scalar_delta_matrix_is_not_inferred_silently() {
+        let (b, vs) = three_phase_source(2400.0);
+        let bmat = vec![
+            vec![0.003, -0.001, -0.002],
+            vec![-0.001, 0.003, -0.002],
+            vec![-0.002, -0.002, 0.004],
+        ];
+        let sh = DistShunt {
+            name: "capx".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3"]),
+            g: vec![vec![0.0; 3]; 3],
+            b: bmat,
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            shunts: vec![sh],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("Capacitor.capx"))
+            .unwrap_or_else(|| panic!("no capacitor emitted in:\n{}", out.text));
+        assert!(line.contains("conn=wye"), "{line}");
+        assert!(
+            out.warnings.iter().any(|w| w.contains("off diagonal")),
+            "{:?}",
+            out.warnings
+        );
+    }
+
+    #[test]
+    fn stashed_delta_matrix_warns_when_scalar_emission_is_lossy() {
+        let (b, vs) = three_phase_source(2400.0);
+        let bmat = vec![
+            vec![0.003, -0.001, -0.002],
+            vec![-0.001, 0.003, -0.002],
+            vec![-0.002, -0.002, 0.004],
+        ];
+        let mut extras = Extras::new();
+        extras.insert("conn".into(), serde_json::json!("delta"));
+        extras.insert("phases".into(), serde_json::json!("3"));
+        let sh = DistShunt {
+            name: "capx".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3"]),
+            g: vec![vec![0.0; 3]; 3],
+            b: bmat,
+            extras,
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            shunts: vec![sh],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("Capacitor.capx"))
+            .unwrap_or_else(|| panic!("no capacitor emitted in:\n{}", out.text));
+        assert!(line.contains("conn=delta"), "{line}");
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("no scalar capacitor expression")),
             "{:?}",
             out.warnings
         );

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -944,90 +944,164 @@ impl DssWriter {
         }
     }
 
+    fn write_impedance_shunt(&mut self, sh: &crate::model::DistShunt, phases: usize) {
+        self.check_name("reactor", &sh.name);
+        let Some((conductance, susceptance)) = first_diag_admittance(&sh.g, &sh.b, phases) else {
+            self.warn(format!(
+                "shunt {}: conductance matrix has no diagonal admittance; dropped from the output",
+                sh.name
+            ));
+            return;
+        };
+        if has_off_diagonal(&sh.g) || has_off_diagonal(&sh.b) {
+            self.warn(format!(
+                "shunt {}: off diagonal admittance has no scalar reactor expression; \
+                 only the first diagonal admittance is regenerated",
+                sh.name
+            ));
+        }
+        if !uniform_diag_admittance(&sh.g, &sh.b, phases, conductance, susceptance) {
+            self.warn(format!(
+                "shunt {}: diagonal admittances differ; only the first diagonal \
+                 admittance is regenerated",
+                sh.name
+            ));
+        }
+        let denom = conductance * conductance + susceptance * susceptance;
+        if !denom.is_finite() || denom <= 0.0 {
+            self.warn(format!(
+                "shunt {}: invalid grounding admittance; dropped from the output",
+                sh.name
+            ));
+            return;
+        }
+        let resistance = conductance / denom;
+        let reactance = -susceptance / denom;
+        let mut extras = sh.extras.clone();
+        extras.remove("kv");
+        extras.remove("kvar");
+        extras.remove("phases");
+        extras.remove("conn");
+        let ground = vec!["0".to_string(); phases.max(1)];
+        let mut line = format!(
+            "New Reactor.{} bus1={} bus2={} phases={} r={} x={}",
+            sh.name,
+            self.bus_ref(&sh.bus, &sh.terminal_map),
+            self.bus_ref(&sh.bus, &ground),
+            phases.max(1),
+            num(resistance),
+            num(reactance),
+        );
+        line.push_str(&self.extras_tail("reactor", &sh.name, &extras));
+        self.line_out(&line);
+    }
+
+    fn shunt_phases(
+        &mut self,
+        sh: &crate::model::DistShunt,
+        conn_delta: bool,
+        inferred_phases: usize,
+    ) -> usize {
+        if let Some(p) = extras_usize(&sh.extras, "phases") {
+            p.max(1)
+        } else if conn_delta {
+            self.element_phases(
+                &sh.extras,
+                &sh.terminal_map,
+                Configuration::Delta,
+                "shunt",
+                &sh.name,
+            )
+        } else {
+            inferred_phases
+        }
+    }
+
+    fn write_kvar_shunt(&mut self, sh: &crate::model::DistShunt, phases: usize, conn_delta: bool) {
+        let (b_max, b_min) = (0..phases.min(sh.b.len()))
+            .map(|idx| sh.b[idx][idx])
+            .fold((0.0_f64, 0.0_f64), |(mx, mn), v| (mx.max(v), mn.min(v)));
+        let (class, b_phase) = if b_max > 0.0 {
+            ("capacitor", b_max)
+        } else if b_min < 0.0 {
+            ("reactor", b_min)
+        } else {
+            self.warn(format!(
+                "shunt {}: no nonzero susceptance; dropped from the output",
+                sh.name
+            ));
+            return;
+        };
+        if b_max > 0.0 && b_min < 0.0 {
+            self.warn(format!(
+                "shunt {}: diagonal mixes capacitive and inductive phases; only the \
+                 {class} phases are regenerated",
+                sh.name
+            ));
+        }
+        self.check_name(class, &sh.name);
+        let off_diag = has_off_diagonal(&sh.b);
+        if off_diag && !conn_delta {
+            self.warn(format!(
+                "shunt {}: off diagonal susceptance has no {class} expression; \
+                 only the diagonal is regenerated",
+                sh.name
+            ));
+        }
+        let edges = if conn_delta {
+            delta_edges(sh.terminal_map.len(), phases)
+        } else {
+            Vec::new()
+        };
+        if conn_delta && edges.is_empty() {
+            self.warn(format!(
+                "shunt {}: delta terminal map has no branch expression; dropped from the output",
+                sh.name
+            ));
+            return;
+        }
+        let configuration = if conn_delta {
+            Configuration::Delta
+        } else {
+            Configuration::Wye
+        };
+        let kv = self.element_kv(&sh.extras, &sh.bus, phases, configuration, &sh.name, class);
+        let kvar = extras_f64(&sh.extras, "kvar")
+            .unwrap_or_else(|| shunt_kvar(sh, phases, conn_delta, &edges, b_phase, kv));
+        let mut extras = sh.extras.clone();
+        extras.remove("kv");
+        extras.remove("kvar");
+        extras.remove("phases");
+        extras.remove("conn");
+        let conn = if conn_delta { "delta" } else { "wye" };
+        let decl = if class == "reactor" {
+            "Reactor"
+        } else {
+            "Capacitor"
+        };
+        let mut line = format!(
+            "New {decl}.{} bus1={} phases={phases} conn={conn} kv={} kvar={}",
+            sh.name,
+            self.bus_ref(&sh.bus, &sh.terminal_map),
+            num(kv),
+            num(kvar),
+        );
+        line.push_str(&self.extras_tail(class, &sh.name, &extras));
+        self.line_out(&line);
+    }
+
     fn shunts(&mut self, net: &DistNetwork) {
         for sh in &net.shunts {
-            // A purely capacitive shunt has positive diagonal susceptance and
-            // regenerates as a Capacitor; a grounding reactor carries the
-            // inductive (negative) sign and regenerates as a Reactor. The
-            // sign is the class discriminator, the mirror of the reader.
-            let phases = extras_usize(&sh.extras, "phases").unwrap_or(sh.terminal_map.len());
-            // One pass over the diagonal for both extremes.
-            let (b_max, b_min) = (0..phases.min(sh.b.len()))
-                .map(|i| sh.b[i][i])
-                .fold((0.0_f64, 0.0_f64), |(mx, mn), v| (mx.max(v), mn.min(v)));
-            let (class, b_phase) = if b_max > 0.0 {
-                ("capacitor", b_max)
-            } else if b_min < 0.0 {
-                ("reactor", b_min)
+            let stashed_delta = shunt_stashed_delta(sh);
+            let inferred_phases =
+                extras_usize(&sh.extras, "phases").unwrap_or_else(|| sh.terminal_map.len().max(1));
+            let conn_delta = stashed_delta || looks_like_delta_shunt(&sh.b, inferred_phases);
+            let phases = self.shunt_phases(sh, conn_delta, inferred_phases);
+            if has_nonzero(&sh.g) {
+                self.write_impedance_shunt(sh, phases);
             } else {
-                self.warn(format!(
-                    "shunt {}: no nonzero susceptance; dropped from the output",
-                    sh.name
-                ));
-                continue;
-            };
-            if b_max > 0.0 && b_min < 0.0 {
-                // Both signs on the diagonal: only the dominant class is
-                // emitted; the opposite-sign phases are not regenerated.
-                self.warn(format!(
-                    "shunt {}: diagonal mixes capacitive and inductive phases; only the \
-                     {class} phases are regenerated",
-                    sh.name
-                ));
+                self.write_kvar_shunt(sh, phases, conn_delta);
             }
-            self.check_name(class, &sh.name);
-            let off_diag =
-                sh.b.iter()
-                    .enumerate()
-                    .any(|(i, row)| row.iter().enumerate().any(|(j, &v)| i != j && v != 0.0));
-            if off_diag {
-                self.warn(format!(
-                    "shunt {}: off diagonal susceptance has no {class} expression; \
-                     only the diagonal is regenerated",
-                    sh.name
-                ));
-            }
-            // Any (kv, kvar) pair with |kvar| = |b| v^2 reproduces the same
-            // admittance; the recorded pair (when the source carried one)
-            // emits verbatim, keeping the text stable across round trips.
-            let kv = self.element_kv(
-                &sh.extras,
-                &sh.bus,
-                phases,
-                Configuration::Wye,
-                &sh.name,
-                class,
-            );
-            let kvar = extras_f64(&sh.extras, "kvar").unwrap_or_else(|| {
-                // The reader's wye convention: line to line kv for 2 and 3
-                // phase, line to neutral for single phase. kvar is the
-                // positive rating; the inductive sign lives in the model's b.
-                let v_phase = if matches!(phases, 2 | 3) {
-                    kv * 1e3 / 3f64.sqrt()
-                } else {
-                    kv * 1e3
-                };
-                b_phase.abs() * v_phase * v_phase * phases as f64 / 1e3
-            });
-            let mut extras = sh.extras.clone();
-            extras.remove("kv");
-            extras.remove("kvar");
-            extras.remove("phases");
-            extras.remove("conn");
-            let decl = if class == "reactor" {
-                "Reactor"
-            } else {
-                "Capacitor"
-            };
-            let mut s = format!(
-                "New {decl}.{} bus1={} phases={phases} conn=wye kv={} kvar={}",
-                sh.name,
-                self.bus_ref(&sh.bus, &sh.terminal_map),
-                num(kv),
-                num(kvar),
-            );
-            s.push_str(&self.extras_tail(class, &sh.name, &extras));
-            self.line_out(&s);
         }
         self.out.push('\n');
     }
@@ -1101,6 +1175,114 @@ fn element_conn(extras: &Extras, configuration: Configuration) -> &'static str {
         Configuration::Delta => "delta",
         Configuration::SinglePhase if stash_delta => "delta",
         _ => "wye",
+    }
+}
+
+fn has_nonzero(m: &Mat) -> bool {
+    m.iter().flatten().any(|&v| v != 0.0)
+}
+
+fn has_off_diagonal(m: &Mat) -> bool {
+    m.iter()
+        .enumerate()
+        .any(|(i, row)| row.iter().enumerate().any(|(j, &v)| i != j && v != 0.0))
+}
+
+fn diag_at(m: &Mat, i: usize) -> f64 {
+    m.get(i).and_then(|row| row.get(i)).copied().unwrap_or(0.0)
+}
+
+fn matrix_scale(m: &Mat) -> f64 {
+    m.iter().flatten().fold(0.0_f64, |acc, &v| acc.max(v.abs()))
+}
+
+fn close(a: f64, b: f64, scale: f64) -> bool {
+    (a - b).abs() <= 1e-12_f64.max(scale * 1e-9)
+}
+
+fn first_diag_admittance(g: &Mat, b: &Mat, phases: usize) -> Option<(f64, f64)> {
+    (0..phases.max(1)).find_map(|i| {
+        let gi = diag_at(g, i);
+        let bi = diag_at(b, i);
+        (gi != 0.0 || bi != 0.0).then_some((gi, bi))
+    })
+}
+
+fn uniform_diag_admittance(g: &Mat, b: &Mat, phases: usize, g0: f64, b0: f64) -> bool {
+    let scale = matrix_scale(g)
+        .max(matrix_scale(b))
+        .max(g0.abs())
+        .max(b0.abs());
+    (0..phases.max(1)).all(|i| close(diag_at(g, i), g0, scale) && close(diag_at(b, i), b0, scale))
+}
+
+fn shunt_stashed_delta(sh: &crate::model::DistShunt) -> bool {
+    sh.extras
+        .get("conn")
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t.to_ascii_lowercase().starts_with('d') || t.eq_ignore_ascii_case("ll"))
+}
+
+fn looks_like_delta_shunt(b: &Mat, phases: usize) -> bool {
+    if b.len() < 2 || !has_off_diagonal(b) {
+        return false;
+    }
+    let scale = matrix_scale(b);
+    if scale == 0.0 {
+        return false;
+    }
+    let n = b.len().min(phases.max(2));
+    b.iter().take(n).all(|row| {
+        let sum: f64 = row.iter().take(n).sum();
+        close(sum, 0.0, scale)
+    })
+}
+
+fn delta_edges(n: usize, phases: usize) -> Vec<(usize, usize)> {
+    if n < 2 {
+        Vec::new()
+    } else if phases >= 3 && n >= 3 {
+        (0..n).map(|i| (i, (i + 1) % n)).collect()
+    } else {
+        let branches = phases.max(1).min(n - 1);
+        (0..branches).map(|i| (i, i + 1)).collect()
+    }
+}
+
+fn delta_branch_abs(b: &Mat, edges: &[(usize, usize)]) -> Option<f64> {
+    if edges.is_empty() {
+        return None;
+    }
+    let mut total = 0.0;
+    let mut count: usize = 0;
+    for &(i, j) in edges {
+        let Some(v) = b.get(i).and_then(|row| row.get(j)).copied() else {
+            continue;
+        };
+        total += v.abs();
+        count += 1;
+    }
+    (count > 0).then_some(total / count as f64)
+}
+
+fn shunt_kvar(
+    sh: &crate::model::DistShunt,
+    phases: usize,
+    conn_delta: bool,
+    edges: &[(usize, usize)],
+    b_phase: f64,
+    kv: f64,
+) -> f64 {
+    if conn_delta {
+        let b_branch = delta_branch_abs(&sh.b, edges).unwrap_or(b_phase.abs());
+        b_branch * (kv * 1e3) * (kv * 1e3) * edges.len() as f64 / 1e3
+    } else {
+        let v_phase = if matches!(phases, 2 | 3) {
+            kv * 1e3 / 3f64.sqrt()
+        } else {
+            kv * 1e3
+        };
+        b_phase.abs() * v_phase * v_phase * phases as f64 / 1e3
     }
 }
 
@@ -1562,6 +1744,79 @@ mod tests {
         let v_phase = kv * 1e3 / 3f64.sqrt();
         let expected = b_phase.abs() * v_phase * v_phase * 3.0 / 1e3;
         assert!(line.contains(&format!("kvar={}", num(expected))), "{line}");
+    }
+
+    #[test]
+    fn conductive_shunt_regenerates_as_grounding_reactor() {
+        let (_, vs) = three_phase_source(2400.0);
+        let b = bus("sb", &["1", "2", "3", "4"], &[]);
+        let sh = DistShunt {
+            name: "gnd".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["4"]),
+            g: vec![vec![1.0 / 0.3]],
+            b: vec![vec![0.0]],
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            shunts: vec![sh],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("Reactor.gnd"))
+            .unwrap_or_else(|| panic!("no reactor emitted in:\n{}", out.text));
+        assert!(line.contains("bus1=sb.4"), "{line}");
+        assert!(line.contains("bus2=sb.0"), "{line}");
+        assert!(line.contains("phases=1"), "{line}");
+        assert!(line.contains("r=0.3"), "{line}");
+        assert!(line.contains("x=-0"), "{line}");
+    }
+
+    #[test]
+    fn delta_shunt_regenerates_conn_delta() {
+        let (b, vs) = three_phase_source(2400.0);
+        let b_branch = 2e-4;
+        let bmat = vec![
+            vec![2.0 * b_branch, -b_branch, -b_branch],
+            vec![-b_branch, 2.0 * b_branch, -b_branch],
+            vec![-b_branch, -b_branch, 2.0 * b_branch],
+        ];
+        let mut extras = Extras::new();
+        extras.insert("conn".into(), serde_json::json!("delta"));
+        extras.insert("phases".into(), serde_json::json!("3"));
+        let sh = DistShunt {
+            name: "capd".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3"]),
+            g: vec![vec![0.0; 3]; 3],
+            b: bmat,
+            extras,
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            shunts: vec![sh],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("Capacitor.capd"))
+            .unwrap_or_else(|| panic!("no capacitor emitted in:\n{}", out.text));
+        assert!(line.contains("phases=3 conn=delta"), "{line}");
+        assert!(
+            !out.warnings.iter().any(|w| w.contains("off diagonal")),
+            "{:?}",
+            out.warnings
+        );
     }
 
     #[test]

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -136,6 +136,57 @@ fn dss_fixtures_emit_valid_bmopf() {
     }
 }
 
+#[test]
+fn dss_grounding_reactors_emit_bmopf_shunts() {
+    let v = schema_validator();
+    let net = parse_dss_str(
+        "New Circuit.c basekv=0.4\n\
+         New Reactor.tx_busgrounding_B179 phases=1 bus1=B179.4 bus2=B179.0 r=0.3 x=0.0\n\
+         New Reactor.loadbusgrounding_B3230 phases=1 bus1=B3230.4 bus2=B3230.0 r=10.0 x=0.0\n\
+         New Reactor.loadbusgrounding_B2656 phases=1 bus1=B2656.4 bus2=B2656.0 r=10.0 x=0.0\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    assert!(
+        !out.warnings
+            .iter()
+            .any(|w| w.contains("reactor") || w.contains("ground")),
+        "{:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let sh = &doc["shunt"];
+    assert_eq!(sh.as_object().unwrap().len(), 3);
+    assert_eq!(
+        sh["tx_busgrounding_B179"]["terminal_map"],
+        serde_json::json!(["4"])
+    );
+    assert_eq!(
+        sh["tx_busgrounding_B179"]["G_1_1"],
+        serde_json::json!(1.0 / 0.3)
+    );
+    assert_eq!(sh["tx_busgrounding_B179"]["B_1_1"], serde_json::json!(0.0));
+    assert_eq!(
+        sh["loadbusgrounding_B3230"]["G_1_1"],
+        serde_json::json!(0.1)
+    );
+}
+
+#[test]
+fn dss_delta_shunts_emit_bmopf_matrices() {
+    let v = schema_validator();
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Capacitor.capd bus1=b2.1.2.3 phases=3 conn=delta kvar=900 kv=4.16\n\
+         New Reactor.rxd bus1=b3.1.2.3 phases=3 conn=delta kvar=600 kv=4.16\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    assert!(doc["shunt"]["capd"]["B_1_2"].as_f64().unwrap() < 0.0);
+    assert!(doc["shunt"]["rxd"]["B_1_2"].as_f64().unwrap() > 0.0);
+}
+
 /// A single phase wye/delta transformer (an open delta leg) must reach the
 /// BMOPF output as a `single_phase` entry, not drop, and the delta winding
 /// must carry both of its phase terminals end to end. This is issue #135's

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -358,6 +358,29 @@ fn grounding_reactor_with_rx_uses_admittance_inverse() {
 }
 
 #[test]
+fn grounding_reactor_bus2_uses_the_dss_fill_rule() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Reactor.rz bus1=b2.1.2.3 bus2=b2.0 phases=3 r=3 x=4\n",
+    );
+    assert!(net.untyped.iter().any(|o| o.name == "rz"));
+    assert!(net.shunts.iter().all(|s| s.name != "rz"));
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("reactor rz") && w.contains("series"))
+    );
+
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Reactor.rz bus1=b2.1.2.3 bus2=b2.0.0.0 phases=3 r=3 x=4\n",
+    );
+    let sh = net.shunts.iter().find(|s| s.name == "rz").unwrap();
+    assert_eq!(sh.terminal_map, vec!["1", "2", "3"]);
+}
+
+#[test]
 fn zero_impedance_grounding_reactor_stays_untyped() {
     use powerio_dist::parse_dss_str;
     let net = parse_dss_str(

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -312,7 +312,88 @@ fn reactor_defaults_are_materialized_and_recorded() {
 }
 
 #[test]
-fn series_and_impedance_reactors_stay_untyped() {
+#[allow(clippy::float_cmp)]
+fn grounding_impedance_reactors_type_as_conductive_shunts() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=0.4\n\
+         New Reactor.tx_busgrounding_B179 phases=1 bus1=B179.4 bus2=B179.0 r=0.3 x=0.0\n\
+         New Reactor.loadbusgrounding_B3230 phases=1 bus1=B3230.4 bus2=B3230.0 r=10.0 x=0.0\n\
+         New Reactor.loadbusgrounding_B2656 phases=1 bus1=B2656.4 bus2=B2656.0 r=10.0 x=0.0\n",
+    );
+    assert_eq!(net.shunts.len(), 3, "{:?}", net.warnings);
+    assert!(
+        net.untyped
+            .iter()
+            .all(|o| !o.class.eq_ignore_ascii_case("reactor"))
+    );
+    let first = net
+        .shunts
+        .iter()
+        .find(|s| s.name == "tx_busgrounding_B179")
+        .unwrap();
+    assert_eq!(first.bus, "B179");
+    assert_eq!(first.terminal_map, vec!["4"]);
+    assert_eq!(first.g[0][0], 1.0 / 0.3);
+    assert_eq!(first.b[0][0], 0.0);
+    let second = net
+        .shunts
+        .iter()
+        .find(|s| s.name == "loadbusgrounding_B3230")
+        .unwrap();
+    assert_eq!(second.terminal_map, vec!["4"]);
+    assert_eq!(second.g[0][0], 0.1);
+    assert_eq!(second.b[0][0], 0.0);
+}
+
+#[test]
+fn grounding_reactor_with_rx_uses_admittance_inverse() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\nNew Reactor.rz bus1=b2.1 bus2=b2.0 phases=1 r=3 x=4\n",
+    );
+    let sh = net.shunts.iter().find(|s| s.name == "rz").unwrap();
+    assert!((sh.g[0][0] - 0.12).abs() < 1e-12, "{}", sh.g[0][0]);
+    assert!((sh.b[0][0] + 0.16).abs() < 1e-12, "{}", sh.b[0][0]);
+}
+
+#[test]
+fn zero_impedance_grounding_reactor_stays_untyped() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\nNew Reactor.rz bus1=b2.1 bus2=b2.0 phases=1 r=0 x=0\n",
+    );
+    assert!(net.untyped.iter().any(|o| o.name == "rz"));
+    assert!(net.shunts.iter().all(|s| s.name != "rz"));
+    assert!(net.warnings.iter().any(|w| w.contains("zero impedance")));
+}
+
+#[test]
+fn delta_capacitor_and_reactor_type_as_shunt_matrices() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=4.16\n\
+         New Capacitor.capd bus1=b2.1.2.3 phases=3 conn=delta kvar=900 kv=4.16\n\
+         New Reactor.rxd bus1=b3.1.2.3 phases=3 conn=delta kvar=600 kv=4.16\n",
+    );
+    assert_eq!(net.shunts.len(), 2, "{:?}", net.warnings);
+    assert!(
+        net.untyped
+            .iter()
+            .all(|o| o.name != "capd" && o.name != "rxd")
+    );
+    let cap = net.shunts.iter().find(|s| s.name == "capd").unwrap();
+    assert_eq!(cap.terminal_map, vec!["1", "2", "3"]);
+    assert!(cap.b[0][0] > 0.0, "{:?}", cap.b);
+    assert!(cap.b[0][1] < 0.0, "{:?}", cap.b);
+    assert!((cap.b[0][0] + cap.b[0][1] + cap.b[0][2]).abs() < 1e-12);
+    let rx = net.shunts.iter().find(|s| s.name == "rxd").unwrap();
+    assert!(rx.b[0][0] < 0.0, "{:?}", rx.b);
+    assert!(rx.b[0][1] > 0.0, "{:?}", rx.b);
+}
+
+#[test]
+fn series_and_non_ground_impedance_reactors_stay_untyped() {
     use powerio_dist::parse_dss_str;
     // Series reactor (bus2): deferred, like the series capacitor.
     let net = parse_dss_str(
@@ -325,8 +406,7 @@ fn series_and_impedance_reactors_stay_untyped() {
             .iter()
             .any(|w| w.contains("reactor rs") && w.contains("series"))
     );
-    // Impedance form (r/x): kvar is ignored by the engine, so we refuse to
-    // invent a susceptance and keep it untyped instead.
+    // Impedance form without an explicit ground return is not a shunt.
     let net =
         parse_dss_str("New Circuit.c basekv=4.16\nNew Reactor.rz bus1=b2 phases=3 r=0.1 x=5\n");
     assert!(net.untyped.iter().any(|o| o.name == "rz"));


### PR DESCRIPTION
## Summary

Fix OpenDSS distribution shunts so they survive BMOPF conversion.

- Type same bus ground return reactors such as `bus1=B179.4 bus2=B179.0 r=0.3 x=0.0` as `DistShunt` admittance matrices instead of untyped reactors.
- Type delta capacitor and reactor banks as shunt matrices with off diagonal branch terms.
- Regenerate conductance shunts as grounding reactors and preserve delta shunts as `conn=delta` when writing DSS.
- Bump the workspace version to `0.3.2` and document the release notes.

Root cause: the DSS reactor reader treated every `bus2` reactor as an untyped series reactor before checking whether the return node was the same bus ground. Delta shunts were also explicitly left untyped.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio-dist`
- `cargo build -p powerio-capi --release`
- PowerIO.jl package tests against the locally built `powerio-capi` library
- PowerIO.jl package tests against the published artifact
- `git diff --check` in both repos