### PR TITLE
[pkg] add .pio.json compiler package envelope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,6 +2023,7 @@ dependencies = [
  "crossterm",
  "powerio-dist",
  "powerio-matrix",
+ "powerio-pkg",
  "ratatui",
  "serde_json",
  "sprs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerio-pkg"
+version = "0.3.3"
+dependencies = [
+ "powerio",
+ "powerio-dist",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "powerio-py"
 version = "0.3.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,12 @@ members = [
     "powerio-py",
     "powerio-capi",
     "powerio-dist",
+    "powerio-pkg",
 ]
 # Bare `cargo build`/`test`/`clippy` touch only the library + CLI crates, so the
 # toolchain never compiles the PyO3 extension (which needs libpython). Build the
 # binding explicitly with `-p powerio-py`.
-default-members = ["powerio", "powerio-matrix", "powerio-cli", "powerio-dist"]
+default-members = ["powerio", "powerio-matrix", "powerio-cli", "powerio-dist", "powerio-pkg"]
 # The fuzz harnesses need nightly + cargo-fuzz; they build on their own (see
 # fuzz/README.md), never as part of the workspace.
 exclude = ["fuzz"]
@@ -33,6 +34,7 @@ homepage = "https://eigenergy.github.io/powerio/"
 powerio = { path = "powerio", version = "0.3.3" }
 powerio-matrix = { path = "powerio-matrix", version = "0.3.3" }
 powerio-dist = { path = "powerio-dist", version = "0.3.3" }
+powerio-pkg = { path = "powerio-pkg", version = "0.3.3" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ This repository contains multiple packages.
 powerio          # parser, Network model, source retaining writers, converters
 powerio-matrix   # sparse matrices, DC sensitivity factors, graph representations
 powerio-dist     # multiconductor distribution model, dss/PMD/BMOPF converters
+powerio-pkg      # .pio.json compiler package envelope
 powerio-cli      # the `powerio` command and ratatui TUI
 powerio-py       # PyO3 extension for the Python `powerio` package
 powerio-capi     # C ABI for C, C++, Julia, and other foreign function interfaces
@@ -127,6 +128,7 @@ powerio convert tests/data/case14.m --to pandapower-json -o case14.pp.json
 powerio convert tests/data/case14.m --to pypsa-csv -o pypsa_case
 powerio convert pypsa_case --from pypsa-csv --to matpower -o case14.m
 powerio convert case.epc --from pslf --to matpower -o case.m
+powerio package tests/data/case14.m -o case14.pio.json
 powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
 powerio sensitivities tests/data/case30.m -o out

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ crate doc comment.
   `dcopf` subcommand writes for a downstream solver.
 - [languages.md](languages.md): canonical Rust, Python, Julia, and C ABI names.
 - [python.md](python.md): Python install extras and API examples.
+- [architecture/](architecture/README.md): the compiler-IR architecture and the
+  `.pio.json` compiler package and its schema.
 - Julia bindings: <https://github.com/eigenergy/PowerIO.jl>.
 
 Rendered API docs (rustdoc) for all crates:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,14 @@
+# Architecture
+
+How PowerIO is organized as a compiler for power system data: distinct model
+families and a `.pio.json` compiler package.
+
+- [compiler-ir.md](compiler-ir.md): the IR layers, the `BalancedNetwork` and
+  `MulticonductorNetwork` model families, and the `CompilerPackage` (`.pio.json`)
+  envelope — explicit model kind, provenance, source maps, structured
+  diagnostics, validation, and lowering.
+- [pio-json-schema.md](pio-json-schema.md): the `.pio.json` field reference and
+  the stability policy — the envelope is versioned, the nested IR payloads are
+  experimental.
+
+The package is implemented in the `powerio-pkg` crate.

--- a/docs/architecture/compiler-ir.md
+++ b/docs/architecture/compiler-ir.md
@@ -1,0 +1,113 @@
+# The PowerIO compiler IR
+
+PowerIO is organized as a compiler for power system data: frontends parse source
+formats into typed IR, passes normalize and lower it, and backends emit target
+artifacts. This document defines the IR boundaries and the `.pio.json` compiler
+package that ties them together. The field-level reference for the package is in
+[pio-json-schema.md](pio-json-schema.md).
+
+The governing decision is that there is no single flattened universal `Network`
+mega-struct. There are concrete model families, and a package object that wraps
+one payload at a time with the metadata that makes a compiler artifact
+trustworthy.
+
+## Model families
+
+PowerIO keeps two concrete static-grid IR families distinct. They share
+conventions, not types; code that needs both holds a package, not a union struct.
+
+### `BalancedNetwork`
+
+`powerio::BalancedNetwork` (an alias of `powerio::Network`) is the scalar
+positive-sequence model for transmission power flow, OPF, matrices, and graph
+analysis. Every electrical quantity is a single `f64`, with no phase or conductor
+dimension. External bus ids are not dense matrix indices; the dense solver view
+is derived separately and preserves external ids. Loads and shunts are
+first-class records, not folded onto bus rows.
+
+### `MulticonductorNetwork`
+
+`powerio_dist::MulticonductorNetwork` (an alias of `powerio_dist::DistNetwork`)
+is the wire-coordinate model for conductor-level distribution. Bus ids are
+strings; terminals are ordered string names; every element carries a terminal
+map; grounding is explicit; units are SI and radians. A neutral is not just
+another phase; it carries grounding and reduction semantics. Format defaults and
+inferred facts are tracked, and unsupported objects are preserved rather than
+dropped.
+
+A balanced model cannot represent conductor-level asymmetry; a multiconductor
+model carries terminal and grounding data that has no place in a positive
+sequence struct. The two families never merge into one struct.
+
+## The compiler package (`.pio.json`)
+
+`powerio_pkg::CompilerPackage` is the readable envelope. It is the object that
+records how a source was interpreted, and it is the interchange layer for
+language bindings. Binary `.pio` is out of scope until the JSON package
+stabilizes.
+
+A package always carries:
+
+- `schema` (URL) and `schema_version` (semver);
+- `producer` metadata;
+- `model_kind`, explicit and authoritative;
+- `model`, the one typed payload, tagged by `kind`;
+- `origin` and `sources`;
+- `source_maps`;
+- `diagnostics`;
+- `validation`;
+- `summary`;
+- `lowering_history`;
+- optional `derived` metadata.
+
+### Explicit model kind
+
+`model_kind` is a standalone field. A reader must never infer whether the payload
+is balanced or multiconductor from which field is present. The payload enum is
+also tagged by `kind`, so the payload is self-describing too;
+`CompilerPackage::kind_is_consistent` asserts the two agree, and a reader should
+reject a package where they do not.
+
+### Payload stability
+
+The envelope is the versioned, documented contract. The nested `balanced_network`
+/ `multiconductor_network` payloads are direct serde snapshots of the live
+PowerIO Rust IR and are experimental until a v1 payload schema is declared; they
+grow whenever the IR grows. See [pio-json-schema.md](pio-json-schema.md).
+
+### Provenance and source maps
+
+`Origin` distinguishes an in-memory model, a single file (with or without
+retained source), a folder dataset, a partially decoded binary, a derived
+product, or a composite. A `SourceMapEntry` answers "where did this canonical
+field come from?" with an `element_path`, a `SourceRef` into a declared source, a
+`mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`, `lowered`,
+`aggregated`, `split`, `synthetic`, `retained_extra`), and a `confidence`. Parser
+bookkeeping that should not live in the IR payload (retained source text,
+default-materialization records) is lifted into this layer rather than the raw
+payload.
+
+### Structured diagnostics
+
+Every finding carries a stable dotted `code`, a `severity` (`debug`, `info`,
+`warning`, `error`, `fatal`; worst-last so a set's dominant severity is its max),
+the `stage` it came from, a human `message`, and where known an `element_path`, a
+`source_ref`, a `details` object, and a `suggested_action`. Human-readable
+warnings are rendered from these, not the other way around. Codes are namespaced
+by leading segment (`PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`,
+`EMIT`, `BINDING`, `PARTNER`, `PERF`), with the conventional shape
+`NAMESPACE.SOURCE_OR_TARGET.SPECIFIC`.
+
+### Lowering
+
+Every pass that transforms one model into another appends a `LoweringRecord`
+(input and output kind, options, assumptions, approximations, dropped fields,
+diagnostics, validation status) to `lowering_history`, so the transformation is
+auditable rather than implicit. This change set defines the record shape; the
+passes themselves are later work.
+
+## Versioning
+
+`schema_version` is semver. Additive envelope fields bump the minor; field moves
+bump the major or ship a migration. Unknown future top-level fields are tolerated
+on read (ignored), so a package from a newer producer still deserializes.

--- a/docs/architecture/pio-json-schema.md
+++ b/docs/architecture/pio-json-schema.md
@@ -1,0 +1,127 @@
+# The `.pio.json` schema
+
+`.pio.json` is the serialized form of `powerio_pkg::CompilerPackage`: a versioned
+envelope around one PowerIO IR payload. This document is the reference for the
+envelope shape and the stability policy. The crate is the implementation;
+`compiler-ir.md` is the architecture.
+
+## Two stability tiers
+
+A `.pio.json` file has two parts with different stability promises.
+
+1. **The envelope** — every field except `model`. This is the versioned,
+   documented contract: `schema`, `schema_version`, `producer`, `model_kind`,
+   `origin`, `sources`, `source_maps`, `diagnostics`, `validation`, `summary`,
+   `lowering_history`, `derived`. Its shape changes only under the versioning
+   policy below.
+
+2. **The payload** — the `model` field's `balanced_network` /
+   `multiconductor_network` object. This is a direct serde snapshot of the live
+   PowerIO Rust IR (`powerio::Network` / `powerio_dist::DistNetwork`). It is
+   **experimental**: it grows and changes whenever the IR does. Adding a new
+   typed field to a model appears in the payload with no envelope version
+   change. Do not treat the payload as a stable schema until
+   a v1 payload schema is declared. Tools that need stability should read the
+   envelope (model kind, summary, diagnostics, provenance) and treat the payload
+   as opaque or version-pinned to a producer.
+
+`schema_version` versions the envelope only. The payload carries no separate
+version yet; pin to `producer.version` if you depend on payload fields.
+
+## Versioning policy (envelope)
+
+- `schema_version` is semver. The current value is `0.1.0`; the `schema` URL is
+  `https://powerio.dev/schema/pio-package/0.1`.
+- Additive envelope fields bump the minor version.
+- Envelope field moves or removals bump the major version, or ship a migration.
+- A reader tolerates unknown future top-level fields (they are ignored, not an
+  error), so a package from a newer producer still loads. A future version may
+  preserve them in an extras map instead of dropping them.
+- Every package states `producer.version` and `schema_version`.
+
+## Explicit model kind
+
+`model_kind` is a standalone top-level field and is authoritative. A reader
+**must** branch on it and **must not** infer the payload kind from which field is
+present. The payload is additionally self-describing: `model` is tagged by
+`kind`, so `model.kind` and `model_kind` carry the same value.
+`CompilerPackage::kind_is_consistent` asserts the two agree; a reader should
+reject a package where they disagree.
+
+```json
+"model_kind": "balanced",
+"model": { "kind": "balanced", "balanced_network": { "...": "..." } }
+```
+
+`model_kind` values: `balanced`, `multiconductor` (the enum is non-exhaustive;
+future families may be added).
+
+## Envelope reference
+
+| field | type | required | notes |
+|---|---|---|---|
+| `schema` | string (URL) | yes | identifies the package format; defaults to the current URL on read |
+| `schema_version` | string (semver) | yes | envelope version; defaults to current on read |
+| `producer` | object | yes | `{tool, version, git_commit?, features[]}` |
+| `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
+| `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
+| `model_kind` | enum | yes | `balanced` \| `multiconductor`; authoritative |
+| `model` | object | yes | `{kind, <kind>_network}`; the experimental payload |
+| `origin` | object | yes | tagged by `kind`: `in_memory` \| `file` \| `folder` \| `binary_file` \| `derived` \| `composite` |
+| `sources` | array | no | declared source artifacts: `{id, kind, path?, format?, hash?}` |
+| `source_maps` | array | no | `{element_path, source_ref, mapping_kind, confidence}` |
+| `diagnostics` | array | no | structured findings (see below) |
+| `validation` | object | yes | `{status, counts, passes[]}` |
+| `summary` | object | yes | `{elements{}, topology?, units?}` |
+| `lowering_history` | array | no | `LoweringRecord` per pass |
+| `derived` | object | no | optional matrix stats / cache keys |
+
+### Diagnostics
+
+Each diagnostic carries a stable dotted `code`, a `severity` (`debug`, `info`,
+`warning`, `error`, `fatal`; ordered worst-last), the `stage` it came from
+(`parse`, `read`, `canonicalize`, `validate`, `lower`, `emit`, `bind`,
+`partner`), a human `message`, and where known an `element_path`, a `source_ref`,
+a `details` object, a `suggested_action`, and a `safe_to_ignore` list. Code
+namespaces by leading segment: `PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`,
+`LOWER`, `EMIT`, `BINDING`, `PARTNER`, `PERF`.
+
+### Source maps
+
+A `source_map` entry records where a canonical field came from: an `element_path`
+(a JSON pointer, or a best-effort locator in v0.1), a `source_ref` into a declared
+source, a `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`,
+`lowered`, `aggregated`, `split`, `synthetic`, `retained_extra`), and a
+`confidence` (`exact`, `high`, `medium`, `low`). When a multiconductor network is
+packaged, its `defaulted` fields lift into source maps with `mapping_kind =
+defaulted`, and its retained source becomes `origin.retained_source`.
+
+## Example
+
+```json
+{
+  "schema": "https://powerio.dev/schema/pio-package/0.1",
+  "schema_version": "0.1.0",
+  "producer": { "tool": "powerio", "version": "0.3.3" },
+  "model_kind": "multiconductor",
+  "model": {
+    "kind": "multiconductor",
+    "multiconductor_network": {
+      "base_frequency": 60.0,
+      "loads": [
+        { "name": "l1", "bus": "b1", "configuration": "wye",
+          "voltage_model": { "model": "zip", "v_nom": [230.0], "alpha_z": [0.5], "...": "..." } }
+      ]
+    }
+  },
+  "origin": { "kind": "file", "format": "dss", "retained_source": true },
+  "sources": [ { "id": "src0", "kind": "file", "format": "dss" } ],
+  "source_maps": [
+    { "element_path": "/model/multiconductor_network/vsource.source#basekv",
+      "source_ref": { "source_id": "src0", "field": "basekv" },
+      "mapping_kind": "defaulted", "confidence": "high" }
+  ],
+  "validation": { "status": "ok", "counts": { "fatal": 0, "error": 0, "warning": 0, "info": 0, "debug": 0 } },
+  "summary": { "elements": { "buses": 1, "loads": 1 }, "units": { "power": "W/var", "angle": "radians" } }
+}
+```

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -24,6 +24,7 @@ powerio-matrix = { workspace = true, features = ["gridfm"] }
 # Unconditional: the CLI always ships the distribution surface (`convert
 # --to dss/pmd-json/bmopf-json`); only the C ABI gates it behind a feature.
 powerio-dist.workspace = true
+powerio-pkg.workspace = true
 sprs.workspace = true
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/powerio-cli/README.md
+++ b/powerio-cli/README.md
@@ -2,10 +2,11 @@
 
 `powerio-cli` provides the `powerio` command for format conversion, matrix
 export, DC OPF bundles, PTDF/LODF exports, GridFM Parquet export, synthetic case
-generation, verification, and the ratatui TUI.
+generation, `.pio.json` package emission, verification, and the ratatui TUI.
 
 ```
 powerio convert tests/data/case14.m --to psse -o case14.raw
+powerio package tests/data/case14.m -o case14.pio.json
 powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
 powerio sensitivities tests/data/case30.m -o out

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -2,9 +2,10 @@
 //!
 //! Subcommands: `batch` (matrix families), `gen` (synthetic cases), `verify`,
 //! `dcopf` (DC OPF bundle), `sensitivities` (PTDF/LODF), `gridfm` (gridfm-datakit
-//! Parquet), and `convert`. With no subcommand it launches the TUI. Run
+//! Parquet), `package` (`.pio.json`), and `convert`. With no subcommand it launches the TUI. Run
 //! `powerio --help` for the full surface.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -15,6 +16,10 @@ use powerio_matrix::matrix::{BuildOptions, DcConvention, Scheme, Units, sddm_che
 use powerio_matrix::opf_pipeline::{DcOpfOptions, write_dcopf_bundle};
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
 use powerio_matrix::synth::{SynthSpec, Topology};
+use powerio_pkg::{
+    CompilerPackage, DiagnosticSeverity, DiagnosticStage, Origin, SourceDescriptor,
+    StructuredDiagnostic, ValidationSummary,
+};
 use serde_json::json;
 mod tui;
 
@@ -116,6 +121,21 @@ enum Command {
         #[arg(long, value_enum)]
         from: Option<FormatArg>,
         /// With `--from gridfm`, which scenario to summarize.
+        #[arg(long, default_value_t = 0)]
+        scenario: i64,
+    },
+    /// Emit the `.pio.json` compiler package for one input.
+    #[command(visible_alias = "pkg")]
+    Package {
+        /// Input case file, PyPSA CSV folder, or gridfm dataset directory.
+        input: PathBuf,
+        /// Output file; `-` or omitted writes to stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Override the inferred input format.
+        #[arg(long, value_enum)]
+        from: Option<FormatArg>,
+        /// With `--from gridfm`, which scenario to package.
         #[arg(long, default_value_t = 0)]
         scenario: i64,
     },
@@ -456,6 +476,12 @@ fn main() -> anyhow::Result<()> {
             from,
             scenario,
         } => run_summary(&input, from, scenario),
+        Command::Package {
+            input,
+            output,
+            from,
+            scenario,
+        } => run_package(&input, output.as_deref(), from, scenario),
         Command::Gridfm {
             inputs,
             output,
@@ -702,6 +728,181 @@ fn run_summary(input: &Path, from: Option<FormatArg>, scenario: i64) -> anyhow::
         };
     println!("{}", serde_json::to_string_pretty(&value)?);
     Ok(())
+}
+
+fn run_package(
+    input: &Path,
+    output: Option<&Path>,
+    from: Option<FormatArg>,
+    scenario: i64,
+) -> anyhow::Result<()> {
+    let text = package_text(input, from, scenario)?;
+    match output {
+        Some(p) if p.as_os_str() != "-" => {
+            std::fs::write(p, &text).with_context(|| format!("writing {}", p.display()))?;
+            eprintln!("wrote {}", p.display());
+        }
+        _ => print!("{text}"),
+    }
+    Ok(())
+}
+
+fn package_text(input: &Path, from: Option<FormatArg>, scenario: i64) -> anyhow::Result<String> {
+    let pkg = build_package(input, from, scenario)?;
+    let text = pkg
+        .to_json_pretty()
+        .context("serializing .pio.json package")?;
+    CompilerPackage::from_json(&text).context("validating .pio.json package readback")?;
+    Ok(text)
+}
+
+fn build_package(
+    input: &Path,
+    from: Option<FormatArg>,
+    scenario: i64,
+) -> anyhow::Result<CompilerPackage> {
+    if from == Some(FormatArg::Gridfm) || (from.is_none() && looks_like_gridfm_dir(input)) {
+        let read = powerio_matrix::read_gridfm_dataset(input, scenario)
+            .with_context(|| format!("reading gridfm dataset {}", input.display()))?;
+        let mut pkg = CompilerPackage::from_balanced(read.network);
+        add_read_warning_diagnostics(&mut pkg, "READ.GRIDFM.FIDELITY_WARNING", &read.warnings);
+        set_package_source(&mut pkg, input, PackageSourceKind::Folder, "gridfm", false);
+        return Ok(pkg);
+    }
+
+    if from.is_some_and(|f| f.distribution().is_some())
+        || (from.is_none() && looks_like_distribution_input(input)?)
+    {
+        let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
+            .with_context(|| format!("reading {}", input.display()))?;
+        let format = net
+            .source_format
+            .map(powerio_dist::DistSourceFormat::name)
+            .or_else(|| from.map(FormatArg::name))
+            .unwrap_or("unknown");
+        let retained_source = net.source.is_some();
+        let mut pkg = CompilerPackage::from_multiconductor(net);
+        set_package_source(
+            &mut pkg,
+            input,
+            package_source_kind(input, format),
+            format,
+            retained_source,
+        );
+        return Ok(pkg);
+    }
+
+    let parsed = powerio_matrix::parse_file(input, from.map(FormatArg::name))
+        .with_context(|| format!("reading {}", input.display()))?;
+    let format = balanced_source_format_name(parsed.network.source_format);
+    let retained_source = parsed.network.source.is_some();
+    let mut pkg = CompilerPackage::from_balanced(parsed.network);
+    add_read_warning_diagnostics(
+        &mut pkg,
+        "READ.TRANSMISSION.PARSE_WARNING",
+        &parsed.warnings,
+    );
+    set_package_source(
+        &mut pkg,
+        input,
+        package_source_kind(input, format),
+        format,
+        retained_source,
+    );
+    Ok(pkg)
+}
+
+fn add_read_warning_diagnostics(pkg: &mut CompilerPackage, code: &str, warnings: &[String]) {
+    pkg.diagnostics.extend(warnings.iter().map(|w| {
+        StructuredDiagnostic::new(
+            code,
+            DiagnosticSeverity::Warning,
+            DiagnosticStage::Read,
+            w.clone(),
+        )
+    }));
+    pkg.validation = ValidationSummary::from_diagnostics(&pkg.diagnostics);
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PackageSourceKind {
+    File,
+    BinaryFile,
+    Folder,
+}
+
+impl PackageSourceKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::BinaryFile => "binary_file",
+            Self::Folder => "folder",
+        }
+    }
+}
+
+fn package_source_kind(input: &Path, format: &str) -> PackageSourceKind {
+    if input.is_dir() {
+        PackageSourceKind::Folder
+    } else if format == "powerworld-pwb" {
+        PackageSourceKind::BinaryFile
+    } else {
+        PackageSourceKind::File
+    }
+}
+
+fn set_package_source(
+    pkg: &mut CompilerPackage,
+    input: &Path,
+    kind: PackageSourceKind,
+    format: &str,
+    retained_source: bool,
+) {
+    let path = input.display().to_string();
+    pkg.origin = match kind {
+        PackageSourceKind::File => Origin::File {
+            path: path.clone(),
+            format: format.to_owned(),
+            hash: None,
+            retained_source,
+        },
+        PackageSourceKind::BinaryFile => Origin::BinaryFile {
+            path: path.clone(),
+            format: format.to_owned(),
+            hash: None,
+            decoded_sections: Vec::new(),
+        },
+        PackageSourceKind::Folder => Origin::Folder {
+            path: path.clone(),
+            format: format.to_owned(),
+            file_hashes: BTreeMap::new(),
+        },
+    };
+    pkg.sources = vec![SourceDescriptor {
+        id: "src0".to_owned(),
+        kind: kind.as_str().to_owned(),
+        path: Some(path),
+        format: Some(format.to_owned()),
+        hash: None,
+    }];
+}
+
+fn balanced_source_format_name(f: powerio_matrix::SourceFormat) -> &'static str {
+    match f {
+        powerio_matrix::SourceFormat::Matpower => "matpower",
+        powerio_matrix::SourceFormat::PowerModelsJson => "powermodels-json",
+        powerio_matrix::SourceFormat::EgretJson => "egret-json",
+        powerio_matrix::SourceFormat::Psse => "psse",
+        powerio_matrix::SourceFormat::PowerWorld => "powerworld",
+        powerio_matrix::SourceFormat::PandapowerJson => "pandapower-json",
+        powerio_matrix::SourceFormat::Pslf => "pslf",
+        powerio_matrix::SourceFormat::PowerWorldBinary => "powerworld-pwb",
+        powerio_matrix::SourceFormat::InMemory => "in-memory",
+        powerio_matrix::SourceFormat::Normalized => "normalized",
+        powerio_matrix::SourceFormat::Gridfm => "gridfm",
+        powerio_matrix::SourceFormat::PypsaCsv => "pypsa-csv",
+        _ => "unknown",
+    }
 }
 
 fn transmission_summary_json(
@@ -973,9 +1174,12 @@ fn read_network(
 #[cfg(test)]
 mod tests {
     use super::{
-        FormatArg, distribution_summary_json, infer_input_family, looks_like_distribution_input,
-        run_convert, transmission_summary_json,
+        Cli, Command, FormatArg, build_package, distribution_summary_json, infer_input_family,
+        looks_like_distribution_input, package_text, run_convert, run_package,
+        transmission_summary_json,
     };
+    use clap::Parser;
+    use powerio_pkg::{CompilerPackage, MappingKind, Origin};
     use std::path::Path;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1031,6 +1235,133 @@ mod tests {
         .unwrap();
         assert!(!looks_like_distribution_input(&tmp).unwrap());
         let _ = std::fs::remove_file(tmp);
+    }
+
+    #[test]
+    fn package_visible_alias_parses() {
+        let cli = Cli::try_parse_from(["powerio", "pkg", "case9.m"]).unwrap();
+        match cli.command.unwrap() {
+            Command::Package { input, .. } => assert_eq!(input, Path::new("case9.m")),
+            other => panic!("expected package command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn package_text_matches_balanced_shape_and_provenance() {
+        let input = data("case9.m");
+        let text = package_text(&input, None, 0).unwrap();
+        let pkg = CompilerPackage::from_json(&text).unwrap();
+        assert_eq!(pkg.model_kind, powerio_pkg::ModelKind::Balanced);
+        assert!(pkg.kind_is_consistent());
+        assert_eq!(pkg.as_balanced().unwrap().buses.len(), 9);
+        match &pkg.origin {
+            Origin::File {
+                path,
+                format,
+                retained_source,
+                ..
+            } => {
+                assert_eq!(path, &input.display().to_string());
+                assert_eq!(format, "matpower");
+                assert!(*retained_source);
+            }
+            other => panic!("expected file origin, got {other:?}"),
+        }
+        assert_eq!(pkg.sources.len(), 1);
+        assert_eq!(pkg.sources[0].id, "src0");
+        assert_eq!(pkg.sources[0].kind, "file");
+        assert_eq!(
+            pkg.sources[0].path.as_deref(),
+            Some(input.to_str().unwrap())
+        );
+        assert_eq!(pkg.sources[0].format.as_deref(), Some("matpower"));
+    }
+
+    #[test]
+    fn package_command_writes_output_file() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let output = std::env::temp_dir().join(format!("powerio-package-{stamp}.pio.json"));
+
+        run_package(&data("case9.m"), Some(&output), None, 0).unwrap();
+        let text = std::fs::read_to_string(&output).unwrap();
+        let pkg = CompilerPackage::from_json(&text).unwrap();
+        assert_eq!(pkg.model_kind, powerio_pkg::ModelKind::Balanced);
+        assert_eq!(pkg.sources[0].format.as_deref(), Some("matpower"));
+
+        let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn package_helper_returns_stdout_text() {
+        let text = package_text(&data("case9.m"), None, 0).unwrap();
+        assert!(text.contains("\"schema\""));
+        let pkg = CompilerPackage::from_json(&text).unwrap();
+        assert_eq!(pkg.summary.elements["buses"], 9);
+    }
+
+    #[test]
+    fn package_distribution_fixture_keeps_defaulted_source_maps() {
+        let input = data("dist/micro/xfmr_single_phase.dss");
+        let pkg = build_package(&input, None, 0).unwrap();
+        assert_eq!(pkg.model_kind, powerio_pkg::ModelKind::Multiconductor);
+        match &pkg.origin {
+            Origin::File { path, format, .. } => {
+                assert_eq!(path, &input.display().to_string());
+                assert_eq!(format, "dss");
+            }
+            other => panic!("expected file origin, got {other:?}"),
+        }
+        assert_eq!(
+            pkg.sources[0].path.as_deref(),
+            Some(input.to_str().unwrap())
+        );
+        assert!(
+            pkg.source_maps
+                .iter()
+                .any(|e| e.mapping_kind == MappingKind::Defaulted),
+            "expected defaulted source map entries: {:?}",
+            pkg.source_maps
+        );
+    }
+
+    #[test]
+    fn package_rejects_non_finite_payload_before_writing() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let input = std::env::temp_dir().join(format!("powerio-package-bad-{stamp}.m"));
+        let output = std::env::temp_dir().join(format!("powerio-package-bad-{stamp}.pio.json"));
+        std::fs::write(
+            &input,
+            "\
+function mpc = bad
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+  1 3 0 0 0 0 1 1 0 230 1 1.1 0.9;
+  2 1 0 0 0 0 1 1 0 230 1 1.1 0.9;
+];
+mpc.branch = [
+  1 2 0.01 0.1 0 0 0 0 0 0 1 NaN Inf;
+];
+",
+        )
+        .unwrap();
+
+        let err = run_package(&input, Some(&output), None, 0).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("validating .pio.json package readback"),
+            "{err}"
+        );
+        assert!(!output.exists());
+
+        let _ = std::fs::remove_file(input);
+        let _ = std::fs::remove_file(output);
     }
 
     #[test]

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -16,13 +16,16 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 pub type Extras = BTreeMap<String, serde_json::Value>;
 
 /// A square matrix in conductor order, row major.
 pub type Mat = Vec<Vec<f64>>;
 
 /// Where the network came from; fixes the echo tier target.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum DistSourceFormat {
     Dss,
@@ -42,7 +45,7 @@ impl DistSourceFormat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct DistBus {
     pub id: String,
     /// Ordered terminal names; OpenDSS node numbers as strings.
@@ -63,7 +66,7 @@ pub struct DistBus {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistLineCode {
     pub name: String,
     pub n_conductors: usize,
@@ -81,7 +84,7 @@ pub struct DistLineCode {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistLine {
     pub name: String,
     pub bus_from: String,
@@ -94,7 +97,7 @@ pub struct DistLine {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistSwitch {
     pub name: String,
     pub bus_from: String,
@@ -106,7 +109,8 @@ pub struct DistSwitch {
     pub extras: Extras,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Configuration {
     Wye,
@@ -114,7 +118,7 @@ pub enum Configuration {
     SinglePhase,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistLoad {
     pub name: String,
     pub bus: String,
@@ -128,7 +132,8 @@ pub struct DistLoad {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "model", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum DistLoadVoltageModel {
     /// Constant power load. `v_nom` is volts per active phase when the source
@@ -178,7 +183,7 @@ impl DistLoadVoltageModel {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistGenerator {
     pub name: String,
     pub bus: String,
@@ -196,7 +201,7 @@ pub struct DistGenerator {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistShunt {
     pub name: String,
     pub bus: String,
@@ -207,14 +212,15 @@ pub struct DistShunt {
     pub extras: Extras,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum WindingConn {
     Wye,
     Delta,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Winding {
     pub bus: String,
     pub terminal_map: Vec<String>,
@@ -228,7 +234,7 @@ pub struct Winding {
     pub tap: f64,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DistTransformer {
     pub name: String,
     pub windings: Vec<Winding>,
@@ -239,7 +245,7 @@ pub struct DistTransformer {
     pub extras: Extras,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VoltageSource {
     pub name: String,
     pub bus: String,
@@ -253,7 +259,7 @@ pub struct VoltageSource {
 
 /// An object the reader recognized but does not type: preserved by class,
 /// name, and raw property text so conversions can warn precisely.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UntypedObject {
     pub class: String,
     pub name: String,
@@ -265,7 +271,7 @@ pub struct UntypedObject {
 /// `source` retains the original text for the byte exact echo tier;
 /// `defaulted` records, per element (`"class.name"` key), the fields the
 /// reader materialized from format defaults rather than the source text.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DistNetwork {
     pub name: Option<String>,
     /// Hz.
@@ -286,8 +292,19 @@ pub struct DistNetwork {
     /// (`solve`, `set mode=...`), in order, as (verb, args).
     pub commands: Vec<(String, String)>,
     pub options: Vec<(String, String)>,
+    /// Per-element record of which fields were materialized from a format
+    /// default. Skipped in the `.pio.json` payload: the field holds
+    /// `&'static str` (no `Deserialize`), and this provenance belongs in the
+    /// compiler package's `source_maps` as `mapping_kind = defaulted`, not in
+    /// the raw IR payload. See `docs/architecture/pio-json-schema.md`.
+    #[serde(skip)]
     pub defaulted: BTreeMap<String, Vec<&'static str>>,
     pub warnings: Vec<String>,
+    /// Retained source text for the byte-exact echo tier. Skipped in the
+    /// `.pio.json` payload (mirrors `powerio::Network::source`): keeping it out
+    /// avoids serde's `rc` feature, and retained source is an envelope concern
+    /// surfaced through `Origin::File { retained_source, .. }`.
+    #[serde(skip)]
     pub source: Option<Arc<String>>,
     pub source_format: Option<DistSourceFormat>,
     pub extras: Extras,

--- a/powerio-pkg/Cargo.toml
+++ b/powerio-pkg/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "powerio-pkg"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "The .pio.json compiler package: a versioned envelope around one PowerIO IR payload with explicit model kind, provenance, source maps, structured diagnostics, validation, and lowering history."
+readme = "README.md"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/powerio-pkg"
+keywords = ["powerio", "compiler", "ir", "diagnostics", "provenance"]
+categories = ["science", "data-structures"]
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+powerio = { workspace = true }
+powerio-dist = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/powerio-pkg/README.md
+++ b/powerio-pkg/README.md
@@ -1,0 +1,42 @@
+# powerio-pkg
+
+The `.pio.json` compiler package: a versioned envelope around one PowerIO IR
+payload.
+
+PowerIO has no single flattened "universal network" struct. It keeps two
+concrete static-grid IR families distinct:
+
+- `powerio::BalancedNetwork` — the scalar positive-sequence transmission model
+  (historically `powerio::Network`);
+- `powerio_dist::MulticonductorNetwork` — the wire-coordinate distribution model
+  (historically `powerio_dist::DistNetwork`).
+
+A `CompilerPackage` wraps exactly one of those payloads at a time and carries the
+metadata a compiler artifact needs to be trustworthy:
+
+- an explicit `model_kind` (never inferred from which field is present);
+- `producer` and `origin` metadata;
+- `sources` and `source_maps` (which canonical field came from which source
+  record, by what `mapping_kind`);
+- structured `diagnostics` with stable codes;
+- a `validation` summary;
+- `lowering_history`.
+
+It serializes to `.pio.json`. Binary `.pio` is out of scope until the JSON
+package stabilizes.
+
+See `docs/architecture/compiler-ir.md` and
+`docs/architecture/pio-json-schema.md` in the repository root.
+
+```rust
+use powerio_pkg::{CompilerPackage, ModelKind};
+
+let net = powerio::BalancedNetwork::in_memory("demo", 100.0, vec![], vec![]);
+let pkg = CompilerPackage::from_balanced(net);
+assert_eq!(pkg.model_kind(), ModelKind::Balanced);
+assert!(pkg.kind_is_consistent());
+
+let json = pkg.to_json_pretty().unwrap();
+let back = CompilerPackage::from_json(&json).unwrap();
+assert_eq!(back.model_kind(), ModelKind::Balanced);
+```

--- a/powerio-pkg/src/diagnostics.rs
+++ b/powerio-pkg/src/diagnostics.rs
@@ -1,0 +1,151 @@
+//! Structured diagnostics.
+//!
+//! A free-form `Vec<String>` warning is useful for a human but opaque to CI, an
+//! agent, or a downstream solver. Every finding a frontend, lowering pass, or
+//! backend records carries a stable [`DiagnosticCode`], a [`DiagnosticSeverity`],
+//! the [`DiagnosticStage`] it came from, a human message, and (where known) the
+//! element path and [`SourceRef`] it refers to. Human-readable warnings should
+//! be rendered from these, not the other way around.
+
+use serde::{Deserialize, Serialize};
+
+use crate::provenance::SourceRef;
+
+/// A stable, dotted diagnostic code, e.g. `EMIT.PSSE.DROP_ANGLE_LIMITS`.
+///
+/// The leading segment is the namespace and names the stage family:
+/// `PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`, `EMIT`, `BINDING`,
+/// `PARTNER`, `PERF`. The conventional shape is `NAMESPACE.SOURCE_OR_TARGET.SPECIFIC`.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DiagnosticCode(pub String);
+
+impl DiagnosticCode {
+    pub fn new(code: impl Into<String>) -> Self {
+        Self(code.into())
+    }
+
+    /// The leading dotted segment (the namespace), e.g. `EMIT` for
+    /// `EMIT.PSSE.DROP_ANGLE_LIMITS`.
+    pub fn namespace(&self) -> &str {
+        self.0.split('.').next().unwrap_or("")
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for DiagnosticCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for DiagnosticCode {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl From<String> for DiagnosticCode {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+/// Severity, ordered worst-last so [`Ord`] gives the dominant severity of a set.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiagnosticSeverity {
+    /// Useful in development; normally hidden.
+    Debug,
+    /// A provenance or normalization event worth recording.
+    Info,
+    /// Usable, but semantics were defaulted, approximated, lost, or the target
+    /// is incomplete.
+    Warning,
+    /// The package exists but the model is not valid for the intended use
+    /// without repair.
+    Error,
+    /// The package could not be produced.
+    Fatal,
+}
+
+/// The compiler stage that emitted a diagnostic.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum DiagnosticStage {
+    Parse,
+    Read,
+    Canonicalize,
+    Validate,
+    Lower,
+    Emit,
+    Bind,
+    Partner,
+}
+
+/// One structured finding.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StructuredDiagnostic {
+    pub code: DiagnosticCode,
+    pub severity: DiagnosticSeverity,
+    pub stage: DiagnosticStage,
+    pub message: String,
+    /// JSON pointer (or best-effort locator) of the element the finding is about.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub element_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_ref: Option<SourceRef>,
+    /// Code-specific structured payload, e.g. `{"dropped_fields": ["angmin"]}`.
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub details: serde_json::Map<String, serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suggested_action: Option<String>,
+    /// Workflows for which this finding is safe to ignore, e.g.
+    /// `["power_flow", "opf"]`. Empty means "no such assurance".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub safe_to_ignore: Vec<String>,
+}
+
+impl StructuredDiagnostic {
+    /// A minimal finding; fill the optional locators with the builder methods.
+    pub fn new(
+        code: impl Into<DiagnosticCode>,
+        severity: DiagnosticSeverity,
+        stage: DiagnosticStage,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code: code.into(),
+            severity,
+            stage,
+            message: message.into(),
+            element_path: None,
+            source_ref: None,
+            details: serde_json::Map::new(),
+            suggested_action: None,
+            safe_to_ignore: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_element_path(mut self, path: impl Into<String>) -> Self {
+        self.element_path = Some(path.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_source_ref(mut self, source_ref: SourceRef) -> Self {
+        self.source_ref = Some(source_ref);
+        self
+    }
+
+    #[must_use]
+    pub fn with_suggested_action(mut self, action: impl Into<String>) -> Self {
+        self.suggested_action = Some(action.into());
+        self
+    }
+}

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -1,0 +1,57 @@
+//! `powerio-pkg`: the `.pio.json` compiler package.
+//!
+//! PowerIO has no single flattened "universal network" struct. It has two
+//! concrete static-grid IR families that stay distinct:
+//!
+//! - [`powerio::BalancedNetwork`] (the scalar positive-sequence transmission
+//!   model, historically `powerio::Network`);
+//! - [`powerio_dist::MulticonductorNetwork`] (the wire-coordinate distribution
+//!   model, historically `powerio_dist::DistNetwork`).
+//!
+//! A [`CompilerPackage`] is the readable envelope that wraps exactly one of
+//! those payloads at a time, alongside the metadata a compiler artifact needs
+//! to be trustworthy: an explicit [`ModelKind`], producer and origin metadata,
+//! source maps, structured diagnostics, a validation summary, and lowering
+//! history. It serializes to `.pio.json`. See
+//! `docs/architecture/compiler-ir.md` for the architecture and
+//! `docs/architecture/pio-json-schema.md` for the field reference.
+//!
+//! The package always carries [`CompilerPackage::model_kind`] explicitly; a
+//! reader must never infer whether the payload is balanced or multiconductor
+//! from which field is present. [`CompilerPackage::kind_is_consistent`] asserts
+//! the explicit kind agrees with the payload variant.
+//!
+//! ```
+//! use powerio_pkg::{CompilerPackage, ModelKind};
+//!
+//! let net = powerio::BalancedNetwork::in_memory("demo", 100.0, vec![], vec![]);
+//! let pkg = CompilerPackage::from_balanced(net);
+//! assert_eq!(pkg.model_kind(), ModelKind::Balanced);
+//! assert!(pkg.kind_is_consistent());
+//! let json = pkg.to_json_pretty().unwrap();
+//! let back = CompilerPackage::from_json(&json).unwrap();
+//! assert_eq!(back.model_kind(), ModelKind::Balanced);
+//! ```
+//!
+//! Binary `.pio` is out of scope until the JSON package stabilizes; this crate
+//! is JSON only.
+
+pub mod diagnostics;
+pub mod lowering;
+pub mod model;
+pub mod package;
+pub mod provenance;
+pub mod summary;
+pub mod validation;
+
+pub use diagnostics::{DiagnosticCode, DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
+pub use lowering::LoweringRecord;
+pub use model::{ModelKind, ModelPayload};
+pub use package::{
+    CompilerPackage, DerivedMetadata, PIO_PACKAGE_SCHEMA_URL, PIO_PACKAGE_SCHEMA_VERSION,
+};
+pub use provenance::{
+    Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
+};
+pub use summary::{ObjectSummary, ObjectTopology, ObjectUnits};
+pub use validation::{ValidationCounts, ValidationPass, ValidationStatus, ValidationSummary};

--- a/powerio-pkg/src/lowering.rs
+++ b/powerio-pkg/src/lowering.rs
@@ -1,0 +1,53 @@
+//! A record of one lowering pass.
+//!
+//! Lowering is where PowerIO is a compiler rather than a parser: every pass that
+//! transforms one model into another (normalization, multiconductor to balanced,
+//! emission to a target format) appends a [`LoweringRecord`] to the package's
+//! `lowering_history`, so the transformation is auditable. The most consequential
+//! case, multiconductor to balanced, must be an explicit pass with diagnostics,
+//! never a silent positive-sequence projection.
+
+use serde::{Deserialize, Serialize};
+
+use crate::diagnostics::StructuredDiagnostic;
+use crate::model::ModelKind;
+use crate::validation::ValidationStatus;
+
+/// One lowering/normalization/emission pass and what it changed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LoweringRecord {
+    /// A stable pass name, e.g. `normalize-balanced` or `multiconductor-to-balanced`.
+    pub pass: String,
+    pub input_kind: ModelKind,
+    pub output_kind: ModelKind,
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub options: serde_json::Map<String, serde_json::Value>,
+    /// Modeling assumptions the pass relied on (e.g. "balanced four-wire feeder").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub assumptions: Vec<String>,
+    /// Approximations the pass introduced (e.g. "Kron reduction of neutral").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub approximations: Vec<String>,
+    /// Fields/constraints dropped because the output family cannot carry them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dropped_fields: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<StructuredDiagnostic>,
+    pub validation_status: ValidationStatus,
+}
+
+impl LoweringRecord {
+    pub fn new(pass: impl Into<String>, input_kind: ModelKind, output_kind: ModelKind) -> Self {
+        Self {
+            pass: pass.into(),
+            input_kind,
+            output_kind,
+            options: serde_json::Map::new(),
+            assumptions: Vec::new(),
+            approximations: Vec::new(),
+            dropped_fields: Vec::new(),
+            diagnostics: Vec::new(),
+            validation_status: ValidationStatus::Ok,
+        }
+    }
+}

--- a/powerio-pkg/src/model.rs
+++ b/powerio-pkg/src/model.rs
@@ -1,0 +1,80 @@
+//! The model kind and the single typed IR payload.
+//!
+//! The two IR families never merge. [`ModelKind`] is stored explicitly on the
+//! package; [`ModelPayload`] is the tagged wrapper around exactly one payload.
+//! The payload's `kind()` must agree with the package's `model_kind` (the
+//! package asserts this), but the authoritative kind is the standalone field, so
+//! a reader never infers the kind from which payload field is present.
+
+use serde::{Deserialize, Serialize};
+
+use powerio::BalancedNetwork;
+use powerio_dist::MulticonductorNetwork;
+
+/// Which concrete static-grid IR family the payload is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ModelKind {
+    /// Scalar positive-sequence transmission model ([`powerio::BalancedNetwork`]).
+    Balanced,
+    /// Wire-coordinate distribution model ([`powerio_dist::MulticonductorNetwork`]).
+    Multiconductor,
+}
+
+/// The one IR payload a package carries, tagged by `kind` in JSON so the payload
+/// is self-describing in addition to the top-level `model_kind`.
+///
+/// The payload is a direct serde snapshot of the live PowerIO Rust IR
+/// ([`powerio::Network`] / [`powerio_dist::DistNetwork`]). It is experimental: it
+/// grows whenever the IR does, with no envelope version change. Only the envelope
+/// is versioned. See `docs/architecture/pio-json-schema.md`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ModelPayload {
+    Balanced {
+        balanced_network: Box<BalancedNetwork>,
+    },
+    Multiconductor {
+        multiconductor_network: Box<MulticonductorNetwork>,
+    },
+}
+
+impl ModelPayload {
+    pub fn balanced(net: BalancedNetwork) -> Self {
+        Self::Balanced {
+            balanced_network: Box::new(net),
+        }
+    }
+
+    pub fn multiconductor(net: MulticonductorNetwork) -> Self {
+        Self::Multiconductor {
+            multiconductor_network: Box::new(net),
+        }
+    }
+
+    pub fn kind(&self) -> ModelKind {
+        match self {
+            ModelPayload::Balanced { .. } => ModelKind::Balanced,
+            ModelPayload::Multiconductor { .. } => ModelKind::Multiconductor,
+        }
+    }
+
+    /// The balanced payload, if this is one.
+    pub fn as_balanced(&self) -> Option<&BalancedNetwork> {
+        match self {
+            ModelPayload::Balanced { balanced_network } => Some(balanced_network),
+            ModelPayload::Multiconductor { .. } => None,
+        }
+    }
+
+    /// The multiconductor payload, if this is one.
+    pub fn as_multiconductor(&self) -> Option<&MulticonductorNetwork> {
+        match self {
+            ModelPayload::Multiconductor {
+                multiconductor_network,
+            } => Some(multiconductor_network),
+            ModelPayload::Balanced { .. } => None,
+        }
+    }
+}

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -1,0 +1,381 @@
+//! The `.pio.json` root object.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use powerio::{BalancedNetwork, SourceFormat};
+use powerio_dist::{DistSourceFormat, MulticonductorNetwork};
+
+use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
+use crate::lowering::LoweringRecord;
+use crate::model::{ModelKind, ModelPayload};
+use crate::provenance::{
+    Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
+};
+use crate::summary::{ObjectSummary, ObjectTopology, ObjectUnits};
+use crate::validation::ValidationSummary;
+
+/// The canonical schema URL for this package version.
+pub const PIO_PACKAGE_SCHEMA_URL: &str = "https://powerio.dev/schema/pio-package/0.1";
+
+/// The package schema version (semver). Additive fields bump the minor; field
+/// moves bump the major (or ship a migration pass).
+pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.1.0";
+
+fn default_schema_url() -> String {
+    PIO_PACKAGE_SCHEMA_URL.to_owned()
+}
+
+fn default_schema_version() -> String {
+    PIO_PACKAGE_SCHEMA_VERSION.to_owned()
+}
+
+/// Optional derived metadata: matrix statistics and cache keys.
+/// Empty by default; the scaffold never populates it.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct DerivedMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matrix_stats: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub cache_keys: BTreeMap<String, String>,
+}
+
+impl DerivedMetadata {
+    fn is_empty(&self) -> bool {
+        self.matrix_stats.is_none() && self.cache_keys.is_empty()
+    }
+}
+
+/// The compiler package: a versioned envelope around one IR payload plus the
+/// provenance, diagnostics, validation, and lowering history that make the
+/// artifact trustworthy. Serializes to `.pio.json`.
+///
+/// `model_kind` is stored explicitly and is authoritative; the payload is also
+/// self-describing (tagged by `kind`). [`CompilerPackage::kind_is_consistent`]
+/// asserts the two agree. Unknown future top-level fields are tolerated on read
+/// (ignored) so a newer producer's package still deserializes here.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CompilerPackage {
+    /// The schema URL identifying this package format.
+    #[serde(default = "default_schema_url")]
+    pub schema: String,
+    /// The package schema version (semver).
+    #[serde(default = "default_schema_version")]
+    pub schema_version: String,
+    pub producer: Producer,
+    /// Stable content id, e.g. `"sha256:..."`. The scaffold leaves it `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package_id: Option<String>,
+    /// RFC 3339 build timestamp. Left `None` by default for deterministic,
+    /// round-trip-stable output; set explicitly when a timestamp is wanted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    /// Explicit model kind. Authoritative; never inferred from field presence.
+    pub model_kind: ModelKind,
+    pub model: ModelPayload,
+    pub origin: Origin,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sources: Vec<SourceDescriptor>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_maps: Vec<SourceMapEntry>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<StructuredDiagnostic>,
+    pub validation: ValidationSummary,
+    #[serde(default)]
+    pub summary: ObjectSummary,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub lowering_history: Vec<LoweringRecord>,
+    #[serde(default, skip_serializing_if = "DerivedMetadata::is_empty")]
+    pub derived: DerivedMetadata,
+}
+
+impl CompilerPackage {
+    /// Wrap a balanced network. Origin is inferred from its source format:
+    /// `InMemory` / `Derived` (normalized) / `File` (a parsed text format,
+    /// recording whether source was retained; the path is not captured here).
+    pub fn from_balanced(net: BalancedNetwork) -> Self {
+        let origin = balanced_origin(&net);
+        let summary = balanced_summary(&net);
+        Self {
+            schema: default_schema_url(),
+            schema_version: default_schema_version(),
+            producer: Producer::powerio(),
+            package_id: None,
+            created_at: None,
+            model_kind: ModelKind::Balanced,
+            model: ModelPayload::balanced(net),
+            origin,
+            sources: Vec::new(),
+            source_maps: Vec::new(),
+            diagnostics: Vec::new(),
+            validation: ValidationSummary::ok(),
+            summary,
+            lowering_history: Vec::new(),
+            derived: DerivedMetadata::default(),
+        }
+    }
+
+    /// Wrap a multiconductor network. Parse `warnings` are lifted into structured
+    /// diagnostics, and `defaulted` fields are lifted into source maps with
+    /// `mapping_kind = defaulted`, so the package surfaces that provenance even
+    /// though those parser-side fields are not part of the IR payload.
+    pub fn from_multiconductor(net: MulticonductorNetwork) -> Self {
+        let summary = multiconductor_summary(&net);
+        let sources = multiconductor_sources(&net);
+        let source_id = sources.first().map(|s| s.id.clone());
+        let source_maps = multiconductor_source_maps(&net, source_id.as_deref());
+        let origin = multiconductor_origin(&net);
+
+        let diagnostics: Vec<StructuredDiagnostic> = net
+            .warnings
+            .iter()
+            .map(|w| {
+                StructuredDiagnostic::new(
+                    "READ.DIST.PARSE_WARNING",
+                    DiagnosticSeverity::Warning,
+                    DiagnosticStage::Read,
+                    w.clone(),
+                )
+            })
+            .collect();
+        let validation = ValidationSummary::from_diagnostics(&diagnostics);
+
+        Self {
+            schema: default_schema_url(),
+            schema_version: default_schema_version(),
+            producer: Producer::powerio(),
+            package_id: None,
+            created_at: None,
+            model_kind: ModelKind::Multiconductor,
+            model: ModelPayload::multiconductor(net),
+            origin,
+            sources,
+            source_maps,
+            diagnostics,
+            validation,
+            summary,
+            lowering_history: Vec::new(),
+            derived: DerivedMetadata::default(),
+        }
+    }
+
+    /// The explicit model kind.
+    pub fn model_kind(&self) -> ModelKind {
+        self.model_kind
+    }
+
+    /// Whether the explicit `model_kind` agrees with the payload variant. A
+    /// reader should reject a package where this is false.
+    pub fn kind_is_consistent(&self) -> bool {
+        self.model_kind == self.model.kind()
+    }
+
+    /// The balanced payload, if this package carries one.
+    pub fn as_balanced(&self) -> Option<&BalancedNetwork> {
+        self.model.as_balanced()
+    }
+
+    /// The multiconductor payload, if this package carries one.
+    pub fn as_multiconductor(&self) -> Option<&MulticonductorNetwork> {
+        self.model.as_multiconductor()
+    }
+
+    /// Serialize to compact `.pio.json`.
+    pub fn to_json(&self) -> serde_json::Result<String> {
+        serde_json::to_string(self)
+    }
+
+    /// Serialize to pretty `.pio.json`.
+    pub fn to_json_pretty(&self) -> serde_json::Result<String> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Deserialize from `.pio.json`.
+    pub fn from_json(text: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(text)
+    }
+
+    #[must_use]
+    pub fn with_origin(mut self, origin: Origin) -> Self {
+        self.origin = origin;
+        self
+    }
+
+    #[must_use]
+    pub fn with_package_id(mut self, id: impl Into<String>) -> Self {
+        self.package_id = Some(id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_created_at(mut self, created_at: impl Into<String>) -> Self {
+        self.created_at = Some(created_at.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_sources(mut self, sources: Vec<SourceDescriptor>) -> Self {
+        self.sources = sources;
+        self
+    }
+
+    #[must_use]
+    pub fn with_source_maps(mut self, source_maps: Vec<SourceMapEntry>) -> Self {
+        self.source_maps = source_maps;
+        self
+    }
+
+    /// Append a lowering record to the history.
+    pub fn push_lowering(&mut self, record: LoweringRecord) {
+        self.lowering_history.push(record);
+    }
+}
+
+/// Canonical format name for a balanced source format.
+fn balanced_format_name(f: SourceFormat) -> &'static str {
+    match f {
+        SourceFormat::Matpower => "matpower",
+        SourceFormat::PowerModelsJson => "powermodels-json",
+        SourceFormat::EgretJson => "egret-json",
+        SourceFormat::Psse => "psse",
+        SourceFormat::PowerWorld => "powerworld",
+        SourceFormat::PandapowerJson => "pandapower-json",
+        SourceFormat::Pslf => "pslf",
+        SourceFormat::PowerWorldBinary => "powerworld-pwb",
+        SourceFormat::InMemory => "in-memory",
+        SourceFormat::Normalized => "normalized",
+        SourceFormat::Gridfm => "gridfm",
+        SourceFormat::PypsaCsv => "pypsa-csv",
+        _ => "unknown",
+    }
+}
+
+fn balanced_origin(net: &BalancedNetwork) -> Origin {
+    match net.source_format {
+        SourceFormat::InMemory => Origin::InMemory,
+        SourceFormat::Normalized => Origin::Derived {
+            parent_package_id: None,
+            pass: "normalize-balanced".to_owned(),
+            options: serde_json::Map::new(),
+        },
+        other => Origin::File {
+            path: String::new(),
+            format: balanced_format_name(other).to_owned(),
+            hash: None,
+            retained_source: net.source.is_some(),
+        },
+    }
+}
+
+fn balanced_summary(net: &BalancedNetwork) -> ObjectSummary {
+    let mut elements = BTreeMap::new();
+    elements.insert("buses".to_owned(), net.buses.len() as u64);
+    elements.insert("loads".to_owned(), net.loads.len() as u64);
+    elements.insert("shunts".to_owned(), net.shunts.len() as u64);
+    elements.insert("branches".to_owned(), net.branches.len() as u64);
+    elements.insert("generators".to_owned(), net.generators.len() as u64);
+    elements.insert("storage".to_owned(), net.storage.len() as u64);
+    elements.insert("hvdc".to_owned(), net.hvdc.len() as u64);
+    elements.insert(
+        "transformers_3w".to_owned(),
+        net.transformers_3w.len() as u64,
+    );
+
+    let reference_buses: Vec<String> = net
+        .buses
+        .iter()
+        .filter(|b| b.kind == powerio::BusType::Ref)
+        .map(|b| b.id.0.to_string())
+        .collect();
+
+    ObjectSummary {
+        elements,
+        topology: Some(ObjectTopology {
+            connected_components: None,
+            reference_buses,
+        }),
+        units: Some(ObjectUnits {
+            power: Some("MW/MVAr".to_owned()),
+            angle: Some("degrees".to_owned()),
+            base_mva: Some(net.base_mva),
+        }),
+    }
+}
+
+fn multiconductor_summary(net: &MulticonductorNetwork) -> ObjectSummary {
+    let mut elements = BTreeMap::new();
+    elements.insert("buses".to_owned(), net.buses.len() as u64);
+    elements.insert("linecodes".to_owned(), net.linecodes.len() as u64);
+    elements.insert("lines".to_owned(), net.lines.len() as u64);
+    elements.insert("switches".to_owned(), net.switches.len() as u64);
+    elements.insert("transformers".to_owned(), net.transformers.len() as u64);
+    elements.insert("loads".to_owned(), net.loads.len() as u64);
+    elements.insert("generators".to_owned(), net.generators.len() as u64);
+    elements.insert("shunts".to_owned(), net.shunts.len() as u64);
+    elements.insert("voltage_sources".to_owned(), net.sources.len() as u64);
+
+    ObjectSummary {
+        elements,
+        topology: None,
+        units: Some(ObjectUnits {
+            power: Some("W/var".to_owned()),
+            angle: Some("radians".to_owned()),
+            base_mva: None,
+        }),
+    }
+}
+
+fn multiconductor_sources(net: &MulticonductorNetwork) -> Vec<SourceDescriptor> {
+    match net.source_format {
+        Some(sf) => vec![SourceDescriptor {
+            id: "src0".to_owned(),
+            kind: "file".to_owned(),
+            path: None,
+            format: Some(dist_format_name(sf).to_owned()),
+            hash: None,
+        }],
+        None => Vec::new(),
+    }
+}
+
+fn dist_format_name(f: DistSourceFormat) -> &'static str {
+    f.name()
+}
+
+fn multiconductor_origin(net: &MulticonductorNetwork) -> Origin {
+    match net.source_format {
+        Some(sf) => Origin::File {
+            path: String::new(),
+            format: dist_format_name(sf).to_owned(),
+            hash: None,
+            retained_source: net.source.is_some(),
+        },
+        None => Origin::InMemory,
+    }
+}
+
+/// Lift the `defaulted` map into source-map entries with `mapping_kind =
+/// defaulted`. Each key is `"class.name"`; each value is the list of fields the
+/// reader materialized from a format default. The element path is a best-effort
+/// locator (a precise JSON pointer into the payload arrays is future work).
+fn multiconductor_source_maps(
+    net: &MulticonductorNetwork,
+    source_id: Option<&str>,
+) -> Vec<SourceMapEntry> {
+    let Some(source_id) = source_id else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    for (element, fields) in &net.defaulted {
+        for field in fields {
+            entries.push(SourceMapEntry {
+                element_path: format!("/model/multiconductor_network/{element}#{field}"),
+                source_ref: SourceRef::new(source_id).with_field((*field).to_owned()),
+                mapping_kind: MappingKind::Defaulted,
+                confidence: Confidence::High,
+            });
+        }
+    }
+    entries
+}

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -193,7 +193,13 @@ impl CompilerPackage {
 
     /// Deserialize from `.pio.json`.
     pub fn from_json(text: &str) -> serde_json::Result<Self> {
-        serde_json::from_str(text)
+        let pkg: Self = serde_json::from_str(text)?;
+        if !pkg.kind_is_consistent() {
+            return Err(<serde_json::Error as serde::de::Error>::custom(
+                "model_kind does not match model.kind",
+            ));
+        }
+        Ok(pkg)
     }
 
     #[must_use]

--- a/powerio-pkg/src/provenance.rs
+++ b/powerio-pkg/src/provenance.rs
@@ -1,0 +1,188 @@
+//! Producer, origin, source descriptors, and source maps.
+//!
+//! These answer the trust questions a compiler artifact must answer: which tool
+//! produced it, what the source was, and which canonical field came from which
+//! source record by what kind of mapping.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// The tool and build that produced the package.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Producer {
+    pub tool: String,
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git_commit: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub features: Vec<String>,
+}
+
+impl Producer {
+    /// The producer for packages built by this crate version of PowerIO.
+    pub fn powerio() -> Self {
+        Self {
+            tool: "powerio".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+            git_commit: None,
+            features: Vec::new(),
+        }
+    }
+}
+
+/// Where the package came from. Internally tagged on `kind` in JSON, so a reader
+/// distinguishes an in-memory model, a single text file (with or without
+/// retained source), a folder dataset, a partially decoded binary, a derived
+/// product of a lowering pass, or a composite of several sources.
+///
+/// The `hash` field is named consistently across all `Origin` variants.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Origin {
+    /// Built in process, no source artifact.
+    InMemory,
+    File {
+        path: String,
+        format: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hash: Option<String>,
+        /// Whether the original source text was retained for a byte-exact
+        /// same-format echo. The retained text itself is not embedded in the
+        /// package; this only records that it exists at the frontend.
+        #[serde(default)]
+        retained_source: bool,
+    },
+    Folder {
+        path: String,
+        format: String,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        file_hashes: BTreeMap<String, String>,
+    },
+    BinaryFile {
+        path: String,
+        format: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hash: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        decoded_sections: Vec<String>,
+    },
+    /// A model produced by a lowering/normalization pass from another package.
+    Derived {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_package_id: Option<String>,
+        pass: String,
+        #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+        options: serde_json::Map<String, serde_json::Value>,
+    },
+    /// Several sources combined, e.g. a static case plus a profile set.
+    Composite { sources: Vec<String> },
+}
+
+/// A declared source artifact, referenced from source maps and diagnostics by
+/// its `id`. (`sources[]` in the package.)
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceDescriptor {
+    pub id: String,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+}
+
+/// A pointer into one source artifact: where a canonical field came from.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRef {
+    pub source_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>,
+    /// Byte offset, for binary sources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub byte_offset: Option<u64>,
+    /// Record / section / object type, e.g. `BUS`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub record: Option<String>,
+    /// Field / property name, e.g. `VM`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+    /// Raw token / value, when safe to embed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_token: Option<String>,
+}
+
+impl SourceRef {
+    pub fn new(source_id: impl Into<String>) -> Self {
+        Self {
+            source_id: source_id.into(),
+            line: None,
+            column: None,
+            byte_offset: None,
+            record: None,
+            field: None,
+            raw_token: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_field(mut self, field: impl Into<String>) -> Self {
+        self.field = Some(field.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_line(mut self, line: u32) -> Self {
+        self.line = Some(line);
+        self
+    }
+}
+
+/// How a canonical field relates to its source value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum MappingKind {
+    /// Copied verbatim from the source.
+    Exact,
+    /// Materialized from a format default rather than the source text.
+    Defaulted,
+    /// Inferred from other source data.
+    Inferred,
+    /// Converted into canonical units (e.g. ohms to per unit).
+    ConvertedUnits,
+    /// Produced by a lowering pass (e.g. positive-sequence equivalent).
+    Lowered,
+    /// One canonical field aggregated from several source records.
+    Aggregated,
+    /// One source record split into several canonical fields/elements.
+    Split,
+    /// Synthesized with no direct source (e.g. a generated bus id).
+    Synthetic,
+    /// A source-specific extra preserved verbatim.
+    RetainedExtra,
+}
+
+/// How confident the source map entry is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Confidence {
+    Exact,
+    High,
+    Medium,
+    Low,
+}
+
+/// One `element_path -> source` mapping.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceMapEntry {
+    /// JSON pointer (or best-effort locator) into the package payload.
+    pub element_path: String,
+    pub source_ref: SourceRef,
+    pub mapping_kind: MappingKind,
+    pub confidence: Confidence,
+}

--- a/powerio-pkg/src/summary.rs
+++ b/powerio-pkg/src/summary.rs
@@ -1,0 +1,38 @@
+//! A human-oriented summary of the payload.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Element counts, topology, and unit conventions, for a quick read of a package
+/// without deserializing the whole payload.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ObjectSummary {
+    /// Element type name -> count, e.g. `{"buses": 118, "branches": 186}`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub elements: BTreeMap<String, u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub topology: Option<ObjectTopology>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub units: Option<ObjectUnits>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectTopology {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connected_components: Option<u64>,
+    /// Reference bus ids as strings (balanced ids are integers, multiconductor
+    /// ids are strings; strings cover both).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reference_buses: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ObjectUnits {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub power: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub angle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_mva: Option<f64>,
+}

--- a/powerio-pkg/src/validation.rs
+++ b/powerio-pkg/src/validation.rs
@@ -1,0 +1,113 @@
+//! The package-level validation summary.
+
+use serde::{Deserialize, Serialize};
+
+use crate::diagnostics::{DiagnosticSeverity, StructuredDiagnostic};
+
+/// Overall validation status, ordered worst-last.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationStatus {
+    Ok,
+    Info,
+    Warning,
+    Error,
+    Fatal,
+}
+
+impl ValidationStatus {
+    fn from_severity(s: DiagnosticSeverity) -> Self {
+        match s {
+            DiagnosticSeverity::Debug => ValidationStatus::Ok,
+            DiagnosticSeverity::Info => ValidationStatus::Info,
+            DiagnosticSeverity::Warning => ValidationStatus::Warning,
+            DiagnosticSeverity::Error => ValidationStatus::Error,
+            DiagnosticSeverity::Fatal => ValidationStatus::Fatal,
+        }
+    }
+}
+
+/// Counts per severity. All five are always present; zero where unused.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationCounts {
+    #[serde(default)]
+    pub fatal: u32,
+    #[serde(default)]
+    pub error: u32,
+    #[serde(default)]
+    pub warning: u32,
+    #[serde(default)]
+    pub info: u32,
+    #[serde(default)]
+    pub debug: u32,
+}
+
+impl ValidationCounts {
+    fn add(&mut self, s: DiagnosticSeverity) {
+        match s {
+            DiagnosticSeverity::Fatal => self.fatal += 1,
+            DiagnosticSeverity::Error => self.error += 1,
+            DiagnosticSeverity::Warning => self.warning += 1,
+            DiagnosticSeverity::Info => self.info += 1,
+            DiagnosticSeverity::Debug => self.debug += 1,
+        }
+    }
+}
+
+/// The status of one named validation pass.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationPass {
+    pub name: String,
+    pub status: ValidationStatus,
+}
+
+impl ValidationPass {
+    pub fn new(name: impl Into<String>, status: ValidationStatus) -> Self {
+        Self {
+            name: name.into(),
+            status,
+        }
+    }
+}
+
+/// A cheap-to-inspect summary of validation: an overall status, per-severity
+/// counts, and the named passes that ran.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationSummary {
+    pub status: ValidationStatus,
+    pub counts: ValidationCounts,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub passes: Vec<ValidationPass>,
+}
+
+impl ValidationSummary {
+    /// A clean pass with no findings.
+    pub fn ok() -> Self {
+        Self {
+            status: ValidationStatus::Ok,
+            counts: ValidationCounts::default(),
+            passes: Vec::new(),
+        }
+    }
+
+    /// Derive counts and the dominant status from a set of diagnostics.
+    pub fn from_diagnostics(diagnostics: &[StructuredDiagnostic]) -> Self {
+        let mut counts = ValidationCounts::default();
+        let mut status = ValidationStatus::Ok;
+        for d in diagnostics {
+            counts.add(d.severity);
+            status = status.max(ValidationStatus::from_severity(d.severity));
+        }
+        Self {
+            status,
+            counts,
+            passes: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_passes(mut self, passes: Vec<ValidationPass>) -> Self {
+        self.passes = passes;
+        self
+    }
+}

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -1,0 +1,322 @@
+//! Serde round-trip and invariant tests for the `.pio.json` compiler package.
+
+use powerio_pkg::{
+    CompilerPackage, Confidence, DiagnosticCode, DiagnosticSeverity, DiagnosticStage, MappingKind,
+    ModelKind, Origin, PIO_PACKAGE_SCHEMA_URL, PIO_PACKAGE_SCHEMA_VERSION, SourceDescriptor,
+    SourceMapEntry, SourceRef, StructuredDiagnostic,
+};
+
+const MATPOWER_SRC: &str = "\
+function mpc = example
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+
+fn balanced_package() -> CompilerPackage {
+    let net = powerio::parse_str(MATPOWER_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+    CompilerPackage::from_balanced(net)
+}
+
+fn multiconductor_package() -> CompilerPackage {
+    // A bare circuit materializes a vsource with several defaulted fields, which
+    // exercises the defaulted -> source-map lift.
+    let net = powerio_dist::parse_str("New Circuit.c1", "dss").expect("parse dss");
+    CompilerPackage::from_multiconductor(net)
+}
+
+/// Serialize -> deserialize -> serialize must be byte-identical (deterministic
+/// serialization), the round-trip check for payloads without `PartialEq`.
+fn assert_json_roundtrips(pkg: &CompilerPackage) {
+    let json1 = pkg.to_json_pretty().expect("serialize");
+    let back = CompilerPackage::from_json(&json1).expect("deserialize");
+    let json2 = back.to_json_pretty().expect("re-serialize");
+    assert_eq!(json1, json2, "package JSON is not round-trip stable");
+}
+
+#[test]
+fn schema_version_present_and_defaulted() {
+    let pkg = balanced_package();
+    assert_eq!(pkg.schema, PIO_PACKAGE_SCHEMA_URL);
+    assert_eq!(pkg.schema_version, PIO_PACKAGE_SCHEMA_VERSION);
+
+    // A package JSON missing schema/schema_version still deserializes, with the
+    // current schema as the default.
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    let obj = v.as_object_mut().unwrap();
+    obj.remove("schema");
+    obj.remove("schema_version");
+    let back = CompilerPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
+    assert_eq!(back.schema, PIO_PACKAGE_SCHEMA_URL);
+    assert_eq!(back.schema_version, PIO_PACKAGE_SCHEMA_VERSION);
+}
+
+#[test]
+fn balanced_payload_roundtrips() {
+    let pkg = balanced_package();
+    assert_eq!(pkg.model_kind(), ModelKind::Balanced);
+    assert!(pkg.kind_is_consistent());
+    assert_eq!(pkg.as_balanced().unwrap().buses.len(), 2);
+    assert!(pkg.as_multiconductor().is_none());
+    assert_json_roundtrips(&pkg);
+
+    // The payload survives the round trip.
+    let json = pkg.to_json_pretty().unwrap();
+    let back = CompilerPackage::from_json(&json).unwrap();
+    assert_eq!(back.as_balanced().unwrap().buses.len(), 2);
+    assert_eq!(back.as_balanced().unwrap().branches.len(), 1);
+}
+
+#[test]
+fn multiconductor_payload_roundtrips() {
+    let pkg = multiconductor_package();
+    assert_eq!(pkg.model_kind(), ModelKind::Multiconductor);
+    assert!(pkg.kind_is_consistent());
+    assert!(pkg.as_multiconductor().is_some());
+    assert!(pkg.as_balanced().is_none());
+    assert_json_roundtrips(&pkg);
+
+    let json = pkg.to_json_pretty().unwrap();
+    let back = CompilerPackage::from_json(&json).unwrap();
+    assert_eq!(back.model_kind(), ModelKind::Multiconductor);
+    // The vsource is present in the payload after the round trip.
+    assert!(!back.as_multiconductor().unwrap().sources.is_empty());
+}
+
+#[test]
+fn explicit_model_kind_is_authoritative() {
+    let pkg = balanced_package();
+    let v = serde_json::to_value(&pkg).unwrap();
+    // The kind is explicit at the top level AND on the payload, never inferred.
+    assert_eq!(v["model_kind"], serde_json::json!("balanced"));
+    assert_eq!(v["model"]["kind"], serde_json::json!("balanced"));
+    assert_eq!(
+        v["model"]["balanced_network"]["base_mva"],
+        serde_json::json!(100.0)
+    );
+
+    let multi = multiconductor_package();
+    let mv = serde_json::to_value(&multi).unwrap();
+    assert_eq!(mv["model_kind"], serde_json::json!("multiconductor"));
+    assert_eq!(mv["model"]["kind"], serde_json::json!("multiconductor"));
+}
+
+#[test]
+fn diagnostics_roundtrip() {
+    let mut pkg = balanced_package();
+    pkg.diagnostics.push(
+        StructuredDiagnostic::new(
+            "EMIT.PSSE.DROP_ANGLE_LIMITS",
+            DiagnosticSeverity::Warning,
+            DiagnosticStage::Emit,
+            "PSS/E RAW target cannot represent branch angle limits.",
+        )
+        .with_element_path("/model/balanced_network/branches/0/angmin")
+        .with_source_ref(SourceRef::new("src0").with_field("ANGMIN").with_line(88))
+        .with_suggested_action("Use MATPOWER if branch angle limits are required."),
+    );
+    pkg.validation = powerio_pkg::ValidationSummary::from_diagnostics(&pkg.diagnostics);
+
+    assert_json_roundtrips(&pkg);
+
+    let json = pkg.to_json_pretty().unwrap();
+    let back = CompilerPackage::from_json(&json).unwrap();
+    assert_eq!(back.diagnostics.len(), 1);
+    let d = &back.diagnostics[0];
+    assert_eq!(d.code, DiagnosticCode::new("EMIT.PSSE.DROP_ANGLE_LIMITS"));
+    assert_eq!(d.code.namespace(), "EMIT");
+    assert_eq!(d.severity, DiagnosticSeverity::Warning);
+    assert_eq!(d.stage, DiagnosticStage::Emit);
+    assert_eq!(
+        d.element_path.as_deref(),
+        Some("/model/balanced_network/branches/0/angmin")
+    );
+    assert_eq!(
+        d.source_ref.as_ref().unwrap().field.as_deref(),
+        Some("ANGMIN")
+    );
+    assert_eq!(
+        back.validation.status,
+        powerio_pkg::ValidationStatus::Warning
+    );
+    assert_eq!(back.validation.counts.warning, 1);
+}
+
+#[test]
+fn source_references_roundtrip() {
+    let mut pkg = balanced_package();
+    pkg = pkg
+        .with_origin(Origin::File {
+            path: "case.raw".to_owned(),
+            format: "psse-raw".to_owned(),
+            hash: Some("sha256:abc".to_owned()),
+            retained_source: true,
+        })
+        .with_sources(vec![SourceDescriptor {
+            id: "src0".to_owned(),
+            kind: "file".to_owned(),
+            path: Some("case.raw".to_owned()),
+            format: Some("psse-raw".to_owned()),
+            hash: Some("sha256:abc".to_owned()),
+        }])
+        .with_source_maps(vec![SourceMapEntry {
+            element_path: "/model/balanced_network/buses/0/vm".to_owned(),
+            source_ref: SourceRef::new("src0").with_field("VM").with_line(103),
+            mapping_kind: MappingKind::Exact,
+            confidence: Confidence::Exact,
+        }]);
+
+    assert_json_roundtrips(&pkg);
+
+    let json = pkg.to_json_pretty().unwrap();
+    let back = CompilerPackage::from_json(&json).unwrap();
+    match &back.origin {
+        Origin::File {
+            path,
+            retained_source,
+            ..
+        } => {
+            assert_eq!(path, "case.raw");
+            assert!(*retained_source);
+        }
+        other => panic!("expected File origin, got {other:?}"),
+    }
+    assert_eq!(back.sources.len(), 1);
+    assert_eq!(back.sources[0].id, "src0");
+    assert_eq!(back.source_maps.len(), 1);
+    assert_eq!(back.source_maps[0].mapping_kind, MappingKind::Exact);
+    assert_eq!(back.source_maps[0].source_ref.field.as_deref(), Some("VM"));
+}
+
+#[test]
+fn defaulted_fields_lift_into_source_maps() {
+    let pkg = multiconductor_package();
+    // The bare circuit's vsource carries defaulted fields; they surface as
+    // source-map entries with mapping_kind = defaulted.
+    assert!(
+        !pkg.source_maps.is_empty(),
+        "expected defaulted fields to lift into source maps"
+    );
+    assert!(
+        pkg.source_maps
+            .iter()
+            .all(|e| e.mapping_kind == MappingKind::Defaulted)
+    );
+    assert_eq!(pkg.sources.len(), 1);
+    assert_eq!(pkg.sources[0].format.as_deref(), Some("dss"));
+    assert_json_roundtrips(&pkg);
+}
+
+#[test]
+fn origin_distinguishes_in_memory_from_file() {
+    let in_mem = CompilerPackage::from_balanced(powerio::BalancedNetwork::in_memory(
+        "t",
+        100.0,
+        vec![],
+        vec![],
+    ));
+    assert!(matches!(in_mem.origin, Origin::InMemory));
+
+    let from_file = balanced_package();
+    assert!(matches!(from_file.origin, Origin::File { .. }));
+}
+
+#[test]
+fn unknown_future_fields_are_tolerated() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    v.as_object_mut()
+        .unwrap()
+        .insert("future_field".to_owned(), serde_json::json!({"x": 1}));
+    let json = serde_json::to_string(&v).unwrap();
+
+    // A package from a newer producer with an unknown field still deserializes,
+    // and the known fields are intact.
+    let back = CompilerPackage::from_json(&json).expect("tolerate unknown field");
+    assert_eq!(back.model_kind(), ModelKind::Balanced);
+    assert!(back.kind_is_consistent());
+    assert_eq!(back.as_balanced().unwrap().buses.len(), 2);
+}
+
+#[test]
+fn lowering_record_roundtrips() {
+    use powerio_pkg::LoweringRecord;
+    let mut pkg = balanced_package();
+    let mut rec = LoweringRecord::new(
+        "multiconductor-to-balanced",
+        ModelKind::Multiconductor,
+        ModelKind::Balanced,
+    );
+    rec.approximations
+        .push("Kron reduction of neutral conductor".to_owned());
+    rec.dropped_fields
+        .push("per-phase voltage bounds".to_owned());
+    pkg.push_lowering(rec);
+
+    assert_json_roundtrips(&pkg);
+    let back = CompilerPackage::from_json(&pkg.to_json_pretty().unwrap()).unwrap();
+    assert_eq!(back.lowering_history.len(), 1);
+    assert_eq!(
+        back.lowering_history[0].input_kind,
+        ModelKind::Multiconductor
+    );
+    assert_eq!(back.lowering_history[0].output_kind, ModelKind::Balanced);
+}
+
+#[test]
+fn load_voltage_model_survives_package_roundtrip() {
+    // The typed load voltage model (DistLoadVoltageModel) is part of the
+    // multiconductor payload; prove it round-trips through the package JSON.
+    use powerio_dist::{Configuration, DistLoad, DistLoadVoltageModel, DistNetwork, Extras};
+
+    let zip = DistLoadVoltageModel::Zip {
+        v_nom: vec![230.0, 230.0, 230.0],
+        alpha_z: vec![0.5, 0.5, 0.5],
+        alpha_i: vec![0.2, 0.2, 0.2],
+        alpha_p: vec![0.3, 0.3, 0.3],
+        beta_z: vec![0.4, 0.4, 0.4],
+        beta_i: vec![0.3, 0.3, 0.3],
+        beta_p: vec![0.3, 0.3, 0.3],
+    };
+    let mut net = DistNetwork::default();
+    net.loads.push(DistLoad {
+        name: "l1".to_owned(),
+        bus: "b1".to_owned(),
+        terminal_map: vec![
+            "a".to_owned(),
+            "b".to_owned(),
+            "c".to_owned(),
+            "n".to_owned(),
+        ],
+        configuration: Configuration::Wye,
+        p_nom: vec![100.0, 100.0, 100.0],
+        q_nom: vec![30.0, 30.0, 30.0],
+        voltage_model: zip.clone(),
+        extras: Extras::new(),
+    });
+
+    let pkg = CompilerPackage::from_multiconductor(net);
+    assert_eq!(pkg.model_kind(), ModelKind::Multiconductor);
+    assert_json_roundtrips(&pkg);
+
+    let back = CompilerPackage::from_json(&pkg.to_json_pretty().unwrap()).unwrap();
+    assert_eq!(
+        back.as_multiconductor().unwrap().loads[0].voltage_model,
+        zip
+    );
+
+    // The voltage model is tagged in the serialized payload.
+    let v = serde_json::to_value(&pkg).unwrap();
+    assert_eq!(
+        v["model"]["multiconductor_network"]["loads"][0]["voltage_model"]["model"],
+        serde_json::json!("zip")
+    );
+}

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -110,6 +110,22 @@ fn explicit_model_kind_is_authoritative() {
 }
 
 #[test]
+fn mismatched_model_kind_is_rejected() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    v.as_object_mut()
+        .unwrap()
+        .insert("model_kind".to_owned(), serde_json::json!("multiconductor"));
+    let json = serde_json::to_string(&v).unwrap();
+
+    let err = CompilerPackage::from_json(&json).expect_err("kind mismatch must be rejected");
+    assert!(
+        err.to_string().contains("model_kind does not match"),
+        "{err}"
+    );
+}
+
+#[test]
 fn diagnostics_roundtrip() {
     let mut pkg = balanced_package();
     pkg.diagnostics.push(

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -793,9 +793,7 @@ fn loads_csv(net: &Network, key_of: &HashMap<BusId, String>) -> String {
 }
 
 fn pypsa_loses_terminal_charging(br: &Branch) -> bool {
-    let Some(charging) = br.charging else {
-        return false;
-    };
+    let charging = br.terminal_charging();
     if br.is_transformer() {
         charging.g_to.abs() > f64::EPSILON || charging.b_to.abs() > f64::EPSILON
     } else {
@@ -1403,6 +1401,22 @@ mod tests {
         assert_eq!(
             csv.lines().nth(1).unwrap(),
             "transformer_1,1,2,0.125,0.5,0.25,0,100,1.05,0,true"
+        );
+    }
+
+    #[test]
+    fn transformer_legacy_b_warns_about_terminal_charging_collapse() {
+        let mut net = net_with(vec![bus(1, None), bus(2, None)]);
+        net.branches = vec![xfmr(1, 2, 50.0)];
+
+        let out = write_pypsa_csv_folder(&net, tmp_dir("xf-legacy-b-warning")).unwrap();
+
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("terminal admittance")),
+            "{:?}",
+            out.warnings
         );
     }
 


### PR DESCRIPTION
## Summary

This PR adds the first version of the PowerIO `.pio.json` compiler-package envelope.

It introduces a new `powerio-pkg` crate with a versioned `CompilerPackage` envelope containing:

- explicit `schema_version`
- explicit `model_kind`
- kind-tagged balanced or multiconductor payload
- producer metadata
- origin/source descriptors
- source references and source-map entries
- structured diagnostics
- validation summaries
- lowering records
- object summaries

The envelope is the documented package contract. The nested `balanced_network` and `multiconductor_network` payloads are currently serde snapshots of the live Rust IR and are documented as experimental until the v1 payload schema is declared.

## Scope

This PR intentionally does not:

- add new parsers;
- change conversion behavior;
- implement format-specific diagnostics;
- add CLI package commands;
- wire MCP/C ABI/Julia/Python package surfaces;
- implement multiconductor-to-balanced lowering;
- add binary `.pio` support;
- rename public `Network`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio-pkg`
- `cargo test -p powerio-dist`
- `cargo test -p powerio-capi`
- `cargo clippy --all-targets`
