### PR TITLE
Stabilize compiler package spine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- `powerio-pkg`: `.pio.json` reads now enforce the envelope compatibility rule:
+  same major `schema_version` values load, while incompatible major versions
+  fail before payload use. The mdBook schema page documents the rule.
+- Python API: removed the one release `powerio.Case` and
+  `powerio.dist.DistCase` compatibility aliases. Use `powerio.Network` /
+  `powerio.BalancedNetwork` and `powerio.dist.MulticonductorNetwork` /
+  `powerio.dist.DistNetwork`.
+
 ## 0.3.3
 
 - MCP server: **unified the advertised tool surface** to semantic verbs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
   fail before payload use. The mdBook schema page documents the rule.
 - `powerio-pkg`: balanced package output now emits source maps for stable bus,
   load, shunt, branch, and generator fields; validation diagnostics attach the
-  matching source reference where a map exists.
+  matching source reference where a map exists. Format folded fields use
+  mapping kinds such as `split`, and defaulted fields are not marked as exact
+  source fields.
 - Converter tests now compare stable per element values across writable legacy
   formats, not only counts and totals. PSLF export now warns when transformer
   charging admittance is dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,18 @@
 - `powerio-pkg`: `.pio.json` reads now enforce the envelope compatibility rule:
   same major `schema_version` values load, while incompatible major versions
   fail before payload use. The mdBook schema page documents the rule.
+- `powerio-pkg`: balanced package output now emits source maps for stable bus,
+  load, shunt, branch, and generator fields; validation diagnostics attach the
+  matching source reference where a map exists.
+- Converter tests now compare stable per element values across writable legacy
+  formats, not only counts and totals. PSLF export now warns when transformer
+  charging admittance is dropped.
 - Python API: removed the one release `powerio.Case` and
   `powerio.dist.DistCase` compatibility aliases. Use `powerio.Network` /
   `powerio.BalancedNetwork` and `powerio.dist.MulticonductorNetwork` /
   `powerio.dist.DistNetwork`.
+- No C ABI rename in this migration slice: `PIO_ABI_VERSION` stays 4 and
+  `PIO_DIST_ABI_VERSION` stays 1.
 
 ## 0.3.3
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -41,13 +41,18 @@ Rendered API docs (rustdoc) for all crates:
 
 ## Architecture
 
-`Network` is the format neutral model. Loads, shunts, branches, and generators
-are first class records. Every reader produces a `Network`; every writer consumes
-one. Adding a format means adding one reader or writer at the hub, not pairwise
+`powerio::Network` is the current balanced transmission model; v0.4 also exports
+`powerio::BalancedNetwork` as the v1 family name for that same type. Loads,
+shunts, branches, and generators are first class records. `powerio_dist` keeps
+the separate `MulticonductorNetwork` distribution model. `.pio.json` packages
+one of those model families with provenance, source maps, diagnostics,
+validation, summaries, and lowering history.
+
+Adding a format means adding one reader or writer at the hub, not pairwise
 converters. `IndexedNetwork` is the dense \\([0,n)\\) analysis view derived from a
-`Network`; matrix builders work from that view. The parser, source retaining
-writer, and converters live in `powerio`; matrix builders and graph outputs live
-in `powerio-matrix`, which re-exports `powerio`.
+balanced `Network`; matrix builders work from that view. The parser, source
+retaining writer, and converters live in `powerio`; matrix builders and graph
+outputs live in `powerio-matrix`, which re-exports `powerio`.
 
 | crate | responsibility |
 | --- | --- |

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -2,7 +2,8 @@
 
 PowerIO parses power system case files into a typed `Network`, converts between
 formats, and builds sparse matrices and graph views for solver and analysis code.
-The guide covers behavior and workflows. Rustdoc covers API details.
+This guide records behavior, conventions, and release checks. Rustdoc covers API
+details.
 
 The rules these pages document are:
 
@@ -23,8 +24,8 @@ Reference pages:
 - [DC OPF bundle](https://eigenergy.github.io/powerio/guide/dcopf-bundle.html): the Matrix Market + manifest schema the
   `dcopf` subcommand writes for a downstream solver.
 - [Generator cost policy](https://eigenergy.github.io/powerio/guide/generator-cost-policy.html): how missing generator
-  costs are handled across PSS/E, MATPOWER, DC OPF, GridFM, and future adapters.
-- [Language APIs](https://eigenergy.github.io/powerio/guide/languages.html): canonical Rust, Python, Julia, and C ABI names.
+  costs are handled across PSS/E, MATPOWER, DC OPF, GridFM, and adapters.
+- [Language APIs](https://eigenergy.github.io/powerio/guide/languages.html): shared Rust, Python, Julia, and C ABI names.
 - [Python](https://eigenergy.github.io/powerio/guide/python.html): Python install extras and API examples.
 - [PowerWorld](https://eigenergy.github.io/powerio/guide/powerworld.html): PowerWorld AUX, PWB, and PWD evidence.
 - [Architecture](https://eigenergy.github.io/powerio/guide/architecture.html): the compiler-IR architecture and the
@@ -43,7 +44,7 @@ Rendered API docs (rustdoc) for all crates:
 `Network` is the format neutral model. Loads, shunts, branches, and generators
 are first class records. Every reader produces a `Network`; every writer consumes
 one. Adding a format means adding one reader or writer at the hub, not pairwise
-converters. `IndexedNetwork` is the dense \([0,n)\) analysis view derived from a
+converters. `IndexedNetwork` is the dense \\([0,n)\\) analysis view derived from a
 `Network`; matrix builders work from that view. The parser, source retaining
 writer, and converters live in `powerio`; matrix builders and graph outputs live
 in `powerio-matrix`, which re-exports `powerio`.
@@ -54,7 +55,7 @@ in `powerio-matrix`, which re-exports `powerio`.
 | `powerio-matrix` | sparse matrices, graph views, DC OPF bundle, GridFM datasets |
 | `powerio-cli` | command line interface and TUI |
 | `powerio-py` | PyO3 extension for the Python package |
-| `powerio-capi` | C ABI used by C, C++, Julia, and other foreign function interfaces |
+| `powerio-capi` | C ABI for C, C++, Julia, and other foreign function interfaces |
 | `powerio-dist` | multiconductor distribution model and converters |
 | `powerio-pkg` | `.pio.json` package envelope |
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,15 +1,16 @@
 # Architecture
 
-How PowerIO is organized as a compiler for power system data: distinct model
-families and a `.pio.json` compiler package.
+PowerIO treats case IO as a compiler pipeline: source formats parse into typed
+models, passes derive normalized or lowered views, and writers emit target
+artifacts.
 
 - [Compiler IR](https://eigenergy.github.io/powerio/guide/compiler-ir.html): the IR layers, the `BalancedNetwork` and
   `MulticonductorNetwork` model families, and the `CompilerPackage` (`.pio.json`)
   envelope — explicit model kind, provenance, source maps, structured
   diagnostics, validation, and lowering.
 - [PIO JSON schema](https://eigenergy.github.io/powerio/guide/pio-json-schema.html): the `.pio.json` field reference and
-  the stability policy — the envelope is versioned, the nested IR payloads are
-  experimental.
+  the stability policy. The envelope is versioned; the nested IR payloads still
+  follow the Rust models.
 - [v0.4 release direction](https://eigenergy.github.io/powerio/guide/v0.4-release-direction.html): the design direction
   for explicit `MulticonductorNetwork` to `BalancedNetwork` lowering.
 

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -87,7 +87,8 @@ retained source), a folder dataset, a partially decoded binary, a derived
 product, or a composite. A `SourceMapEntry` points from a payload field to its
 source with an `element_path`, a `SourceRef` into a declared source, a
 `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`, `lowered`,
-`aggregated`, `split`, `synthetic`, `retained_extra`), and a `confidence`. Parser
+`aggregated`, `split`, `synthetic`, `retained_extra`), and a `confidence`.
+Balanced `source_ref.field` values use canonical payload field names. Parser
 bookkeeping that should not live in the IR payload (retained source text,
 default-materialization records) is lifted into this layer rather than the raw
 payload.

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -2,14 +2,13 @@
 
 PowerIO is organized as a compiler for power system data: frontends parse source
 formats into typed IR, passes normalize and lower it, and backends emit target
-artifacts. This document defines the IR boundaries and the `.pio.json` compiler
-package that ties them together. The field-level reference for the package is in
+artifacts. The IR boundaries and the `.pio.json` package are below. The field
+reference for the package is in
 [the PIO JSON schema guide](https://eigenergy.github.io/powerio/guide/pio-json-schema.html).
 
-The governing decision is that there is no single flattened universal `Network`
-mega-struct. There are concrete model families, and a package object that wraps
-one payload at a time with the metadata that makes a compiler artifact
-trustworthy.
+There is no flattened universal `Network` mega-struct. PowerIO keeps concrete
+model families separate. The package wraps one payload at a time with source,
+diagnostic, validation, and lowering metadata.
 
 ## Model families
 
@@ -39,12 +38,17 @@ A balanced model cannot represent conductor-level asymmetry; a multiconductor
 model carries terminal and grounding data that has no place in a positive
 sequence struct. The two families never merge into one struct.
 
+BMOPF JSON is the strict exchange format for the distribution family. The
+`.pio.json` package uses the same `MulticonductorNetwork` model and wraps it
+with compiler metadata: model kind, provenance, source maps, diagnostics,
+validation, and lowering history.
+
 ## The compiler package (`.pio.json`)
 
 `powerio_pkg::CompilerPackage` is the readable envelope. It is the object that
-records how a source was interpreted, and it is the interchange layer for
-language bindings. Binary `.pio` is out of scope until the JSON package
-stabilizes.
+records how a source was interpreted. Language bindings can pass the package
+without guessing whether it holds balanced or multiconductor data. Binary `.pio`
+is out of scope until the JSON package settles.
 
 A package always carries:
 
@@ -72,16 +76,16 @@ reject a package where they do not.
 
 The envelope is the versioned, documented surface. The nested `balanced_network`
 / `multiconductor_network` payloads are direct serde snapshots of the live
-PowerIO Rust IR and are experimental until a v1 payload schema is declared; they
-grow whenever the IR grows. See
+PowerIO Rust IR. They can change whenever the Rust models change, until a v1
+payload schema is declared. See
 [the PIO JSON schema guide](https://eigenergy.github.io/powerio/guide/pio-json-schema.html).
 
 ### Provenance and source maps
 
 `Origin` distinguishes an in-memory model, a single file (with or without
 retained source), a folder dataset, a partially decoded binary, a derived
-product, or a composite. A `SourceMapEntry` answers "where did this canonical
-field come from?" with an `element_path`, a `SourceRef` into a declared source, a
+product, or a composite. A `SourceMapEntry` points from a payload field to its
+source with an `element_path`, a `SourceRef` into a declared source, a
 `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`, `lowered`,
 `aggregated`, `split`, `synthetic`, `retained_extra`), and a `confidence`. Parser
 bookkeeping that should not live in the IR payload (retained source text,
@@ -101,11 +105,11 @@ by leading segment (`PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`,
 
 ### Lowering
 
-Every pass that transforms one model into another appends a `LoweringRecord`
+Each pass that transforms one model into another appends a `LoweringRecord`
 (input and output kind, options, assumptions, approximations, dropped fields,
-diagnostics, validation status) to `lowering_history`, so the transformation is
-auditable rather than implicit. This change set defines the record shape; the
-passes themselves are later work. The v0.4.0 design direction for
+diagnostics, validation status) to `lowering_history`. The record makes the
+transformation explicit. This change set defines the record shape; lowering
+implementations are separate work. The v0.4.0 direction for
 `MulticonductorNetwork` to `BalancedNetwork` lowering is in
 [the v0.4 release direction](https://eigenergy.github.io/powerio/guide/v0.4-release-direction.html); the implementation is
 tracked in #145.

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -114,4 +114,6 @@ tracked in #145.
 
 `schema_version` is semver. Additive envelope fields bump the minor; field moves
 bump the major or ship a migration. Unknown future top-level fields are tolerated
-on read (ignored), so a package from a newer producer still deserializes.
+on read (ignored), so a package from a newer producer still deserializes when
+the `schema_version` major version matches. A different major version is
+rejected before payload use.

--- a/docs/src/dcopf-bundle.md
+++ b/docs/src/dcopf-bundle.md
@@ -1,9 +1,8 @@
-# DC OPF Bundle Schema (experimental)
+# DC OPF Bundle Schema
 
 `powerio dcopf <case>.m -o <out>` (or `opf_pipeline::write_dcopf_bundle`) writes
 `<out>/<case>_dcopf/`: a set of Matrix Market files plus `dcopf_meta.json`.
-Everything is a pure function of the case. This documents what each file is and
-the conventions a consumer (e.g. a C++ Laplacian solver) needs.
+Everything is a pure function of the case. The files and conventions are below.
 
 ## Conventions
 
@@ -13,14 +12,14 @@ the conventions a consumer (e.g. a C++ Laplacian solver) needs.
 - **Index base.** `.mtx` row/column indices are **1-based** (Matrix Market
   standard). `reference_buses` in the manifest are **0-based** dense bus indices.
 - **Sign convention.** The Laplacians are the **positive (M-matrix) form**:
-  diagonal \(> 0\), off-diagonal \(< 0\), with
-  \(L_{ii} = \sum_j \lvert L_{ij} \rvert\) for \(L\). An off-diagonal entry is
-  \(L_{ij} = -b_e\) for the branch between \(i\) and \(j\), so a consumer
-  recovers the edge weight as \(-L_{ij} > 0\).
+  diagonal \\(> 0\\), off-diagonal \\(< 0\\), with
+  \\(L_{ii} = \sum_j \lvert L_{ij} \rvert\\) for \\(L\\). An off-diagonal entry is
+  \\(L_{ij} = -b_e\\) for the branch between \\(i\\) and \\(j\\), so a consumer
+  recovers the edge weight as \\(-L_{ij} > 0\\).
 - **Units.** `PerUnit` by default: power divided by `base_mva`, cost scaled so
   it is a function of per unit power:
-  \(q \leftarrow 2c_2 \cdot \mathrm{base}^2\) and
-  \(c \leftarrow c_1 \cdot \mathrm{base}\). `Native` keeps MW / native cost.
+  \\(q \leftarrow 2c_2 \cdot \mathrm{base}^2\\) and
+  \\(c \leftarrow c_1 \cdot \mathrm{base}\\). `Native` keeps MW / native cost.
   The choice is recorded in the manifest.
 - **Generator costs.** The default DC OPF export policy is `require`: an
   in-service generator without cost data is an error. Use `--missing-gen-cost`
@@ -29,27 +28,27 @@ the conventions a consumer (e.g. a C++ Laplacian solver) needs.
   as a 0-based dense index. Each in-service island needs at least one reference.
   If several references lie in one island, the bundle fixes all of those voltage
   angles to zero; it is not a participation factor slack model.
-- **DC convention.** `PaperPure` by default (\(b_e = 1/x\), taps and phase shifts
-  ignored). `Matpower` uses \(b_e = 1/(x \tau)\) plus the phase shift injection
+- **DC convention.** `PaperPure` by default (\\(b_e = 1/x\\), taps and phase shifts
+  ignored). `Matpower` uses \\(b_e = 1/(x \tau)\\) plus the phase shift injection
   `p_shift`. Recorded in the manifest.
 
 ## Matrices
 
 | file | shape | what |
 |------|-------|------|
-| `A.mtx` | \(n \times m\) | signed incidence; column \(e\) has \(+1\) at from-bus, \(-1\) at to-bus |
-| `L.mtx` | \(n \times n\) | generic Laplacian \(L = A \operatorname{diag}(b) A^\mathsf{T}\), singular with \(\operatorname{rank}(L) = n - 1\), \(\mathbf{1} \in \ker L\) |
-| `L_grounded.mtx` | \((n-k) \times (n-k)\) | \(L\) with \(k\) reference rows and columns removed; SPD when every island is grounded |
-| `BAt.mtx` | \(m \times n\) | flow map \(B A^\mathsf{T}\), where \(f = B A^\mathsf{T} \theta\) |
-| `Cg.mtx` | \(n \times n_{\mathrm{gen}}\) | generator-to-bus incidence, one \(1\) per column |
+| `A.mtx` | \\(n \times m\\) | signed incidence; column \\(e\\) has \\(+1\\) at from-bus, \\(-1\\) at to-bus |
+| `L.mtx` | \\(n \times n\\) | generic Laplacian \\(L = A \operatorname{diag}(b) A^\mathsf{T}\\), singular with \\(\operatorname{rank}(L) = n - 1\\), \\(\mathbf{1} \in \ker L\\) |
+| `L_grounded.mtx` | \\((n-k) \times (n-k)\\) | \\(L\\) with \\(k\\) reference rows and columns removed; SPD when every island is grounded |
+| `BAt.mtx` | \\(m \times n\\) | flow map \\(B A^\mathsf{T}\\), where \\(f = B A^\mathsf{T} \theta\\) |
+| `Cg.mtx` | \\(n \times n_{\mathrm{gen}}\\) | generator-to-bus incidence, one \\(1\\) per column |
 
 ## Vectors
 
-Bus-indexed (length \(n\)): `pd` (load), `q`/`c` (cost diag/linear), `pmax`/`pmin`
-(generation bounds), `e_r` (reference indicator: \(1\) at every reference bus, else \(0\)),
+Bus-indexed (length \\(n\\)): `pd` (load), `q`/`c` (cost diag/linear), `pmax`/`pmin`
+(generation bounds), `e_r` (reference indicator: \\(1\\) at every reference bus, else \\(0\\)),
 `p_shift` (phase shift injection, all zero unless `Matpower` + shifters).
-Branch-indexed (length \(m\)): `b` (susceptances), `fmax` (thermal limits; \(0\) means
-unlimited per MATPOWER). Generator-space provenance (length \(n_{\mathrm{gen}}\)): `q_gen`,
+Branch-indexed (length \\(m\\)): `b` (susceptances), `fmax` (thermal limits; \\(0\\) means
+unlimited per MATPOWER). Generator-space provenance (length \\(n_{\mathrm{gen}}\\)): `q_gen`,
 `c_gen`, `pmax_gen`, `pmin_gen`.
 
 ## Manifest (`dcopf_meta.json`)
@@ -61,11 +60,11 @@ unlimited per MATPOWER). Generator-space provenance (length \(n_{\mathrm{gen}}\)
 ## Solving with it
 
 The grounded system is the one to factor: `L_grounded` is SPD when every island
-has a reference. For DC power flow \(L\theta = p\) with net injection
-\(p = g - d\), drop all `reference_buses` entries from \(p\), solve
-\(L_{\mathrm{grounded}}\theta_{\mathrm{red}} = p_{\mathrm{red}}\), and set each
-reference angle to \(0\). `e_r` identifies the grounded buses without parsing the
-manifest. The full singular \(L\) can be used instead with a consistent zero-sum
+has a reference. For DC power flow \\(L\theta = p\\) with net injection
+\\(p = g - d\\), drop all `reference_buses` entries from \\(p\\), solve
+\\(L_{\mathrm{grounded}}\theta_{\mathrm{red}} = p_{\mathrm{red}}\\), and set each
+reference angle to \\(0\\). `e_r` identifies the grounded buses without parsing the
+manifest. The full singular \\(L\\) can be used instead with a consistent zero-sum
 RHS.
 
 An interior point DC OPF solver builds *reweighted* Laplacians each Newton step

--- a/docs/src/format-fidelity.md
+++ b/docs/src/format-fidelity.md
@@ -12,17 +12,17 @@ implementations and the matching powerio code:
 
 | Quantity | Convention | Reference | powerio |
 | --- | --- | --- | --- |
-| Bus type codes | \(1 = \mathrm{PQ}\), \(2 = \mathrm{PV}\), \(3 = \mathrm{ref}\), \(4 = \mathrm{isolated}\) | MATPOWER `idx_bus` | `network::BusType` |
+| Bus type codes | \\(1 = \mathrm{PQ}\\), \\(2 = \mathrm{PV}\\), \\(3 = \mathrm{ref}\\), \\(4 = \mathrm{isolated}\\) | MATPOWER `idx_bus` | `network::BusType` |
 | Impedance, susceptance | per unit on `baseMVA`, never rescaled | MATPOWER `idx_brch` (`BR_B` already per unit) | `format::matpower` |
 | Branch terminal admittance | MATPOWER `BR_B` splits half to each end; richer sources use canonical `g_fr`/`b_fr`/`g_to`/`b_to`; one-value targets receive the total susceptance projection | PowerModels `matpower.jl`; MATPOWER `idx_brch` | `network::BranchCharging`, `Branch::terminal_charging` |
 | Tap ratio | `0` means a line (treated as `1`); nonzero is a transformer | MATPOWER `idx_brch` `TAP` | `Branch::effective_tap` |
 | Phase shift, angle | degrees in the model; PowerModels JSON carries radians | PowerModels `make_per_unit!` | `format::powermodels` |
 | Angle limits | `angmin`/`angmax` default ±360 (unconstrained) | MATPOWER `idx_brch` `ANGMIN`/`ANGMAX` | `Branch::has_angle_limits` |
-| pandapower/PyPSA impedance | line `r/x` are converted between per unit and ohms with \(Z_{\mathrm{base}} = V_{\mathrm{kV}}^2 / \mathrm{baseMVA}\); pandapower line charging is capacitance per km (`c_nf_per_km`, converted via \(2\pi f \ell Z_{\mathrm{base}}\)); PyPSA line `b` is siemens | pandapower PPC conversion, PyPSA static components | `format::pandapower`, `format::pypsa` |
+| pandapower/PyPSA impedance | line `r/x` are converted between per unit and ohms with \\(Z_{\mathrm{base}} = V_{\mathrm{kV}}^2 / \mathrm{baseMVA}\\); pandapower line charging is capacitance per km (`c_nf_per_km`, converted via \\(2\pi f \ell Z_{\mathrm{base}}\\)); PyPSA line `b` is siemens | pandapower PPC conversion, PyPSA static components | `format::pandapower`, `format::pypsa` |
 | dcline `Pt`/`Qf`/`Qt` | sign flips vs MATPOWER | PowerModels `matpower.jl` | `format::powermodels` |
-| Generator cost | \(c_2 p^2 + c_1 p\) maps to \(q = 2c_2\), \(c = c_1\); coefficients high order first | MATPOWER `idx_cost`, egret `matpower_parser` | `GenCost::quadratic` |
+| Generator cost | \\(c_2 p^2 + c_1 p\\) maps to \\(q = 2c_2\\), \\(c = c_1\\); coefficients high order first | MATPOWER `idx_cost`, egret `matpower_parser` | `GenCost::quadratic` |
 | `source_id` | `["bus", id]` for bus-tied elements | PowerModels `matpower.jl` | `format::powermodels` |
-| PSLF shunts | EPC `pu_mw`/`pu_mvar` are per unit on `sbase`; `Network::Shunt` stores MW/MVAr at \(V = 1\) | paired EPC/RAW case checks | `format::pslf` |
+| PSLF shunts | EPC `pu_mw`/`pu_mvar` are per unit on `sbase`; `Network::Shunt` stores MW/MVAr at \\(V = 1\\) | paired EPC/RAW case checks | `format::pslf` |
 
 egret's own MATPOWER parser uses the same reductions (bus type as
 `matpower_bustype`, polynomial coefficients reversed to a `{degree: coefficient}`
@@ -52,9 +52,9 @@ sources into the non-PowerModels targets), rest on the Rust round trip suite.
 - **ExaPowerIO.jl** (`validate_exapowerio.jl`). Reads MATPOWER through powerio's C
   ABI and compares value for value.
 - **pandapower** (`validate_pandapower.py`,
-  `validate_pandapower_converter.py`). Cross-checks MATPOWER parse/\(Y_{\mathrm{bus}}\) and
+  `validate_pandapower_converter.py`). Cross-checks MATPOWER parse/\\(Y_{\mathrm{bus}}\\) and
   imports powerio's pandapower JSON output back into pandapower, comparing counts
-  and \(Y_{\mathrm{bus}}\).
+  and \\(Y_{\mathrm{bus}}\\).
 - **PyPSA** (`validate_pypsa.py`). Imports powerio's PyPSA CSV folder output and
   checks counts, totals, line r/x/b rebased from ohms on the bus0 voltage, and
   transformer r/x/tap_ratio/s_nom rebased from the transformer `s_nom` base; a
@@ -104,12 +104,12 @@ in Python), naming the table and counting the affected rows.
 `convert_file`/`convert_str` fold the read warnings into `Conversion::warnings`.
 
 - **PSS/E** reads revisions 33, 34, and 35. 3-winding transformers are kept as
-  typed records and star-lowered into \(Y_{\mathrm{bus}}\)/connectivity by the indexed view;
+  typed records and star-lowered into \\(Y_{\mathrm{bus}}\\)/connectivity by the indexed view;
   two-terminal DC lines map to the neutral HVDC model. A switched shunt keeps its
   steady-state susceptance `BINIT` as the shunt `b` and carries its mode, voltage
   band, regulated bus, and step blocks. A 2-winding transformer's magnetizing
-  susceptance round-trips through `MAG2` (\(\mathrm{CM} = 1\)). Impedances are assumed on the
-  system base (\(\mathrm{CZ} = \mathrm{CW} = 1\)).
+  susceptance round-trips through `MAG2` (\\(\mathrm{CM} = 1\\)). Impedances are assumed on the
+  system base (\\(\mathrm{CZ} = \mathrm{CW} = 1\\)).
 - **PowerWorld** `.aux` carries no system base, so the reader defaults to 100 MVA.
   No third-party `.aux` reader exists, so that writer is validated by powerio's own
   read back plus a PowerModels JSON bridge.
@@ -117,7 +117,7 @@ in Python), naming the table and counting the affected rows.
   buses, lines, two- and three-winding transformers, generators, loads, fixed
   shunts, controlled shunts at initial `g/b`, and limited two-terminal DC records.
   Three-winding transformers are kept as typed records and star-lowered into
-  \(Y_{\mathrm{bus}}\)/connectivity by the indexed view. Unsupported sections stay in the
+  \\(Y_{\mathrm{bus}}\\)/connectivity by the indexed view. Unsupported sections stay in the
   retained source text and emit warnings.
 - **MATPOWER** canonical output (for a case that did not originate as MATPOWER)
   omits dcline; the byte exact echo path keeps it when the case was read from
@@ -128,13 +128,13 @@ in Python), naming the table and counting the affected rows.
 - **pandapower JSON** writes the power flow core as split oriented
   `pandapowerNet` tables. Line ohms are referred to the from bus voltage, as
   pandapower's `build_branch` reads them; a bus with baseKV 0 writes
-  `vn_kv` set to \(1\) (warned) so the per unit impedances survive. A branch with a
+  `vn_kv` set to \\(1\\) (warned) so the per unit impedances survive. A branch with a
   tap, a shift, or terminals on two voltage levels becomes a `trafo` row with
   `tap_changer_type = "Ratio"`; its MATPOWER charging b rides as one bus
-  shunt per terminal (warned, \(Y_{\mathrm{bus}}\) exact) because pandapower's magnetizing
+  shunt per terminal (warned, \\(Y_{\mathrm{bus}}\\) exact) because pandapower's magnetizing
   model is inductive only.
-  The file is labeled with `f_hz` set to \(50\) and `c_nf_per_km` compensated, so
-  a 60 Hz source keeps its exact \(Y_{\mathrm{bus}}\). Reference buses without a generator
+  The file is labeled with `f_hz` set to \\(50\\) and `c_nf_per_km` compensated, so
+  a 60 Hz source keeps its exact \\(Y_{\mathrm{bus}}\\). Reference buses without a generator
   get an `ext_grid` row, which reads back as a Ref generator. The writer also
   warns on dropped HVDC, storage, capability columns, angle limits, rate B/C,
   non-finite values (written as JSON null), and costs `poly_cost` cannot
@@ -163,7 +163,7 @@ in Python), naming the table and counting the affected rows.
   it can't recover original bus ids (synthesized `1..n`), per element load/shunt
   granularity (folded one synthetic element per bus), piecewise/cubic gen costs
   (read as none), or HVDC/storage. Because the writer stores the *effective* tap,
-  a branch with unit tap and no phase shift is read back as a line (raw \(\mathrm{tap} = 0\));
+  a branch with unit tap and no phase shift is read back as a line (raw \\(\mathrm{tap} = 0\\));
   a unity ratio, zero shift transformer in the source is thus read as a line (the
   power flow is identical). The losses are returned as a warnings list on
   `GridfmRead`, mirroring `Conversion::warnings`. The same direction writer is

--- a/docs/src/generator-cost-policy.md
+++ b/docs/src/generator-cost-policy.md
@@ -38,5 +38,5 @@ zero cost columns, but the manifest separates `missing_cost_gens`,
 `unsupported_cost_gens`, `zeroed_cost_gens`, and `synthesized_gen_costs`.
 
 OPFDataset is not a supported powerio format yet. Add a schema or sample fixture
-before implementing an adapter; if its schema requires cost columns, it should use
-the same policy rather than silently treating missing costs as real zeros.
+before implementing an adapter. If its schema requires cost columns, use the
+same policy rather than silently treating missing costs as real zeros.

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -91,6 +91,22 @@ Binding checks covered in this audit:
 | GridFM | Julia and C read GridFM through `pio_read_dir` / `"gridfm"` and surface schema losses as warnings |
 | Distribution | Python, Julia, Rust, and C use separate distribution handles; transmission and distribution conversion paths do not mix |
 
+## v0.4 naming migration
+
+The v1 naming direction separates the concrete model families from the package
+object that can hold either family. v0.4 starts that migration without changing
+parse or conversion behavior.
+
+| Surface | Removed or old name | v0.4 name | Notes |
+|---|---|---|---|
+| Rust transmission model | `powerio::Network` | `powerio::BalancedNetwork` alias | `Network` remains the concrete type in 0.4; the alias lets new code use the v1 family name. |
+| Rust distribution model | `powerio_dist::DistNetwork` | `powerio_dist::MulticonductorNetwork` alias | `DistNetwork` remains the concrete type in 0.4. |
+| Rust package object | n/a | `powerio_pkg::CompilerPackage` | Serializes to `.pio.json` and carries `model_kind`. |
+| Python transmission handle | `powerio.Case` | `powerio.Network` / `powerio.BalancedNetwork` | `Case` is removed in 0.4. |
+| Python distribution handle | `powerio.dist.DistCase` | `powerio.dist.MulticonductorNetwork` / `powerio.dist.DistNetwork` | `DistCase` is removed in 0.4. |
+| C ABI | n/a | unchanged `pio_*` / `pio_dist_*` handles | Symbol renames are not part of the 0.4 package spine. |
+| MCP | raw JSON transport | package transport later | `.pio.json` transport is tracked in #157. |
+
 ## Distribution surface (`powerio-dist`)
 
 The multiconductor distribution model follows the same taxonomy under its own

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -1,8 +1,8 @@
 # Language APIs
 
-PowerIO keeps the same IO vocabulary across Rust, Python, Julia, and the C ABI
-while using each language's own style. The goal is that a new format or dataset
-appears as a format string or convenience wrapper, not as a new naming scheme.
+PowerIO uses the same IO vocabulary across Rust, Python, Julia, and the C ABI,
+with language-specific spelling where needed. A new format or dataset should
+appear as a format string or convenience wrapper, not as a new naming scheme.
 
 Verb taxonomy:
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -6,8 +6,9 @@ appear as a format string or convenience wrapper, not as a new naming scheme.
 
 Verb taxonomy:
 
-- `parse_*`: bytes, paths, or text to typed parsed values. Case parsers return
-  `Network`; display parsers return display data.
+- `parse_*`: bytes, paths, or text to typed parsed values. Transmission parsers
+  return a balanced network handle; distribution parsers return a
+  multiconductor network handle; display parsers return display data.
 - `to_*`: `Network` to a new value
 - `convert_file`: path to target text convenience
 - `write_*`: filesystem outputs (`write_gridfm`, `write_pypsa_csv_folder`,
@@ -97,15 +98,15 @@ The v1 naming direction separates the concrete model families from the package
 object that can hold either family. v0.4 starts that migration without changing
 parse or conversion behavior.
 
-| Surface | Removed or old name | v0.4 name | Notes |
-|---|---|---|---|
-| Rust transmission model | `powerio::Network` | `powerio::BalancedNetwork` alias | `Network` remains the concrete type in 0.4; the alias lets new code use the v1 family name. |
-| Rust distribution model | `powerio_dist::DistNetwork` | `powerio_dist::MulticonductorNetwork` alias | `DistNetwork` remains the concrete type in 0.4. |
-| Rust package object | n/a | `powerio_pkg::CompilerPackage` | Serializes to `.pio.json` and carries `model_kind`. |
-| Python transmission handle | `powerio.Case` | `powerio.Network` / `powerio.BalancedNetwork` | `Case` is removed in 0.4. |
-| Python distribution handle | `powerio.dist.DistCase` | `powerio.dist.MulticonductorNetwork` / `powerio.dist.DistNetwork` | `DistCase` is removed in 0.4. |
-| C ABI | n/a | unchanged `pio_*` / `pio_dist_*` handles | Symbol renames are not part of the 0.4 package spine. |
-| MCP | raw JSON transport | package transport later | `.pio.json` transport is tracked in #157. |
+| Surface | Old name | New name | First alias release | Removal timing | Notes |
+|---|---|---|---|---|---|
+| Rust transmission model | `powerio::Network` | `powerio::BalancedNetwork` alias | 0.4.0 | none in 0.4 | `Network` remains the concrete type in 0.4; the alias lets new code use the v1 family name. |
+| Rust distribution model | `powerio_dist::DistNetwork` | `powerio_dist::MulticonductorNetwork` alias | 0.4.0 | none in 0.4 | `DistNetwork` remains the concrete type in 0.4. |
+| Rust package object | n/a | `powerio_pkg::CompilerPackage` | n/a | n/a | Serializes to `.pio.json` and carries `model_kind`. |
+| Python transmission handle | `powerio.Case` | `powerio.Network` / `powerio.BalancedNetwork` | 0.3.3 | removed in 0.4.0 | `Case` is no longer importable. |
+| Python distribution handle | `powerio.dist.DistCase` | `powerio.dist.MulticonductorNetwork` / `powerio.dist.DistNetwork` | 0.3.3 | removed in 0.4.0 | `DistCase` is no longer importable. |
+| C ABI | `PioNetwork` / `PioDistNetwork` | unchanged `pio_*` / `pio_dist_*` handles | n/a | n/a | `PIO_ABI_VERSION` stays 4 and `PIO_DIST_ABI_VERSION` stays 1; symbol renames are not part of the 0.4 package spine. |
+| MCP | older case helper names | `parse`, `save`, `summary`, `display` | 0.3.3 | kept as Python compatibility wrappers in 0.4 | Advertised tools use the semantic names; `.pio.json` MCP transport is tracked in #157. |
 
 ## Distribution surface (`powerio-dist`)
 

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -1,9 +1,9 @@
 # Matrix outputs and conventions
 
 The `powerio-matrix` crate builds sparse matrices and graph outputs for common power system representations. The outputs are derived from a parsed `Network`. The builders take the densely indexed `IndexedNetwork`, which maps bus ids to a
-contiguous \([0,n)\).
+contiguous \\([0,n)\\).
 
-The experimental DC OPF bundle has its own schema in
+The DC OPF bundle has its own schema in
 [the DC OPF bundle guide](https://eigenergy.github.io/powerio/guide/dcopf-bundle.html). Per-builder API detail is in the
 [crate docs](https://eigenergy.github.io/powerio/powerio_matrix/).
 
@@ -11,22 +11,24 @@ The experimental DC OPF bundle has its own schema in
 
 | matrix | shape | builder | notes |
 | --- | --- | --- | --- |
-| B' (FDPF) | \(n \times n\) | `build_bprime` | singular positive Laplacian, \(\operatorname{rank}(L) = n - 1\), shuntless |
-| B'' (FDPF) | \(n \times n\) | `build_bdoubleprime` | SDDM when bus shunts are present |
-| \(\Re(Y_{\mathrm{bus}})\), \(-\Im(Y_{\mathrm{bus}})\) | \(n \times n\) | `build_ybus` | full admittance, keeps taps and shifts |
-| LACPF (linear AC power flow) block | \(2n \times 2n\) | `build_lacpf` | \(\begin{bmatrix}G & -B \\\\ -B & -G\end{bmatrix}\), flat start, indefinite |
-| signed incidence \(A\) | \(n \times m\) | `build_incidence` | column \(e\) has \(+1\) at from-bus, \(-1\) at to-bus |
-| weighted Laplacian \(L\) | \(n \times n\) | `build_weighted_laplacian` | \(L = A \operatorname{diag}(w) A^\mathsf{T}\), `ground_at` removes a row/col |
-| flow map \(B A^\mathsf{T}\) | \(m \times n\) | `build_flow_map` | \(f = B A^\mathsf{T}\theta\) |
-| PTDF | \(m \times n\) | `build_ptdf` | dense; factors the Laplacian grounded at the reference buses |
-| LODF | \(m \times m\) | `build_lodf` | dense DC line-outage factors |
-| adjacency | \(n \times n\) | `build_adjacency` | sparse graph adjacency |
+| B' (FDPF) | \\(n \times n\\) | `build_bprime` | singular positive Laplacian, \\(\operatorname{rank}(L) = n - 1\\), shuntless |
+| B'' (FDPF) | \\(n \times n\\) | `build_bdoubleprime` | SDDM when bus shunts are present |
+| \\(\Re(Y_{\mathrm{bus}})\\), \\(-\Im(Y_{\mathrm{bus}})\\) | \\(n \times n\\) | `build_ybus` | full admittance, keeps taps and shifts |
+| LACPF (linear AC power flow) block | \\(2n \times 2n\\) | `build_lacpf` | \\(\begin{bmatrix}G & -B \\\\ -B & -G\end{bmatrix}\\), flat start, indefinite |
+| signed incidence \\(A\\) | \\(n \times m\\) | `build_incidence` | column \\(e\\) has \\(+1\\) at from-bus, \\(-1\\) at to-bus |
+| weighted Laplacian \\(L\\) | \\(n \times n\\) | `build_weighted_laplacian` | \\(L = A \operatorname{diag}(w) A^\mathsf{T}\\), `ground_at` removes a row/col |
+| flow map \\(B A^\mathsf{T}\\) | \\(m \times n\\) | `build_flow_map` | \\(f = B A^\mathsf{T}\theta\\) |
+| PTDF | \\(m \times n\\) | `build_ptdf` | dense; factors the Laplacian grounded at the reference buses |
+| LODF | \\(m \times m\\) | `build_lodf` | dense DC line-outage factors |
+| adjacency | \\(n \times n\\) | `build_adjacency` | sparse graph adjacency |
 | petgraph graph | n/a | `IndexedNetwork::to_petgraph` | `UnGraph<bus_idx, branch_idx>` |
 
-Computing PTDF and LODF matrices requires a linear solve, which is not the focus of powerio. Both factor the Laplacian with one row and column removed for each reference bus, using the dense Cholesky in
+Computing PTDF and LODF matrices requires a linear solve. Both factor the
+Laplacian with one row and column removed for each reference bus, using the dense
+Cholesky in
 `matrix::sensitivity`. Every connected component must contain at least one
-reference bus. PTDF is dense \(m \times n\). The DC OPF
-instance bundle (\(A\), \(b\), \(L\), costs, bounds, thermal limits, \(C_g\)) is documented in
+reference bus. PTDF is dense \\(m \times n\\). The DC OPF
+instance bundle (\\(A\\), \\(b\\), \\(L\\), costs, bounds, thermal limits, \\(C_g\\)) is documented in
 [the DC OPF bundle guide](https://eigenergy.github.io/powerio/guide/dcopf-bundle.html).
 
 ## GridFM datasets
@@ -44,31 +46,31 @@ are returned as warnings.
 
 ## Conventions
 
-- **Positive Laplacian matrices.** Off-diagonal \(< 0\), diagonal \(> 0\), with
-  \(L_{ii} = \sum_j \lvert L_{ij} \rvert\)
+- **Positive Laplacian matrices.** Off-diagonal \\(< 0\\), diagonal \\(> 0\\), with
+  \\(L_{ii} = \sum_j \lvert L_{ij} \rvert\\)
   for B' susceptance matrices. This is the M-matrix form an SDDM (symmetric diagonally dominant
   M-matrix) or Cholesky solver expects; a consumer can recover an edge weight as
-  \(-L_{ij} > 0\).
+  \\(-L_{ij} > 0\\).
 - **Bus indexing.** Bus ids are 1-based and preserved on the model as a newtype
   (the Rust [New Type Idiom](https://doc.rust-lang.org/rust-by-example/generics/new_types.html)).
-  `IndexedNetwork::bus_index(id)` is the only mapping into the dense \([0,n)\); an id
+  `IndexedNetwork::bus_index(id)` is the only mapping into the dense \\([0,n)\\); an id
   out of range is an `Error::UnknownBus`.
-- **Taps and shifts.** \(\mathrm{tap} = 0\) means \(\mathrm{tap} = 1\)
+- **Taps and shifts.** \\(\mathrm{tap} = 0\\) means \\(\mathrm{tap} = 1\\)
   (`Branch::effective_tap`). B' ignores taps and shifts; B'' keeps taps and
-  zeros only shifts; \(Y_{\mathrm{bus}}\) keeps both.
+  zeros only shifts; \\(Y_{\mathrm{bus}}\\) keeps both.
 - **Branch shunt admittance is stored per unit.** `Branch::charging` is the
-  canonical per terminal admittance when present: `g_fr`, `b_fr`, `g_to`, and
+  stored per terminal admittance when present: `g_fr`, `b_fr`, `g_to`, and
   `b_to` are already per unit on the system base. `Branch::b` is the legacy
   MATPOWER `BR_B` total projection for formats that carry only one charging
-  value. Matrix builders use `Branch::terminal_charging()`, so richer terminal
-  values feed \(Y_{\mathrm{bus}}\) even when the legacy total is zero or stale.
+  value. Matrix builders use `Branch::terminal_charging()`, so terminal values
+  feed \\(Y_{\mathrm{bus}}\\) even when the legacy total is zero or stale.
 - **B' scheme.** `Scheme` selects between the two fast decoupled load flow
-  variants for B': `Xb` weights a branch by \(1/x\) (series resistance ignored),
-  `Bx` (the default) by \(x/(r^2 + x^2)\).
+  variants for B': `Xb` weights a branch by \\(1/x\\) (series resistance ignored),
+  `Bx` (the default) by \\(x/(r^2 + x^2)\\).
 - **Zero impedance branches.** B' skips them by default
   (`BuildOptions::skip_zero_impedance`; set it `false` to get
-  `Error::ZeroImpedance`). \(Y_{\mathrm{bus}}\) scatters no admittance for them
-  (\(r^2 + x^2 = 0\))
+  `Error::ZeroImpedance`). \\(Y_{\mathrm{bus}}\\) scatters no admittance for them
+  (\\(r^2 + x^2 = 0\\))
   and the incidence builder drops them, both unconditionally. The gridfm export
   counts the drops (`dropped_zero_impedance` in `gridfm_meta.json`).
 - **Reference coverage.** `IndexedNetwork::check_reference_coverage` verifies that
@@ -76,10 +78,10 @@ are returned as warnings.
 - **Susceptance conventions for the DC approximation.** `DcConvention` selects
   the branch weight the DC builders (incidence, weighted Laplacian, PTDF/LODF,
   the DC OPF bundle) use. The default `PaperPure` is the textbook DC power flow
-  weight \(b = 1/x\), taps and shifts ignored; the resulting
-  \(L = A \operatorname{diag}(b) A^\mathsf{T}\)
+  weight \\(b = 1/x\\), taps and shifts ignored; the resulting
+  \\(L = A \operatorname{diag}(b) A^\mathsf{T}\\)
   equals B' under `Scheme::Xb`. `Matpower` reproduces MATPOWER's `makeBdc`:
-  \(b = 1/(x\tau)\) for a transformer with tap ratio \(\tau\), plus the phase shift
+  \\(b = 1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus the phase shift
   injection vector `p_shift`.
 
 ## Output
@@ -92,4 +94,4 @@ the relevant family with a JSON manifest.
 `IndexedNetwork::to_petgraph` returns the network as an undirected
 [petgraph](https://docs.rs/petgraph) graph, one node per bus and one edge per
 in-service branch. The connectivity report and the radial check are built on
-it, and it is the entry point for any other graph algorithm petgraph provides.
+it. Use the returned graph directly for other petgraph algorithms.

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -32,16 +32,17 @@ python3 benchmarks/render_tables.py
 python3 benchmarks/render_tables.py --check
 ```
 
-PowerWorld `.pwb` and `.aux` numbers come from Criterion. Fetch the public
-fixtures, run `cargo bench -p powerio --bench parse -- "parse_aux_|parse_pwb_"`,
-then run `python3 benchmarks/extract_powerworld_bench.py` before rendering the
-tables. If the Texas7k local row is published, pass its aux and pwb paths through
+PowerWorld `.pwb` and `.aux` parse timings are measured by the Rust Criterion
+benchmarks. Fetch the public fixtures, run
+`cargo bench -p powerio --bench parse -- "parse_aux_|parse_pwb_"`, then run
+`python3 benchmarks/extract_powerworld_bench.py` before rendering the tables. If
+the Texas7k local row is published, pass its aux and pwb paths through
 `POWERIO_BENCH_AUX` and `POWERIO_BENCH_PWB` during the Criterion run.
 
 Matrix builder timings are separate from parse timings. The matrix benchmark
 parses each fixture once, builds `IndexedNetwork` once, and times only derived
 matrix construction. Its pipeline row measures `Pipeline::run` for the paired
-\(Y_{\mathrm{bus}}\) export, including MTX, shunt, and metadata writes:
+\\(Y_{\mathrm{bus}}\\) export, including MTX, shunt, and metadata writes:
 
 ```sh
 cargo bench -p powerio-matrix --bench matrix

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -107,11 +107,11 @@ several canonical elements into one source row, the source map records that
 relation with another mapping kind; MATPOWER load and shunt fields use
 `mapping_kind = split` and point to the bus record while keeping fields such as
 `p`, `q`, `g`, and `b`. Values that the source format does not carry are not
-marked as exact source fields; MATPOWER `base_frequency` has no source map. When
-a multiconductor network is packaged, its `defaulted` fields lift into source
-maps with `mapping_kind = defaulted`, and its retained source becomes
-`origin.retained_source`. Validation diagnostics attach the matching
-`source_ref` when the package has a source map for the reported field.
+mapped as exact; MATPOWER `base_frequency` has no source map. When a
+multiconductor network is packaged, its `defaulted` fields lift into source maps
+with `mapping_kind = defaulted`, and its retained source becomes
+`origin.retained_source`. Validation diagnostics attach the matching `source_ref`
+when the package has a source map for the reported field.
 
 ## Example
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -1,9 +1,9 @@
 # The `.pio.json` schema
 
 `.pio.json` is the serialized form of `powerio_pkg::CompilerPackage`: a versioned
-envelope around one PowerIO IR payload. This document is the reference for the
-envelope shape and the stability policy. The crate is the implementation;
-`compiler-ir.md` is the architecture.
+envelope around one PowerIO IR payload. The envelope shape and stability policy
+are below. The crate is the implementation; `compiler-ir.md` is the architecture
+note.
 
 ## Two stability tiers
 
@@ -17,16 +17,21 @@ A `.pio.json` file has two parts with different stability promises.
 
 2. **The payload** — the `model` field's `balanced_network` /
    `multiconductor_network` object. This is a direct serde snapshot of the live
-   PowerIO Rust IR (`powerio::Network` / `powerio_dist::DistNetwork`). It is
-   **experimental**: it grows and changes whenever the IR does. Adding a new
-   typed field to a model appears in the payload with no envelope version
-   change. Do not treat the payload as a stable schema until
-   a v1 payload schema is declared. Tools that need stability should read the
-   envelope (model kind, summary, diagnostics, provenance) and treat the payload
-   as opaque or version-pinned to a producer.
+   PowerIO Rust IR (`powerio::Network` / `powerio_dist::DistNetwork`). It can
+   grow whenever the IR grows. Adding a typed field to a model appears in the
+   payload with no envelope version change. Until a v1 payload schema exists,
+   tools that need a stable contract should read the envelope (model kind,
+   summary, diagnostics, provenance) and treat the payload as opaque or pinned
+   to a producer version.
 
 `schema_version` versions the envelope only. The payload carries no separate
 version yet; pin to `producer.version` if you depend on payload fields.
+
+For distribution models, the payload follows the same multiconductor model used
+by the BMOPF reader and writer. The surrounding `.pio.json` object is the
+PowerIO package envelope: it adds model kind, provenance, source maps,
+diagnostics, validation, and lowering metadata around that model. Use the
+`bmopf-json` writer when a standalone BMOPF exchange file is needed.
 
 ## Versioning policy (envelope)
 
@@ -34,8 +39,8 @@ version yet; pin to `producer.version` if you depend on payload fields.
   `https://powerio.dev/schema/pio-package/0.1`.
 - Additive envelope fields bump the minor version.
 - Envelope field moves or removals bump the major version, or ship a migration.
-- A reader tolerates unknown future top-level fields (they are ignored, not an
-  error), so a package from a newer producer still loads. A future version may
+- A reader tolerates unknown later top-level fields (they are ignored, not an
+  error), so a package from a newer producer still loads. A later version can
   preserve them in an extras map instead of dropping them.
 - A reader accepts same major `schema_version` values and rejects a different
   major version before using the payload.
@@ -56,7 +61,7 @@ reject a package where they disagree.
 ```
 
 `model_kind` values: `balanced`, `multiconductor` (the enum is non-exhaustive;
-future families may be added).
+later families can be added).
 
 ## Envelope reference
 
@@ -68,7 +73,7 @@ future families may be added).
 | `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
 | `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
 | `model_kind` | enum | yes | `balanced` \| `multiconductor`; authoritative |
-| `model` | object | yes | `{kind, <kind>_network}`; the experimental payload |
+| `model` | object | yes | `{kind, <kind>_network}`; follows the Rust model payload |
 | `origin` | object | yes | tagged by `kind`: `in_memory` \| `file` \| `folder` \| `binary_file` \| `derived` \| `composite` |
 | `sources` | array | no | declared source artifacts: `{id, kind, path?, format?, hash?}` |
 | `source_maps` | array | no | `{element_path, source_ref, mapping_kind, confidence}` |

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -37,6 +37,8 @@ version yet; pin to `producer.version` if you depend on payload fields.
 - A reader tolerates unknown future top-level fields (they are ignored, not an
   error), so a package from a newer producer still loads. A future version may
   preserve them in an extras map instead of dropping them.
+- A reader accepts same major `schema_version` values and rejects a different
+  major version before using the payload.
 - Every package states `producer.version` and `schema_version`.
 
 ## Explicit model kind

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -100,16 +100,18 @@ A `source_map` entry records where a canonical field came from: an `element_path
 source, a `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`,
 `lowered`, `aggregated`, `split`, `synthetic`, `retained_extra`), and a
 `confidence` (`exact`, `high`, `medium`, `low`). Balanced packages emit source
-maps for stable bus, load, shunt, branch, and generator fields. Most point to an
-exact source record and field. When a source format folds several canonical
-elements into one source row, the source map records that relation with another
-mapping kind; MATPOWER load and shunt fields use `mapping_kind = split` and point
-to the bus row `PD` / `QD` / `GS` / `BS` fields. Values that the source format
-does not carry are not marked as exact source fields; MATPOWER `base_frequency`
-has no source map. When a multiconductor network is packaged, its `defaulted`
-fields lift into source maps with `mapping_kind = defaulted`, and its retained
-source becomes `origin.retained_source`. Validation diagnostics attach the
-matching `source_ref` when the package has a source map for the reported field.
+maps for stable bus, load, shunt, branch, and generator fields. Balanced
+`source_ref.field` values use the same canonical field names as the payload, so
+they can be compared directly with `element_path`. When a source format folds
+several canonical elements into one source row, the source map records that
+relation with another mapping kind; MATPOWER load and shunt fields use
+`mapping_kind = split` and point to the bus record while keeping fields such as
+`p`, `q`, `g`, and `b`. Values that the source format does not carry are not
+marked as exact source fields; MATPOWER `base_frequency` has no source map. When
+a multiconductor network is packaged, its `defaulted` fields lift into source
+maps with `mapping_kind = defaulted`, and its retained source becomes
+`origin.retained_source`. Validation diagnostics attach the matching
+`source_ref` when the package has a source map for the reported field.
 
 ## Example
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -99,12 +99,17 @@ A `source_map` entry records where a canonical field came from: an `element_path
 (a JSON pointer, or a best-effort locator in v0.1), a `source_ref` into a declared
 source, a `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`,
 `lowered`, `aggregated`, `split`, `synthetic`, `retained_extra`), and a
-`confidence` (`exact`, `high`, `medium`, `low`). Balanced packages emit exact
-record and field maps for stable bus, load, shunt, branch, and generator fields.
-When a multiconductor network is packaged, its `defaulted` fields lift into
-source maps with `mapping_kind = defaulted`, and its retained source becomes
-`origin.retained_source`. Validation diagnostics attach the matching
-`source_ref` when the package has a source map for the reported field.
+`confidence` (`exact`, `high`, `medium`, `low`). Balanced packages emit source
+maps for stable bus, load, shunt, branch, and generator fields. Most point to an
+exact source record and field. When a source format folds several canonical
+elements into one source row, the source map records that relation with another
+mapping kind; MATPOWER load and shunt fields use `mapping_kind = split` and point
+to the bus row `PD` / `QD` / `GS` / `BS` fields. Values that the source format
+does not carry are not marked as exact source fields; MATPOWER `base_frequency`
+has no source map. When a multiconductor network is packaged, its `defaulted`
+fields lift into source maps with `mapping_kind = defaulted`, and its retained
+source becomes `origin.retained_source`. Validation diagnostics attach the
+matching `source_ref` when the package has a source map for the reported field.
 
 ## Example
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -99,9 +99,12 @@ A `source_map` entry records where a canonical field came from: an `element_path
 (a JSON pointer, or a best-effort locator in v0.1), a `source_ref` into a declared
 source, a `mapping_kind` (`exact`, `defaulted`, `inferred`, `converted_units`,
 `lowered`, `aggregated`, `split`, `synthetic`, `retained_extra`), and a
-`confidence` (`exact`, `high`, `medium`, `low`). When a multiconductor network is
-packaged, its `defaulted` fields lift into source maps with `mapping_kind =
-defaulted`, and its retained source becomes `origin.retained_source`.
+`confidence` (`exact`, `high`, `medium`, `low`). Balanced packages emit exact
+record and field maps for stable bus, load, shunt, branch, and generator fields.
+When a multiconductor network is packaged, its `defaulted` fields lift into
+source maps with `mapping_kind = defaulted`, and its retained source becomes
+`origin.retained_source`. Validation diagnostics attach the matching
+`source_ref` when the package has a source map for the reported field.
 
 ## Example
 

--- a/docs/src/powerworld.md
+++ b/docs/src/powerworld.md
@@ -464,7 +464,7 @@ Two structures carry substations when the display includes substation symbols:
   dual coordinate equality, magnitude in [1, 1e7), and a marker plus
   number link to every identity row in table order. Two real decoy groups
   force that gauntlet: the era B substation field label group (same
-  count, different order; positional pairing scores \(r^2 = 0.01\) against the
+  count, different order; positional pairing scores \\(r^2 = 0.01\\) against the
   oracle) and the Texas2016 interleaved label group (marker 0x05). Both
   fail the link check; if several groups ever pass, the reader rejects
   rather than guesses.
@@ -476,18 +476,18 @@ bus symbols and other drawing objects remain undecoded.
 The coordinates are diagram positions, not geography (no probed file
 stores latitude or longitude; needle scans came back empty). The auto
 generated layouts match:
-\[
+\\[
 x = k \cdot \mathrm{longitude}, \qquad
 y = k \cdot \mathrm{merc}(\mathrm{latitude})
-\]
+\\]
 with
-\[
+\\[
 \mathrm{merc}(\mathrm{lat}) =
 \operatorname{degrees}\!\left(\ln\left(\tan\left(45^\circ + \frac{\mathrm{lat}}{2}\right)\right)\right)
-\]
+\\]
 
 Hawaii40, never hand edited, reproduces it to f64 rounding (max residual
-\(2.9 \times 10^{-11}\)) and pins \(k = 535.8160803622592\). The TAMU layouts
+\\(2.9 \times 10^{-11}\\)) and pins \\(k = 535.8160803622592\\). The TAMU layouts
 carry hand moved symbols (median residual 0.006 to 43 units across files), and
 the June 2016 writer used a different transform entirely. The reader therefore
 exposes x/y as stored;
@@ -498,7 +498,7 @@ longitude instead.
 Per file evidence (powerio/tests/powerworld_pwd.rs asserts the committed
 subset; the rest ran in the scout probes):
 
-| file | substations | aux (number, name) match | x vs longitude \(r^2\) | y vs merc(lat) \(r^2\) |
+| file | substations | aux (number, name) match | x vs longitude \\(r^2\\) | y vs merc(lat) \\(r^2\\) |
 |---|---|---|---|---|
 | ACTIVSg200 (vendored) | 111 | 111/111 | 0.99992 | 0.99980 |
 | Illinois display mislabeled ACTIVSg2000.pwd | 111 | 111/111 | 0.9972 | 0.9951 |

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -42,6 +42,16 @@ bprime = net.bprime()        # needs powerio[matrix]
 graph = net.to_networkx()    # needs powerio[graph]
 ```
 
+## Model names
+
+`powerio.Network` is the existing balanced transmission handle. v0.4 also
+exports `powerio.BalancedNetwork` as the v1 family name for the same handle.
+The old `powerio.Case` compatibility alias was removed in v0.4.
+
+For distribution models, use `powerio.dist.MulticonductorNetwork` or the
+existing `powerio.dist.DistNetwork` handle name. The old
+`powerio.dist.DistCase` alias was removed in v0.4.
+
 `parse_file(path, from_=None)` reads network case files (inferred from the
 extension, or forced with `from_`); `parse_str(text, format)` reads in-memory
 case text. Display artifacts are not network cases, so they use the separate

--- a/docs/src/reliability.md
+++ b/docs/src/reliability.md
@@ -49,13 +49,13 @@ a setup failure.
 
 ## What Is Proved
 
-The gates prove these properties when all required legs pass:
+When all required legs pass, the gates cover these properties:
 
 - writing back to the original file type preserves retained source text for
   formats whose readers keep it;
 - conversions to another file type preserve the electrical core checked by the
   oracle suite;
-- \(Y_{\mathrm{bus}}\) agrees with pandapower/PYPOWER on the MATPOWER corpus;
+- \\(Y_{\mathrm{bus}}\\) agrees with pandapower/PYPOWER on the MATPOWER corpus;
 - PSS/E read and write paths agree with PowerModels.jl on counts and aggregate
   power quantities;
 - PowerModels JSON writer and reader paths are checked separately;
@@ -67,7 +67,7 @@ The gates prove these properties when all required legs pass:
   with Arrow, GridFM, and distribution features enabled;
 - Python parse, conversion, matrix, graph, package, and display paths pass their
   binding tests when extras are installed.
-- ASV discovers and runs the Python parse, \(Y_{\mathrm{bus}}\), and B' benchmark definitions
+- ASV discovers and runs the Python parse, \\(Y_{\mathrm{bus}}\\), and B' benchmark definitions
   against the installed wheel.
 - the parser fuzz targets build and enter libFuzzer, covering the hand written
   text and binary readers.
@@ -78,4 +78,4 @@ The gates prove these properties when all required legs pass:
   integration tests.
 
 The gates do not prove every source format field is lossless. Known losses are
-part of the public behavior and must surface as warnings.
+part of the public behavior and surface as warnings.

--- a/docs/src/v0.4-release-direction.md
+++ b/docs/src/v0.4-release-direction.md
@@ -1,9 +1,9 @@
 # v0.4.0 scope: multiconductor to balanced lowering
 
-v0.4.0 scopes the first explicit lowering path from `MulticonductorNetwork` to
-`BalancedNetwork`. Issue #145 tracks the implementation. The release includes
-the design scope, the preflight helper, and lowering for transparent three phase
-inputs.
+v0.4.0 starts the explicit lowering path from `MulticonductorNetwork` to
+`BalancedNetwork`. Issue #145 tracks the implementation. The release scope is
+the design contract, the preflight helper, and lowering for transparent three
+phase inputs.
 
 ## IR boundary
 
@@ -16,10 +16,9 @@ scalar positive sequence model. It is not a merger of the two model structs, and
 it is not hidden inside package readback, format conversion, matrix builders, or
 bindings.
 
-The pass must produce a new balanced package payload and append a
-`LoweringRecord` to `lowering_history`. The record is the public audit trail for
-the pass: options, assumptions, approximations, dropped fields, diagnostics, and
-final validation status.
+The pass produces a new balanced package payload and appends a `LoweringRecord`
+to `lowering_history`. The record carries the options, assumptions,
+approximations, dropped fields, diagnostics, and final validation status.
 
 ## Supported starting point
 
@@ -30,11 +29,11 @@ and two wire inputs are not projected into positive sequence; they return
 structured diagnostics that reject the lowering or explain the approximation if
 a later policy permits one.
 
-The implementation must choose and document the sequence transform convention
-before it emits balanced data. That convention must state whether the transform
-is power invariant. Tests and diagnostics should refer to the convention by
-name, so downstream users can tell which projection produced the result. The
-initial convention is `FortescuePowerInvariant`.
+The lowering implementation names the sequence transform convention before it
+emits balanced data. The convention states whether the transform is power
+invariant. Tests and diagnostics use the same name, so downstream users can tell
+which projection produced the result. The initial convention is
+`FortescuePowerInvariant`.
 
 ## v0.4.0 implementation
 
@@ -43,9 +42,9 @@ The preflight helper checks whether a `MulticonductorNetwork` is ready for
 `LOWER.MULTI_TO_BALANCED.*` diagnostics. The lowering pass uses that result and
 emits balanced data for transparent three phase inputs.
 
-The lowering pass must emit a derived balanced model only for supported inputs.
+The lowering pass emits a derived balanced model only for supported inputs.
 Unsupported conductor sets, transformers, untyped objects, and missing phase
-references stay explicit diagnostics rather than implicit approximations.
+references stay diagnostics rather than hidden approximations.
 
 ## Diagnostics and provenance
 
@@ -54,7 +53,7 @@ unsupported conductor sets, ambiguous one wire or two wire inputs, lossy phase
 aggregation, dropped grounding or conductor detail, and any source object that
 cannot be represented in `BalancedNetwork`.
 
-The lowered package should also preserve provenance:
+The lowered package also preserves provenance:
 
 - `lowering_history` records the pass name, input and output model kinds,
   transform convention, assumptions, approximations, dropped fields, diagnostics,

--- a/docs/src/v0.4-release-direction.md
+++ b/docs/src/v0.4-release-direction.md
@@ -59,7 +59,7 @@ The lowered package also preserves provenance:
   transform convention, assumptions, approximations, dropped fields, diagnostics,
   and validation status.
 - `source_maps` use `mapping_kind = lowered`, `aggregated`, `synthetic`, or
-  `retained_extra` where balanced fields do not map exactly to one source field.
+  `retained_extra` where balanced fields do not map exactly to one source value.
 - `diagnostics` use `LOWER.*` codes for pass findings and `VALIDATE.*` codes for
   validation findings after lowering.
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1508,7 +1508,7 @@ mod tests {
                     && entry.element_path == "/model/balanced_network/buses/0/vm"
                     && entry.source_ref.source_id == "src0"
                     && entry.source_ref.record.as_deref() == Some("bus")
-                    && entry.source_ref.field.as_deref() == Some("vm")
+                    && entry.source_ref.field.as_deref() == Some("VM")
             }),
             "expected balanced source map entries: {:?}",
             pkg.source_maps

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1508,7 +1508,7 @@ mod tests {
                     && entry.element_path == "/model/balanced_network/buses/0/vm"
                     && entry.source_ref.source_id == "src0"
                     && entry.source_ref.record.as_deref() == Some("bus")
-                    && entry.source_ref.field.as_deref() == Some("VM")
+                    && entry.source_ref.field.as_deref() == Some("vm")
             }),
             "expected balanced source map entries: {:?}",
             pkg.source_maps

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1502,6 +1502,17 @@ mod tests {
             Some(input.to_str().unwrap())
         );
         assert_eq!(pkg.sources[0].format.as_deref(), Some("matpower"));
+        assert!(
+            pkg.source_maps.iter().any(|entry| {
+                entry.mapping_kind == MappingKind::Exact
+                    && entry.element_path == "/model/balanced_network/buses/0/vm"
+                    && entry.source_ref.source_id == "src0"
+                    && entry.source_ref.record.as_deref() == Some("bus")
+                    && entry.source_ref.field.as_deref() == Some("vm")
+            }),
+            "expected balanced source map entries: {:?}",
+            pkg.source_maps
+        );
     }
 
     #[test]

--- a/powerio-pkg/README.md
+++ b/powerio-pkg/README.md
@@ -25,8 +25,8 @@ metadata a compiler artifact needs to be trustworthy:
 It serializes to `.pio.json`. Binary `.pio` is out of scope until the JSON
 package stabilizes.
 
-See `docs/architecture/compiler-ir.md` and
-`docs/architecture/pio-json-schema.md` in the repository root.
+See `docs/src/compiler-ir.md` and `docs/src/pio-json-schema.md` in the
+repository root.
 
 ```rust
 use powerio_pkg::{CompilerPackage, ModelKind};

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -12,9 +12,8 @@
 //! those payloads at a time, alongside the metadata a compiler artifact needs
 //! to be trustworthy: an explicit [`ModelKind`], producer and origin metadata,
 //! source maps, structured diagnostics, a validation summary, and lowering
-//! history. It serializes to `.pio.json`. See
-//! `docs/architecture/compiler-ir.md` for the architecture and
-//! `docs/architecture/pio-json-schema.md` for the field reference.
+//! history. It serializes to `.pio.json`. See `docs/src/compiler-ir.md` for the
+//! architecture and `docs/src/pio-json-schema.md` for the field reference.
 //!
 //! The package always carries [`CompilerPackage::model_kind`] explicitly; a
 //! reader must never infer whether the payload is balanced or multiconductor

--- a/powerio-pkg/src/model.rs
+++ b/powerio-pkg/src/model.rs
@@ -28,7 +28,7 @@ pub enum ModelKind {
 /// The payload is a direct serde snapshot of the live PowerIO Rust IR
 /// ([`powerio::Network`] / [`powerio_dist::DistNetwork`]). It is experimental: it
 /// grows whenever the IR does, with no envelope version change. Only the envelope
-/// is versioned. See `docs/architecture/pio-json-schema.md`.
+/// is versioned. See `docs/src/pio-json-schema.md`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ModelPayload {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -430,11 +430,20 @@ fn balanced_value_finding_path(
         .strip_prefix("generator at bus ")
         .and_then(|s| s.parse::<usize>().ok())
     {
-        let idx = net.generators.iter().position(|g| {
-            g.bus.0 == id
-                && generator_field(g, finding.field)
-                    .is_some_and(|v| v.to_bits() == finding.old.to_bits())
-        })?;
+        let mut matches = net
+            .generators
+            .iter()
+            .enumerate()
+            .filter(|(_, g)| {
+                g.bus.0 == id
+                    && generator_field(g, finding.field)
+                        .is_some_and(|v| v.to_bits() == finding.old.to_bits())
+            })
+            .map(|(idx, _)| idx);
+        let idx = matches.next()?;
+        if matches.next().is_some() {
+            return None;
+        }
         return Some(format!(
             "/model/balanced_network/generators/{idx}/{}",
             finding.field
@@ -927,51 +936,85 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
         return Vec::new();
     };
     let mut entries = Vec::new();
+    push_balanced_network_maps(&mut entries, source_id, net.source_format);
+    push_balanced_bus_maps(&mut entries, source_id, net.buses.len());
+    push_balanced_injection_maps(&mut entries, source_id, net);
+    push_balanced_branch_maps(&mut entries, source_id, net);
+    push_balanced_generator_maps(&mut entries, source_id, net.generators.len());
+    entries
+}
+
+fn push_balanced_network_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    source_format: SourceFormat,
+) {
     push_balanced_map(
-        &mut entries,
+        entries,
         source_id,
         "/model/balanced_network/base_mva",
         "case",
         "base_mva",
     );
-    push_balanced_map(
-        &mut entries,
-        source_id,
-        "/model/balanced_network/base_frequency",
-        "case",
-        "base_frequency",
-    );
+    if let Some((record, field)) = balanced_frequency_source(source_format) {
+        push_balanced_map(
+            entries,
+            source_id,
+            "/model/balanced_network/base_frequency",
+            record,
+            field,
+        );
+    }
+}
 
+fn push_balanced_bus_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
     push_balanced_record_maps(
-        &mut entries,
+        entries,
         source_id,
         "buses",
-        net.buses.len(),
+        len,
         "bus",
         &[
             "id", "kind", "vm", "va", "base_kv", "vmax", "vmin", "area", "zone",
         ],
     );
-    push_balanced_record_maps(
-        &mut entries,
-        source_id,
-        "loads",
-        net.loads.len(),
-        "load",
-        &["bus", "p", "q", "in_service"],
-    );
-    push_balanced_record_maps(
-        &mut entries,
-        source_id,
-        "shunts",
-        net.shunts.len(),
-        "shunt",
-        &["bus", "g", "b", "in_service"],
-    );
+}
 
+fn push_balanced_injection_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    net: &BalancedNetwork,
+) {
+    if net.source_format == SourceFormat::Matpower {
+        push_matpower_injection_maps(entries, source_id, net);
+    } else {
+        push_balanced_record_maps(
+            entries,
+            source_id,
+            "loads",
+            net.loads.len(),
+            "load",
+            &["bus", "p", "q", "in_service"],
+        );
+        push_balanced_record_maps(
+            entries,
+            source_id,
+            "shunts",
+            net.shunts.len(),
+            "shunt",
+            &["bus", "g", "b", "in_service"],
+        );
+    }
+}
+
+fn push_balanced_branch_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    net: &BalancedNetwork,
+) {
     for (i, branch) in net.branches.iter().enumerate() {
         push_balanced_record_map(
-            &mut entries,
+            entries,
             source_id,
             "branches",
             i,
@@ -995,7 +1038,7 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
         if branch.charging.is_some() {
             for field in ["g_fr", "b_fr", "g_to", "b_to"] {
                 push_balanced_map(
-                    &mut entries,
+                    entries,
                     source_id,
                     &format!("/model/balanced_network/branches/{i}/charging/{field}"),
                     "branch",
@@ -1004,12 +1047,14 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
             }
         }
     }
+}
 
+fn push_balanced_generator_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
     push_balanced_record_maps(
-        &mut entries,
+        entries,
         source_id,
         "generators",
-        net.generators.len(),
+        len,
         "generator",
         &[
             "bus",
@@ -1024,8 +1069,55 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
             "in_service",
         ],
     );
+}
 
-    entries
+fn balanced_frequency_source(source_format: SourceFormat) -> Option<(&'static str, &'static str)> {
+    match source_format {
+        SourceFormat::Psse => Some(("header", "BASFRQ")),
+        SourceFormat::PandapowerJson => Some(("network", "f_hz")),
+        _ => None,
+    }
+}
+
+fn push_matpower_injection_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    net: &BalancedNetwork,
+) {
+    for (i, load) in net.loads.iter().enumerate() {
+        if net.buses.iter().any(|b| b.id == load.bus) {
+            push_matpower_split_map(entries, source_id, "loads", i, "bus", "BUS_I");
+            push_matpower_split_map(entries, source_id, "loads", i, "p", "PD");
+            push_matpower_split_map(entries, source_id, "loads", i, "q", "QD");
+            push_matpower_split_map(entries, source_id, "loads", i, "in_service", "BUS_TYPE");
+        }
+    }
+    for (i, shunt) in net.shunts.iter().enumerate() {
+        if net.buses.iter().any(|b| b.id == shunt.bus) {
+            push_matpower_split_map(entries, source_id, "shunts", i, "bus", "BUS_I");
+            push_matpower_split_map(entries, source_id, "shunts", i, "g", "GS");
+            push_matpower_split_map(entries, source_id, "shunts", i, "b", "BS");
+            push_matpower_split_map(entries, source_id, "shunts", i, "in_service", "BUS_TYPE");
+        }
+    }
+}
+
+fn push_matpower_split_map(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    collection: &str,
+    i: usize,
+    field: &str,
+    source_field: &str,
+) {
+    entries.push(SourceMapEntry {
+        element_path: format!("/model/balanced_network/{collection}/{i}/{field}"),
+        source_ref: SourceRef::new(source_id)
+            .with_record("bus")
+            .with_field(source_field),
+        mapping_kind: MappingKind::Split,
+        confidence: Confidence::High,
+    });
 }
 
 fn push_balanced_record_maps(

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -961,10 +961,15 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
     };
     let mut entries = Vec::new();
     push_balanced_network_maps(&mut entries, source_id, net.source_format);
-    push_balanced_bus_maps(&mut entries, source_id, net.buses.len());
+    push_balanced_bus_maps(&mut entries, source_id, net.source_format, net.buses.len());
     push_balanced_injection_maps(&mut entries, source_id, net);
     push_balanced_branch_maps(&mut entries, source_id, net);
-    push_balanced_generator_maps(&mut entries, source_id, net.generators.len());
+    push_balanced_generator_maps(
+        &mut entries,
+        source_id,
+        net.source_format,
+        net.generators.len(),
+    );
     entries
 }
 
@@ -978,7 +983,7 @@ fn push_balanced_network_maps(
         source_id,
         "/model/balanced_network/base_mva",
         "case",
-        "base_mva",
+        balanced_network_source_field(source_format, "base_mva"),
     );
     if let Some((record, field)) = balanced_frequency_source(source_format) {
         push_balanced_map(
@@ -991,10 +996,16 @@ fn push_balanced_network_maps(
     }
 }
 
-fn push_balanced_bus_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
+fn push_balanced_bus_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    source_format: SourceFormat,
+    len: usize,
+) {
     push_balanced_record_maps(
         entries,
         source_id,
+        source_format,
         "buses",
         len,
         "bus",
@@ -1015,6 +1026,7 @@ fn push_balanced_injection_maps(
         push_balanced_record_maps(
             entries,
             source_id,
+            net.source_format,
             "loads",
             net.loads.len(),
             "load",
@@ -1023,6 +1035,7 @@ fn push_balanced_injection_maps(
         push_balanced_record_maps(
             entries,
             source_id,
+            net.source_format,
             "shunts",
             net.shunts.len(),
             "shunt",
@@ -1040,6 +1053,7 @@ fn push_balanced_branch_maps(
         push_balanced_record_map(
             entries,
             source_id,
+            net.source_format,
             "branches",
             i,
             "branch",
@@ -1073,10 +1087,16 @@ fn push_balanced_branch_maps(
     }
 }
 
-fn push_balanced_generator_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
+fn push_balanced_generator_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    source_format: SourceFormat,
+    len: usize,
+) {
     push_balanced_record_maps(
         entries,
         source_id,
+        source_format,
         "generators",
         len,
         "generator",
@@ -1099,6 +1119,58 @@ fn balanced_frequency_source(source_format: SourceFormat) -> Option<(&'static st
     match source_format {
         SourceFormat::Psse => Some(("header", "BASFRQ")),
         SourceFormat::PandapowerJson => Some(("network", "f_hz")),
+        _ => None,
+    }
+}
+
+fn balanced_network_source_field(source_format: SourceFormat, field: &str) -> &str {
+    match source_format {
+        SourceFormat::Matpower if field == "base_mva" => "baseMVA",
+        _ => field,
+    }
+}
+
+fn balanced_source_field<'a>(source_format: SourceFormat, record: &str, field: &'a str) -> &'a str {
+    if source_format == SourceFormat::Matpower {
+        return matpower_source_field(record, field).unwrap_or(field);
+    }
+    field
+}
+
+fn matpower_source_field(record: &str, field: &str) -> Option<&'static str> {
+    match (record, field) {
+        ("bus", "id") => Some("BUS_I"),
+        ("bus", "kind") => Some("BUS_TYPE"),
+        ("bus", "vm") => Some("VM"),
+        ("bus", "va") => Some("VA"),
+        ("bus", "base_kv") => Some("BASE_KV"),
+        ("bus", "vmax") => Some("VMAX"),
+        ("bus", "vmin") => Some("VMIN"),
+        ("bus", "area") => Some("BUS_AREA"),
+        ("bus", "zone") => Some("ZONE"),
+        ("branch", "from") => Some("F_BUS"),
+        ("branch", "to") => Some("T_BUS"),
+        ("branch", "r") => Some("BR_R"),
+        ("branch", "x") => Some("BR_X"),
+        ("branch", "b") => Some("BR_B"),
+        ("branch", "rate_a") => Some("RATE_A"),
+        ("branch", "rate_b") => Some("RATE_B"),
+        ("branch", "rate_c") => Some("RATE_C"),
+        ("branch", "tap") => Some("TAP"),
+        ("branch", "shift") => Some("SHIFT"),
+        ("branch", "in_service") => Some("BR_STATUS"),
+        ("branch", "angmin") => Some("ANGMIN"),
+        ("branch", "angmax") => Some("ANGMAX"),
+        ("generator", "bus") => Some("GEN_BUS"),
+        ("generator", "pg") => Some("PG"),
+        ("generator", "qg") => Some("QG"),
+        ("generator", "qmax") => Some("QMAX"),
+        ("generator", "qmin") => Some("QMIN"),
+        ("generator", "vg") => Some("VG"),
+        ("generator", "mbase") => Some("MBASE"),
+        ("generator", "in_service") => Some("GEN_STATUS"),
+        ("generator", "pmax") => Some("PMAX"),
+        ("generator", "pmin") => Some("PMIN"),
         _ => None,
     }
 }
@@ -1173,19 +1245,29 @@ fn push_matpower_split_map(
 fn push_balanced_record_maps(
     entries: &mut Vec<SourceMapEntry>,
     source_id: &str,
+    source_format: SourceFormat,
     collection: &str,
     len: usize,
     record: &str,
     fields: &[&str],
 ) {
     for i in 0..len {
-        push_balanced_record_map(entries, source_id, collection, i, record, fields);
+        push_balanced_record_map(
+            entries,
+            source_id,
+            source_format,
+            collection,
+            i,
+            record,
+            fields,
+        );
     }
 }
 
 fn push_balanced_record_map(
     entries: &mut Vec<SourceMapEntry>,
     source_id: &str,
+    source_format: SourceFormat,
     collection: &str,
     i: usize,
     record: &str,
@@ -1197,7 +1279,7 @@ fn push_balanced_record_map(
             source_id,
             &format!("/model/balanced_network/{collection}/{i}/{field}"),
             record,
-            field,
+            balanced_source_field(source_format, record, field),
         );
     }
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -197,12 +197,28 @@ impl CompilerPackage {
     /// Deserialize from `.pio.json`.
     pub fn from_json(text: &str) -> serde_json::Result<Self> {
         let pkg: Self = serde_json::from_str(text)?;
+        if !Self::supports_schema_version(&pkg.schema_version) {
+            return Err(<serde_json::Error as serde::de::Error>::custom(format!(
+                "unsupported .pio.json schema_version {}; this reader supports major version {}",
+                pkg.schema_version,
+                supported_schema_major()
+            )));
+        }
         if !pkg.kind_is_consistent() {
             return Err(<serde_json::Error as serde::de::Error>::custom(
                 "model_kind does not match model.kind",
             ));
         }
         Ok(pkg)
+    }
+
+    /// Whether this reader accepts the envelope schema version.
+    ///
+    /// The `.pio.json` compatibility contract is envelope scoped: unknown
+    /// future top-level fields are ignored, additive same major versions load,
+    /// and a different major version is rejected before payload use.
+    pub fn supports_schema_version(version: &str) -> bool {
+        schema_major(version).is_some_and(|major| major == supported_schema_major())
     }
 
     #[must_use]
@@ -274,6 +290,21 @@ impl CompilerPackage {
         self.validation =
             ValidationSummary::from_diagnostics(&self.diagnostics).with_passes(passes);
     }
+}
+
+fn schema_major(version: &str) -> Option<u64> {
+    let mut parts = version.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    let patch = parts.next()?;
+    if major.is_empty() || minor.is_empty() || patch.is_empty() {
+        return None;
+    }
+    major.parse().ok()
+}
+
+fn supported_schema_major() -> u64 {
+    schema_major(PIO_PACKAGE_SCHEMA_VERSION).expect("package schema version has a major number")
 }
 
 const SANE_VALIDATION_CODES: [&str; 6] = [

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -301,10 +301,13 @@ fn schema_major(version: &str) -> Option<u64> {
     let major = parts.next()?;
     let minor = parts.next()?;
     let patch = parts.next()?;
-    if major.is_empty() || minor.is_empty() || patch.is_empty() {
+    if major.is_empty() || minor.is_empty() || patch.is_empty() || parts.next().is_some() {
         return None;
     }
-    major.parse().ok()
+    let major = major.parse().ok()?;
+    let _minor: u64 = minor.parse().ok()?;
+    let _patch: u64 = patch.parse().ok()?;
+    Some(major)
 }
 
 fn supported_schema_major() -> u64 {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -1,6 +1,6 @@
 //! The `.pio.json` root object.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -297,16 +297,20 @@ impl CompilerPackage {
 }
 
 fn schema_major(version: &str) -> Option<u64> {
-    let mut parts = version.split('.');
+    // Accept a semver core `MAJOR.MINOR.PATCH` with an optional prerelease
+    // (`-...`) or build (`+...`) tag: same-major additive versions load, so a
+    // forward-compatible writer that stamps e.g. `0.2.0-rc.1` is not rejected.
+    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let mut parts = core.split('.');
     let major = parts.next()?;
     let minor = parts.next()?;
     let patch = parts.next()?;
-    if major.is_empty() || minor.is_empty() || patch.is_empty() || parts.next().is_some() {
+    if parts.next().is_some() {
         return None;
     }
     let major = major.parse().ok()?;
-    let _minor: u64 = minor.parse().ok()?;
-    let _patch: u64 = patch.parse().ok()?;
+    minor.parse::<u64>().ok()?;
+    patch.parse::<u64>().ok()?;
     Some(major)
 }
 
@@ -354,15 +358,22 @@ fn sane_validate_balanced(
         ));
     }
 
+    let bus_index: HashMap<usize, usize> = net
+        .buses
+        .iter()
+        .enumerate()
+        .map(|(idx, b)| (b.id.0, idx))
+        .collect();
     let mut value_domain = Vec::new();
     for finding in net.validate_values() {
-        let element_path = balanced_value_finding_path(net, &finding).unwrap_or_else(|| {
-            format!(
-                "/model/balanced_network/{}#{}",
-                finding.element.replace(' ', "_"),
-                finding.field
-            )
-        });
+        let element_path =
+            balanced_value_finding_path(net, &bus_index, &finding).unwrap_or_else(|| {
+                format!(
+                    "/model/balanced_network/{}#{}",
+                    finding.element.replace(' ', "_"),
+                    finding.field
+                )
+            });
         let mut d = StructuredDiagnostic::new(
             "VALIDATE.BALANCED.VALUE_DOMAIN",
             DiagnosticSeverity::Warning,
@@ -396,6 +407,15 @@ fn sane_validate_balanced(
 }
 
 fn attach_source_refs(diagnostics: &mut [StructuredDiagnostic], source_maps: &[SourceMapEntry]) {
+    // Index by element path once: `source_maps` holds a row per field per
+    // element, so a per-diagnostic linear scan is quadratic. First entry wins,
+    // matching the previous `iter().find` order.
+    let mut by_path: HashMap<&str, &SourceRef> = HashMap::with_capacity(source_maps.len());
+    for map in source_maps {
+        by_path
+            .entry(map.element_path.as_str())
+            .or_insert(&map.source_ref);
+    }
     for diagnostic in diagnostics {
         if diagnostic.source_ref.is_some() {
             continue;
@@ -403,14 +423,15 @@ fn attach_source_refs(diagnostics: &mut [StructuredDiagnostic], source_maps: &[S
         let Some(path) = diagnostic.element_path.as_deref() else {
             continue;
         };
-        if let Some(map) = source_maps.iter().find(|m| m.element_path == path) {
-            diagnostic.source_ref = Some(map.source_ref.clone());
+        if let Some(source_ref) = by_path.get(path) {
+            diagnostic.source_ref = Some((*source_ref).clone());
         }
     }
 }
 
 fn balanced_value_finding_path(
     net: &BalancedNetwork,
+    bus_index: &HashMap<usize, usize>,
     finding: &powerio::Diagnostic,
 ) -> Option<String> {
     if let Some(id) = finding
@@ -418,7 +439,7 @@ fn balanced_value_finding_path(
         .strip_prefix("bus ")
         .and_then(|s| s.parse::<usize>().ok())
     {
-        let idx = net.buses.iter().position(|b| b.id.0 == id)?;
+        let idx = *bus_index.get(&id)?;
         return Some(format!(
             "/model/balanced_network/buses/{idx}/{}",
             finding.field
@@ -430,6 +451,9 @@ fn balanced_value_finding_path(
         .strip_prefix("generator at bus ")
         .and_then(|s| s.parse::<usize>().ok())
     {
+        // When several units at a bus share the same out-of-domain value the
+        // finding cannot be pinned to one array index, so skip the precise path
+        // rather than misattribute it (see the ambiguity test).
         let mut matches = net
             .generators
             .iter()
@@ -1084,20 +1108,46 @@ fn push_matpower_injection_maps(
     source_id: &str,
     net: &BalancedNetwork,
 ) {
-    for (i, load) in net.loads.iter().enumerate() {
-        if net.buses.iter().any(|b| b.id == load.bus) {
-            push_matpower_split_map(entries, source_id, "loads", i, "bus", "BUS_I");
-            push_matpower_split_map(entries, source_id, "loads", i, "p", "PD");
-            push_matpower_split_map(entries, source_id, "loads", i, "q", "QD");
-            push_matpower_split_map(entries, source_id, "loads", i, "in_service", "BUS_TYPE");
-        }
-    }
-    for (i, shunt) in net.shunts.iter().enumerate() {
-        if net.buses.iter().any(|b| b.id == shunt.bus) {
-            push_matpower_split_map(entries, source_id, "shunts", i, "bus", "BUS_I");
-            push_matpower_split_map(entries, source_id, "shunts", i, "g", "GS");
-            push_matpower_split_map(entries, source_id, "shunts", i, "b", "BS");
-            push_matpower_split_map(entries, source_id, "shunts", i, "in_service", "BUS_TYPE");
+    // MATPOWER folds loads and shunts into the bus record, so each canonical
+    // field maps back to a real bus column. Loads/shunts always reference an
+    // existing bus by construction, so no per-element bus existence check is
+    // needed.
+    push_matpower_split_maps(
+        entries,
+        source_id,
+        "loads",
+        net.loads.len(),
+        &[
+            ("bus", "BUS_I"),
+            ("p", "PD"),
+            ("q", "QD"),
+            ("in_service", "BUS_TYPE"),
+        ],
+    );
+    push_matpower_split_maps(
+        entries,
+        source_id,
+        "shunts",
+        net.shunts.len(),
+        &[
+            ("bus", "BUS_I"),
+            ("g", "GS"),
+            ("b", "BS"),
+            ("in_service", "BUS_TYPE"),
+        ],
+    );
+}
+
+fn push_matpower_split_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    collection: &str,
+    len: usize,
+    fields: &[(&str, &str)],
+) {
+    for i in 0..len {
+        for &(field, source_field) in fields {
+            push_matpower_split_map(entries, source_id, collection, i, field, source_field);
         }
     }
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -979,6 +979,7 @@ fn push_balanced_network_maps(
         "/model/balanced_network/base_mva",
         "case",
         "base_mva",
+        MappingKind::Exact,
     );
     if balanced_has_frequency_source(source_format) {
         push_balanced_map(
@@ -987,6 +988,7 @@ fn push_balanced_network_maps(
             "/model/balanced_network/base_frequency",
             "case",
             "base_frequency",
+            MappingKind::Exact,
         );
     }
 }
@@ -1001,6 +1003,7 @@ fn push_balanced_bus_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, le
         &[
             "id", "kind", "vm", "va", "base_kv", "vmax", "vmin", "area", "zone",
         ],
+        MappingKind::Exact,
     );
 }
 
@@ -1019,6 +1022,7 @@ fn push_balanced_injection_maps(
             net.loads.len(),
             "load",
             &["bus", "p", "q", "in_service"],
+            MappingKind::Exact,
         );
         push_balanced_record_maps(
             entries,
@@ -1027,6 +1031,7 @@ fn push_balanced_injection_maps(
             net.shunts.len(),
             "shunt",
             &["bus", "g", "b", "in_service"],
+            MappingKind::Exact,
         );
     }
 }
@@ -1058,6 +1063,7 @@ fn push_balanced_branch_maps(
                 "angmin",
                 "angmax",
             ],
+            MappingKind::Exact,
         );
         if branch.charging.is_some() {
             for field in ["g_fr", "b_fr", "g_to", "b_to"] {
@@ -1067,6 +1073,7 @@ fn push_balanced_branch_maps(
                     &format!("/model/balanced_network/branches/{i}/charging/{field}"),
                     "branch",
                     field,
+                    MappingKind::Exact,
                 );
             }
         }
@@ -1092,6 +1099,7 @@ fn push_balanced_generator_maps(entries: &mut Vec<SourceMapEntry>, source_id: &s
             "mbase",
             "in_service",
         ],
+        MappingKind::Exact,
     );
 }
 
@@ -1110,51 +1118,24 @@ fn push_matpower_injection_maps(
     // MATPOWER folds loads and shunts into the bus record. Keep the source
     // field token canonical like the rest of the balanced source maps; the
     // record and mapping kind carry the folded-row relationship.
-    push_matpower_split_maps(
+    push_balanced_record_maps(
         entries,
         source_id,
         "loads",
         net.loads.len(),
+        "bus",
         &["bus", "p", "q", "in_service"],
+        MappingKind::Split,
     );
-    push_matpower_split_maps(
+    push_balanced_record_maps(
         entries,
         source_id,
         "shunts",
         net.shunts.len(),
+        "bus",
         &["bus", "g", "b", "in_service"],
+        MappingKind::Split,
     );
-}
-
-fn push_matpower_split_maps(
-    entries: &mut Vec<SourceMapEntry>,
-    source_id: &str,
-    collection: &str,
-    len: usize,
-    fields: &[&str],
-) {
-    for i in 0..len {
-        for &field in fields {
-            push_matpower_split_map(entries, source_id, collection, i, field);
-        }
-    }
-}
-
-fn push_matpower_split_map(
-    entries: &mut Vec<SourceMapEntry>,
-    source_id: &str,
-    collection: &str,
-    i: usize,
-    field: &str,
-) {
-    entries.push(SourceMapEntry {
-        element_path: format!("/model/balanced_network/{collection}/{i}/{field}"),
-        source_ref: SourceRef::new(source_id)
-            .with_record("bus")
-            .with_field(field),
-        mapping_kind: MappingKind::Split,
-        confidence: Confidence::High,
-    });
 }
 
 fn push_balanced_record_maps(
@@ -1164,9 +1145,18 @@ fn push_balanced_record_maps(
     len: usize,
     record: &str,
     fields: &[&str],
+    mapping_kind: MappingKind,
 ) {
     for i in 0..len {
-        push_balanced_record_map(entries, source_id, collection, i, record, fields);
+        push_balanced_record_map(
+            entries,
+            source_id,
+            collection,
+            i,
+            record,
+            fields,
+            mapping_kind,
+        );
     }
 }
 
@@ -1177,6 +1167,7 @@ fn push_balanced_record_map(
     i: usize,
     record: &str,
     fields: &[&str],
+    mapping_kind: MappingKind,
 ) {
     for &field in fields {
         push_balanced_map(
@@ -1185,6 +1176,7 @@ fn push_balanced_record_map(
             &format!("/model/balanced_network/{collection}/{i}/{field}"),
             record,
             field,
+            mapping_kind,
         );
     }
 }
@@ -1195,13 +1187,14 @@ fn push_balanced_map(
     element_path: &str,
     record: &str,
     field: &str,
+    mapping_kind: MappingKind,
 ) {
     entries.push(SourceMapEntry {
         element_path: element_path.to_owned(),
         source_ref: SourceRef::new(source_id)
             .with_record(record)
             .with_field(field),
-        mapping_kind: MappingKind::Exact,
+        mapping_kind,
         confidence: Confidence::High,
     });
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -300,7 +300,23 @@ fn schema_major(version: &str) -> Option<u64> {
     // Accept a semver core `MAJOR.MINOR.PATCH` with an optional prerelease
     // (`-...`) or build (`+...`) tag: same-major additive versions load, so a
     // forward-compatible writer that stamps e.g. `0.2.0-rc.1` is not rejected.
-    let core = version.split(['-', '+']).next().unwrap_or(version);
+    let (core, suffix) = match version.split_once('-') {
+        Some((core, rest)) => match rest.split_once('+') {
+            Some((pre, build)) => (core, Some((Some(pre), Some(build)))),
+            None => (core, Some((Some(rest), None))),
+        },
+        None => match version.split_once('+') {
+            Some((core, build)) => (core, Some((None, Some(build)))),
+            None => (version, None),
+        },
+    };
+    if let Some((pre, build)) = suffix {
+        if pre.is_some_and(|s| !valid_semver_suffix(s))
+            || build.is_some_and(|s| !valid_semver_suffix(s))
+        {
+            return None;
+        }
+    }
     let mut parts = core.split('.');
     let major = parts.next()?;
     let minor = parts.next()?;
@@ -308,10 +324,25 @@ fn schema_major(version: &str) -> Option<u64> {
     if parts.next().is_some() {
         return None;
     }
-    let major = major.parse().ok()?;
-    minor.parse::<u64>().ok()?;
-    patch.parse::<u64>().ok()?;
+    let major = parse_semver_number(major)?;
+    parse_semver_number(minor)?;
+    parse_semver_number(patch)?;
     Some(major)
+}
+
+fn parse_semver_number(s: &str) -> Option<u64> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) || (s.len() > 1 && s.starts_with('0'))
+    {
+        return None;
+    }
+    s.parse().ok()
+}
+
+fn valid_semver_suffix(s: &str) -> bool {
+    !s.is_empty()
+        && s.split('.').all(|part| {
+            !part.is_empty() && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        })
 }
 
 fn supported_schema_major() -> u64 {
@@ -888,6 +919,17 @@ fn balanced_origin(net: &BalancedNetwork) -> Origin {
             parent_package_id: None,
             pass: "normalize-balanced".to_owned(),
             options: serde_json::Map::new(),
+        },
+        SourceFormat::Gridfm | SourceFormat::PypsaCsv => Origin::Folder {
+            path: String::new(),
+            format: balanced_format_name(net.source_format).to_owned(),
+            file_hashes: BTreeMap::new(),
+        },
+        SourceFormat::PowerWorldBinary => Origin::BinaryFile {
+            path: String::new(),
+            format: balanced_format_name(net.source_format).to_owned(),
+            hash: None,
+            decoded_sections: Vec::new(),
         },
         other => Origin::File {
             path: String::new(),

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -961,15 +961,10 @@ fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<S
     };
     let mut entries = Vec::new();
     push_balanced_network_maps(&mut entries, source_id, net.source_format);
-    push_balanced_bus_maps(&mut entries, source_id, net.source_format, net.buses.len());
+    push_balanced_bus_maps(&mut entries, source_id, net.buses.len());
     push_balanced_injection_maps(&mut entries, source_id, net);
     push_balanced_branch_maps(&mut entries, source_id, net);
-    push_balanced_generator_maps(
-        &mut entries,
-        source_id,
-        net.source_format,
-        net.generators.len(),
-    );
+    push_balanced_generator_maps(&mut entries, source_id, net.generators.len());
     entries
 }
 
@@ -983,29 +978,23 @@ fn push_balanced_network_maps(
         source_id,
         "/model/balanced_network/base_mva",
         "case",
-        balanced_network_source_field(source_format, "base_mva"),
+        "base_mva",
     );
-    if let Some((record, field)) = balanced_frequency_source(source_format) {
+    if balanced_has_frequency_source(source_format) {
         push_balanced_map(
             entries,
             source_id,
             "/model/balanced_network/base_frequency",
-            record,
-            field,
+            "case",
+            "base_frequency",
         );
     }
 }
 
-fn push_balanced_bus_maps(
-    entries: &mut Vec<SourceMapEntry>,
-    source_id: &str,
-    source_format: SourceFormat,
-    len: usize,
-) {
+fn push_balanced_bus_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
     push_balanced_record_maps(
         entries,
         source_id,
-        source_format,
         "buses",
         len,
         "bus",
@@ -1026,7 +1015,6 @@ fn push_balanced_injection_maps(
         push_balanced_record_maps(
             entries,
             source_id,
-            net.source_format,
             "loads",
             net.loads.len(),
             "load",
@@ -1035,7 +1023,6 @@ fn push_balanced_injection_maps(
         push_balanced_record_maps(
             entries,
             source_id,
-            net.source_format,
             "shunts",
             net.shunts.len(),
             "shunt",
@@ -1053,7 +1040,6 @@ fn push_balanced_branch_maps(
         push_balanced_record_map(
             entries,
             source_id,
-            net.source_format,
             "branches",
             i,
             "branch",
@@ -1087,16 +1073,10 @@ fn push_balanced_branch_maps(
     }
 }
 
-fn push_balanced_generator_maps(
-    entries: &mut Vec<SourceMapEntry>,
-    source_id: &str,
-    source_format: SourceFormat,
-    len: usize,
-) {
+fn push_balanced_generator_maps(entries: &mut Vec<SourceMapEntry>, source_id: &str, len: usize) {
     push_balanced_record_maps(
         entries,
         source_id,
-        source_format,
         "generators",
         len,
         "generator",
@@ -1115,64 +1095,11 @@ fn push_balanced_generator_maps(
     );
 }
 
-fn balanced_frequency_source(source_format: SourceFormat) -> Option<(&'static str, &'static str)> {
-    match source_format {
-        SourceFormat::Psse => Some(("header", "BASFRQ")),
-        SourceFormat::PandapowerJson => Some(("network", "f_hz")),
-        _ => None,
-    }
-}
-
-fn balanced_network_source_field(source_format: SourceFormat, field: &str) -> &str {
-    match source_format {
-        SourceFormat::Matpower if field == "base_mva" => "baseMVA",
-        _ => field,
-    }
-}
-
-fn balanced_source_field<'a>(source_format: SourceFormat, record: &str, field: &'a str) -> &'a str {
-    if source_format == SourceFormat::Matpower {
-        return matpower_source_field(record, field).unwrap_or(field);
-    }
-    field
-}
-
-fn matpower_source_field(record: &str, field: &str) -> Option<&'static str> {
-    match (record, field) {
-        ("bus", "id") => Some("BUS_I"),
-        ("bus", "kind") => Some("BUS_TYPE"),
-        ("bus", "vm") => Some("VM"),
-        ("bus", "va") => Some("VA"),
-        ("bus", "base_kv") => Some("BASE_KV"),
-        ("bus", "vmax") => Some("VMAX"),
-        ("bus", "vmin") => Some("VMIN"),
-        ("bus", "area") => Some("BUS_AREA"),
-        ("bus", "zone") => Some("ZONE"),
-        ("branch", "from") => Some("F_BUS"),
-        ("branch", "to") => Some("T_BUS"),
-        ("branch", "r") => Some("BR_R"),
-        ("branch", "x") => Some("BR_X"),
-        ("branch", "b") => Some("BR_B"),
-        ("branch", "rate_a") => Some("RATE_A"),
-        ("branch", "rate_b") => Some("RATE_B"),
-        ("branch", "rate_c") => Some("RATE_C"),
-        ("branch", "tap") => Some("TAP"),
-        ("branch", "shift") => Some("SHIFT"),
-        ("branch", "in_service") => Some("BR_STATUS"),
-        ("branch", "angmin") => Some("ANGMIN"),
-        ("branch", "angmax") => Some("ANGMAX"),
-        ("generator", "bus") => Some("GEN_BUS"),
-        ("generator", "pg") => Some("PG"),
-        ("generator", "qg") => Some("QG"),
-        ("generator", "qmax") => Some("QMAX"),
-        ("generator", "qmin") => Some("QMIN"),
-        ("generator", "vg") => Some("VG"),
-        ("generator", "mbase") => Some("MBASE"),
-        ("generator", "in_service") => Some("GEN_STATUS"),
-        ("generator", "pmax") => Some("PMAX"),
-        ("generator", "pmin") => Some("PMIN"),
-        _ => None,
-    }
+fn balanced_has_frequency_source(source_format: SourceFormat) -> bool {
+    matches!(
+        source_format,
+        SourceFormat::Psse | SourceFormat::PandapowerJson
+    )
 }
 
 fn push_matpower_injection_maps(
@@ -1180,33 +1107,22 @@ fn push_matpower_injection_maps(
     source_id: &str,
     net: &BalancedNetwork,
 ) {
-    // MATPOWER folds loads and shunts into the bus record, so each canonical
-    // field maps back to a real bus column. Loads/shunts always reference an
-    // existing bus by construction, so no per-element bus existence check is
-    // needed.
+    // MATPOWER folds loads and shunts into the bus record. Keep the source
+    // field token canonical like the rest of the balanced source maps; the
+    // record and mapping kind carry the folded-row relationship.
     push_matpower_split_maps(
         entries,
         source_id,
         "loads",
         net.loads.len(),
-        &[
-            ("bus", "BUS_I"),
-            ("p", "PD"),
-            ("q", "QD"),
-            ("in_service", "BUS_TYPE"),
-        ],
+        &["bus", "p", "q", "in_service"],
     );
     push_matpower_split_maps(
         entries,
         source_id,
         "shunts",
         net.shunts.len(),
-        &[
-            ("bus", "BUS_I"),
-            ("g", "GS"),
-            ("b", "BS"),
-            ("in_service", "BUS_TYPE"),
-        ],
+        &["bus", "g", "b", "in_service"],
     );
 }
 
@@ -1215,11 +1131,11 @@ fn push_matpower_split_maps(
     source_id: &str,
     collection: &str,
     len: usize,
-    fields: &[(&str, &str)],
+    fields: &[&str],
 ) {
     for i in 0..len {
-        for &(field, source_field) in fields {
-            push_matpower_split_map(entries, source_id, collection, i, field, source_field);
+        for &field in fields {
+            push_matpower_split_map(entries, source_id, collection, i, field);
         }
     }
 }
@@ -1230,13 +1146,12 @@ fn push_matpower_split_map(
     collection: &str,
     i: usize,
     field: &str,
-    source_field: &str,
 ) {
     entries.push(SourceMapEntry {
         element_path: format!("/model/balanced_network/{collection}/{i}/{field}"),
         source_ref: SourceRef::new(source_id)
             .with_record("bus")
-            .with_field(source_field),
+            .with_field(field),
         mapping_kind: MappingKind::Split,
         confidence: Confidence::High,
     });
@@ -1245,29 +1160,19 @@ fn push_matpower_split_map(
 fn push_balanced_record_maps(
     entries: &mut Vec<SourceMapEntry>,
     source_id: &str,
-    source_format: SourceFormat,
     collection: &str,
     len: usize,
     record: &str,
     fields: &[&str],
 ) {
     for i in 0..len {
-        push_balanced_record_map(
-            entries,
-            source_id,
-            source_format,
-            collection,
-            i,
-            record,
-            fields,
-        );
+        push_balanced_record_map(entries, source_id, collection, i, record, fields);
     }
 }
 
 fn push_balanced_record_map(
     entries: &mut Vec<SourceMapEntry>,
     source_id: &str,
-    source_format: SourceFormat,
     collection: &str,
     i: usize,
     record: &str,
@@ -1279,7 +1184,7 @@ fn push_balanced_record_map(
             source_id,
             &format!("/model/balanced_network/{collection}/{i}/{field}"),
             record,
-            balanced_source_field(source_format, record, field),
+            field,
         );
     }
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -100,6 +100,9 @@ impl CompilerPackage {
     pub fn from_balanced(net: BalancedNetwork) -> Self {
         let origin = balanced_origin(&net);
         let summary = balanced_summary(&net);
+        let sources = balanced_sources(&net);
+        let source_id = sources.first().map(|s| s.id.clone());
+        let source_maps = balanced_source_maps(&net, source_id.as_deref());
         Self {
             schema: default_schema_url(),
             schema_version: default_schema_version(),
@@ -109,8 +112,8 @@ impl CompilerPackage {
             model_kind: ModelKind::Balanced,
             model: ModelPayload::balanced(net),
             origin,
-            sources: Vec::new(),
-            source_maps: Vec::new(),
+            sources,
+            source_maps,
             diagnostics: Vec::new(),
             validation: ValidationSummary::ok(),
             summary,
@@ -279,13 +282,14 @@ impl CompilerPackage {
         self.diagnostics
             .retain(|d| !is_sane_validation_code(d.code.as_str()));
 
-        let (diagnostics, passes) = match &self.model {
+        let (mut diagnostics, passes) = match &self.model {
             ModelPayload::Balanced { balanced_network } => sane_validate_balanced(balanced_network),
             ModelPayload::Multiconductor {
                 multiconductor_network,
             } => sane_validate_multiconductor(multiconductor_network),
         };
 
+        attach_source_refs(&mut diagnostics, &self.source_maps);
         self.diagnostics.extend(diagnostics);
         self.validation =
             ValidationSummary::from_diagnostics(&self.diagnostics).with_passes(passes);
@@ -349,6 +353,13 @@ fn sane_validate_balanced(
 
     let mut value_domain = Vec::new();
     for finding in net.validate_values() {
+        let element_path = balanced_value_finding_path(net, &finding).unwrap_or_else(|| {
+            format!(
+                "/model/balanced_network/{}#{}",
+                finding.element.replace(' ', "_"),
+                finding.field
+            )
+        });
         let mut d = StructuredDiagnostic::new(
             "VALIDATE.BALANCED.VALUE_DOMAIN",
             DiagnosticSeverity::Warning,
@@ -358,11 +369,7 @@ fn sane_validate_balanced(
                 finding.element, finding.field, finding.new
             ),
         )
-        .with_element_path(format!(
-            "/model/balanced_network/{}#{}",
-            finding.element.replace(' ', "_"),
-            finding.field
-        ))
+        .with_element_path(element_path)
         .with_suggested_action("Run the explicit repair pass if these defaults are desired.");
         d.details
             .insert("element".to_owned(), serde_json::json!(finding.element));
@@ -383,6 +390,63 @@ fn sane_validate_balanced(
     ];
     structure.extend(value_domain);
     (structure, passes)
+}
+
+fn attach_source_refs(diagnostics: &mut [StructuredDiagnostic], source_maps: &[SourceMapEntry]) {
+    for diagnostic in diagnostics {
+        if diagnostic.source_ref.is_some() {
+            continue;
+        }
+        let Some(path) = diagnostic.element_path.as_deref() else {
+            continue;
+        };
+        if let Some(map) = source_maps.iter().find(|m| m.element_path == path) {
+            diagnostic.source_ref = Some(map.source_ref.clone());
+        }
+    }
+}
+
+fn balanced_value_finding_path(
+    net: &BalancedNetwork,
+    finding: &powerio::Diagnostic,
+) -> Option<String> {
+    if let Some(id) = finding
+        .element
+        .strip_prefix("bus ")
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        let idx = net.buses.iter().position(|b| b.id.0 == id)?;
+        return Some(format!(
+            "/model/balanced_network/buses/{idx}/{}",
+            finding.field
+        ));
+    }
+
+    if let Some(id) = finding
+        .element
+        .strip_prefix("generator at bus ")
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        let idx = net.generators.iter().position(|g| {
+            g.bus.0 == id
+                && generator_field(g, finding.field)
+                    .is_some_and(|v| v.to_bits() == finding.old.to_bits())
+        })?;
+        return Some(format!(
+            "/model/balanced_network/generators/{idx}/{}",
+            finding.field
+        ));
+    }
+
+    None
+}
+
+fn generator_field(generator: &powerio::Generator, field: &str) -> Option<f64> {
+    Some(match field {
+        "mbase" => generator.mbase,
+        "vg" => generator.vg,
+        _ => return None,
+    })
 }
 
 fn sane_validate_multiconductor(
@@ -798,6 +862,28 @@ fn balanced_origin(net: &BalancedNetwork) -> Origin {
     }
 }
 
+fn balanced_sources(net: &BalancedNetwork) -> Vec<SourceDescriptor> {
+    let Some(kind) = balanced_source_kind(net.source_format) else {
+        return Vec::new();
+    };
+    vec![SourceDescriptor {
+        id: "src0".to_owned(),
+        kind: kind.to_owned(),
+        path: None,
+        format: Some(balanced_format_name(net.source_format).to_owned()),
+        hash: None,
+    }]
+}
+
+fn balanced_source_kind(f: SourceFormat) -> Option<&'static str> {
+    match f {
+        SourceFormat::InMemory | SourceFormat::Normalized => None,
+        SourceFormat::Gridfm | SourceFormat::PypsaCsv => Some("folder"),
+        SourceFormat::PowerWorldBinary => Some("binary_file"),
+        _ => Some("file"),
+    }
+}
+
 fn balanced_summary(net: &BalancedNetwork) -> ObjectSummary {
     let mut elements = BTreeMap::new();
     elements.insert("buses".to_owned(), net.buses.len() as u64);
@@ -831,6 +917,161 @@ fn balanced_summary(net: &BalancedNetwork) -> ObjectSummary {
             base_mva: Some(net.base_mva),
         }),
     }
+}
+
+fn balanced_source_maps(net: &BalancedNetwork, source_id: Option<&str>) -> Vec<SourceMapEntry> {
+    let Some(source_id) = source_id else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    push_balanced_map(
+        &mut entries,
+        source_id,
+        "/model/balanced_network/base_mva",
+        "case",
+        "base_mva",
+    );
+    push_balanced_map(
+        &mut entries,
+        source_id,
+        "/model/balanced_network/base_frequency",
+        "case",
+        "base_frequency",
+    );
+
+    push_balanced_record_maps(
+        &mut entries,
+        source_id,
+        "buses",
+        net.buses.len(),
+        "bus",
+        &[
+            "id", "kind", "vm", "va", "base_kv", "vmax", "vmin", "area", "zone",
+        ],
+    );
+    push_balanced_record_maps(
+        &mut entries,
+        source_id,
+        "loads",
+        net.loads.len(),
+        "load",
+        &["bus", "p", "q", "in_service"],
+    );
+    push_balanced_record_maps(
+        &mut entries,
+        source_id,
+        "shunts",
+        net.shunts.len(),
+        "shunt",
+        &["bus", "g", "b", "in_service"],
+    );
+
+    for (i, branch) in net.branches.iter().enumerate() {
+        push_balanced_record_map(
+            &mut entries,
+            source_id,
+            "branches",
+            i,
+            "branch",
+            &[
+                "from",
+                "to",
+                "r",
+                "x",
+                "b",
+                "rate_a",
+                "rate_b",
+                "rate_c",
+                "tap",
+                "shift",
+                "in_service",
+                "angmin",
+                "angmax",
+            ],
+        );
+        if branch.charging.is_some() {
+            for field in ["g_fr", "b_fr", "g_to", "b_to"] {
+                push_balanced_map(
+                    &mut entries,
+                    source_id,
+                    &format!("/model/balanced_network/branches/{i}/charging/{field}"),
+                    "branch",
+                    field,
+                );
+            }
+        }
+    }
+
+    push_balanced_record_maps(
+        &mut entries,
+        source_id,
+        "generators",
+        net.generators.len(),
+        "generator",
+        &[
+            "bus",
+            "pg",
+            "qg",
+            "pmax",
+            "pmin",
+            "qmax",
+            "qmin",
+            "vg",
+            "mbase",
+            "in_service",
+        ],
+    );
+
+    entries
+}
+
+fn push_balanced_record_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    collection: &str,
+    len: usize,
+    record: &str,
+    fields: &[&str],
+) {
+    for i in 0..len {
+        push_balanced_record_map(entries, source_id, collection, i, record, fields);
+    }
+}
+
+fn push_balanced_record_map(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    collection: &str,
+    i: usize,
+    record: &str,
+    fields: &[&str],
+) {
+    for &field in fields {
+        push_balanced_map(
+            entries,
+            source_id,
+            &format!("/model/balanced_network/{collection}/{i}/{field}"),
+            record,
+            field,
+        );
+    }
+}
+
+fn push_balanced_map(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    element_path: &str,
+    record: &str,
+    field: &str,
+) {
+    entries.push(SourceMapEntry {
+        element_path: element_path.to_owned(),
+        source_ref: SourceRef::new(source_id)
+            .with_record(record)
+            .with_field(field),
+        mapping_kind: MappingKind::Exact,
+        confidence: Confidence::High,
+    });
 }
 
 fn multiconductor_summary(net: &MulticonductorNetwork) -> ObjectSummary {

--- a/powerio-pkg/src/provenance.rs
+++ b/powerio-pkg/src/provenance.rs
@@ -117,6 +117,7 @@ pub struct SourceRef {
 }
 
 impl SourceRef {
+    /// Create a reference to a declared source artifact.
     pub fn new(source_id: impl Into<String>) -> Self {
         Self {
             source_id: source_id.into(),
@@ -129,18 +130,21 @@ impl SourceRef {
         }
     }
 
+    /// Set the source field or property name.
     #[must_use]
     pub fn with_field(mut self, field: impl Into<String>) -> Self {
         self.field = Some(field.into());
         self
     }
 
+    /// Set the source record, section, or object type.
     #[must_use]
     pub fn with_record(mut self, record: impl Into<String>) -> Self {
         self.record = Some(record.into());
         self
     }
 
+    /// Set the source line number.
     #[must_use]
     pub fn with_line(mut self, line: u32) -> Self {
         self.line = Some(line);

--- a/powerio-pkg/src/provenance.rs
+++ b/powerio-pkg/src/provenance.rs
@@ -136,6 +136,12 @@ impl SourceRef {
     }
 
     #[must_use]
+    pub fn with_record(mut self, record: impl Into<String>) -> Self {
+        self.record = Some(record.into());
+        self
+    }
+
+    #[must_use]
     pub fn with_line(mut self, line: u32) -> Self {
         self.line = Some(line);
         self

--- a/powerio-pkg/src/provenance.rs
+++ b/powerio-pkg/src/provenance.rs
@@ -105,10 +105,10 @@ pub struct SourceRef {
     /// Byte offset, for binary sources.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub byte_offset: Option<u64>,
-    /// Record / section / object type, e.g. `BUS`.
+    /// Record / section / object type, e.g. `bus`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub record: Option<String>,
-    /// Field / property name, e.g. `VM`.
+    /// Canonical field / property name, e.g. `vm`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     /// Raw token / value, when safe to embed.
@@ -130,7 +130,7 @@ impl SourceRef {
         }
     }
 
-    /// Set the source field or property name.
+    /// Set the field or property name.
     #[must_use]
     pub fn with_field(mut self, field: impl Into<String>) -> Self {
         self.field = Some(field.into());

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -335,6 +335,57 @@ fn unknown_future_fields_are_tolerated() {
 }
 
 #[test]
+fn future_same_major_schema_version_is_tolerated() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    v.as_object_mut()
+        .unwrap()
+        .insert("schema_version".to_owned(), serde_json::json!("0.2.0"));
+    v.as_object_mut()
+        .unwrap()
+        .insert("future_field".to_owned(), serde_json::json!({"x": 1}));
+    let json = serde_json::to_string(&v).unwrap();
+
+    let back = CompilerPackage::from_json(&json).expect("same major schema version loads");
+    assert_eq!(back.schema_version, "0.2.0");
+    assert_eq!(back.model_kind(), ModelKind::Balanced);
+}
+
+#[test]
+fn incompatible_schema_major_is_rejected() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    v.as_object_mut()
+        .unwrap()
+        .insert("schema_version".to_owned(), serde_json::json!("1.0.0"));
+    let json = serde_json::to_string(&v).unwrap();
+
+    let err = CompilerPackage::from_json(&json).expect_err("major version mismatch must fail");
+    assert!(
+        err.to_string()
+            .contains("unsupported .pio.json schema_version 1.0.0"),
+        "{err}"
+    );
+}
+
+#[test]
+fn invalid_schema_version_is_rejected() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    v.as_object_mut()
+        .unwrap()
+        .insert("schema_version".to_owned(), serde_json::json!("0"));
+    let json = serde_json::to_string(&v).unwrap();
+
+    let err = CompilerPackage::from_json(&json).expect_err("invalid semver must fail");
+    assert!(
+        err.to_string()
+            .contains("unsupported .pio.json schema_version 0"),
+        "{err}"
+    );
+}
+
+#[test]
 fn sane_validation_records_balanced_value_domain_findings() {
     let src = "\
 function mpc = bad_values

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -424,6 +424,28 @@ fn origin_distinguishes_in_memory_from_file() {
 }
 
 #[test]
+fn balanced_origin_matches_source_artifact_kind() {
+    let mut net = powerio::parse_str(MATPOWER_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+
+    net.source_format = powerio::SourceFormat::Gridfm;
+    let gridfm = CompilerPackage::from_balanced(net.clone());
+    assert!(matches!(gridfm.origin, Origin::Folder { .. }));
+    assert_eq!(gridfm.sources[0].kind, "folder");
+
+    net.source_format = powerio::SourceFormat::PypsaCsv;
+    let pypsa = CompilerPackage::from_balanced(net.clone());
+    assert!(matches!(pypsa.origin, Origin::Folder { .. }));
+    assert_eq!(pypsa.sources[0].kind, "folder");
+
+    net.source_format = powerio::SourceFormat::PowerWorldBinary;
+    let pwb = CompilerPackage::from_balanced(net);
+    assert!(matches!(pwb.origin, Origin::BinaryFile { .. }));
+    assert_eq!(pwb.sources[0].kind, "binary_file");
+}
+
+#[test]
 fn unknown_future_fields_are_tolerated() {
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();
@@ -493,7 +515,16 @@ fn incompatible_schema_major_is_rejected() {
 #[test]
 fn invalid_schema_version_is_rejected() {
     let pkg = balanced_package();
-    for version in ["0", "0.x.0", "0.1.0.1"] {
+    for version in [
+        "0",
+        "0.x.0",
+        "0.1.0.1",
+        "00.1.0",
+        "0.1.0-",
+        "0.1.0+",
+        "0.1.0-alpha..1",
+        "0.1.0+build!",
+    ] {
         let mut v = serde_json::to_value(&pkg).unwrap();
         v.as_object_mut()
             .unwrap()

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -400,18 +400,20 @@ fn incompatible_schema_major_is_rejected() {
 #[test]
 fn invalid_schema_version_is_rejected() {
     let pkg = balanced_package();
-    let mut v = serde_json::to_value(&pkg).unwrap();
-    v.as_object_mut()
-        .unwrap()
-        .insert("schema_version".to_owned(), serde_json::json!("0"));
-    let json = serde_json::to_string(&v).unwrap();
+    for version in ["0", "0.x.0", "0.1.0.1"] {
+        let mut v = serde_json::to_value(&pkg).unwrap();
+        v.as_object_mut()
+            .unwrap()
+            .insert("schema_version".to_owned(), serde_json::json!(version));
+        let json = serde_json::to_string(&v).unwrap();
 
-    let err = CompilerPackage::from_json(&json).expect_err("invalid semver must fail");
-    assert!(
-        err.to_string()
-            .contains("unsupported .pio.json schema_version 0"),
-        "{err}"
-    );
+        let err = CompilerPackage::from_json(&json).expect_err("invalid semver must fail");
+        assert!(
+            err.to_string()
+                .contains(&format!("unsupported .pio.json schema_version {version}")),
+            "{err}"
+        );
+    }
 }
 
 #[test]

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -445,6 +445,22 @@ fn future_same_major_schema_version_is_tolerated() {
 }
 
 #[test]
+fn same_major_prerelease_or_build_schema_version_is_tolerated() {
+    for version in ["0.2.0-rc.1", "0.1.0+build.5", "0.3.0-alpha.2+exp"] {
+        let pkg = balanced_package();
+        let mut v = serde_json::to_value(&pkg).unwrap();
+        v.as_object_mut()
+            .unwrap()
+            .insert("schema_version".to_owned(), serde_json::json!(version));
+        let json = serde_json::to_string(&v).unwrap();
+
+        let back = CompilerPackage::from_json(&json)
+            .unwrap_or_else(|e| panic!("same-major {version} should load: {e}"));
+        assert_eq!(back.schema_version, version);
+    }
+}
+
+#[test]
 fn incompatible_schema_major_is_rejected() {
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -333,6 +333,70 @@ fn balanced_fields_lift_into_source_maps() {
 }
 
 #[test]
+fn matpower_default_frequency_is_not_mapped_as_source_field() {
+    let pkg = balanced_package();
+
+    assert!(
+        !pkg.source_maps
+            .iter()
+            .any(|e| e.element_path == "/model/balanced_network/base_frequency"),
+        "MATPOWER has no source frequency field: {:?}",
+        pkg.source_maps
+    );
+}
+
+#[test]
+fn matpower_loads_and_shunts_map_to_bus_row_fields() {
+    let src = "\
+function mpc = injections
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t12\t3\t0.5\t0.25\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+    let net = powerio::parse_str(src, "matpower").unwrap().network;
+    let pkg = CompilerPackage::from_balanced(net);
+
+    let has_split_bus_field = |path: &str, field: &str| {
+        pkg.source_maps.iter().any(|e| {
+            e.element_path == path
+                && e.mapping_kind == MappingKind::Split
+                && e.confidence == Confidence::High
+                && e.source_ref.record.as_deref() == Some("bus")
+                && e.source_ref.field.as_deref() == Some(field)
+        })
+    };
+    assert!(has_split_bus_field(
+        "/model/balanced_network/loads/0/p",
+        "PD"
+    ));
+    assert!(has_split_bus_field(
+        "/model/balanced_network/loads/0/q",
+        "QD"
+    ));
+    assert!(has_split_bus_field(
+        "/model/balanced_network/shunts/0/g",
+        "GS"
+    ));
+    assert!(has_split_bus_field(
+        "/model/balanced_network/shunts/0/b",
+        "BS"
+    ));
+    assert!(
+        !pkg.source_maps
+            .iter()
+            .any(|e| matches!(e.source_ref.record.as_deref(), Some("load" | "shunt"))),
+        "MATPOWER injections are bus row fields: {:?}",
+        pkg.source_maps
+    );
+}
+
+#[test]
 fn origin_distinguishes_in_memory_from_file() {
     let in_mem = CompilerPackage::from_balanced(powerio::BalancedNetwork::in_memory(
         "t",
@@ -454,6 +518,44 @@ mpc.branch = [
         pkg.validation.passes
     );
     assert_json_roundtrips(&pkg);
+}
+
+#[test]
+fn sane_validation_skips_ambiguous_generator_source_refs() {
+    let src = "\
+function mpc = duplicate_bad_gens
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t10\t0\t30\t-30\t0\t100\t1\t50\t0;
+\t1\t20\t0\t30\t-30\t0\t100\t1\t60\t0;
+];
+mpc.branch = [
+\t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+    let net = powerio::parse_str(src, "matpower").unwrap().network;
+    let mut pkg = CompilerPackage::from_balanced(net);
+    pkg.run_sane_validation();
+
+    let generator_vg: Vec<_> = pkg
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == DiagnosticCode::new("VALIDATE.BALANCED.VALUE_DOMAIN")
+                && d.details["element"] == "generator at bus 1"
+                && d.details["field"] == "vg"
+        })
+        .collect();
+    assert_eq!(generator_vg.len(), 2, "{:?}", pkg.diagnostics);
+    assert!(
+        generator_vg.iter().all(|d| d.source_ref.is_none()),
+        "ambiguous generator diagnostics must not pick the first row: {generator_vg:?}"
+    );
 }
 
 #[test]

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -314,7 +314,7 @@ fn balanced_fields_lift_into_source_maps() {
                 && e.mapping_kind == MappingKind::Exact
                 && e.confidence == Confidence::High
                 && e.source_ref.record.as_deref() == Some("bus")
-                && e.source_ref.field.as_deref() == Some("vm")
+                && e.source_ref.field.as_deref() == Some("VM")
         }),
         "expected bus voltage source map: {:?}",
         pkg.source_maps
@@ -324,7 +324,7 @@ fn balanced_fields_lift_into_source_maps() {
             e.element_path == "/model/balanced_network/branches/0/angmax"
                 && e.mapping_kind == MappingKind::Exact
                 && e.source_ref.record.as_deref() == Some("branch")
-                && e.source_ref.field.as_deref() == Some("angmax")
+                && e.source_ref.field.as_deref() == Some("ANGMAX")
         }),
         "expected branch angle source map: {:?}",
         pkg.source_maps
@@ -354,6 +354,9 @@ mpc.baseMVA = 100;
 mpc.bus = [
 \t1\t3\t12\t3\t0.5\t0.25\t1\t1\t0\t230\t1\t1.1\t0.9;
 \t2\t1\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t10\t2\t30\t-30\t1\t100\t1\t50\t0;
 ];
 mpc.branch = [
 \t1\t2\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
@@ -387,6 +390,16 @@ mpc.branch = [
         "/model/balanced_network/shunts/0/b",
         "BS"
     ));
+    assert!(
+        pkg.source_maps.iter().any(|e| {
+            e.element_path == "/model/balanced_network/generators/0/pg"
+                && e.mapping_kind == MappingKind::Exact
+                && e.source_ref.record.as_deref() == Some("generator")
+                && e.source_ref.field.as_deref() == Some("PG")
+        }),
+        "expected generator dispatch source map: {:?}",
+        pkg.source_maps
+    );
     assert!(
         !pkg.source_maps
             .iter()
@@ -520,7 +533,7 @@ mpc.branch = [
             && d.details["field"] == "vm"
             && d.element_path.as_deref() == Some("/model/balanced_network/buses/0/vm")
             && d.source_ref.as_ref().and_then(|r| r.record.as_deref()) == Some("bus")
-            && d.source_ref.as_ref().and_then(|r| r.field.as_deref()) == Some("vm")),
+            && d.source_ref.as_ref().and_then(|r| r.field.as_deref()) == Some("VM")),
         "expected voltage magnitude finding: {:?}",
         pkg.diagnostics
     );

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -208,7 +208,7 @@ fn diagnostics_roundtrip() {
             "PSS/E RAW target cannot represent branch angle limits.",
         )
         .with_element_path("/model/balanced_network/branches/0/angmin")
-        .with_source_ref(SourceRef::new("src0").with_field("ANGMIN").with_line(88))
+        .with_source_ref(SourceRef::new("src0").with_field("angmin").with_line(88))
         .with_suggested_action("Use MATPOWER if branch angle limits are required."),
     );
     pkg.validation = powerio_pkg::ValidationSummary::from_diagnostics(&pkg.diagnostics);
@@ -229,7 +229,7 @@ fn diagnostics_roundtrip() {
     );
     assert_eq!(
         d.source_ref.as_ref().unwrap().field.as_deref(),
-        Some("ANGMIN")
+        Some("angmin")
     );
     assert_eq!(
         back.validation.status,
@@ -257,7 +257,7 @@ fn source_references_roundtrip() {
         }])
         .with_source_maps(vec![SourceMapEntry {
             element_path: "/model/balanced_network/buses/0/vm".to_owned(),
-            source_ref: SourceRef::new("src0").with_field("VM").with_line(103),
+            source_ref: SourceRef::new("src0").with_field("vm").with_line(103),
             mapping_kind: MappingKind::Exact,
             confidence: Confidence::Exact,
         }]);
@@ -281,7 +281,7 @@ fn source_references_roundtrip() {
     assert_eq!(back.sources[0].id, "src0");
     assert_eq!(back.source_maps.len(), 1);
     assert_eq!(back.source_maps[0].mapping_kind, MappingKind::Exact);
-    assert_eq!(back.source_maps[0].source_ref.field.as_deref(), Some("VM"));
+    assert_eq!(back.source_maps[0].source_ref.field.as_deref(), Some("vm"));
 }
 
 #[test]
@@ -314,7 +314,7 @@ fn balanced_fields_lift_into_source_maps() {
                 && e.mapping_kind == MappingKind::Exact
                 && e.confidence == Confidence::High
                 && e.source_ref.record.as_deref() == Some("bus")
-                && e.source_ref.field.as_deref() == Some("VM")
+                && e.source_ref.field.as_deref() == Some("vm")
         }),
         "expected bus voltage source map: {:?}",
         pkg.source_maps
@@ -324,7 +324,7 @@ fn balanced_fields_lift_into_source_maps() {
             e.element_path == "/model/balanced_network/branches/0/angmax"
                 && e.mapping_kind == MappingKind::Exact
                 && e.source_ref.record.as_deref() == Some("branch")
-                && e.source_ref.field.as_deref() == Some("ANGMAX")
+                && e.source_ref.field.as_deref() == Some("angmax")
         }),
         "expected branch angle source map: {:?}",
         pkg.source_maps
@@ -376,26 +376,26 @@ mpc.branch = [
     };
     assert!(has_split_bus_field(
         "/model/balanced_network/loads/0/p",
-        "PD"
+        "p"
     ));
     assert!(has_split_bus_field(
         "/model/balanced_network/loads/0/q",
-        "QD"
+        "q"
     ));
     assert!(has_split_bus_field(
         "/model/balanced_network/shunts/0/g",
-        "GS"
+        "g"
     ));
     assert!(has_split_bus_field(
         "/model/balanced_network/shunts/0/b",
-        "BS"
+        "b"
     ));
     assert!(
         pkg.source_maps.iter().any(|e| {
             e.element_path == "/model/balanced_network/generators/0/pg"
                 && e.mapping_kind == MappingKind::Exact
                 && e.source_ref.record.as_deref() == Some("generator")
-                && e.source_ref.field.as_deref() == Some("PG")
+                && e.source_ref.field.as_deref() == Some("pg")
         }),
         "expected generator dispatch source map: {:?}",
         pkg.source_maps
@@ -533,7 +533,7 @@ mpc.branch = [
             && d.details["field"] == "vm"
             && d.element_path.as_deref() == Some("/model/balanced_network/buses/0/vm")
             && d.source_ref.as_ref().and_then(|r| r.record.as_deref()) == Some("bus")
-            && d.source_ref.as_ref().and_then(|r| r.field.as_deref()) == Some("VM")),
+            && d.source_ref.as_ref().and_then(|r| r.field.as_deref()) == Some("vm")),
         "expected voltage magnitude finding: {:?}",
         pkg.diagnostics
     );

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -304,6 +304,35 @@ fn defaulted_fields_lift_into_source_maps() {
 }
 
 #[test]
+fn balanced_fields_lift_into_source_maps() {
+    let pkg = balanced_package();
+    assert_eq!(pkg.sources.len(), 1);
+    assert_eq!(pkg.sources[0].format.as_deref(), Some("matpower"));
+    assert!(
+        pkg.source_maps.iter().any(|e| {
+            e.element_path == "/model/balanced_network/buses/0/vm"
+                && e.mapping_kind == MappingKind::Exact
+                && e.confidence == Confidence::High
+                && e.source_ref.record.as_deref() == Some("bus")
+                && e.source_ref.field.as_deref() == Some("vm")
+        }),
+        "expected bus voltage source map: {:?}",
+        pkg.source_maps
+    );
+    assert!(
+        pkg.source_maps.iter().any(|e| {
+            e.element_path == "/model/balanced_network/branches/0/angmax"
+                && e.mapping_kind == MappingKind::Exact
+                && e.source_ref.record.as_deref() == Some("branch")
+                && e.source_ref.field.as_deref() == Some("angmax")
+        }),
+        "expected branch angle source map: {:?}",
+        pkg.source_maps
+    );
+    assert_json_roundtrips(&pkg);
+}
+
+#[test]
 fn origin_distinguishes_in_memory_from_file() {
     let in_mem = CompilerPackage::from_balanced(powerio::BalancedNetwork::in_memory(
         "t",
@@ -406,7 +435,10 @@ mpc.branch = [
     assert!(
         pkg.diagnostics.iter().any(|d| d.code
             == DiagnosticCode::new("VALIDATE.BALANCED.VALUE_DOMAIN")
-            && d.details["field"] == "vm"),
+            && d.details["field"] == "vm"
+            && d.element_path.as_deref() == Some("/model/balanced_network/buses/0/vm")
+            && d.source_ref.as_ref().and_then(|r| r.record.as_deref()) == Some("bus")
+            && d.source_ref.as_ref().and_then(|r| r.field.as_deref()) == Some("vm")),
         "expected voltage magnitude finding: {:?}",
         pkg.diagnostics
     );

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -1421,10 +1421,13 @@ pub fn write_pslf(net: &Network) -> Conversion {
     if net.generators.iter().any(|g| g.cost.is_some()) {
         warnings.push("generator cost curves dropped: PSLF .epc carries no cost data".into());
     }
+    // Transformer branches drop their charging entirely (warned separately
+    // below), so exclude them here: only line records carry the collapsed total
+    // susceptance this message describes.
     let terminal_charging = net
         .branches
         .iter()
-        .filter(|b| b.has_non_matpower_charging())
+        .filter(|b| b.has_non_matpower_charging() && !b.is_transformer())
         .count();
     if terminal_charging > 0 {
         warnings.push(format!(

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -1431,6 +1431,20 @@ pub fn write_pslf(net: &Network) -> Conversion {
             "{terminal_charging} branch terminal admittance record(s) collapsed to total susceptance: PSLF branch records written here cannot carry conductance or asymmetric terminal charging"
         ));
     }
+    let transformer_charging = net
+        .branches
+        .iter()
+        .filter(|b| {
+            b.is_transformer()
+                && (b.terminal_charging().total_g().abs() > 1e-12
+                    || b.terminal_charging().total_b().abs() > 1e-12)
+        })
+        .count();
+    if transformer_charging > 0 {
+        warnings.push(format!(
+            "{transformer_charging} transformer charging admittance record(s) dropped: PSLF transformer records written here carry series impedance, tap, shift, and ratings only"
+        ));
+    }
     let current_ratings = net
         .branches
         .iter()
@@ -1687,6 +1701,76 @@ end
         let mut warnings = Vec::new();
         let net = parse_pslf_source(Arc::new(epc.to_string()), None, &mut warnings).unwrap();
         assert_eq!(net.source.as_deref().map(String::as_str), Some(epc));
+    }
+
+    #[test]
+    fn transformer_charging_drop_is_warned_on_write() {
+        let mut net = Network::in_memory(
+            "charging",
+            100.0,
+            vec![
+                Bus {
+                    id: BusId(1),
+                    kind: BusType::Ref,
+                    vm: 1.0,
+                    va: 0.0,
+                    base_kv: 230.0,
+                    vmax: 1.1,
+                    vmin: 0.9,
+                    evhi: None,
+                    evlo: None,
+                    area: 1,
+                    zone: 1,
+                    name: None,
+                    extras: Extras::new(),
+                },
+                Bus {
+                    id: BusId(2),
+                    kind: BusType::Pq,
+                    vm: 1.0,
+                    va: 0.0,
+                    base_kv: 230.0,
+                    vmax: 1.1,
+                    vmin: 0.9,
+                    evhi: None,
+                    evlo: None,
+                    area: 1,
+                    zone: 1,
+                    name: None,
+                    extras: Extras::new(),
+                },
+            ],
+            Vec::new(),
+        );
+        net.branches.push(Branch {
+            from: BusId(1),
+            to: BusId(2),
+            r: 0.01,
+            x: 0.1,
+            b: 0.02,
+            charging: None,
+            rate_a: 100.0,
+            rate_b: 100.0,
+            rate_c: 100.0,
+            current_ratings: None,
+            tap: 1.0,
+            shift: 0.0,
+            in_service: true,
+            angmin: -360.0,
+            angmax: 360.0,
+            control: None,
+            solution: None,
+            extras: Extras::new(),
+        });
+
+        let conv = write_pslf(&net);
+        assert!(
+            conv.warnings
+                .iter()
+                .any(|w| w.contains("transformer charging admittance")),
+            "{:?}",
+            conv.warnings
+        );
     }
 
     #[test]

--- a/powerio/tests/roundtrip_formats.rs
+++ b/powerio/tests/roundtrip_formats.rs
@@ -141,10 +141,20 @@ fn value_fingerprint(net: &Network, target: TargetFormat) -> ValueFingerprint {
     ValueFingerprint {
         base_mva: round_value(net.base_mva),
         buses: bus_values(net),
-        loads_by_bus: bus_injections(net.loads.iter().map(|load| (load.bus.0, load.p, load.q))),
+        // Sum only in-service injections: the by-bus aggregation cannot carry a
+        // per-element service flag, so counting out-of-service p/q would both
+        // mask a writer that flips in_service and fail a writer that correctly
+        // drops out-of-service injections.
+        loads_by_bus: bus_injections(
+            net.loads
+                .iter()
+                .filter(|load| load.in_service)
+                .map(|load| (load.bus.0, load.p, load.q)),
+        ),
         shunts_by_bus: bus_injections(
             net.shunts
                 .iter()
+                .filter(|shunt| shunt.in_service)
                 .map(|shunt| (shunt.bus.0, shunt.g, shunt.b)),
         ),
         branches: branch_values(net, target),

--- a/powerio/tests/roundtrip_formats.rs
+++ b/powerio/tests/roundtrip_formats.rs
@@ -13,10 +13,11 @@
 //! value-for-value checks against the reference tools live in
 //! `benchmarks/validate_powermodels.jl` and `benchmarks/validate_egret.py`.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use powerio::{
-    Network, TargetFormat, parse_egret_json, parse_matpower_file, parse_powermodels_json,
+    BusType, Network, TargetFormat, parse_egret_json, parse_matpower_file, parse_powermodels_json,
     parse_powerworld, parse_pslf, parse_psse, write_as, write_egret_json, write_powermodels_json,
     write_powerworld, write_pslf, write_psse, write_psse_rev,
 };
@@ -66,6 +67,220 @@ fn fingerprint(net: &Network) -> Fingerprint {
         load_q: r(net.loads.iter().map(|l| l.q).sum()),
         gen_p: r(net.generators.iter().map(|g| g.pg).sum()),
         base_mva: r(net.base_mva),
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct ValueFingerprint {
+    base_mva: i64,
+    buses: Vec<BusValue>,
+    loads_by_bus: Vec<BusInjection>,
+    shunts_by_bus: Vec<BusInjection>,
+    branches: Vec<BranchValue>,
+    generators: Vec<GeneratorValue>,
+}
+
+#[derive(Debug, PartialEq)]
+struct BusValue {
+    id: usize,
+    kind: BusType,
+    vm: i64,
+    va: i64,
+    base_kv: i64,
+    vmax: i64,
+    vmin: i64,
+    area: usize,
+    zone: usize,
+}
+
+#[derive(Debug, PartialEq)]
+struct BusInjection {
+    bus: usize,
+    p_or_g: i64,
+    q_or_b: i64,
+}
+
+#[derive(Debug, PartialEq)]
+struct BranchValue {
+    from: usize,
+    to: usize,
+    occurrence: usize,
+    r: i64,
+    x: i64,
+    b: Option<i64>,
+    rate_a: i64,
+    rate_b: i64,
+    rate_c: i64,
+    tap: i64,
+    shift: i64,
+    in_service: bool,
+    angmin: i64,
+    angmax: i64,
+}
+
+#[derive(Debug, PartialEq)]
+struct GeneratorValue {
+    bus: usize,
+    occurrence: usize,
+    pg: i64,
+    qg: i64,
+    pmax: i64,
+    pmin: i64,
+    qmax: i64,
+    qmin: i64,
+    vg: Option<i64>,
+    mbase: i64,
+    in_service: bool,
+}
+
+fn round_value(x: f64) -> i64 {
+    (x * 1e5).round() as i64
+}
+
+fn value_fingerprint(net: &Network, target: TargetFormat) -> ValueFingerprint {
+    ValueFingerprint {
+        base_mva: round_value(net.base_mva),
+        buses: bus_values(net),
+        loads_by_bus: bus_injections(net.loads.iter().map(|load| (load.bus.0, load.p, load.q))),
+        shunts_by_bus: bus_injections(
+            net.shunts
+                .iter()
+                .map(|shunt| (shunt.bus.0, shunt.g, shunt.b)),
+        ),
+        branches: branch_values(net, target),
+        generators: generator_values(net, target),
+    }
+}
+
+fn bus_values(net: &Network) -> Vec<BusValue> {
+    let mut buses: Vec<_> = net
+        .buses
+        .iter()
+        .map(|bus| BusValue {
+            id: bus.id.0,
+            kind: bus.kind,
+            vm: round_value(bus.vm),
+            va: round_value(bus.va),
+            base_kv: round_value(bus.base_kv),
+            vmax: round_value(bus.vmax),
+            vmin: round_value(bus.vmin),
+            area: bus.area,
+            zone: bus.zone,
+        })
+        .collect();
+    buses.sort_by_key(|b| b.id);
+    buses
+}
+
+fn bus_injections<I>(values: I) -> Vec<BusInjection>
+where
+    I: IntoIterator<Item = (usize, f64, f64)>,
+{
+    let mut by_bus = BTreeMap::<usize, (f64, f64)>::new();
+    for (bus, p_or_g, q_or_b) in values {
+        let entry = by_bus.entry(bus).or_default();
+        entry.0 += p_or_g;
+        entry.1 += q_or_b;
+    }
+    by_bus
+        .into_iter()
+        .map(|(bus, (p_or_g, q_or_b))| BusInjection {
+            bus,
+            p_or_g: round_value(p_or_g),
+            q_or_b: round_value(q_or_b),
+        })
+        .collect()
+}
+
+fn branch_values(net: &Network, target: TargetFormat) -> Vec<BranchValue> {
+    let mut branch_counts = BTreeMap::<(usize, usize), usize>::new();
+    let mut branches: Vec<_> = net
+        .branches
+        .iter()
+        .map(|branch| {
+            let key = (branch.from.0, branch.to.0);
+            let occurrence = *branch_counts
+                .entry(key)
+                .and_modify(|n| *n += 1)
+                .or_insert(0);
+            BranchValue {
+                from: branch.from.0,
+                to: branch.to.0,
+                occurrence,
+                r: round_value(branch.r),
+                x: round_value(branch.x),
+                b: (!(target == TargetFormat::Pslf && branch.is_transformer()))
+                    .then_some(round_value(branch.legacy_total_charging_b())),
+                rate_a: round_value(branch.rate_a),
+                rate_b: round_value(branch.rate_b),
+                rate_c: round_value(branch.rate_c),
+                tap: round_value(branch.tap),
+                shift: round_value(branch.shift),
+                in_service: branch.in_service,
+                angmin: round_value(branch.angmin),
+                angmax: round_value(branch.angmax),
+            }
+        })
+        .collect();
+    branches.sort_by_key(|b| (b.from, b.to, b.occurrence));
+    branches
+}
+
+fn generator_values(net: &Network, target: TargetFormat) -> Vec<GeneratorValue> {
+    let mut generator_counts = BTreeMap::<usize, usize>::new();
+    let mut generators: Vec<_> = net
+        .generators
+        .iter()
+        .map(|generator| {
+            let occurrence = *generator_counts
+                .entry(generator.bus.0)
+                .and_modify(|n| *n += 1)
+                .or_insert(0);
+            GeneratorValue {
+                bus: generator.bus.0,
+                occurrence,
+                pg: round_value(generator.pg),
+                qg: round_value(generator.qg),
+                pmax: round_value(generator.pmax),
+                pmin: round_value(generator.pmin),
+                qmax: round_value(generator.qmax),
+                qmin: round_value(generator.qmin),
+                vg: (target != TargetFormat::Pslf).then_some(round_value(generator.vg)),
+                mbase: round_value(generator.mbase),
+                in_service: generator.in_service,
+            }
+        })
+        .collect();
+    generators.sort_by_key(|g| (g.bus, g.occurrence));
+    generators
+}
+
+fn assert_value_fingerprint_eq(got: &ValueFingerprint, expected: &ValueFingerprint, context: &str) {
+    assert_eq!(got.base_mva, expected.base_mva, "{context}: base_mva");
+    assert_eq!(got.buses, expected.buses, "{context}: buses");
+    assert_eq!(
+        got.loads_by_bus, expected.loads_by_bus,
+        "{context}: loads by bus"
+    );
+    assert_eq!(
+        got.shunts_by_bus, expected.shunts_by_bus,
+        "{context}: shunts by bus"
+    );
+    assert_eq!(
+        got.branches.len(),
+        expected.branches.len(),
+        "{context}: branch count"
+    );
+    for (i, (got, expected)) in got.branches.iter().zip(&expected.branches).enumerate() {
+        assert_eq!(got, expected, "{context}: branch {i}");
+    }
+    assert_eq!(
+        got.generators.len(),
+        expected.generators.len(),
+        "{context}: generator count"
+    );
+    for (i, (got, expected)) in got.generators.iter().zip(&expected.generators).enumerate() {
+        assert_eq!(got, expected, "{context}: generator {i}");
     }
 }
 
@@ -137,6 +352,22 @@ fn core_preserved_through_each_format() {
                 fp0,
                 "{case} via {}: electrical core changed",
                 fmt.name
+            );
+        }
+    }
+}
+
+#[test]
+fn stable_element_values_preserved_through_each_format() {
+    for case in CASES {
+        let net0 = parse_matpower_file(data(case)).unwrap();
+        for fmt in roundtrippable() {
+            let fp0 = value_fingerprint(&net0, fmt.format);
+            let net1 = (fmt.read)(&(fmt.write)(&net0));
+            assert_value_fingerprint_eq(
+                &value_fingerprint(&net1, fmt.format),
+                &fp0,
+                &format!("{case} via {}", fmt.name),
             );
         }
     }

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -41,6 +41,7 @@ from ._powerio import PowerIODataError, PowerIOError, PowerIOParseError, __versi
 
 __all__ = [
     "Network",
+    "BalancedNetwork",
     "Incidence",
     "YbusParts",
     "Conversion",
@@ -476,9 +477,9 @@ class Network:
         return g
 
 
-# Deprecated compatibility alias. Kept out of ``__all__`` and docs; remove in
-# 0.4.0.
-Case = Network
+# v1 name for the scalar positive sequence model. ``Network`` remains the
+# existing Python handle name in 0.4.
+BalancedNetwork = Network
 
 
 def parse_file(path: Any, from_: Optional[str] = None) -> Network:

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -225,7 +225,7 @@ class Network:
         gen_cost_csv: Optional[Any] = ...,
     ) -> Dict[str, Any]: ...
 
-Case = Network
+BalancedNetwork = Network
 
 class Conversion(NamedTuple):
     text: str

--- a/python/powerio/dist.py
+++ b/python/powerio/dist.py
@@ -23,7 +23,7 @@ from . import Conversion, _powerio
 
 __all__ = [
     "DistNetwork",
-    "DistCase",
+    "MulticonductorNetwork",
     "parse_file",
     "parse_str",
     "convert_file",
@@ -96,12 +96,12 @@ class DistNetwork:
         return self._inner.__repr__()
 
 
-# Deprecated compatibility alias. Kept because it was exported before the
-# DistNetwork rename; remove in 0.4.0.
-DistCase = DistNetwork
+# v1 name for the wire coordinate distribution model. ``DistNetwork`` remains
+# available in 0.4 because it is the existing handle name.
+MulticonductorNetwork = DistNetwork
 
 
-def parse_file(path: Any, from_: Optional[str] = None) -> DistNetwork:
+def parse_file(path: Any, from_: Optional[str] = None) -> MulticonductorNetwork:
     """Parse a distribution network file.
 
     The format comes from ``from_`` when given, else from the file itself:
@@ -111,7 +111,7 @@ def parse_file(path: Any, from_: Optional[str] = None) -> DistNetwork:
     return DistNetwork(_powerio.dist_parse_file(str(path), from_))
 
 
-def parse_str(text: str, format: str) -> DistNetwork:
+def parse_str(text: str, format: str) -> MulticonductorNetwork:
     """Parse an in-memory distribution network of the named ``format``."""
     return DistNetwork(_powerio.dist_parse_str(text, format))
 

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -5,10 +5,10 @@ The advertised MCP surface is semantic and format neutral:
 ``convert``, ``save``, ``summary``, ``parse``, ``normalize``, ``matrix``,
 ``display``.
 
-Network tools route transmission cases, distribution cases, PyPSA CSV folders,
-and gridfm datasets through the lower level powerio APIs. Transmission parses
-serialize through the ``powerio-json`` transport. Distribution parses serialize
-through canonical ``bmopf-json``.
+Network tools route balanced transmission models, multiconductor distribution
+models, PyPSA CSV folders, and gridfm datasets through the lower level powerio
+APIs. Transmission parses serialize through the ``powerio-json`` transport.
+Distribution parses serialize through canonical ``bmopf-json``.
 """
 
 from __future__ import annotations
@@ -839,7 +839,7 @@ def _summary_tool(
     json_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Return the canonical network summary JSON."""
+    """Return canonical summary JSON for a balanced or multiconductor model."""
     return _summary_impl(path, content, json, from_format, json_format, options)
 
 
@@ -850,7 +850,7 @@ def _parse_tool(
     from_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Parse a network and return its serial JSON transport plus summary."""
+    """Parse a balanced or multiconductor model and return JSON plus summary."""
     return _parse_impl(path, content, from_format, options)
 
 

--- a/python/tests/test_dist.py
+++ b/python/tests/test_dist.py
@@ -20,11 +20,13 @@ def test_parse_file_counts_and_source_format():
     assert isinstance(case.warnings, list)
 
 
-def test_distcase_compatibility_alias():
+def test_multiconductor_alias_and_distcase_removed():
     case = dist.parse_file(FOURWIRE)
-    assert dist.DistCase is dist.DistNetwork
-    assert "DistCase" in dist.__all__
-    assert isinstance(case, dist.DistCase)
+    assert dist.MulticonductorNetwork is dist.DistNetwork
+    assert "MulticonductorNetwork" in dist.__all__
+    assert "DistCase" not in dist.__all__
+    assert not hasattr(dist, "DistCase")
+    assert isinstance(case, dist.MulticonductorNetwork)
 
 
 def test_same_format_write_echoes_source():

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -75,7 +75,9 @@ def test_parse_metadata(case9):
 
 def test_public_type_is_network(case9):
     assert isinstance(case9, powerio.Network)
-    assert powerio.Case is powerio.Network
+    assert powerio.BalancedNetwork is powerio.Network
+    assert "BalancedNetwork" in powerio.__all__
+    assert not hasattr(powerio, "Case")
     assert repr(case9).startswith("Network(")
 
 


### PR DESCRIPTION
## Summary

- Enforce `.pio.json` envelope schema compatibility before payload use.
- Add balanced package source maps for stable records and attach source references to validation diagnostics when a source map matches. Keep provenance honest for defaulted and format folded fields: MATPOWER load and shunt payload fields point back to bus row fields, MATPOWER default frequency has no exact source map, and ambiguous generator diagnostics do not guess a source row.
- Keep the v0.4 naming migration coherent across Rust, Python, MCP wording, C ABI notes, changelog, and the mdBook guide; remove Python `Case` / `DistCase`.
- Strengthen converter tests to compare stable per element values and add an explicit PSLF warning for dropped transformer charging.
- Fix mdBook math delimiters and tighten guide wording around PowerWorld benchmark data and BMOPF distribution payloads.

## Issue scope

Closes #29.
Closes #129.
Closes #142.
Closes #144.
Closes #153.

Leaves #145, #157, #158, #85, and #159 for follow up branches.

## Checks

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --all-targets`
- `cargo test -p powerio-pkg`
- `cargo doc -p powerio-pkg --no-deps`
- `cargo test -p powerio --test roundtrip_formats`
- `cargo test -p powerio-cli package`
- `cargo test`
- `cargo test -p powerio-capi`
- `.venv/bin/python -m pytest python/tests`
- `mdbook build docs`
- `mdbook test docs`
