### PR TITLE
Implement multiconductor lowering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,8 @@ dependencies = [
  "num-complex",
  "parquet",
  "powerio",
+ "powerio-dist",
+ "powerio-pkg",
  "rand 0.9.4",
  "rand_chacha",
  "rayon",
@@ -2067,6 +2069,7 @@ dependencies = [
 name = "powerio-pkg"
 version = "0.3.3"
 dependencies = [
+ "num-complex",
  "powerio",
  "powerio-dist",
  "serde",

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -109,11 +109,19 @@ by leading segment (`PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`,
 Each pass that transforms one model into another appends a `LoweringRecord`
 (input and output kind, options, assumptions, approximations, dropped fields,
 diagnostics, validation status) to `lowering_history`. The record makes the
-transformation explicit. This change set defines the record shape; lowering
-implementations are separate work. The v0.4.0 direction for
-`MulticonductorNetwork` to `BalancedNetwork` lowering is in
-[the v0.4 release direction](https://eigenergy.github.io/powerio/guide/v0.4-release-direction.html); the implementation is
-tracked in #145.
+transformation explicit.
+
+`powerio_pkg::lower_multiconductor_to_balanced` lowers transparent three phase
+`MulticonductorNetwork` values into `BalancedNetwork` using the
+`FortescuePowerInvariant` sequence convention. Neutral conductors are Kron
+reduced before the sequence transform. One wire and two wire inputs,
+transformers, untyped objects, missing phase references, and closed switches
+return structured `LOWER.MULTI_TO_BALANCED.*` diagnostics. The package method
+`CompilerPackage::lower_multiconductor_to_balanced` returns a derived balanced
+package and appends the record. This pass is explicit only; readers, writers,
+matrix builders, bindings, and MCP operations do not run it implicitly. The
+v0.4.0 direction is in
+[the v0.4 release direction](https://eigenergy.github.io/powerio/guide/v0.4-release-direction.html).
 
 ## Versioning
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -113,6 +113,16 @@ with `mapping_kind = defaulted`, and its retained source becomes
 `origin.retained_source`. Validation diagnostics attach the matching `source_ref`
 when the package has a source map for the reported field.
 
+`CompilerPackage::lower_multiconductor_to_balanced(options)` returns a new
+balanced package with `origin.kind = derived` and
+`origin.pass = "multiconductor-to-balanced"`. It preserves the parent
+`lowering_history` and appends a `LoweringRecord` whose options, assumptions,
+approximations, dropped fields, diagnostics, and validation status describe the
+pass. Lowered balanced source maps use `lowered`, `aggregated`,
+`converted_units`, `synthetic`, and `defaulted` mapping kinds. The pass is never
+implicit during package readback, format conversion, matrix construction,
+bindings, or MCP operations.
+
 ## Example
 
 ```json

--- a/docs/src/v0.4-release-direction.md
+++ b/docs/src/v0.4-release-direction.md
@@ -1,9 +1,8 @@
 # v0.4.0 scope: multiconductor to balanced lowering
 
-v0.4.0 starts the explicit lowering path from `MulticonductorNetwork` to
-`BalancedNetwork`. Issue #145 tracks the implementation. The release scope is
-the design contract, the preflight helper, and lowering for transparent three
-phase inputs.
+v0.4.0 adds the explicit lowering path from `MulticonductorNetwork` to
+`BalancedNetwork`. The release scope is the design contract, the preflight
+helper, and lowering for transparent three phase inputs.
 
 ## IR boundary
 
@@ -37,14 +36,27 @@ which projection produced the result. The initial convention is
 
 ## v0.4.0 implementation
 
-The preflight helper checks whether a `MulticonductorNetwork` is ready for
-`BalancedNetwork` lowering and returns structured
+The raw lowering API is
+`powerio_pkg::lower_multiconductor_to_balanced(net, options)`. It first runs the
+same preflight checks exposed by
+`check_multiconductor_to_balanced_lowering`, then returns either a
+`MulticonductorToBalancedLowering { network, record }` or a
+`MulticonductorToBalancedError` with structured
 `LOWER.MULTI_TO_BALANCED.*` diagnostics. The lowering pass uses that result and
 emits balanced data for transparent three phase inputs.
 
 The lowering pass emits a derived balanced model only for supported inputs.
 Unsupported conductor sets, transformers, untyped objects, and missing phase
-references stay diagnostics rather than hidden approximations.
+references stay diagnostics rather than hidden approximations. Open switches are
+dropped with provenance. Closed switches are rejected rather than lowered into
+zero impedance branches.
+
+`CompilerPackage::lower_multiconductor_to_balanced(options)` only accepts a
+multiconductor package. It returns a new package with `model_kind = balanced`,
+`Origin::Derived { pass: "multiconductor-to-balanced", ... }`, the parent
+`lowering_history` plus one appended record, and source maps for lowered fields.
+Normal parse, convert, matrix, binding, and MCP operations never invoke this pass
+implicitly.
 
 ## Diagnostics and provenance
 
@@ -58,8 +70,9 @@ The lowered package also preserves provenance:
 - `lowering_history` records the pass name, input and output model kinds,
   transform convention, assumptions, approximations, dropped fields, diagnostics,
   and validation status.
-- `source_maps` use `mapping_kind = lowered`, `aggregated`, `synthetic`, or
-  `retained_extra` where balanced fields do not map exactly to one source value.
+- `source_maps` use `mapping_kind = lowered`, `aggregated`, `converted_units`,
+  `synthetic`, or `retained_extra` where balanced fields do not map exactly to
+  one source value.
 - `diagnostics` use `LOWER.*` codes for pass findings and `VALIDATE.*` codes for
   validation findings after lowering.
 

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -47,6 +47,8 @@ parquet = { version = "59", default-features = false, features = ["arrow", "snap
 [dev-dependencies]
 approx = "0.5"
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+powerio-dist.workspace = true
+powerio-pkg.workspace = true
 tempfile = "3"
 
 [[bench]]

--- a/powerio-matrix/tests/lowered_balanced.rs
+++ b/powerio-matrix/tests/lowered_balanced.rs
@@ -1,0 +1,21 @@
+use powerio_matrix::{BuildOptions, IndexedNetwork, build_bprime, build_ybus};
+use powerio_pkg::{MulticonductorToBalancedOptions, lower_multiconductor_to_balanced};
+
+#[test]
+fn lowered_multiconductor_balanced_model_builds_matrices() {
+    let text = include_str!("../../tests/data/dist/micro/fourwire_linecode.dss");
+    let net = powerio_dist::parse_str(text, "dss").expect("parse distribution fixture");
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .expect("lower to balanced");
+
+    let view = IndexedNetwork::new(&lowered.network);
+    let bprime = build_bprime(&view, &BuildOptions::default()).expect("build B prime");
+    let ybus = build_ybus(&view, &BuildOptions::default()).expect("build Y bus");
+
+    assert_eq!(bprime.rows(), view.n());
+    assert_eq!(bprime.cols(), view.n());
+    assert_eq!(ybus.g.rows(), view.n());
+    assert_eq!(ybus.b.cols(), view.n());
+    assert!(bprime.nnz() > 0);
+}

--- a/powerio-pkg/Cargo.toml
+++ b/powerio-pkg/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["science", "data-structures"]
 all-features = true
 
 [dependencies]
+num-complex = { workspace = true }
 powerio = { workspace = true }
 powerio-dist = { workspace = true }
 serde = { workspace = true }

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -45,8 +45,10 @@ pub mod validation;
 
 pub use diagnostics::{DiagnosticCode, DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
 pub use lowering::{
-    LoweringRecord, MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,
+    LoweringRecord, MulticonductorToBalancedError, MulticonductorToBalancedLowering,
+    MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,
     SequenceTransformConvention, check_multiconductor_to_balanced_lowering,
+    lower_multiconductor_to_balanced,
 };
 pub use model::{ModelKind, ModelPayload};
 pub use package::{

--- a/powerio-pkg/src/lowering.rs
+++ b/powerio-pkg/src/lowering.rs
@@ -7,11 +7,17 @@
 //! case, multiconductor to balanced, must be an explicit pass with diagnostics,
 //! never a silent positive sequence projection.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::f64::consts::PI;
 
+use num_complex::Complex64;
 use serde::{Deserialize, Serialize};
 
-use powerio_dist::{DistBus, MulticonductorNetwork};
+use powerio::{
+    BalancedNetwork, Branch, BranchCharging, Bus, BusId, BusType, Extras as BalancedExtras,
+    Generator, Load, Network, Shunt, SourceFormat,
+};
+use powerio_dist::{DistBus, DistLineCode, DistLoadVoltageModel, Mat, MulticonductorNetwork};
 
 use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
 use crate::model::ModelKind;
@@ -71,24 +77,37 @@ impl std::fmt::Display for SequenceTransformConvention {
     }
 }
 
-/// Options for the multiconductor to balanced lowering preflight.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+const DEFAULT_LOWERING_BASE_MVA: f64 = 100.0;
+const SQRT_3: f64 = 1.732_050_807_568_877_2;
+const COUPLING_TOLERANCE: f64 = 1.0e-9;
+
+fn default_lowering_base_mva() -> f64 {
+    DEFAULT_LOWERING_BASE_MVA
+}
+
+/// Options for the multiconductor to balanced lowering preflight and pass.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MulticonductorToBalancedOptions {
     pub convention: SequenceTransformConvention,
+    /// Three phase system power base used for the balanced per-unit projection.
+    #[serde(default = "default_lowering_base_mva")]
+    pub base_mva: f64,
 }
 
 impl Default for MulticonductorToBalancedOptions {
     fn default() -> Self {
         Self {
             convention: SequenceTransformConvention::FortescuePowerInvariant,
+            base_mva: DEFAULT_LOWERING_BASE_MVA,
         }
     }
 }
 
-/// Readiness report for the future multiconductor to balanced lowering pass.
+/// Readiness report for the multiconductor to balanced lowering pass.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MulticonductorToBalancedReadiness {
     pub convention: SequenceTransformConvention,
+    pub base_mva: f64,
     pub status: ValidationStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub assumptions: Vec<String>,
@@ -105,7 +124,47 @@ impl MulticonductorToBalancedReadiness {
     }
 }
 
-/// Check whether a multiconductor package is ready for the future lowering pass.
+/// A successful raw multiconductor to balanced lowering result.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MulticonductorToBalancedLowering {
+    pub network: BalancedNetwork,
+    pub record: LoweringRecord,
+}
+
+/// Structured failure from the raw multiconductor to balanced lowering pass.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct MulticonductorToBalancedError {
+    pub options: MulticonductorToBalancedOptions,
+    pub status: ValidationStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<StructuredDiagnostic>,
+}
+
+impl MulticonductorToBalancedError {
+    pub fn new(
+        options: MulticonductorToBalancedOptions,
+        diagnostics: Vec<StructuredDiagnostic>,
+    ) -> Self {
+        Self {
+            options,
+            status: status_from_diagnostics(&diagnostics),
+            diagnostics,
+        }
+    }
+}
+
+impl std::fmt::Display for MulticonductorToBalancedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.diagnostics.first() {
+            Some(diagnostic) => write!(f, "{}", diagnostic.message),
+            None => f.write_str("multiconductor to balanced lowering failed"),
+        }
+    }
+}
+
+impl std::error::Error for MulticonductorToBalancedError {}
+
+/// Check whether a multiconductor package is ready for the lowering pass.
 ///
 /// This is a preflight only: it reports the assumptions and blockers that the
 /// lowering would need to account for, but it does not produce a balanced model
@@ -117,6 +176,7 @@ pub fn check_multiconductor_to_balanced_lowering(
 ) -> MulticonductorToBalancedReadiness {
     let mut report = MulticonductorToBalancedReadiness {
         convention: options.convention,
+        base_mva: options.base_mva,
         status: ValidationStatus::Ok,
         assumptions: vec![format!(
             "sequence transform convention: {}",
@@ -126,13 +186,1119 @@ pub fn check_multiconductor_to_balanced_lowering(
         diagnostics: Vec::new(),
     };
 
+    check_options(options, &mut report);
     check_bus_conductor_sets(net, &mut report);
     check_phase_reference(net, &mut report);
+    check_line_terminal_maps(net, &mut report);
+    check_linecodes(net, &mut report);
+    check_switches(net, &mut report);
     check_transformers(net, &mut report);
     check_untyped_objects(net, &mut report);
 
     report.status = status_from_diagnostics(&report.diagnostics);
     report
+}
+
+/// Lower a transparent three phase multiconductor network to a balanced model.
+///
+/// The pass is explicit. It does not run from readers, writers, matrix builders,
+/// bindings, or package deserialization. Unsupported inputs return structured
+/// `LOWER.MULTI_TO_BALANCED.*` diagnostics in [`MulticonductorToBalancedError`].
+pub fn lower_multiconductor_to_balanced(
+    net: &MulticonductorNetwork,
+    options: MulticonductorToBalancedOptions,
+) -> Result<MulticonductorToBalancedLowering, MulticonductorToBalancedError> {
+    let readiness = check_multiconductor_to_balanced_lowering(net, options);
+    if !readiness.is_ready() {
+        return Err(MulticonductorToBalancedError::new(
+            options,
+            readiness.diagnostics,
+        ));
+    }
+
+    let mut state = LoweringState::new(net, options, readiness);
+    state.lower()
+}
+
+struct LoweringState<'a> {
+    net: &'a MulticonductorNetwork,
+    options: MulticonductorToBalancedOptions,
+    neutral_terminals: BTreeSet<String>,
+    bus_ids: BTreeMap<String, BusId>,
+    record: LoweringRecord,
+}
+
+impl<'a> LoweringState<'a> {
+    fn new(
+        net: &'a MulticonductorNetwork,
+        options: MulticonductorToBalancedOptions,
+        readiness: MulticonductorToBalancedReadiness,
+    ) -> Self {
+        let mut record = LoweringRecord::new(
+            "multiconductor-to-balanced",
+            ModelKind::Multiconductor,
+            ModelKind::Balanced,
+        );
+        record.options = options_map(options);
+        record.assumptions = readiness.assumptions;
+        record.approximations = readiness.approximations;
+        record.diagnostics = readiness.diagnostics;
+        record
+            .assumptions
+            .push(format!("balanced power base: {} MVA", options.base_mva));
+        record
+            .assumptions
+            .push("balanced bus ids are synthesized from multiconductor bus order".to_owned());
+        record.approximations.push(
+            "wire-coordinate branch and shunt matrices are projected to positive sequence"
+                .to_owned(),
+        );
+        record.approximations.push(
+            "phase injection records are aggregated into scalar balanced injections".to_owned(),
+        );
+        record.approximations.push(
+            "units are converted from W/var/V/ohm/siemens/radians to MW/MVAr/per-unit/degrees"
+                .to_owned(),
+        );
+        if net.switches.iter().any(|sw| sw.open) {
+            record
+                .dropped_fields
+                .push("open switches dropped from balanced model".to_owned());
+        }
+
+        let bus_ids = net
+            .buses
+            .iter()
+            .enumerate()
+            .map(|(idx, bus)| (bus.id.to_ascii_lowercase(), BusId(idx + 1)))
+            .collect();
+
+        Self {
+            net,
+            options,
+            neutral_terminals: global_neutral_terminals(net),
+            bus_ids,
+            record,
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn lower(&mut self) -> Result<MulticonductorToBalancedLowering, MulticonductorToBalancedError> {
+        let Some(base) = self.voltage_base()? else {
+            return Err(MulticonductorToBalancedError::new(
+                self.options,
+                self.record.diagnostics.clone(),
+            ));
+        };
+
+        let buses = self.lower_buses(base);
+        let branches = self.lower_lines(base)?;
+        let loads = self.lower_loads();
+        let shunts = self.lower_shunts(base)?;
+        let generators = self.lower_generators(&buses);
+
+        let network = Network {
+            name: self
+                .net
+                .name
+                .clone()
+                .unwrap_or_else(|| "lowered-multiconductor".to_owned()),
+            base_mva: self.options.base_mva,
+            base_frequency: self.net.base_frequency,
+            buses,
+            loads,
+            shunts,
+            branches,
+            switches: Vec::new(),
+            generators,
+            storage: Vec::new(),
+            hvdc: Vec::new(),
+            transformers_3w: Vec::new(),
+            areas: Vec::new(),
+            solver: None,
+            source_format: SourceFormat::InMemory,
+            source: None,
+        };
+
+        if let Err(err) = network.validate() {
+            self.record.diagnostics.push(StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.INVALID_BALANCED_OUTPUT",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!("lowered balanced network failed structural validation: {err}"),
+            ));
+            return Err(MulticonductorToBalancedError::new(
+                self.options,
+                self.record.diagnostics.clone(),
+            ));
+        }
+        for finding in network.validate_values() {
+            self.record.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.BALANCED_VALUE_DOMAIN",
+                    DiagnosticSeverity::Warning,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "{} field `{}` is outside its value domain after lowering",
+                        finding.element, finding.field
+                    ),
+                )
+                .with_suggested_action(
+                    "Inspect the multiconductor source values before using the lowered model.",
+                ),
+            );
+        }
+
+        self.record.validation_status = status_from_diagnostics(&self.record.diagnostics);
+        Ok(MulticonductorToBalancedLowering {
+            network,
+            record: self.record.clone(),
+        })
+    }
+
+    fn voltage_base(&mut self) -> Result<Option<VoltageBase>, MulticonductorToBalancedError> {
+        for (idx, source) in self.net.sources.iter().enumerate() {
+            let Some(bus) = self.net.bus(&source.bus) else {
+                self.record.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.UNKNOWN_SOURCE_BUS",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "voltage source {} references unknown bus {}",
+                            source.name, source.bus
+                        ),
+                    )
+                    .with_element_path(format!("/model/multiconductor_network/sources/{idx}/bus")),
+                );
+                continue;
+            };
+            let positions =
+                active_positions(&source.terminal_map, Some(bus), &self.neutral_terminals);
+            if positions.len() != 3 {
+                continue;
+            }
+            let Some(v1) = positive_sequence_voltage(source, &positions) else {
+                self.record.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.INVALID_PHASE_REFERENCE",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "voltage source {} does not carry finite three phase voltage magnitudes and angles",
+                            source.name
+                        ),
+                    )
+                    .with_element_path(format!("/model/multiconductor_network/sources/{idx}")),
+                );
+                continue;
+            };
+            let line_to_line_volts = v1.norm();
+            if !line_to_line_volts.is_finite() || line_to_line_volts <= 0.0 {
+                self.record.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.INVALID_PHASE_REFERENCE",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "voltage source {} produced a non-positive positive-sequence voltage base",
+                            source.name
+                        ),
+                    )
+                    .with_element_path(format!("/model/multiconductor_network/sources/{idx}")),
+                );
+                continue;
+            }
+            self.record.assumptions.push(format!(
+                "voltage base synthesized from source {} positive-sequence voltage: {} kV line-to-line",
+                source.name,
+                line_to_line_volts / 1000.0
+            ));
+            return Ok(Some(VoltageBase { line_to_line_volts }));
+        }
+
+        if self
+            .record
+            .diagnostics
+            .iter()
+            .any(|d| d.severity >= DiagnosticSeverity::Error)
+        {
+            return Err(MulticonductorToBalancedError::new(
+                self.options,
+                self.record.diagnostics.clone(),
+            ));
+        }
+        self.record.diagnostics.push(StructuredDiagnostic::new(
+            "LOWER.MULTI_TO_BALANCED.MISSING_PHASE_REFERENCE",
+            DiagnosticSeverity::Error,
+            DiagnosticStage::Lower,
+            "multiconductor to balanced lowering requires a finite three phase voltage source reference",
+        ));
+        Ok(None)
+    }
+
+    fn lower_buses(&mut self, base: VoltageBase) -> Vec<Bus> {
+        self.net
+            .buses
+            .iter()
+            .enumerate()
+            .map(|(idx, bus)| {
+                let source = self
+                    .net
+                    .sources
+                    .iter()
+                    .find(|source| source.bus.eq_ignore_ascii_case(&bus.id));
+                let (vm, va) = source
+                    .and_then(|source| {
+                        let positions = active_positions(
+                            &source.terminal_map,
+                            Some(bus),
+                            &self.neutral_terminals,
+                        );
+                        positive_sequence_voltage(source, &positions)
+                    })
+                    .map_or((1.0, 0.0), |v| {
+                        (
+                            v.norm() / base.line_to_line_volts,
+                            radians_to_degrees(v.arg()),
+                        )
+                    });
+                if source.is_none() {
+                    self.record.dropped_fields.push(format!(
+                        "bus {} voltage magnitude and angle defaulted to 1.0 p.u. and 0 degrees",
+                        bus.id
+                    ));
+                }
+                let (vmin, vmax) = match (bus.v_min, bus.v_max) {
+                    (Some(vmin), Some(vmax)) if vmin.is_finite() && vmax.is_finite() => (
+                        vmin / base.line_to_line_volts,
+                        vmax / base.line_to_line_volts,
+                    ),
+                    _ => {
+                        self.record.dropped_fields.push(format!(
+                            "bus {} voltage bounds defaulted to 0.9/1.1 p.u.",
+                            bus.id
+                        ));
+                        (0.9, 1.1)
+                    }
+                };
+                self.record_bus_bound_drops(bus);
+                Bus {
+                    id: BusId(idx + 1),
+                    kind: self.bus_kind(&bus.id),
+                    vm,
+                    va,
+                    base_kv: base.line_to_line_volts / 1000.0,
+                    vmax,
+                    vmin,
+                    evhi: None,
+                    evlo: None,
+                    area: 1,
+                    zone: 1,
+                    name: Some(bus.id.clone()),
+                    extras: source_extra("multiconductor_bus_id", &bus.id),
+                }
+            })
+            .collect()
+    }
+
+    fn record_bus_bound_drops(&mut self, bus: &DistBus) {
+        if bus.vpn_min.is_some()
+            || bus.vpn_max.is_some()
+            || bus.vpp_min.is_some()
+            || bus.vpp_max.is_some()
+            || bus.vsym_min.is_some()
+            || bus.vsym_max.is_some()
+        {
+            self.record.dropped_fields.push(format!(
+                "bus {} conductor voltage bound families dropped",
+                bus.id
+            ));
+        }
+    }
+
+    fn bus_kind(&self, bus_id: &str) -> BusType {
+        if self
+            .net
+            .sources
+            .iter()
+            .any(|source| source.bus.eq_ignore_ascii_case(bus_id))
+        {
+            BusType::Ref
+        } else if self
+            .net
+            .generators
+            .iter()
+            .any(|generator| generator.bus.eq_ignore_ascii_case(bus_id))
+        {
+            BusType::Pv
+        } else {
+            BusType::Pq
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn lower_lines(
+        &mut self,
+        base: VoltageBase,
+    ) -> Result<Vec<Branch>, MulticonductorToBalancedError> {
+        let mut branches = Vec::with_capacity(self.net.lines.len());
+        for (idx, line) in self.net.lines.iter().enumerate() {
+            let Some(code) = self.net.linecode(&line.linecode) else {
+                self.record.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.UNKNOWN_LINECODE",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "line {} references unknown linecode `{}`",
+                            line.name, line.linecode
+                        ),
+                    )
+                    .with_element_path(format!(
+                        "/model/multiconductor_network/lines/{idx}/linecode"
+                    )),
+                );
+                continue;
+            };
+            if !same_active_phase_order(
+                self.net.bus(&line.bus_from),
+                &line.terminal_map_from,
+                self.net.bus(&line.bus_to),
+                &line.terminal_map_to,
+                &self.neutral_terminals,
+            ) {
+                self.record.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.PHASE_MAP_MISMATCH",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "line {} connects different active terminal orders and cannot be lowered transparently",
+                            line.name
+                        ),
+                    )
+                    .with_element_path(format!("/model/multiconductor_network/lines/{idx}")),
+                );
+                continue;
+            }
+            let Some(from) = self.bus_id(&line.bus_from) else {
+                self.unknown_bus_diag("line", &line.name, &line.bus_from, idx, "bus_from");
+                continue;
+            };
+            let Some(to) = self.bus_id(&line.bus_to) else {
+                self.unknown_bus_diag("line", &line.name, &line.bus_to, idx, "bus_to");
+                continue;
+            };
+            let from_bus = self.net.bus(&line.bus_from);
+            let active =
+                active_positions(&line.terminal_map_from, from_bus, &self.neutral_terminals);
+            let neutral =
+                neutral_positions(&line.terminal_map_from, from_bus, &self.neutral_terminals);
+            let z_ohm =
+                self.line_positive_sequence_impedance(idx, code, &active, &neutral, line.length)?;
+            let y_from = self.line_positive_sequence_admittance(
+                idx,
+                code,
+                &active,
+                &neutral,
+                line.length,
+                ShuntSide::From,
+            )?;
+            let y_to = self.line_positive_sequence_admittance(
+                idx,
+                code,
+                &active,
+                &neutral,
+                line.length,
+                ShuntSide::To,
+            )?;
+            let z_base = base.z_base_ohm(self.options.base_mva);
+            let y_scale = z_base;
+            let charging = BranchCharging {
+                g_fr: y_from.re * y_scale,
+                b_fr: y_from.im * y_scale,
+                g_to: y_to.re * y_scale,
+                b_to: y_to.im * y_scale,
+            };
+            let rate = line_rate_mva(code, &active, base.line_to_line_volts).unwrap_or_else(|| {
+                self.record.dropped_fields.push(format!(
+                    "line {} thermal rating defaulted to 0 MVA",
+                    line.name
+                ));
+                0.0
+            });
+            branches.push(Branch {
+                from,
+                to,
+                r: z_ohm.re / z_base,
+                x: z_ohm.im / z_base,
+                b: charging.total_b(),
+                charging: Some(charging),
+                rate_a: rate,
+                rate_b: rate,
+                rate_c: rate,
+                current_ratings: None,
+                tap: 0.0,
+                shift: 0.0,
+                in_service: true,
+                angmin: -360.0,
+                angmax: 360.0,
+                control: None,
+                solution: None,
+                extras: source_extra("multiconductor_line", &line.name),
+            });
+        }
+        self.err_if_errors()?;
+        Ok(branches)
+    }
+
+    fn line_positive_sequence_impedance(
+        &mut self,
+        line_idx: usize,
+        code: &DistLineCode,
+        active: &[usize],
+        neutral: &[usize],
+        length: f64,
+    ) -> Result<Complex64, MulticonductorToBalancedError> {
+        let matrix = complex_matrix(&code.r_series, &code.x_series, length);
+        let reduced = kron_or_select(&matrix, active, neutral).map_err(|message| {
+            self.matrix_error(line_idx, &code.name, "series impedance", &message)
+        })?;
+        Ok(self.positive_sequence_from_matrix(line_idx, &code.name, "series impedance", &reduced))
+    }
+
+    fn line_positive_sequence_admittance(
+        &mut self,
+        line_idx: usize,
+        code: &DistLineCode,
+        active: &[usize],
+        neutral: &[usize],
+        length: f64,
+        side: ShuntSide,
+    ) -> Result<Complex64, MulticonductorToBalancedError> {
+        let (g, b, label) = match side {
+            ShuntSide::From => (&code.g_from, &code.b_from, "from shunt admittance"),
+            ShuntSide::To => (&code.g_to, &code.b_to, "to shunt admittance"),
+        };
+        let matrix = complex_matrix(g, b, length);
+        let reduced = kron_or_select(&matrix, active, neutral)
+            .map_err(|message| self.matrix_error(line_idx, &code.name, label, &message))?;
+        Ok(self.positive_sequence_from_matrix(line_idx, &code.name, label, &reduced))
+    }
+
+    fn positive_sequence_from_matrix(
+        &mut self,
+        line_idx: usize,
+        code_name: &str,
+        label: &str,
+        matrix: &[Vec<Complex64>],
+    ) -> Complex64 {
+        let seq = sequence_matrix(matrix);
+        let coupling = sequence_coupling_norm(&seq);
+        if coupling > COUPLING_TOLERANCE {
+            self.record.approximations.push(format!(
+                "linecode {code_name} {label} has sequence coupling norm {coupling}; positive-sequence diagonal retained"
+            ));
+            let mut diagnostic = StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.SEQUENCE_COUPLING_DROPPED",
+                DiagnosticSeverity::Info,
+                DiagnosticStage::Lower,
+                format!(
+                    "linecode {code_name} {label} has nonzero sequence coupling; the balanced model keeps the positive-sequence diagonal"
+                ),
+            )
+            .with_element_path(format!("/model/multiconductor_network/lines/{line_idx}/linecode"));
+            diagnostic.details.insert(
+                "sequence_coupling_norm".to_owned(),
+                serde_json::json!(coupling),
+            );
+            self.record.diagnostics.push(diagnostic);
+        }
+        seq[1][1]
+    }
+
+    fn matrix_error(
+        &self,
+        line_idx: usize,
+        code_name: &str,
+        label: &str,
+        message: &str,
+    ) -> MulticonductorToBalancedError {
+        let mut diagnostics = self.record.diagnostics.clone();
+        diagnostics.push(
+            StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.INVALID_LINECODE_MATRIX",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!("linecode {code_name} {label} cannot be lowered: {message}"),
+            )
+            .with_element_path(format!(
+                "/model/multiconductor_network/lines/{line_idx}/linecode"
+            )),
+        );
+        MulticonductorToBalancedError::new(self.options, diagnostics)
+    }
+
+    fn lower_loads(&mut self) -> Vec<Load> {
+        self.net
+            .loads
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, load)| {
+                let Some(bus) = self.bus_id(&load.bus) else {
+                    self.unknown_bus_diag("load", &load.name, &load.bus, idx, "bus");
+                    return None;
+                };
+                if !matches!(
+                    load.voltage_model,
+                    DistLoadVoltageModel::ConstantPower { .. }
+                ) {
+                    self.record.dropped_fields.push(format!(
+                        "load {} voltage model dropped; balanced load is constant power",
+                        load.name
+                    ));
+                    self.record.diagnostics.push(
+                        StructuredDiagnostic::new(
+                            "LOWER.MULTI_TO_BALANCED.DROPPED_LOAD_VOLTAGE_MODEL",
+                            DiagnosticSeverity::Warning,
+                            DiagnosticStage::Lower,
+                            format!(
+                                "load {} voltage model cannot be represented by the conservative balanced lowering",
+                                load.name
+                            ),
+                        )
+                        .with_element_path(format!("/model/multiconductor_network/loads/{idx}/voltage_model")),
+                    );
+                }
+                Some(Load {
+                    bus,
+                    p: si_power_to_mega(load.p_nom.iter().sum()),
+                    q: si_power_to_mega(load.q_nom.iter().sum()),
+                    voltage_model: None,
+                    in_service: true,
+                    extras: source_extra("multiconductor_load", &load.name),
+                })
+            })
+            .collect()
+    }
+
+    fn lower_shunts(
+        &mut self,
+        base: VoltageBase,
+    ) -> Result<Vec<Shunt>, MulticonductorToBalancedError> {
+        let mut shunts = Vec::with_capacity(self.net.shunts.len());
+        for (idx, shunt) in self.net.shunts.iter().enumerate() {
+            let Some(bus) = self.bus_id(&shunt.bus) else {
+                self.unknown_bus_diag("shunt", &shunt.name, &shunt.bus, idx, "bus");
+                continue;
+            };
+            let dist_bus = self.net.bus(&shunt.bus);
+            let active = active_positions(&shunt.terminal_map, dist_bus, &self.neutral_terminals);
+            let neutral = neutral_positions(&shunt.terminal_map, dist_bus, &self.neutral_terminals);
+            let y = if active.len() == 3 {
+                let matrix = complex_matrix(&shunt.g, &shunt.b, 1.0);
+                let reduced = kron_or_select(&matrix, &active, &neutral)
+                    .map_err(|message| self.shunt_matrix_error(idx, &shunt.name, &message))?;
+                let seq = sequence_matrix(&reduced);
+                seq[1][1]
+            } else {
+                self.record.approximations.push(format!(
+                    "shunt {} has {} active terminal(s); diagonal admittance averaged into balanced shunt",
+                    shunt.name,
+                    active.len()
+                ));
+                average_diagonal_admittance(&shunt.g, &shunt.b, &active)
+            };
+            let scale = base.line_to_line_volts * base.line_to_line_volts / 1_000_000.0;
+            shunts.push(Shunt {
+                bus,
+                g: y.re * scale,
+                b: y.im * scale,
+                in_service: true,
+                control: None,
+                extras: source_extra("multiconductor_shunt", &shunt.name),
+            });
+        }
+        self.err_if_errors()?;
+        Ok(shunts)
+    }
+
+    fn shunt_matrix_error(
+        &self,
+        shunt_idx: usize,
+        name: &str,
+        message: &str,
+    ) -> MulticonductorToBalancedError {
+        let mut diagnostics = self.record.diagnostics.clone();
+        diagnostics.push(
+            StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.INVALID_SHUNT_MATRIX",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!("shunt {name} cannot be lowered: {message}"),
+            )
+            .with_element_path(format!("/model/multiconductor_network/shunts/{shunt_idx}")),
+        );
+        MulticonductorToBalancedError::new(self.options, diagnostics)
+    }
+
+    fn lower_generators(&mut self, buses: &[Bus]) -> Vec<Generator> {
+        self.net
+            .generators
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, generator)| {
+                let Some(bus) = self.bus_id(&generator.bus) else {
+                    self.unknown_bus_diag("generator", &generator.name, &generator.bus, idx, "bus");
+                    return None;
+                };
+                let pg = si_power_to_mega(generator.p_nom.iter().sum());
+                let qg = si_power_to_mega(generator.q_nom.iter().sum());
+                let pmin = option_vec_sum_mw(generator.p_min.as_deref()).unwrap_or_else(|| {
+                    self.record.dropped_fields.push(format!(
+                        "generator {} p_min defaulted to pg",
+                        generator.name
+                    ));
+                    pg
+                });
+                let pmax = option_vec_sum_mw(generator.p_max.as_deref()).unwrap_or_else(|| {
+                    self.record.dropped_fields.push(format!(
+                        "generator {} p_max defaulted to pg",
+                        generator.name
+                    ));
+                    pg
+                });
+                let qmin = option_vec_sum_mw(generator.q_min.as_deref()).unwrap_or_else(|| {
+                    self.record.dropped_fields.push(format!(
+                        "generator {} q_min defaulted to qg",
+                        generator.name
+                    ));
+                    qg
+                });
+                let qmax = option_vec_sum_mw(generator.q_max.as_deref()).unwrap_or_else(|| {
+                    self.record.dropped_fields.push(format!(
+                        "generator {} q_max defaulted to qg",
+                        generator.name
+                    ));
+                    qg
+                });
+                if generator.cost.is_some() {
+                    self.record.dropped_fields.push(format!(
+                        "generator {} scalar distribution cost dropped",
+                        generator.name
+                    ));
+                }
+                let vg = buses
+                    .iter()
+                    .find(|balanced_bus| balanced_bus.id == bus)
+                    .map_or(1.0, |balanced_bus| balanced_bus.vm);
+                Some(Generator {
+                    bus,
+                    pg,
+                    qg,
+                    pmax,
+                    pmin,
+                    qmax,
+                    qmin,
+                    vg,
+                    mbase: self.options.base_mva,
+                    in_service: true,
+                    cost: None,
+                    caps: Default::default(),
+                    regulated_bus: None,
+                })
+            })
+            .collect()
+    }
+
+    fn bus_id(&self, bus: &str) -> Option<BusId> {
+        self.bus_ids.get(&bus.to_ascii_lowercase()).copied()
+    }
+
+    fn unknown_bus_diag(&mut self, element: &str, name: &str, bus: &str, idx: usize, field: &str) {
+        self.record.diagnostics.push(
+            StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.UNKNOWN_BUS",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!("{element} {name} references unknown bus {bus}"),
+            )
+            .with_element_path(format!(
+                "/model/multiconductor_network/{element}s/{idx}/{field}"
+            )),
+        );
+    }
+
+    fn err_if_errors(&self) -> Result<(), MulticonductorToBalancedError> {
+        if self
+            .record
+            .diagnostics
+            .iter()
+            .any(|d| d.severity >= DiagnosticSeverity::Error)
+        {
+            Err(MulticonductorToBalancedError::new(
+                self.options,
+                self.record.diagnostics.clone(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct VoltageBase {
+    line_to_line_volts: f64,
+}
+
+impl VoltageBase {
+    fn z_base_ohm(self, base_mva: f64) -> f64 {
+        self.line_to_line_volts * self.line_to_line_volts / (base_mva * 1_000_000.0)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ShuntSide {
+    From,
+    To,
+}
+
+fn options_map(
+    options: MulticonductorToBalancedOptions,
+) -> serde_json::Map<String, serde_json::Value> {
+    serde_json::to_value(options)
+        .ok()
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default()
+}
+
+fn source_extra(key: &str, value: &str) -> BalancedExtras {
+    let mut extras = BalancedExtras::new();
+    extras.insert(key.to_owned(), serde_json::Value::String(value.to_owned()));
+    extras
+}
+
+fn active_positions(
+    terminals: &[String],
+    bus: Option<&DistBus>,
+    neutral_terminals: &BTreeSet<String>,
+) -> Vec<usize> {
+    terminals
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, terminal)| {
+            (!is_neutral_terminal(terminal, bus, neutral_terminals)).then_some(idx)
+        })
+        .collect()
+}
+
+fn neutral_positions(
+    terminals: &[String],
+    bus: Option<&DistBus>,
+    neutral_terminals: &BTreeSet<String>,
+) -> Vec<usize> {
+    terminals
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, terminal)| {
+            is_neutral_terminal(terminal, bus, neutral_terminals).then_some(idx)
+        })
+        .collect()
+}
+
+fn same_active_phase_order(
+    from_bus: Option<&DistBus>,
+    from_terminals: &[String],
+    to_bus: Option<&DistBus>,
+    to_terminals: &[String],
+    neutral_terminals: &BTreeSet<String>,
+) -> bool {
+    let from: Vec<_> = from_terminals
+        .iter()
+        .filter(|terminal| !is_neutral_terminal(terminal, from_bus, neutral_terminals))
+        .map(|terminal| terminal.to_ascii_lowercase())
+        .collect();
+    let to: Vec<_> = to_terminals
+        .iter()
+        .filter(|terminal| !is_neutral_terminal(terminal, to_bus, neutral_terminals))
+        .map(|terminal| terminal.to_ascii_lowercase())
+        .collect();
+    from == to
+}
+
+fn positive_sequence_voltage(
+    source: &powerio_dist::VoltageSource,
+    positions: &[usize],
+) -> Option<Complex64> {
+    if positions.len() != 3 {
+        return None;
+    }
+    let mut phase = [Complex64::new(0.0, 0.0); 3];
+    for (out, &idx) in phase.iter_mut().zip(positions.iter()) {
+        let magnitude = *source.v_magnitude.get(idx)?;
+        let angle = *source.v_angle.get(idx)?;
+        if !magnitude.is_finite() || !angle.is_finite() {
+            return None;
+        }
+        *out = Complex64::from_polar(magnitude, angle);
+    }
+    let basis = sequence_basis();
+    let mut seq = [Complex64::new(0.0, 0.0); 3];
+    for (sequence_idx, out) in seq.iter_mut().enumerate() {
+        for phase_idx in 0..3 {
+            *out += basis[phase_idx][sequence_idx].conj() * phase[phase_idx];
+        }
+    }
+    Some(seq[1])
+}
+
+fn complex_matrix(g_or_r: &Mat, b_or_x: &Mat, scale: f64) -> Vec<Vec<Complex64>> {
+    g_or_r
+        .iter()
+        .zip(b_or_x.iter())
+        .map(|(g_row, b_row)| {
+            g_row
+                .iter()
+                .zip(b_row.iter())
+                .map(|(&g, &b)| Complex64::new(g * scale, b * scale))
+                .collect()
+        })
+        .collect()
+}
+
+fn kron_or_select(
+    matrix: &[Vec<Complex64>],
+    active: &[usize],
+    neutral: &[usize],
+) -> Result<Vec<Vec<Complex64>>, String> {
+    if active.len() != 3 {
+        return Err(format!(
+            "expected three active conductors, got {}",
+            active.len()
+        ));
+    }
+    validate_indices(matrix, active)?;
+    validate_indices(matrix, neutral)?;
+    if neutral.is_empty() {
+        return Ok(submatrix(matrix, active, active));
+    }
+
+    let m_pp = submatrix(matrix, active, active);
+    let m_pn = submatrix(matrix, active, neutral);
+    let m_np = submatrix(matrix, neutral, active);
+    let m_nn = submatrix(matrix, neutral, neutral);
+    if matrix_is_near_zero(&m_pn) && matrix_is_near_zero(&m_np) && matrix_is_near_zero(&m_nn) {
+        return Ok(m_pp);
+    }
+    let inv_nn = invert_complex_matrix(&m_nn)?;
+    let correction = matmul(&matmul(&m_pn, &inv_nn), &m_np);
+    Ok(matrix_sub(&m_pp, &correction))
+}
+
+fn matrix_is_near_zero(matrix: &[Vec<Complex64>]) -> bool {
+    matrix
+        .iter()
+        .flatten()
+        .all(|value| value.norm() <= f64::EPSILON)
+}
+
+fn validate_indices(matrix: &[Vec<Complex64>], indices: &[usize]) -> Result<(), String> {
+    let n = matrix.len();
+    if matrix.iter().any(|row| row.len() != n) {
+        return Err("matrix is not square".to_owned());
+    }
+    if indices.iter().any(|&idx| idx >= n) {
+        return Err("terminal map references a conductor outside the matrix".to_owned());
+    }
+    Ok(())
+}
+
+fn submatrix(matrix: &[Vec<Complex64>], rows: &[usize], cols: &[usize]) -> Vec<Vec<Complex64>> {
+    rows.iter()
+        .map(|&row| cols.iter().map(|&col| matrix[row][col]).collect())
+        .collect()
+}
+
+#[allow(clippy::needless_range_loop)]
+fn invert_complex_matrix(matrix: &[Vec<Complex64>]) -> Result<Vec<Vec<Complex64>>, String> {
+    let n = matrix.len();
+    if n == 0 || matrix.iter().any(|row| row.len() != n) {
+        return Err("neutral block is not square".to_owned());
+    }
+    let mut aug = vec![vec![Complex64::new(0.0, 0.0); 2 * n]; n];
+    for i in 0..n {
+        for j in 0..n {
+            aug[i][j] = matrix[i][j];
+        }
+        aug[i][n + i] = Complex64::new(1.0, 0.0);
+    }
+
+    for col in 0..n {
+        let pivot = (col..n)
+            .max_by(|&a, &b| aug[a][col].norm_sqr().total_cmp(&aug[b][col].norm_sqr()))
+            .ok_or_else(|| "neutral block is singular".to_owned())?;
+        if aug[pivot][col].norm() <= f64::EPSILON {
+            return Err("neutral block is singular".to_owned());
+        }
+        if pivot != col {
+            aug.swap(pivot, col);
+        }
+        let pivot_value = aug[col][col];
+        for j in 0..(2 * n) {
+            aug[col][j] /= pivot_value;
+        }
+        for row in 0..n {
+            if row == col {
+                continue;
+            }
+            let factor = aug[row][col];
+            if factor.norm() <= f64::EPSILON {
+                continue;
+            }
+            for j in 0..(2 * n) {
+                let pivot_entry = aug[col][j];
+                aug[row][j] -= factor * pivot_entry;
+            }
+        }
+    }
+
+    Ok(aug
+        .into_iter()
+        .map(|row| row.into_iter().skip(n).collect())
+        .collect())
+}
+
+fn matmul(a: &[Vec<Complex64>], b: &[Vec<Complex64>]) -> Vec<Vec<Complex64>> {
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
+    }
+    let rows = a.len();
+    let cols = b[0].len();
+    let inner = b.len();
+    let mut out = vec![vec![Complex64::new(0.0, 0.0); cols]; rows];
+    for i in 0..rows {
+        for k in 0..inner {
+            for j in 0..cols {
+                out[i][j] += a[i][k] * b[k][j];
+            }
+        }
+    }
+    out
+}
+
+fn matrix_sub(a: &[Vec<Complex64>], b: &[Vec<Complex64>]) -> Vec<Vec<Complex64>> {
+    a.iter()
+        .zip(b.iter())
+        .map(|(a_row, b_row)| {
+            a_row
+                .iter()
+                .zip(b_row.iter())
+                .map(|(&a_value, &b_value)| a_value - b_value)
+                .collect()
+        })
+        .collect()
+}
+
+#[allow(clippy::many_single_char_names)]
+fn sequence_basis() -> [[Complex64; 3]; 3] {
+    let scale = 1.0 / SQRT_3;
+    let a = Complex64::from_polar(1.0, 2.0 * PI / 3.0);
+    let a2 = a * a;
+    [
+        [
+            Complex64::new(scale, 0.0),
+            Complex64::new(scale, 0.0),
+            Complex64::new(scale, 0.0),
+        ],
+        [Complex64::new(scale, 0.0), a2 * scale, a * scale],
+        [Complex64::new(scale, 0.0), a * scale, a2 * scale],
+    ]
+}
+
+fn sequence_matrix(matrix: &[Vec<Complex64>]) -> [[Complex64; 3]; 3] {
+    let basis = sequence_basis();
+    let mut seq = [[Complex64::new(0.0, 0.0); 3]; 3];
+    for p in 0..3 {
+        for q in 0..3 {
+            for i in 0..3 {
+                for j in 0..3 {
+                    seq[p][q] += basis[i][p].conj() * matrix[i][j] * basis[j][q];
+                }
+            }
+        }
+    }
+    seq
+}
+
+fn sequence_coupling_norm(seq: &[[Complex64; 3]; 3]) -> f64 {
+    let mut sum = 0.0;
+    for (i, row) in seq.iter().enumerate() {
+        for (j, value) in row.iter().enumerate() {
+            if i != j {
+                sum += value.norm_sqr();
+            }
+        }
+    }
+    sum.sqrt()
+}
+
+fn line_rate_mva(code: &DistLineCode, active: &[usize], line_to_line_volts: f64) -> Option<f64> {
+    if let Some(s_max) = &code.s_max {
+        let values: Vec<_> = active
+            .iter()
+            .filter_map(|&idx| s_max.get(idx).copied())
+            .collect();
+        if !values.is_empty() && values.iter().all(|value| value.is_finite()) {
+            return Some(values.iter().sum::<f64>() / 1_000_000.0);
+        }
+    }
+    let i_max = code.i_max.as_ref()?;
+    let amps: Vec<_> = active
+        .iter()
+        .filter_map(|&idx| i_max.get(idx).copied())
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .collect();
+    let amps = amps.into_iter().reduce(f64::min)?;
+    Some(SQRT_3 * line_to_line_volts * amps / 1_000_000.0)
+}
+
+fn average_diagonal_admittance(g: &Mat, b: &Mat, active: &[usize]) -> Complex64 {
+    let mut total = Complex64::new(0.0, 0.0);
+    let mut count = 0_u32;
+    for &idx in active {
+        let Some(g_row) = g.get(idx) else {
+            continue;
+        };
+        let Some(b_row) = b.get(idx) else {
+            continue;
+        };
+        let Some(&g_value) = g_row.get(idx) else {
+            continue;
+        };
+        let Some(&b_value) = b_row.get(idx) else {
+            continue;
+        };
+        total += Complex64::new(g_value, b_value);
+        count += 1;
+    }
+    if count == 0 {
+        Complex64::new(0.0, 0.0)
+    } else {
+        total / f64::from(count)
+    }
+}
+
+fn si_power_to_mega(value: f64) -> f64 {
+    value / 1_000_000.0
+}
+
+fn option_vec_sum_mw(values: Option<&[f64]>) -> Option<f64> {
+    values.map(|v| si_power_to_mega(v.iter().sum()))
+}
+
+fn radians_to_degrees(value: f64) -> f64 {
+    value * 180.0 / PI
 }
 
 fn status_from_diagnostics(diagnostics: &[StructuredDiagnostic]) -> ValidationStatus {
@@ -147,6 +1313,23 @@ fn status_from_diagnostics(diagnostics: &[StructuredDiagnostic]) -> ValidationSt
         })
         .max()
         .unwrap_or(ValidationStatus::Ok)
+}
+
+fn check_options(
+    options: MulticonductorToBalancedOptions,
+    report: &mut MulticonductorToBalancedReadiness,
+) {
+    if !options.base_mva.is_finite() || options.base_mva <= 0.0 {
+        report.diagnostics.push(StructuredDiagnostic::new(
+            "LOWER.MULTI_TO_BALANCED.INVALID_BASE_MVA",
+            DiagnosticSeverity::Error,
+            DiagnosticStage::Lower,
+            format!(
+                "base_mva must be positive and finite for multiconductor to balanced lowering; got {}",
+                options.base_mva
+            ),
+        ));
+    }
 }
 
 fn check_bus_conductor_sets(
@@ -215,6 +1398,143 @@ fn check_bus_conductor_sets(
     }
 }
 
+fn check_line_terminal_maps(
+    net: &MulticonductorNetwork,
+    report: &mut MulticonductorToBalancedReadiness,
+) {
+    let neutral_terminals = global_neutral_terminals(net);
+    for (i, line) in net.lines.iter().enumerate() {
+        for (field, bus_id, terminal_map) in [
+            (
+                "terminal_map_from",
+                line.bus_from.as_str(),
+                line.terminal_map_from.as_slice(),
+            ),
+            (
+                "terminal_map_to",
+                line.bus_to.as_str(),
+                line.terminal_map_to.as_slice(),
+            ),
+        ] {
+            let bus = net.bus(bus_id);
+            let active_count = active_terminal_count(terminal_map, bus, &neutral_terminals);
+            if active_count != 3 {
+                report.diagnostics.push(
+                    StructuredDiagnostic::new(
+                        "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_CONDUCTOR_SET",
+                        DiagnosticSeverity::Error,
+                        DiagnosticStage::Lower,
+                        format!(
+                            "line {} {field} has {active_count} active terminal(s); balanced branch lowering requires three active phase conductors",
+                            line.name
+                        ),
+                    )
+                    .with_element_path(format!("/model/multiconductor_network/lines/{i}/{field}")),
+                );
+            }
+        }
+    }
+}
+
+fn check_linecodes(net: &MulticonductorNetwork, report: &mut MulticonductorToBalancedReadiness) {
+    for (i, line) in net.lines.iter().enumerate() {
+        let Some(code) = net.linecode(&line.linecode) else {
+            report.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.UNKNOWN_LINECODE",
+                    DiagnosticSeverity::Error,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "line {} references unknown linecode `{}`",
+                        line.name, line.linecode
+                    ),
+                )
+                .with_element_path(format!("/model/multiconductor_network/lines/{i}/linecode")),
+            );
+            continue;
+        };
+        if code.n_conductors != line.terminal_map_from.len()
+            || code.n_conductors != line.terminal_map_to.len()
+        {
+            report.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.LINECODE_TERMINAL_MISMATCH",
+                    DiagnosticSeverity::Error,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "line {} uses linecode {} with {} conductor(s), but its terminal maps have {} and {} terminal(s)",
+                        line.name,
+                        code.name,
+                        code.n_conductors,
+                        line.terminal_map_from.len(),
+                        line.terminal_map_to.len()
+                    ),
+                )
+                .with_element_path(format!("/model/multiconductor_network/lines/{i}/linecode")),
+            );
+        }
+        if !square_matrix_shape(&code.r_series, code.n_conductors)
+            || !square_matrix_shape(&code.x_series, code.n_conductors)
+            || !square_matrix_shape(&code.g_from, code.n_conductors)
+            || !square_matrix_shape(&code.b_from, code.n_conductors)
+            || !square_matrix_shape(&code.g_to, code.n_conductors)
+            || !square_matrix_shape(&code.b_to, code.n_conductors)
+        {
+            report.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.INVALID_LINECODE_MATRIX",
+                    DiagnosticSeverity::Error,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "linecode {} does not carry square {} conductor matrices",
+                        code.name, code.n_conductors
+                    ),
+                )
+                .with_element_path(format!(
+                    "/model/multiconductor_network/linecodes/{}",
+                    code.name
+                )),
+            );
+        }
+    }
+}
+
+fn square_matrix_shape(matrix: &Mat, n: usize) -> bool {
+    matrix.len() == n && matrix.iter().all(|row| row.len() == n)
+}
+
+fn check_switches(net: &MulticonductorNetwork, report: &mut MulticonductorToBalancedReadiness) {
+    for (i, sw) in net.switches.iter().enumerate() {
+        if sw.open {
+            report.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.DROPPED_OPEN_SWITCH",
+                    DiagnosticSeverity::Info,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "open switch {} is dropped by multiconductor to balanced lowering",
+                        sw.name
+                    ),
+                )
+                .with_element_path(format!("/model/multiconductor_network/switches/{i}")),
+            );
+        } else {
+            report.diagnostics.push(
+                StructuredDiagnostic::new(
+                    "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_CLOSED_SWITCH",
+                    DiagnosticSeverity::Error,
+                    DiagnosticStage::Lower,
+                    format!(
+                        "closed switch {} is not lowered into a zero impedance balanced branch",
+                        sw.name
+                    ),
+                )
+                .with_element_path(format!("/model/multiconductor_network/switches/{i}")),
+            );
+        }
+    }
+}
+
 fn global_neutral_terminals(net: &MulticonductorNetwork) -> BTreeSet<String> {
     net.buses
         .iter()
@@ -229,11 +1549,19 @@ fn active_terminal_count(
 ) -> usize {
     terminals
         .iter()
-        .filter(|terminal| {
-            !bus.is_some_and(|b| b.grounded.contains(*terminal))
-                && !neutral_terminals.contains(*terminal)
-        })
+        .filter(|terminal| !is_neutral_terminal(terminal, bus, neutral_terminals))
         .count()
+}
+
+fn is_neutral_terminal(
+    terminal: &str,
+    bus: Option<&DistBus>,
+    neutral_terminals: &BTreeSet<String>,
+) -> bool {
+    terminal == "0"
+        || terminal.eq_ignore_ascii_case("n")
+        || bus.is_some_and(|b| b.grounded.iter().any(|g| g == terminal))
+        || neutral_terminals.contains(terminal)
 }
 
 fn check_phase_reference(

--- a/powerio-pkg/src/lowering.rs
+++ b/powerio-pkg/src/lowering.rs
@@ -296,6 +296,7 @@ impl<'a> LoweringState<'a> {
         let loads = self.lower_loads();
         let shunts = self.lower_shunts(base)?;
         let generators = self.lower_generators(&buses);
+        self.err_if_errors()?;
 
         let network = Network {
             name: self
@@ -804,11 +805,11 @@ impl<'a> LoweringState<'a> {
                 seq[1][1]
             } else {
                 self.record.approximations.push(format!(
-                    "shunt {} has {} active terminal(s); diagonal admittance averaged into balanced shunt",
+                    "shunt {} has {} active terminal(s); diagonal admittance projected with missing phases as zero",
                     shunt.name,
                     active.len()
                 ));
-                average_diagonal_admittance(&shunt.g, &shunt.b, &active)
+                partial_phase_admittance(&shunt.g, &shunt.b, &active)
             };
             let scale = base.line_to_line_volts * base.line_to_line_volts / 1_000_000.0;
             shunts.push(Shunt {
@@ -1263,9 +1264,8 @@ fn line_rate_mva(code: &DistLineCode, active: &[usize], line_to_line_volts: f64)
     Some(SQRT_3 * line_to_line_volts * amps / 1_000_000.0)
 }
 
-fn average_diagonal_admittance(g: &Mat, b: &Mat, active: &[usize]) -> Complex64 {
+fn partial_phase_admittance(g: &Mat, b: &Mat, active: &[usize]) -> Complex64 {
     let mut total = Complex64::new(0.0, 0.0);
-    let mut count = 0_u32;
     for &idx in active {
         let Some(g_row) = g.get(idx) else {
             continue;
@@ -1280,13 +1280,8 @@ fn average_diagonal_admittance(g: &Mat, b: &Mat, active: &[usize]) -> Complex64 
             continue;
         };
         total += Complex64::new(g_value, b_value);
-        count += 1;
     }
-    if count == 0 {
-        Complex64::new(0.0, 0.0)
-    } else {
-        total / f64::from(count)
-    }
+    total / 3.0
 }
 
 fn si_power_to_mega(value: f64) -> f64 {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -9,8 +9,9 @@ use powerio_dist::{DistSourceFormat, MulticonductorNetwork};
 
 use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
 use crate::lowering::{
-    LoweringRecord, MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,
-    check_multiconductor_to_balanced_lowering,
+    LoweringRecord, MulticonductorToBalancedError, MulticonductorToBalancedOptions,
+    MulticonductorToBalancedReadiness, check_multiconductor_to_balanced_lowering,
+    lower_multiconductor_to_balanced,
 };
 use crate::model::{ModelKind, ModelPayload};
 use crate::provenance::{
@@ -260,7 +261,7 @@ impl CompilerPackage {
     }
 
     /// Check whether this package's multiconductor payload is ready for the
-    /// future explicit multiconductor to balanced lowering pass.
+    /// explicit multiconductor to balanced lowering pass.
     #[must_use]
     pub fn check_multiconductor_to_balanced_lowering(
         &self,
@@ -271,6 +272,52 @@ impl CompilerPackage {
                 MulticonductorToBalancedOptions::default(),
             )
         })
+    }
+
+    /// Explicitly lower a multiconductor package to a derived balanced package.
+    ///
+    /// This method only accepts packages whose payload is
+    /// [`ModelKind::Multiconductor`]. It does not mutate the input package.
+    pub fn lower_multiconductor_to_balanced(
+        &self,
+        options: MulticonductorToBalancedOptions,
+    ) -> Result<Self, MulticonductorToBalancedError> {
+        let Some(net) = self.as_multiconductor() else {
+            let diagnostic = StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.WRONG_MODEL_KIND",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!(
+                    "multiconductor to balanced lowering requires a multiconductor package, got {:?}",
+                    self.model_kind
+                ),
+            );
+            return Err(MulticonductorToBalancedError::new(
+                options,
+                vec![diagnostic],
+            ));
+        };
+
+        let lowered = lower_multiconductor_to_balanced(net, options)?;
+        let mut record = lowered.record;
+        let mut output = CompilerPackage::from_balanced(lowered.network);
+        output.origin = Origin::Derived {
+            parent_package_id: self.package_id.clone(),
+            pass: "multiconductor-to-balanced".to_owned(),
+            options: record.options.clone(),
+        };
+        output.sources = derived_sources(self);
+        let source_id = output.sources.first().map(|source| source.id.as_str());
+        output.source_maps = match output.as_balanced() {
+            Some(balanced) => lowered_balanced_source_maps(net, balanced, source_id),
+            None => Vec::new(),
+        };
+        output.diagnostics.clone_from(&record.diagnostics);
+        output.lowering_history.clone_from(&self.lowering_history);
+        output.run_sane_validation();
+        record.validation_status = output.validation.status;
+        output.push_lowering(record);
+        Ok(output)
     }
 
     /// Run the package semantic validation profile and record its findings.
@@ -1291,6 +1338,258 @@ fn multiconductor_origin(net: &MulticonductorNetwork) -> Origin {
         },
         None => Origin::InMemory,
     }
+}
+
+fn derived_sources(parent: &CompilerPackage) -> Vec<SourceDescriptor> {
+    if !parent.sources.is_empty() {
+        return parent.sources.clone();
+    }
+    vec![SourceDescriptor {
+        id: "parent".to_owned(),
+        kind: "package".to_owned(),
+        path: None,
+        format: Some("pio-json".to_owned()),
+        hash: parent.package_id.clone(),
+    }]
+}
+
+fn lowered_balanced_source_maps(
+    input: &MulticonductorNetwork,
+    balanced: &BalancedNetwork,
+    source_id: Option<&str>,
+) -> Vec<SourceMapEntry> {
+    let Some(source_id) = source_id else {
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    push_lowered_bus_maps(&mut entries, source_id, input);
+    push_lowered_branch_maps(&mut entries, source_id, input, balanced);
+    push_lowered_load_maps(&mut entries, source_id, input, balanced);
+    push_lowered_shunt_maps(&mut entries, source_id, input, balanced);
+    push_lowered_generator_maps(&mut entries, source_id, input, balanced);
+    entries
+}
+
+fn push_lowered_bus_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    input: &MulticonductorNetwork,
+) {
+    for (idx, bus) in input.buses.iter().enumerate() {
+        for (field, mapping_kind) in [
+            ("id", MappingKind::Synthetic),
+            ("kind", MappingKind::Lowered),
+            ("vm", MappingKind::ConvertedUnits),
+            ("va", MappingKind::ConvertedUnits),
+            ("base_kv", MappingKind::ConvertedUnits),
+            ("area", MappingKind::Defaulted),
+            ("zone", MappingKind::Defaulted),
+            ("name", MappingKind::Lowered),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/buses/{idx}/{field}"),
+                "multiconductor_bus",
+                field,
+                mapping_kind,
+            );
+        }
+        for field in ["vmin", "vmax"] {
+            let mapping_kind = if bus.v_min.is_some() && bus.v_max.is_some() {
+                MappingKind::ConvertedUnits
+            } else {
+                MappingKind::Defaulted
+            };
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/buses/{idx}/{field}"),
+                "multiconductor_bus",
+                field,
+                mapping_kind,
+            );
+        }
+    }
+}
+
+fn push_lowered_branch_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    input: &MulticonductorNetwork,
+    balanced: &BalancedNetwork,
+) {
+    for (idx, branch) in balanced.branches.iter().enumerate() {
+        let record = "multiconductor_line";
+        for (field, mapping_kind) in [
+            ("from", MappingKind::Lowered),
+            ("to", MappingKind::Lowered),
+            ("r", MappingKind::ConvertedUnits),
+            ("x", MappingKind::ConvertedUnits),
+            ("b", MappingKind::ConvertedUnits),
+            ("in_service", MappingKind::Lowered),
+            ("tap", MappingKind::Defaulted),
+            ("shift", MappingKind::Defaulted),
+            ("angmin", MappingKind::Defaulted),
+            ("angmax", MappingKind::Defaulted),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/branches/{idx}/{field}"),
+                record,
+                field,
+                mapping_kind,
+            );
+        }
+        let has_rating = input
+            .lines
+            .get(idx)
+            .and_then(|line| input.linecode(&line.linecode))
+            .is_some_and(|code| code.i_max.is_some() || code.s_max.is_some());
+        let rate_kind = if has_rating {
+            MappingKind::ConvertedUnits
+        } else {
+            MappingKind::Defaulted
+        };
+        for field in ["rate_a", "rate_b", "rate_c"] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/branches/{idx}/{field}"),
+                record,
+                field,
+                rate_kind,
+            );
+        }
+        if branch.charging.is_some() {
+            for field in ["g_fr", "b_fr", "g_to", "b_to"] {
+                push_lowered_map(
+                    entries,
+                    source_id,
+                    &format!("/model/balanced_network/branches/{idx}/charging/{field}"),
+                    record,
+                    field,
+                    MappingKind::ConvertedUnits,
+                );
+            }
+        }
+    }
+}
+
+fn push_lowered_load_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    input: &MulticonductorNetwork,
+    balanced: &BalancedNetwork,
+) {
+    for idx in 0..balanced.loads.len().min(input.loads.len()) {
+        for (field, mapping_kind) in [
+            ("bus", MappingKind::Lowered),
+            ("p", MappingKind::Aggregated),
+            ("q", MappingKind::Aggregated),
+            ("in_service", MappingKind::Lowered),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/loads/{idx}/{field}"),
+                "multiconductor_load",
+                field,
+                mapping_kind,
+            );
+        }
+    }
+}
+
+fn push_lowered_shunt_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    input: &MulticonductorNetwork,
+    balanced: &BalancedNetwork,
+) {
+    for idx in 0..balanced.shunts.len().min(input.shunts.len()) {
+        for (field, mapping_kind) in [
+            ("bus", MappingKind::Lowered),
+            ("g", MappingKind::Aggregated),
+            ("b", MappingKind::Aggregated),
+            ("in_service", MappingKind::Lowered),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/shunts/{idx}/{field}"),
+                "multiconductor_shunt",
+                field,
+                mapping_kind,
+            );
+        }
+    }
+}
+
+fn push_lowered_generator_maps(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    input: &MulticonductorNetwork,
+    balanced: &BalancedNetwork,
+) {
+    for idx in 0..balanced.generators.len().min(input.generators.len()) {
+        let generator = &input.generators[idx];
+        for (field, mapping_kind) in [
+            ("bus", MappingKind::Lowered),
+            ("pg", MappingKind::Aggregated),
+            ("qg", MappingKind::Aggregated),
+            ("vg", MappingKind::Defaulted),
+            ("mbase", MappingKind::Synthetic),
+            ("in_service", MappingKind::Lowered),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/generators/{idx}/{field}"),
+                "multiconductor_generator",
+                field,
+                mapping_kind,
+            );
+        }
+        for (field, present) in [
+            ("pmin", generator.p_min.is_some()),
+            ("pmax", generator.p_max.is_some()),
+            ("qmin", generator.q_min.is_some()),
+            ("qmax", generator.q_max.is_some()),
+        ] {
+            push_lowered_map(
+                entries,
+                source_id,
+                &format!("/model/balanced_network/generators/{idx}/{field}"),
+                "multiconductor_generator",
+                field,
+                if present {
+                    MappingKind::Aggregated
+                } else {
+                    MappingKind::Defaulted
+                },
+            );
+        }
+    }
+}
+
+fn push_lowered_map(
+    entries: &mut Vec<SourceMapEntry>,
+    source_id: &str,
+    element_path: &str,
+    record: &str,
+    field: &str,
+    mapping_kind: MappingKind,
+) {
+    entries.push(SourceMapEntry {
+        element_path: element_path.to_owned(),
+        source_ref: SourceRef::new(source_id)
+            .with_record(record)
+            .with_field(field),
+        mapping_kind,
+        confidence: Confidence::High,
+    });
 }
 
 /// Lift the `defaulted` map into source-map entries with `mapping_kind =

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2,9 +2,10 @@
 
 use powerio_pkg::{
     CompilerPackage, Confidence, DiagnosticCode, DiagnosticSeverity, DiagnosticStage, MappingKind,
-    ModelKind, MulticonductorToBalancedReadiness, Origin, PIO_PACKAGE_SCHEMA_URL,
-    PIO_PACKAGE_SCHEMA_VERSION, SequenceTransformConvention, SourceDescriptor, SourceMapEntry,
-    SourceRef, StructuredDiagnostic, ValidationStatus, check_multiconductor_to_balanced_lowering,
+    ModelKind, MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness, Origin,
+    PIO_PACKAGE_SCHEMA_URL, PIO_PACKAGE_SCHEMA_VERSION, SequenceTransformConvention,
+    SourceDescriptor, SourceMapEntry, SourceRef, StructuredDiagnostic, ValidationStatus,
+    check_multiconductor_to_balanced_lowering, lower_multiconductor_to_balanced,
 };
 
 const MATPOWER_SRC: &str = "\
@@ -42,11 +43,42 @@ fn zero_matrix(n: usize) -> powerio_dist::Mat {
     vec![vec![0.0; n]; n]
 }
 
+fn diagonal_matrix(n: usize, value: f64) -> powerio_dist::Mat {
+    let mut matrix = zero_matrix(n);
+    for (idx, row) in matrix.iter_mut().enumerate() {
+        row[idx] = value;
+    }
+    matrix
+}
+
+fn phase_reference(terminals: &[&str], grounded: &[&str]) -> (Vec<f64>, Vec<f64>) {
+    let phase_angles = [
+        0.0,
+        -2.0 * std::f64::consts::PI / 3.0,
+        2.0 * std::f64::consts::PI / 3.0,
+    ];
+    let mut magnitudes = vec![0.0; terminals.len()];
+    let mut angles = vec![0.0; terminals.len()];
+    let mut active = 0;
+    for (idx, terminal) in terminals.iter().enumerate() {
+        if grounded.contains(terminal) || *terminal == "0" {
+            continue;
+        }
+        magnitudes[idx] = 240.0;
+        if active < phase_angles.len() {
+            angles[idx] = phase_angles[active];
+        }
+        active += 1;
+    }
+    (magnitudes, angles)
+}
+
 fn preflight_network(terminals: &[&str], grounded: &[&str]) -> powerio_dist::DistNetwork {
     use powerio_dist::{DistBus, DistLine, DistLineCode, DistNetwork, Extras, VoltageSource};
 
     let n = terminals.len();
     let terminal_map = strings(terminals);
+    let (v_magnitude, v_angle) = phase_reference(terminals, grounded);
     let mut net = DistNetwork::default();
     for id in ["sourcebus", "loadbus"] {
         net.buses.push(DistBus {
@@ -67,8 +99,8 @@ fn preflight_network(terminals: &[&str], grounded: &[&str]) -> powerio_dist::Dis
     net.linecodes.push(DistLineCode {
         name: "lc".to_owned(),
         n_conductors: n,
-        r_series: zero_matrix(n),
-        x_series: zero_matrix(n),
+        r_series: diagonal_matrix(n, 0.01),
+        x_series: diagonal_matrix(n, 0.10),
         g_from: zero_matrix(n),
         b_from: zero_matrix(n),
         g_to: zero_matrix(n),
@@ -91,8 +123,8 @@ fn preflight_network(terminals: &[&str], grounded: &[&str]) -> powerio_dist::Dis
         name: "source".to_owned(),
         bus: "sourcebus".to_owned(),
         terminal_map,
-        v_magnitude: vec![1.0; n],
-        v_angle: vec![0.0; n],
+        v_magnitude,
+        v_angle,
         extras: Extras::new(),
     });
     net
@@ -103,6 +135,22 @@ fn has_lowering_code(report: &MulticonductorToBalancedReadiness, code: &str) -> 
         .diagnostics
         .iter()
         .any(|d| d.code == DiagnosticCode::new(code))
+}
+
+fn has_diagnostic_code(diagnostics: &[StructuredDiagnostic], code: &str) -> bool {
+    diagnostics
+        .iter()
+        .any(|d| d.code == DiagnosticCode::new(code))
+}
+
+fn assert_lowering_rejects(net: &powerio_dist::DistNetwork, code: &str) {
+    let err = lower_multiconductor_to_balanced(net, MulticonductorToBalancedOptions::default())
+        .expect_err("lowering must reject unsupported input");
+    assert!(
+        has_diagnostic_code(&err.diagnostics, code),
+        "missing {code}: {:?}",
+        err.diagnostics
+    );
 }
 
 /// Serialize -> deserialize -> serialize must be byte-identical (deterministic
@@ -853,6 +901,205 @@ fn package_lowering_preflight_helper_is_read_only() {
         .expect("multiconductor package has readiness");
     assert_eq!(report.status, ValidationStatus::Ok);
     assert!(pkg.lowering_history.is_empty());
+}
+
+#[test]
+fn lowering_produces_balanced_three_phase_without_neutral() {
+    let net = preflight_network(&["1", "2", "3"], &[]);
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .expect("lower three phase");
+
+    let balanced = lowered.network;
+    assert_eq!(balanced.buses.len(), 2);
+    assert_eq!(balanced.branches.len(), 1);
+    assert_eq!(balanced.loads.len(), 0);
+    assert_eq!(balanced.buses[0].kind, powerio::BusType::Ref);
+    assert_eq!(balanced.buses[1].kind, powerio::BusType::Pq);
+    assert!(balanced.branches[0].x > 0.0);
+    assert_eq!(balanced.source_format, powerio::SourceFormat::InMemory);
+    assert_eq!(lowered.record.input_kind, ModelKind::Multiconductor);
+    assert_eq!(lowered.record.output_kind, ModelKind::Balanced);
+    assert_eq!(lowered.record.validation_status, ValidationStatus::Ok);
+}
+
+#[test]
+fn lowering_produces_balanced_three_phase_with_neutral_kron() {
+    let net = preflight_network(&["1", "2", "3", "4"], &["4"]);
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .expect("lower four wire");
+
+    assert_eq!(lowered.network.buses.len(), 2);
+    assert_eq!(lowered.network.branches.len(), 1);
+    assert!(has_diagnostic_code(
+        &lowered.record.diagnostics,
+        "LOWER.MULTI_TO_BALANCED.KRON_REDUCTION_REQUIRED"
+    ));
+    assert!(
+        lowered
+            .record
+            .approximations
+            .iter()
+            .any(|a| a.contains("Kron reduction")),
+        "{:?}",
+        lowered.record.approximations
+    );
+}
+
+#[test]
+fn lowering_produces_balanced_source_grounded_four_wire_fixture() {
+    let text = include_str!("../../tests/data/dist/micro/fourwire_linecode.dss");
+    let net = powerio_dist::parse_str(text, "dss").expect("parse four wire fixture");
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .expect("lower source grounded four wire fixture");
+
+    assert!(lowered.network.buses.len() >= 2);
+    assert_eq!(lowered.network.branches.len(), 1);
+    assert_eq!(lowered.network.loads.len(), 3);
+    assert!(lowered.network.loads.iter().all(|load| load.p > 0.0));
+    assert!(has_diagnostic_code(
+        &lowered.record.diagnostics,
+        "LOWER.MULTI_TO_BALANCED.KRON_REDUCTION_REQUIRED"
+    ));
+}
+
+#[test]
+fn lowering_rejects_one_phase_input() {
+    assert_lowering_rejects(
+        &preflight_network(&["1"], &[]),
+        "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_CONDUCTOR_SET",
+    );
+}
+
+#[test]
+fn lowering_rejects_two_wire_input() {
+    assert_lowering_rejects(
+        &preflight_network(&["1", "2"], &[]),
+        "LOWER.MULTI_TO_BALANCED.AMBIGUOUS_TERMINAL_MAP",
+    );
+}
+
+#[test]
+fn lowering_rejects_missing_phase_reference() {
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.sources.clear();
+    assert_lowering_rejects(&net, "LOWER.MULTI_TO_BALANCED.MISSING_PHASE_REFERENCE");
+}
+
+#[test]
+fn lowering_rejects_transformer_input() {
+    use powerio_dist::{DistTransformer, Extras};
+
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.transformers.push(DistTransformer {
+        name: "t1".to_owned(),
+        windings: Vec::new(),
+        xsc_pct: Vec::new(),
+        phases: 3,
+        extras: Extras::new(),
+    });
+    assert_lowering_rejects(&net, "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_TRANSFORMER");
+}
+
+#[test]
+fn lowering_rejects_untyped_object_input() {
+    use powerio_dist::UntypedObject;
+
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.untyped.push(UntypedObject {
+        class: "regcontrol".to_owned(),
+        name: "r1".to_owned(),
+        props: Vec::new(),
+    });
+    assert_lowering_rejects(&net, "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_OBJECT");
+}
+
+#[test]
+fn lowering_rejects_closed_switch_input() {
+    use powerio_dist::{DistSwitch, Extras};
+
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.switches.push(DistSwitch {
+        name: "sw1".to_owned(),
+        bus_from: "sourcebus".to_owned(),
+        bus_to: "loadbus".to_owned(),
+        terminal_map_from: strings(&["1", "2", "3"]),
+        terminal_map_to: strings(&["1", "2", "3"]),
+        open: false,
+        i_max: None,
+        extras: Extras::new(),
+    });
+    assert_lowering_rejects(&net, "LOWER.MULTI_TO_BALANCED.UNSUPPORTED_CLOSED_SWITCH");
+}
+
+#[test]
+fn package_lowering_returns_derived_balanced_package() {
+    let mut parent =
+        CompilerPackage::from_multiconductor(preflight_network(&["1", "2", "3", "4"], &["4"]));
+    parent.push_lowering(powerio_pkg::LoweringRecord::new(
+        "previous-pass",
+        ModelKind::Multiconductor,
+        ModelKind::Multiconductor,
+    ));
+    let lowered = parent
+        .lower_multiconductor_to_balanced(MulticonductorToBalancedOptions::default())
+        .expect("lower package");
+
+    assert_eq!(lowered.model_kind(), ModelKind::Balanced);
+    assert!(lowered.as_balanced().is_some());
+    assert!(lowered.as_multiconductor().is_none());
+    match &lowered.origin {
+        Origin::Derived { pass, .. } => assert_eq!(pass, "multiconductor-to-balanced"),
+        other => panic!("expected derived origin, got {other:?}"),
+    }
+    assert_eq!(lowered.lowering_history.len(), 2);
+    assert_eq!(
+        lowered.lowering_history[1].pass,
+        "multiconductor-to-balanced"
+    );
+    assert!(has_diagnostic_code(
+        &lowered.diagnostics,
+        "LOWER.MULTI_TO_BALANCED.KRON_REDUCTION_REQUIRED"
+    ));
+    assert!(
+        lowered
+            .source_maps
+            .iter()
+            .any(|entry| entry.mapping_kind == MappingKind::Synthetic),
+        "missing synthetic provenance: {:?}",
+        lowered.source_maps
+    );
+    assert!(
+        lowered
+            .source_maps
+            .iter()
+            .any(|entry| entry.mapping_kind == MappingKind::ConvertedUnits),
+        "missing unit conversion provenance: {:?}",
+        lowered.source_maps
+    );
+    assert!(
+        lowered
+            .validation
+            .passes
+            .iter()
+            .any(|pass| pass.name == "balanced.structure" && pass.status == ValidationStatus::Ok),
+        "balanced sane validation did not run: {:?}",
+        lowered.validation.passes
+    );
+    assert_json_roundtrips(&lowered);
+}
+
+#[test]
+fn package_lowering_rejects_balanced_package() {
+    let err = balanced_package()
+        .lower_multiconductor_to_balanced(MulticonductorToBalancedOptions::default())
+        .expect_err("balanced package is not accepted");
+    assert!(has_diagnostic_code(
+        &err.diagnostics,
+        "LOWER.MULTI_TO_BALANCED.WRONG_MODEL_KIND"
+    ));
 }
 
 #[test]

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -1035,6 +1035,65 @@ fn lowering_rejects_closed_switch_input() {
 }
 
 #[test]
+fn lowering_rejects_generator_unknown_bus() {
+    use powerio_dist::{Configuration, DistGenerator, Extras};
+
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.generators.push(DistGenerator {
+        name: "g_missing".to_owned(),
+        bus: "missing".to_owned(),
+        terminal_map: strings(&["1", "2", "3"]),
+        configuration: Configuration::Wye,
+        p_nom: vec![1_000.0, 1_000.0, 1_000.0],
+        q_nom: vec![0.0, 0.0, 0.0],
+        p_min: None,
+        p_max: None,
+        q_min: None,
+        q_max: None,
+        cost: None,
+        extras: Extras::new(),
+    });
+
+    assert_lowering_rejects(&net, "LOWER.MULTI_TO_BALANCED.UNKNOWN_BUS");
+}
+
+#[test]
+fn lowering_preserves_single_phase_shunt_total() {
+    use powerio_dist::{DistShunt, Extras};
+
+    let mut net = preflight_network(&["1", "2", "3"], &[]);
+    net.shunts.push(DistShunt {
+        name: "s1".to_owned(),
+        bus: "loadbus".to_owned(),
+        terminal_map: strings(&["1"]),
+        g: vec![vec![0.03]],
+        b: vec![vec![0.06]],
+        extras: Extras::new(),
+    });
+
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .expect("lower single phase shunt");
+    assert_eq!(lowered.network.shunts.len(), 1);
+
+    let expected_g = 0.03 * 240.0 * 240.0 / 1_000_000.0;
+    let expected_b = 0.06 * 240.0 * 240.0 / 1_000_000.0;
+    let shunt = &lowered.network.shunts[0];
+    assert!(
+        (shunt.g - expected_g).abs() < 1.0e-12,
+        "got {}, expected {}",
+        shunt.g,
+        expected_g
+    );
+    assert!(
+        (shunt.b - expected_b).abs() < 1.0e-12,
+        "got {}, expected {}",
+        shunt.b,
+        expected_b
+    );
+}
+
+#[test]
 fn package_lowering_returns_derived_balanced_package() {
     let mut parent =
         CompilerPackage::from_multiconductor(preflight_network(&["1", "2", "3", "4"], &["4"]));


### PR DESCRIPTION
Adds explicit multiconductor to balanced lowering with package provenance, diagnostics, tests, and docs.

Validation:
- cargo fmt --all --check
- cargo test -p powerio-pkg
- cargo clippy -p powerio-pkg --all-targets -- -D warnings
- cargo test -p powerio
- cargo test -p powerio-matrix lowered_multiconductor_balanced_model_builds_matrices

Closes #145 