### PR TITLE
[codex] Accept PSS/E Start of section markers

### DIFF
--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -890,33 +890,24 @@ enum Section {
     Skip,
 }
 
-/// The section a `BEGIN <name> DATA` terminator introduces. Sections we don't
-/// model map to [`Section::Skip`]. Case-insensitive on the marker text, so the
-/// number of skipped sections between the modeled ones doesn't matter.
+/// The section a terminator introduces. Sections we don't model map to
+/// [`Section::Skip`]. Case-insensitive on the marker text, so the number of
+/// skipped sections between the modeled ones doesn't matter.
 fn section_after_marker(line: &str) -> Section {
-    let u = line.to_ascii_uppercase();
-    if u.contains("BEGIN BUS DATA") {
-        Section::Bus
-    } else if u.contains("BEGIN LOAD DATA") {
-        Section::Load
-    } else if u.contains("BEGIN FIXED SHUNT DATA") {
-        Section::FixedShunt
-    } else if u.contains("BEGIN SWITCHED SHUNT DATA") {
-        Section::SwitchedShunt
-    } else if u.contains("BEGIN GENERATOR DATA") {
-        Section::Generator
-    } else if u.contains("BEGIN BRANCH DATA") {
-        Section::Branch
-    } else if u.contains("BEGIN TRANSFORMER DATA") {
-        Section::Transformer
-    } else if u.contains("BEGIN TWO-TERMINAL DC DATA") {
-        Section::TwoTerminalDc
-    } else if u.contains("BEGIN AREA DATA") {
-        // Distinct from "BEGIN INTER-AREA TRANSFER DATA", which doesn't contain
-        // the exact "BEGIN AREA DATA" run.
-        Section::Area
-    } else {
-        Section::Skip
+    match introduced_section_name(line).as_deref() {
+        Some("BUS") => Section::Bus,
+        Some("LOAD") => Section::Load,
+        Some("FIXED SHUNT") => Section::FixedShunt,
+        Some("SWITCHED SHUNT") => Section::SwitchedShunt,
+        Some("GENERATOR") | Some("GEN") => Section::Generator,
+        Some("BRANCH") => Section::Branch,
+        Some("TRANSFORMER") => Section::Transformer,
+        Some("TWO-TERMINAL DC")
+        | Some("TWO TERMINAL DC")
+        | Some("2-TERMINAL DC")
+        | Some("2 TERMINAL DC") => Section::TwoTerminalDc,
+        Some("AREA") | Some("AREA INTERCHANGE") => Section::Area,
+        _ => Section::Skip,
     }
 }
 
@@ -976,13 +967,18 @@ fn is_section_marker(line: &str) -> bool {
         return false;
     }
     let u = line.to_ascii_uppercase();
-    u.contains("END OF") || u.contains("BEGIN ")
+    u.contains("END OF") || u.contains("BEGIN ") || u.contains("START OF ")
 }
 
-/// The upper-cased section name a `BEGIN <name> DATA` marker introduces.
-fn begin_section_name(line: &str) -> Option<String> {
+/// The upper-cased section name a `BEGIN <name> DATA` or `START OF <name> DATA`
+/// marker introduces.
+fn introduced_section_name(line: &str) -> Option<String> {
     let u = line.to_ascii_uppercase();
-    let start = u.find("BEGIN ")? + "BEGIN ".len();
+    let (start, prefix_len) = u
+        .find("BEGIN ")
+        .map(|idx| (idx, "BEGIN ".len()))
+        .or_else(|| u.find("START OF ").map(|idx| (idx, "START OF ".len())))?;
+    let start = start + prefix_len;
     let rest = &u[start..];
     let end = rest.find(" DATA")?;
     Some(rest[..end].trim().to_string())
@@ -1017,7 +1013,7 @@ fn warn_unmodeled_sections(content: &str, warnings: &mut Vec<String>) {
         if is_section_marker(t) {
             close(current.as_ref(), rows, &mut totals);
             rows = 0;
-            current = begin_section_name(t)
+            current = introduced_section_name(t)
                 .map(|n| (n, matches!(section_after_marker(t), Section::Skip)));
         } else {
             rows += 1;
@@ -2330,6 +2326,33 @@ Q
         assert_eq!(net.branches.len(), 1);
         close(net.branches[0].rate_a, 100.0);
         assert!(net.branches[0].in_service);
+    }
+
+    #[test]
+    fn reads_start_of_section_markers_and_gen_alias() {
+        let raw = r#"0, 100.00, 33, 0, 0, 60.00 / synthetic v33 export
+CASE
+COMMENT
+1,'BUS1        ', 230.0000,3,1,1,1,1.00000,0.0000,1.1000,0.9000,1.1000,0.9000
+2,'BUS2        ', 230.0000,1,1,1,1,1.00000,0.0000,1.1000,0.9000,1.1000,0.9000
+0 / End of Bus Data, Start of Load Data
+2,'1 ',1,1,1,10.0,5.0
+0 / End of Load Data, Start of Fixed Shunt Data
+0 / End of Fixed Shunt Data, Start of Gen Data
+1,'1 ',50.0,5.0,20.0,-10.0,1.0,0,100.0,0.0,1.0,0.0,0.0,1.0,1,100.0,80.0,10.0
+0 / End of Gen Data, Start of Branch Data
+1,2,'1 ',0.01,0.05,0.001,100.0,90.0,80.0,0.0,0.0,0.0,0.0,1,1,0.0,1,1
+0 / End of Branch Data, Start of Transformer Data
+0 / End of Transformer Data, Start of Area Interchange Data
+Q
+"#;
+
+        let net = parse_psse(raw).unwrap();
+
+        assert_eq!(net.buses.len(), 2);
+        assert_eq!(net.loads.len(), 1);
+        assert_eq!(net.generators.len(), 1);
+        assert_eq!(net.branches.len(), 1);
     }
 
     #[test]

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -899,14 +899,13 @@ fn section_after_marker(line: &str) -> Section {
         Some("LOAD") => Section::Load,
         Some("FIXED SHUNT") => Section::FixedShunt,
         Some("SWITCHED SHUNT") => Section::SwitchedShunt,
-        Some("GENERATOR") | Some("GEN") => Section::Generator,
+        Some("GENERATOR" | "GEN") => Section::Generator,
         Some("BRANCH") => Section::Branch,
         Some("TRANSFORMER") => Section::Transformer,
-        Some("TWO-TERMINAL DC")
-        | Some("TWO TERMINAL DC")
-        | Some("2-TERMINAL DC")
-        | Some("2 TERMINAL DC") => Section::TwoTerminalDc,
-        Some("AREA") | Some("AREA INTERCHANGE") => Section::Area,
+        Some("TWO-TERMINAL DC" | "TWO TERMINAL DC" | "2-TERMINAL DC" | "2 TERMINAL DC") => {
+            Section::TwoTerminalDc
+        }
+        Some("AREA" | "AREA INTERCHANGE") => Section::Area,
         _ => Section::Skip,
     }
 }
@@ -2330,7 +2329,7 @@ Q
 
     #[test]
     fn reads_start_of_section_markers_and_gen_alias() {
-        let raw = r#"0, 100.00, 33, 0, 0, 60.00 / synthetic v33 export
+        let raw = r"0, 100.00, 33, 0, 0, 60.00 / synthetic v33 export
 CASE
 COMMENT
 1,'BUS1        ', 230.0000,3,1,1,1,1.00000,0.0000,1.1000,0.9000,1.1000,0.9000
@@ -2345,7 +2344,7 @@ COMMENT
 0 / End of Branch Data, Start of Transformer Data
 0 / End of Transformer Data, Start of Area Interchange Data
 Q
-"#;
+";
 
         let net = parse_psse(raw).unwrap();
 

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -42,6 +42,23 @@ mpc.gencost = [
 ];
 """
 
+PSSE_START_OF_MARKERS = """0, 100.00, 33, 0, 0, 60.00 / synthetic v33 export
+CASE
+COMMENT
+1,'BUS1        ', 230.0000,3,1,1,1,1.00000,0.0000,1.1000,0.9000,1.1000,0.9000
+2,'BUS2        ', 230.0000,1,1,1,1,1.00000,0.0000,1.1000,0.9000,1.1000,0.9000
+0 / End of Bus Data, Start of Load Data
+2,'1 ',1,1,1,10.0,5.0
+0 / End of Load Data, Start of Fixed Shunt Data
+0 / End of Fixed Shunt Data, Start of Gen Data
+1,'1 ',50.0,5.0,20.0,-10.0,1.0,0,100.0,0.0,1.0,0.0,0.0,1.0,1,100.0,80.0,10.0
+0 / End of Gen Data, Start of Branch Data
+1,2,'1 ',0.01,0.05,0.001,100.0,90.0,80.0,0.0,0.0,0.0,0.0,1,1,0.0,1,1
+0 / End of Branch Data, Start of Transformer Data
+0 / End of Transformer Data, Start of Area Interchange Data
+Q
+"""
+
 
 def load(name):
     return powerio.parse_file(DATA / f"{name}.m")
@@ -685,6 +702,18 @@ def test_convert_round_trip_through_psse(tmp_path):
     back = powerio.convert_file(str(p), "matpower")  # PSS/E inferred from .raw extension
     case = powerio.parse_str(back.text)
     assert case.n_buses == 30
+
+
+def test_convert_psse_start_of_markers_to_powermodels(tmp_path):
+    p = tmp_path / "start_markers.raw"
+    p.write_text(PSSE_START_OF_MARKERS)
+
+    pm = json.loads(powerio.convert_file(p, "powermodels-json", from_="psse").text)
+
+    assert len(pm["bus"]) == 2
+    assert len(pm["load"]) == 1
+    assert len(pm["gen"]) == 1
+    assert len(pm["branch"]) == 1
 
 
 def test_convert_unknown_format_raises():


### PR DESCRIPTION
## Summary

Fixes PSS/E RAW parsing for section terminators that use `Start of ... Data` instead of `BEGIN ... DATA`.

The parser was already routed through the PSS/E reader for `.raw` / `from_="psse"`, but section detection only recognized `BEGIN` markers. Files that used `Start of Gen Data` or `Start of Branch Data` left the parser in the skipped section state, so buses parsed while loads, generators, and branches were dropped.

## Changes

- Recognize both `BEGIN <section> DATA` and `START OF <section> DATA` markers.
- Accept common aliases including `Gen Data` and `Area Interchange Data`.
- Add Rust and Python regression coverage for PSS/E to PowerModels JSON conversion with `Start of` markers.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio psse`
- `cargo build -p powerio-py`
- Direct `_powerio` smoke test for PSS/E `Start of` marker conversion to PowerModels JSON

Local `pytest` was not available in the workspace Python environments. CI installs pytest and runs `pytest python/tests -q` in `.github/workflows/python.yml`, so it should cover the Python regression on the PR.