### PR TITLE
Add package C ABI surface

### DIFF
--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -46,11 +46,10 @@ jobs:
       if: steps.powerio-jl.outputs.available == 'true'
     - name: Build powerio-capi
       if: steps.powerio-jl.outputs.available == 'true'
-      # --features arrow,gridfm,dist so PowerIO.jl's Arrow export, gridfm reader,
-      # and the pio_dist_* distribution surface bind against real symbols rather
-      # than skipping (arrow_available() / gridfm_available() / pio_has_feature
-      # gate them).
-      run: cargo build -p powerio-capi --release --features arrow,gridfm,dist
+      # --features arrow,gridfm,dist,pkg so PowerIO.jl's Arrow export, gridfm
+      # reader, distribution surface, and package surface bind against real
+      # symbols rather than skipping behind feature probes.
+      run: cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
     - name: Check out PowerIO.jl
       if: steps.powerio-jl.outputs.available == 'true'
       uses: actions/checkout@v6

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,10 +1,10 @@
 name: Release binaries
 
-# Build the powerio-capi cdylib (with the arrow, gridfm, and dist features) for the five platforms
-# PowerIO.jl's Artifacts.toml covers, package each as the artifact tarball that
-# file references (lib/ or bin/ layout, Julia platform triplet in the name), and
-# attach them to the GitHub release on a version tag. A workflow_dispatch run
-# builds the same tarballs as workflow artifacts only — the pre-release dry run.
+# Build the powerio-capi cdylib (with arrow, gridfm, dist, and pkg features) for
+# the five platforms PowerIO.jl's Artifacts.toml covers, package each as the
+# artifact tarball that file references (lib/ or bin/ layout, Julia platform
+# triplet in the name), and attach them to the GitHub release on a version tag.
+# A workflow_dispatch run builds the same tarballs as workflow artifacts only.
 #
 # After tagging, run PowerIO.jl's gen/update_artifacts.jl <tag> to rewrite its
 # Artifacts.toml with the real sha256/git-tree-sha1 of these tarballs.
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get install -y ${{ matrix.cross_gcc }}
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Build powerio-capi
-        run: cargo build -p powerio-capi --release --features arrow,gridfm,dist --target ${{ matrix.rust_target }}
+        run: cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg --target ${{ matrix.rust_target }}
       # Artifact layout PowerIO.jl's _artifact_lib() resolves: the cdylib under
       # lib/ (bin/ on Windows, renamed to the lib-prefixed name BinaryBuilder
       # would produce), the C header under include/, licenses at the root.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,8 +157,8 @@ jobs:
       with:
         components: clippy
     - uses: Swatinem/rust-cache@v2
-    - name: Build powerio-capi --features arrow,gridfm,dist
-      run: cargo build -p powerio-capi --release --features arrow,gridfm,dist
+    - name: Build powerio-capi --features arrow,gridfm,dist,pkg
+      run: cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
     # The cfg-gated optional symbols still appear in the source symbol grep,
     # so they must be declared in the header (inside their PIO_* guards);
     # parity holds for the release feature set.
@@ -170,20 +170,20 @@ jobs:
       run: |
         rm -rf /tmp/pio-gridfm-smoke
         cargo run -p powerio-cli -- gridfm tests/data/case9.m -o /tmp/pio-gridfm-smoke
-        cc -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST \
+        cc -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG \
            -I powerio-capi/include powerio-capi/examples/smoke.c \
            -L target/release -lpowerio_capi -o pio_smoke_gridfm
         LD_LIBRARY_PATH=target/release ./pio_smoke_gridfm tests/data/case9.m /tmp/pio-gridfm-smoke/case9/raw
     - name: Compile and run the C++ header sanity check (release features)
       run: |
-        c++ -std=c++17 -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST \
+        c++ -std=c++17 -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG \
            -I powerio-capi/include powerio-capi/examples/header_cpp.cpp \
            -L target/release -lpowerio_capi -o pio_header_cpp_release
         LD_LIBRARY_PATH=target/release ./pio_header_cpp_release
     - name: Tests + clippy (release features)
       run: |
-        cargo test -p powerio-capi --features arrow,gridfm,dist --verbose
-        cargo clippy -p powerio-capi --all-targets --features arrow,gridfm,dist -- -D warnings
+        cargo test -p powerio-capi --features arrow,gridfm,dist,pkg --verbose
+        cargo clippy -p powerio-capi --all-targets --features arrow,gridfm,dist,pkg -- -D warnings
 
   c-abi-dist:
     name: C ABI (dist feature)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,8 @@ dependencies = [
  "powerio",
  "powerio-dist",
  "powerio-matrix",
+ "powerio-pkg",
+ "serde_json",
  "tempfile",
 ]
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ and Julia as `to_normalized(case)`.
 ### C ABI
 
 `powerio-capi` exposes parse, query, conversion, JSON transport, normalization,
-and numeric table extraction through `pio_*` functions. The public header is
+`.pio.json` package handles, and numeric table extraction through `pio_*`
+functions. The public header is
 [powerio-capi/include/powerio.h](https://github.com/eigenergy/powerio/blob/main/powerio-capi/include/powerio.h).
 Build with `--features arrow` to enable `pio_to_arrow` over the
 [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).

--- a/docs/src/contributor-workflow.md
+++ b/docs/src/contributor-workflow.md
@@ -37,9 +37,9 @@ gates before a release claim.
 | rich model fields | `bash benchmarks/run_rich_validation.sh` |
 | matrix builders or DC OPF bundles | `cargo test -p powerio-matrix`; `cargo bench -p powerio-matrix --bench matrix` |
 | PowerWorld binary reader | PowerWorld parser tests plus `cargo bench -p powerio --bench parse -- "parse_aux_|parse_pwb_"` |
-| C ABI | `scripts/capi-header-parity.sh`; `scripts/capi-smoke.sh`; `cargo test -p powerio-capi --no-default-features`; `cargo test -p powerio-capi --features arrow,gridfm,dist`; matching clippy runs |
+| C ABI | `scripts/capi-header-parity.sh`; `scripts/capi-smoke.sh`; `cargo test -p powerio-capi --no-default-features`; `cargo test -p powerio-capi --features arrow,gridfm,dist,pkg`; matching clippy runs |
 | Python package metadata or extras | `maturin build --release --out /tmp/powerio-wheel-check`; inspect wheel `METADATA` |
-| Julia binding compatibility | build `powerio-capi --features arrow,gridfm,dist`, then run `PowerIO.jl` tests with `POWERIO_CAPI` |
+| Julia binding compatibility | build `powerio-capi --features arrow,gridfm,dist,pkg`, then run `PowerIO.jl` tests with `POWERIO_CAPI` |
 | CLI behavior | `cargo test -p powerio-cli --test cli` |
 | documentation or website | `mdbook build docs`; `mdbook test docs`; check stale links to retired guide outputs |
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -34,6 +34,7 @@ Verb taxonomy:
 | Parsed conversion | `net.to_format(to)` | `net.to_format(to)` | `to_format(net, to)` | `pio_to_format` |
 | MATPOWER text | `net.to_matpower()` | `net.to_matpower()` | `to_matpower(net)` | `pio_to_format` + `"matpower"` |
 | JSON text | `net.to_json()` | `net.to_json()` | `to_json(net)` | `pio_to_format` + `"powerio-json"` |
+| Package JSON | `CompilerPackage::to_json()` | package transport | `to_package` / `write_package` | `pio_package_*` |
 | Normalized copy | `net.to_normalized()` | `net.to_normalized()` | `to_normalized(net)` | `pio_normalize` |
 | Dense tables | typed table API | `to_dense` | `to_dense` | `pio_*` extractors |
 | PyPSA CSV folder | `read_pypsa_csv_folder` / `write_pypsa_csv_folder` | `read_pypsa_csv_folder` / `net.write_pypsa_csv_folder` | `parse_file(dir; from="pypsa-csv")` / `write_pypsa_csv_folder` | `pio_parse_file` / `pio_write_dir` + `"pypsa-csv"` |
@@ -49,9 +50,11 @@ language APIs keep their per-format conveniences (`to_matpower`, `from_json`,
 ## C ABI and binding compatibility
 
 The C ABI is the stable boundary for non Rust callers. Handles own parsed
-networks. Callers free network handles with `pio_network_free`, free returned
-text with `pio_string_free`, size output buffers before filling them, and treat
-every format name as a string routed through the same parser and writer hub.
+networks. `PioPackage` handles own `.pio.json` compiler packages. Callers free
+network handles with `pio_network_free`, package handles with
+`pio_package_free`, free returned text with `pio_string_free`, size output
+buffers before filling them, and treat every format name as a string routed
+through the same parser and writer hub.
 
 C ABI review points:
 
@@ -61,21 +64,22 @@ C ABI review points:
 - returned text and warning buffers must be NUL terminated when capacity permits;
 - reported lengths must let callers allocate exact buffers;
 - header declarations and exported Rust symbols must match;
-- feature gated exports such as Arrow and GridFM must be additive;
+- feature gated exports such as Arrow, GridFM, distribution, and packages must
+  be additive;
 - ownership rules must be documented in the header, README, and binding code.
 
-Julia's `PowerIO.jl` uses the C ABI for handles, dense extractors, Arrow, GridFM,
-PyPSA CSV folders, and distribution conversion. Whole-network transport uses
-`powerio-json`, so the binding does not stitch together a separate model from
-individual table calls. The Julia binding checks `pio_abi_version()` against
-`PIO_ABI_VERSION` on first use. Distribution calls also check
-`pio_dist_abi_version()`.
+Julia's `PowerIO.jl` uses the C ABI for handles, dense extractors, Arrow,
+GridFM, PyPSA CSV folders, distribution conversion, and `.pio.json` package
+construction. Whole-network transport uses `powerio-json`, so the binding does
+not stitch together a separate model from individual table calls. The Julia
+binding checks `pio_abi_version()` against `PIO_ABI_VERSION` on first use.
+Distribution calls also check `pio_dist_abi_version()`.
 
 During development, test the sibling Julia binding against the local C ABI
 instead of an artifact:
 
 ```sh
-cargo build -p powerio-capi --release --features arrow,gridfm,dist
+cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
 POWERIO_CAPI=$PWD/target/release/libpowerio_capi.dylib \
   julia --project=../PowerIO.jl -e 'using Pkg; Pkg.test()'
 ```
@@ -105,7 +109,8 @@ parse or conversion behavior.
 | Rust package object | n/a | `powerio_pkg::CompilerPackage` | n/a | n/a | Serializes to `.pio.json` and carries `model_kind`. |
 | Python transmission handle | `powerio.Case` | `powerio.Network` / `powerio.BalancedNetwork` | 0.3.3 | removed in 0.4.0 | `Case` is no longer importable. |
 | Python distribution handle | `powerio.dist.DistCase` | `powerio.dist.MulticonductorNetwork` / `powerio.dist.DistNetwork` | 0.3.3 | removed in 0.4.0 | `DistCase` is no longer importable. |
-| C ABI | `PioNetwork` / `PioDistNetwork` | unchanged `pio_*` / `pio_dist_*` handles | n/a | n/a | `PIO_ABI_VERSION` stays 4 and `PIO_DIST_ABI_VERSION` stays 1; symbol renames are not part of the 0.4 package spine. |
+| C ABI network handles | `PioNetwork` / `PioDistNetwork` | unchanged `pio_*` / `pio_dist_*` handles | n/a | n/a | `PIO_ABI_VERSION` stays 4 and `PIO_DIST_ABI_VERSION` stays 1; symbol renames are not part of the 0.4 package spine. |
+| C ABI package handle | n/a | `PioPackage` / `pio_package_*` | 0.4.0 | n/a | The package functions use `balanced` and `multiconductor` where the model family matters. |
 | MCP | older case helper names | `parse`, `save`, `summary`, `display` | 0.3.3 | kept as Python compatibility wrappers in 0.4 | Advertised tools use the semantic names; `.pio.json` package transport is accepted by the network tools. |
 
 ## Distribution surface (`powerio-dist`)

--- a/docs/src/reliability.md
+++ b/docs/src/reliability.md
@@ -13,15 +13,15 @@ cargo test
 cargo test -p powerio-cli --test cli
 cargo test -p powerio-capi
 cargo test -p powerio-capi --no-default-features
-cargo test -p powerio-capi --features arrow,gridfm,dist
+cargo test -p powerio-capi --features arrow,gridfm,dist,pkg
 cargo clippy -p powerio-capi --all-targets --no-default-features -- -D warnings
-cargo clippy -p powerio-capi --all-targets --features arrow,gridfm,dist -- -D warnings
+cargo clippy -p powerio-capi --all-targets --features arrow,gridfm,dist,pkg -- -D warnings
 cargo build -p powerio-py
 python3.12 -m venv .venv
 .venv/bin/python -m pip install --upgrade pip maturin -r benchmarks/requirements.txt
 env VIRTUAL_ENV=$PWD/.venv .venv/bin/maturin develop --release
 .venv/bin/pytest python/tests
-cargo build -p powerio-capi --release --features arrow,gridfm,dist
+cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
 scripts/capi-header-parity.sh
 scripts/capi-smoke.sh
 POWERIO_CAPI=$PWD/target/release/libpowerio_capi.dylib \
@@ -64,7 +64,7 @@ When all required legs pass, the gates cover these properties:
 - the checked in C header declares the same `pio_*` symbols exported from the
   Rust C ABI source;
 - the checked in C and C++ examples compile and run against the release C ABI
-  with Arrow, GridFM, and distribution features enabled;
+  with Arrow, GridFM, distribution, and package features enabled;
 - Python parse, conversion, matrix, graph, package, and display paths pass their
   binding tests when extras are installed.
 - ASV discovers and runs the Python parse, \\(Y_{\mathrm{bus}}\\), and B' benchmark definitions
@@ -72,7 +72,7 @@ When all required legs pass, the gates cover these properties:
 - the parser fuzz targets build and enter libFuzzer, covering the hand written
   text and binary readers.
 - Julia's `PowerIO.jl` passes against the local release C ABI with Arrow,
-  GridFM, and distribution features enabled.
+  GridFM, distribution, and package features enabled.
 - CLI help, stdout/stderr, JSON summary, batch matrix export metadata,
   directory target errors, and family mismatch exits pass through the binary
   integration tests.

--- a/powerio-capi/Cargo.toml
+++ b/powerio-capi/Cargo.toml
@@ -15,9 +15,10 @@ name = "powerio_capi"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
-# Distribution is first class: every powerio build ships the pio_dist_* surface
-# by default. Opt out with --no-default-features for a transmission-only library.
-default = ["dist"]
+# Distribution and package support are first class: every default powerio build
+# ships the pio_dist_* and pio_package_* surfaces. Opt out with
+# --no-default-features for a transmission-only library.
+default = ["dist", "pkg"]
 # Zero-copy raw network export over the Arrow C Data Interface (`pio_to_arrow`).
 # Off by default so the base ABI pulls in nothing but `powerio`.
 arrow = ["dep:arrow"]
@@ -28,15 +29,19 @@ dist = ["dep:powerio-dist"]
 # Off by default so the base ABI pulls in nothing but `powerio`; enabling it pulls
 # in powerio-matrix (arrow + parquet) for the reader.
 gridfm = ["dep:powerio-matrix", "powerio-matrix/gridfm"]
+# `.pio.json` compiler package envelope (`pio_package_*`). On by default.
+pkg = ["dep:powerio-pkg"]
 
 [dependencies]
 powerio.workspace = true
 powerio-dist = { workspace = true, optional = true }
+powerio-pkg = { workspace = true, optional = true }
 # Only the C Data Interface (`ffi`) is needed; the heavy arrow defaults stay off.
 arrow = { workspace = true, features = ["ffi"], optional = true }
 # Pulled in only by the `gridfm` feature: the reader lives in powerio-matrix.
 # It re-exports powerio, so `Network` is the same type `make_network` already takes.
 powerio-matrix = { workspace = true, optional = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 # Only the gridfm C-ABI test uses it (write a dataset to a temp dir, read it back).

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -30,6 +30,7 @@ cargo test -p powerio-capi --no-default-features
 cargo test -p powerio-capi --features arrow
 cargo test -p powerio-capi --features gridfm
 cargo test -p powerio-capi --features dist
+cargo test -p powerio-capi --features arrow,gridfm,dist,pkg
 scripts/capi-header-parity.sh
 scripts/capi-smoke.sh
 ```
@@ -119,6 +120,32 @@ the transport the Julia package consumes: one call instead of stitching the
 snapshot omits, so a reloaded handle reformats on write rather than echoing a
 byte-exact original.
 
+## The `.pio.json` package surface
+
+The default build includes the package surface (`PIO_PKG`). Probe it with
+`pio_has_feature("pkg")` when loading dynamically. `PioPackage` is an opaque
+compiler package handle, distinct from the parsed network handles:
+
+- `pio_package_parse_file` and `pio_package_parse_str` read `.pio.json`.
+- `pio_package_to_json` returns compact `.pio.json`; free it with
+  `pio_string_free`.
+- `pio_package_from_balanced_network` wraps a `PioNetwork`, the historical C
+  handle for `powerio::BalancedNetwork`.
+- `pio_package_from_multiconductor_network` wraps a `PioDistNetwork`, the
+  historical C handle for `powerio_dist::MulticonductorNetwork`, when both
+  `PIO_PKG` and `PIO_DIST` are present.
+- `pio_package_validate`, `pio_package_validation_json`, and
+  `pio_package_diagnostics_json` expose structured validation state.
+- `pio_package_multiconductor_to_balanced_preflight_json` reports structured
+  blockers before lowering, and `pio_package_lower_multiconductor_to_balanced`
+  returns a new balanced package when the input is ready.
+
+Options cross as JSON objects. `NULL` and `{}` mean defaults. The balanced
+constructor accepts `include_solver_metadata` (default `false`). The
+multiconductor lowering calls accept `base_mva` (default `100.0`) and
+`convention` (default `fortescue_power_invariant`). Unknown option keys are
+errors.
+
 ## API names
 
 The grammar is written out in the header preamble; the short version:
@@ -129,6 +156,8 @@ The grammar is written out in the header preamble; the short version:
   `pio_convert_file`/`pio_convert_str` transcode without keeping a handle.
 - `pio_to_format` is the one text serializer; `pio_to_arrow` earns its own
   symbol only because its output type is Arrow C Data Interface structs.
+- `pio_package_*` functions operate on the package envelope, not on a new
+  network handle family.
 - Format names never appear in symbols: `matpower`, `psse`, `powerio-json`,
   `pypsa-csv`, `gridfm`, and every future format are strings, so a new format
   never changes this ABI.
@@ -156,7 +185,8 @@ Every entry point is hardened at the boundary:
   never dereferenced past its NUL.
 - Ownership is symmetric: handles from `pio_parse_*`/`pio_read_dir`/
   `pio_normalize` are freed with `pio_network_free`, strings from
-  `pio_to_format`/`pio_convert_*` with `pio_string_free`, each exactly once.
+  `pio_to_format`/`pio_convert_*` with `pio_string_free`, package handles with
+  `pio_package_free`, each exactly once.
   The Arrow export hands the caller two C Data Interface structs whose
   non-NULL `release` callbacks must each be invoked exactly once.
 - The table extractors (`pio_branches`, `pio_gens`, ...) write at most `cap`
@@ -199,9 +229,10 @@ the formats reversed. It is the reason the `pio_abi_version()` handshake is
 not optional.
 
 The grammar v4 fixed is the freeze: existing signatures never change again,
-new data means new symbols, and rich or multiconductor data rides the Arrow
-and `powerio-json` schemas, which evolve without touching a C signature. Any
-future break would bump `PIO_ABI_VERSION` in lockstep with PowerIO.jl.
+new data means new symbols, and rich or multiconductor data rides the Arrow,
+`powerio-json`, and `.pio.json` schemas, which evolve without touching a C
+signature. Any future break would bump `PIO_ABI_VERSION` in lockstep with
+PowerIO.jl.
 
 The optional `pio_dist_*` surface has its own version check:
 `pio_dist_abi_version()` against `PIO_DIST_ABI_VERSION`, after confirming
@@ -212,7 +243,7 @@ appeared before this split should be treated as experimental.
 
 Every public `PIO_*` macro, opaque typedef, and `pio_*` prototype in
 `powerio.h` is pinned by a Cargo test, and CI compiles the C smoke program
-against the no-default core ABI plus the arrow, gridfm, and dist feature
+against the no-default core ABI plus the arrow, gridfm, dist, and pkg feature
 surfaces. CI also compiles and links a C++ header sanity program to keep the
 `extern "C"` path honest. Source/header symbol parity is checked separately, so
 adding, renaming, or deleting a public entry point fails before release.

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -140,11 +140,12 @@ compiler package handle, distinct from the parsed network handles:
   blockers before lowering, and `pio_package_lower_multiconductor_to_balanced`
   returns a new balanced package when the input is ready.
 
-Options cross as JSON objects. `NULL` and `{}` mean defaults. The balanced
-constructor accepts `include_solver_metadata` (default `false`). The
-multiconductor lowering calls accept `base_mva` (default `100.0`) and
-`convention` (default `fortescue_power_invariant`). Unknown option keys are
-errors.
+Constructor and lowering options cross as typed parameters. The balanced
+constructor takes `include_solver_metadata`; any nonzero value records compact
+normalized solver table metadata. The multiconductor lowering calls take
+`base_mva`, the three phase system power base used for the balanced per-unit
+projection. The transform convention is fixed by these functions; if another
+convention becomes a real public option, it should get a new additive symbol.
 
 ## API names
 

--- a/powerio-capi/cbindgen.toml
+++ b/powerio-capi/cbindgen.toml
@@ -81,17 +81,21 @@ header = """
  *
  * Optional: build with `--features arrow` for pio_to_arrow (guarded by
  * PIO_ARROW), `--features gridfm` for pio_read_dir / pio_scenario_ids
- * (guarded by PIO_GRIDFM), and `--features dist` for the pio_dist_* entry
+ * (guarded by PIO_GRIDFM), `--features dist` for the pio_dist_* entry
  * points (guarded by PIO_DIST): multiconductor distribution cases (OpenDSS,
  * PMD ENGINEERING JSON, BMOPF JSON) behind their own PioDistNetwork handle,
- * freed with pio_dist_network_free, string outputs freed with pio_string_free.
+ * freed with pio_dist_network_free, string outputs freed with pio_string_free,
+ * and `--features pkg` for the pio_package_* entry points (guarded by
+ * PIO_PKG): `.pio.json` compiler packages behind their own PioPackage handle,
+ * freed with pio_package_free.
  * The distribution surface is EXPERIMENTAL while the IEEE BMOPF schema is a
  * draft: supported dist C usage starts at PIO_DIST_ABI_VERSION = 1, with
  * pio_dist_convert_*(input, from, to, ...). Dist C signature changes bump
  * PIO_DIST_ABI_VERSION, not PIO_ABI_VERSION. Its JSON payloads (bmopf-json,
  * powerio-dist-json) carry their own meta.version and may evolve; pin a
  * vintage from the payload meta.
- * Probe optional surfaces at runtime with pio_has_feature("arrow"|"gridfm"|"dist").
+ * Probe optional surfaces at runtime with
+ * pio_has_feature("arrow"|"gridfm"|"dist"|"pkg").
  *
  * Checked in and generated; regenerate from the Rust source with
  *   cbindgen --config cbindgen.toml --crate powerio-capi --output include/powerio.h
@@ -110,20 +114,21 @@ struct ArrowSchema;
 
 [export]
 prefix = ""
-include = ["PioNetwork", "PioDistNetwork"]
+include = ["PioNetwork", "PioDistNetwork", "PioPackage"]
 
 [export.rename]
 "FFI_ArrowArray" = "struct ArrowArray"
 "FFI_ArrowSchema" = "struct ArrowSchema"
 
 # Gate the optional features behind #ifdef (PIO_ARROW for `arrow`, PIO_DIST
-# for `dist`, PIO_GRIDFM for `gridfm`): cbindgen emits the cfg-gated symbols
-# inside `#if defined(...)` even on a default (no-feature) generation, so the
-# checked-in header always carries every block.
+# for `dist`, PIO_GRIDFM for `gridfm`, PIO_PKG for `pkg`): cbindgen emits the
+# cfg-gated symbols inside `#if defined(...)` even on a default (no-feature)
+# generation, so the checked-in header always carries every block.
 [defines]
 "feature = arrow" = "PIO_ARROW"
 "feature = dist" = "PIO_DIST"
 "feature = gridfm" = "PIO_GRIDFM"
+"feature = pkg" = "PIO_PKG"
 
 [parse]
 parse_deps = false

--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -123,6 +123,40 @@ int main(int argc, char **argv) {
     pio_string_free(json);
     pio_network_free(c2);
 
+#ifdef PIO_PKG
+    /* Compiler package surface: wrap the live balanced handle, validate the
+     * package, serialize it, and parse it back. */
+    {
+        CHECK(pio_has_feature("pkg") == 1, "pio_has_feature(pkg) should be 1");
+        PioPackage *pkg = pio_package_from_balanced_network(c, NULL, err, sizeof err);
+        CHECK(pkg != NULL, err);
+        CHECK(pio_package_validate(pkg, err, sizeof err) == 0, err);
+
+        char *validation = pio_package_validation_json(pkg, err, sizeof err);
+        CHECK(validation != NULL, err);
+        CHECK(strstr(validation, "\"status\":\"ok\"") != NULL,
+              "package validation JSON did not report ok");
+        pio_string_free(validation);
+
+        char *diagnostics = pio_package_diagnostics_json(pkg, err, sizeof err);
+        CHECK(diagnostics != NULL, err);
+        CHECK(strcmp(diagnostics, "[]") == 0, "unexpected package diagnostics");
+        pio_string_free(diagnostics);
+
+        char *pkg_json = pio_package_to_json(pkg, err, sizeof err);
+        CHECK(pkg_json != NULL, err);
+        CHECK(strstr(pkg_json, "\"model_kind\":\"balanced\"") != NULL,
+              "package JSON lost the balanced model kind");
+
+        PioPackage *pkg2 = pio_package_parse_str(pkg_json, err, sizeof err);
+        CHECK(pkg2 != NULL, err);
+        pio_package_free(pkg2);
+        pio_string_free(pkg_json);
+        pio_package_free(pkg);
+        printf("package surface OK\n");
+    }
+#endif
+
     /* In-memory parse: read the bytes ourselves and parse them with an explicit
      * format, then confirm it agrees with the path-based parse. */
     {

--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -128,7 +128,7 @@ int main(int argc, char **argv) {
      * package, serialize it, and parse it back. */
     {
         CHECK(pio_has_feature("pkg") == 1, "pio_has_feature(pkg) should be 1");
-        PioPackage *pkg = pio_package_from_balanced_network(c, NULL, err, sizeof err);
+        PioPackage *pkg = pio_package_from_balanced_network(c, 0, err, sizeof err);
         CHECK(pkg != NULL, err);
         CHECK(pio_package_validate(pkg, err, sizeof err) == 0, err);
 

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -614,12 +614,12 @@ char *pio_package_to_json(const PioPackage *pkg, char *errbuf, size_t errlen);
 #if defined(PIO_PKG)
 /**
  * Wrap a balanced [`PioNetwork`] handle in a `.pio.json` package. The C handle
- * name is historical; the payload is `powerio::BalancedNetwork`. `options_json`
- * may be NULL or `{}`. The optional key `include_solver_metadata` attaches
- * compact normalized solver table metadata.
+ * name is historical; the payload is `powerio::BalancedNetwork`.
+ * `include_solver_metadata != 0` attaches compact normalized solver table
+ * metadata.
  */
 PioPackage *pio_package_from_balanced_network(const PioNetwork *net,
-                                              const char *options_json,
+                                              int32_t include_solver_metadata,
                                               char *errbuf,
                                               size_t errlen);
 #endif
@@ -628,10 +628,9 @@ PioPackage *pio_package_from_balanced_network(const PioNetwork *net,
 /**
  * Wrap a multiconductor [`PioDistNetwork`] handle in a `.pio.json` package. The
  * C handle name is historical; the payload is
- * `powerio_dist::MulticonductorNetwork`. `options_json` may be NULL or `{}`.
+ * `powerio_dist::MulticonductorNetwork`.
  */
 PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net,
-                                                    const char *options_json,
                                                     char *errbuf,
                                                     size_t errlen);
 #endif
@@ -663,12 +662,11 @@ char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t e
 #if defined(PIO_PKG)
 /**
  * Return the multiconductor-to-balanced lowering preflight report as JSON.
- * `options_json` may be NULL or `{}`; accepted keys are `base_mva` and
- * `convention`. Returns `NULL` if the package is not multiconductor or the
- * options are invalid.
+ * `base_mva` is the three phase system power base used for the balanced
+ * per-unit projection. Returns `NULL` if the package is not multiconductor.
  */
 char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg,
-                                                            const char *options_json,
+                                                            double base_mva,
                                                             char *errbuf,
                                                             size_t errlen);
 #endif
@@ -677,11 +675,11 @@ char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pk
 /**
  * Lower a multiconductor package to a new balanced package. Call
  * [`pio_package_multiconductor_to_balanced_preflight_json`] first when the
- * caller needs structured blockers for unsupported inputs. `options_json` uses
- * the same defaults and keys as the preflight function.
+ * caller needs structured blockers for unsupported inputs. `base_mva` is the
+ * three phase system power base used for the balanced per-unit projection.
  */
 PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg,
-                                                         const char *options_json,
+                                                         double base_mva,
                                                          char *errbuf,
                                                          size_t errlen);
 #endif

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -68,17 +68,21 @@
  *
  * Optional: build with `--features arrow` for pio_to_arrow (guarded by
  * PIO_ARROW), `--features gridfm` for pio_read_dir / pio_scenario_ids
- * (guarded by PIO_GRIDFM), and `--features dist` for the pio_dist_* entry
+ * (guarded by PIO_GRIDFM), `--features dist` for the pio_dist_* entry
  * points (guarded by PIO_DIST): multiconductor distribution cases (OpenDSS,
  * PMD ENGINEERING JSON, BMOPF JSON) behind their own PioDistNetwork handle,
- * freed with pio_dist_network_free, string outputs freed with pio_string_free.
+ * freed with pio_dist_network_free, string outputs freed with pio_string_free,
+ * and `--features pkg` for the pio_package_* entry points (guarded by
+ * PIO_PKG): `.pio.json` compiler packages behind their own PioPackage handle,
+ * freed with pio_package_free.
  * The distribution surface is EXPERIMENTAL while the IEEE BMOPF schema is a
  * draft: supported dist C usage starts at PIO_DIST_ABI_VERSION = 1, with
  * pio_dist_convert_*(input, from, to, ...). Dist C signature changes bump
  * PIO_DIST_ABI_VERSION, not PIO_ABI_VERSION. Its JSON payloads (bmopf-json,
  * powerio-dist-json) carry their own meta.version and may evolve; pin a
  * vintage from the payload meta.
- * Probe optional surfaces at runtime with pio_has_feature("arrow"|"gridfm"|"dist").
+ * Probe optional surfaces at runtime with
+ * pio_has_feature("arrow"|"gridfm"|"dist"|"pkg").
  *
  * Checked in and generated; regenerate from the Rust source with
  *   cbindgen --config cbindgen.toml --crate powerio-capi --output include/powerio.h
@@ -209,6 +213,15 @@ typedef struct PioDistNetwork PioDistNetwork;
  */
 typedef struct PioNetwork PioNetwork;
 
+#if defined(PIO_PKG)
+/**
+ * Opaque `.pio.json` compiler package handle. A package owns one
+ * [`powerio_pkg::CompilerPackage`], which wraps either a balanced
+ * [`PioNetwork`] payload or a multiconductor [`PioDistNetwork`] payload.
+ */
+typedef struct PioPackage PioPackage;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -230,12 +243,13 @@ uint32_t pio_dist_abi_version(void);
 
 /**
  * Whether an optional build feature is compiled in: pass `"arrow"`, `"gridfm"`,
- * or `"dist"`. Returns 1 if present, 0 otherwise (and 0 for a NULL or unknown
- * name). The optional surfaces (`pio_to_arrow`, the `pio_read_dir`/gridfm path,
- * the `pio_dist_*` block) are only linked when their feature is built, so a
- * consumer that loaded the library at runtime probes for them here instead of
- * resolving symbols blind. Feature names are strings — like format names, a new
- * feature never changes this signature. Infallible.
+ * `"dist"`, or `"pkg"`. Returns 1 if present, 0 otherwise (and 0 for a NULL or
+ * unknown name). The optional surfaces (`pio_to_arrow`, the `pio_read_dir`/
+ * gridfm path, the `pio_dist_*` block, and the `pio_package_*` block) are only
+ * linked when their feature is built, so a consumer that loaded the library at
+ * runtime probes for them here instead of resolving symbols blind. Feature
+ * names are strings like format names, so a new feature never changes this
+ * signature. Infallible.
  */
 int32_t pio_has_feature(const char *feature);
 
@@ -559,6 +573,117 @@ int32_t pio_to_arrow(const PioNetwork *net,
                      struct ArrowSchema *out_schema,
                      char *errbuf,
                      size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Parse a `.pio.json` package file into an opaque package handle. This reads
+ * only the package envelope; case format names still enter through
+ * [`pio_parse_file`] / [`pio_dist_parse_file`] and package constructors.
+ * Returns `NULL` on error and writes the message into `errbuf`. Free the handle
+ * with [`pio_package_free`].
+ */
+PioPackage *pio_package_parse_file(const char *path, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Parse in-memory `.pio.json` text into an opaque package handle. Returns
+ * `NULL` on error and writes the message into `errbuf`. Free the handle with
+ * [`pio_package_free`].
+ */
+PioPackage *pio_package_parse_str(const char *text, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Free a package handle returned by `pio_package_*`. NULL is a no-op; free
+ * exactly once.
+ */
+void pio_package_free(PioPackage *pkg);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Serialize a package handle to compact `.pio.json`. Returns an owned C string
+ * (free with [`pio_string_free`]) or `NULL` on error.
+ */
+char *pio_package_to_json(const PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Wrap a balanced [`PioNetwork`] handle in a `.pio.json` package. The C handle
+ * name is historical; the payload is `powerio::BalancedNetwork`. `options_json`
+ * may be NULL or `{}`. The optional key `include_solver_metadata` attaches
+ * compact normalized solver table metadata.
+ */
+PioPackage *pio_package_from_balanced_network(const PioNetwork *net,
+                                              const char *options_json,
+                                              char *errbuf,
+                                              size_t errlen);
+#endif
+
+#if (defined(PIO_PKG) && defined(PIO_DIST))
+/**
+ * Wrap a multiconductor [`PioDistNetwork`] handle in a `.pio.json` package. The
+ * C handle name is historical; the payload is
+ * `powerio_dist::MulticonductorNetwork`. `options_json` may be NULL or `{}`.
+ */
+PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net,
+                                                    const char *options_json,
+                                                    char *errbuf,
+                                                    size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Run the package semantic validation profile in place. Returns `0` on
+ * success, `-1` on error.
+ */
+int32_t pio_package_validate(PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Return the package validation summary as JSON. The returned string is owned
+ * by the library; free it with [`pio_string_free`].
+ */
+char *pio_package_validation_json(const PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Return the package structured diagnostics array as JSON. The returned string
+ * is owned by the library; free it with [`pio_string_free`].
+ */
+char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Return the multiconductor-to-balanced lowering preflight report as JSON.
+ * `options_json` may be NULL or `{}`; accepted keys are `base_mva` and
+ * `convention`. Returns `NULL` if the package is not multiconductor or the
+ * options are invalid.
+ */
+char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg,
+                                                            const char *options_json,
+                                                            char *errbuf,
+                                                            size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Lower a multiconductor package to a new balanced package. Call
+ * [`pio_package_multiconductor_to_balanced_preflight_json`] first when the
+ * caller needs structured blockers for unsupported inputs. `options_json` uses
+ * the same defaults and keys as the preflight function.
+ */
+PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg,
+                                                         const char *options_json,
+                                                         char *errbuf,
+                                                         size_t errlen);
 #endif
 
 #if defined(PIO_DIST)

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -198,12 +198,13 @@ pub extern "C" fn pio_dist_abi_version() -> u32 {
 }
 
 /// Whether an optional build feature is compiled in: pass `"arrow"`, `"gridfm"`,
-/// or `"dist"`. Returns 1 if present, 0 otherwise (and 0 for a NULL or unknown
-/// name). The optional surfaces (`pio_to_arrow`, the `pio_read_dir`/gridfm path,
-/// the `pio_dist_*` block) are only linked when their feature is built, so a
-/// consumer that loaded the library at runtime probes for them here instead of
-/// resolving symbols blind. Feature names are strings — like format names, a new
-/// feature never changes this signature. Infallible.
+/// `"dist"`, or `"pkg"`. Returns 1 if present, 0 otherwise (and 0 for a NULL or
+/// unknown name). The optional surfaces (`pio_to_arrow`, the `pio_read_dir`/
+/// gridfm path, the `pio_dist_*` block, and the `pio_package_*` block) are only
+/// linked when their feature is built, so a consumer that loaded the library at
+/// runtime probes for them here instead of resolving symbols blind. Feature
+/// names are strings like format names, so a new feature never changes this
+/// signature. Infallible.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_has_feature(feature: *const c_char) -> i32 {
     unsafe {
@@ -213,6 +214,7 @@ pub unsafe extern "C" fn pio_has_feature(feature: *const c_char) -> i32 {
                 ("arrow", cfg!(feature = "arrow")),
                 ("gridfm", cfg!(feature = "gridfm")),
                 ("dist", cfg!(feature = "dist")),
+                ("pkg", cfg!(feature = "pkg")),
             ];
             i32::from(features.iter().any(|&(n, on)| n == name && on))
         })
@@ -245,6 +247,13 @@ fn optional_cstr<'a>(p: *const c_char, name: &str) -> Result<Option<&'a str>, St
             .map(Some)
             .ok_or_else(|| format!("{name} is not UTF-8"))
     }
+}
+
+/// Like [`cstr`] but a NULL or non-UTF-8 pointer is an error naming the
+/// offending parameter. Entry points use this for required strings.
+#[cfg(any(feature = "dist", feature = "pkg"))]
+fn required_cstr<'a>(p: *const c_char, name: &str) -> Result<&'a str, String> {
+    unsafe { cstr(p) }.ok_or_else(|| format!("{name} is NULL or not UTF-8"))
 }
 
 /// Parse `path` (format from extension, or `from` if non-NULL) into a network
@@ -1038,6 +1047,465 @@ pub unsafe extern "C" fn pio_to_arrow(
 }
 
 // ---------------------------------------------------------------------------
+// Package surface (`pkg` feature). `.pio.json` compiler packages sit above the
+// balanced and multiconductor handles: a package wraps exactly one payload and
+// carries provenance, validation, diagnostics, and lowering history.
+// ---------------------------------------------------------------------------
+
+/// Opaque `.pio.json` compiler package handle. A package owns one
+/// [`powerio_pkg::CompilerPackage`], which wraps either a balanced
+/// [`PioNetwork`] payload or a multiconductor [`PioDistNetwork`] payload.
+#[cfg(feature = "pkg")]
+pub struct PioPackage {
+    package: powerio_pkg::CompilerPackage,
+}
+
+#[cfg(feature = "pkg")]
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<PioPackage>();
+};
+
+#[cfg(feature = "pkg")]
+#[derive(Default)]
+struct BalancedPackageOptions {
+    include_solver_metadata: bool,
+}
+
+#[cfg(feature = "pkg")]
+fn json_object_from_options(
+    options_json: *const c_char,
+    name: &str,
+) -> Result<serde_json::Map<String, serde_json::Value>, String> {
+    let Some(text) = optional_cstr(options_json, name)? else {
+        return Ok(serde_json::Map::new());
+    };
+    if text.trim().is_empty() {
+        return Ok(serde_json::Map::new());
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| format!("{name} is not valid JSON: {e}"))?;
+    match value {
+        serde_json::Value::Object(obj) => Ok(obj),
+        _ => Err(format!("{name} must be a JSON object")),
+    }
+}
+
+#[cfg(feature = "pkg")]
+fn take_bool_option(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<bool>, String> {
+    match obj.remove(key) {
+        Some(serde_json::Value::Bool(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("option `{key}` must be a boolean")),
+        None => Ok(None),
+    }
+}
+
+#[cfg(feature = "pkg")]
+fn take_f64_option(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<f64>, String> {
+    match obj.remove(key) {
+        Some(serde_json::Value::Number(value)) => value
+            .as_f64()
+            .ok_or_else(|| format!("option `{key}` must be a finite number"))
+            .map(Some),
+        Some(_) => Err(format!("option `{key}` must be a number")),
+        None => Ok(None),
+    }
+}
+
+#[cfg(feature = "pkg")]
+fn take_string_option(
+    obj: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Result<Option<String>, String> {
+    match obj.remove(key) {
+        Some(serde_json::Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("option `{key}` must be a string")),
+        None => Ok(None),
+    }
+}
+
+#[cfg(feature = "pkg")]
+fn reject_unknown_options(obj: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
+    match obj.keys().next() {
+        Some(key) => Err(format!("unknown option `{key}`")),
+        None => Ok(()),
+    }
+}
+
+#[cfg(feature = "pkg")]
+fn parse_balanced_package_options(
+    options_json: *const c_char,
+) -> Result<BalancedPackageOptions, String> {
+    let mut obj = json_object_from_options(options_json, "options_json")?;
+    let include_solver_metadata =
+        take_bool_option(&mut obj, "include_solver_metadata")?.unwrap_or(false);
+    reject_unknown_options(&obj)?;
+    Ok(BalancedPackageOptions {
+        include_solver_metadata,
+    })
+}
+
+#[cfg(feature = "pkg")]
+fn parse_empty_package_options(options_json: *const c_char) -> Result<(), String> {
+    let obj = json_object_from_options(options_json, "options_json")?;
+    reject_unknown_options(&obj)
+}
+
+#[cfg(feature = "pkg")]
+fn parse_lowering_options(
+    options_json: *const c_char,
+) -> Result<powerio_pkg::MulticonductorToBalancedOptions, String> {
+    let mut obj = json_object_from_options(options_json, "options_json")?;
+    let mut options = powerio_pkg::MulticonductorToBalancedOptions::default();
+    if let Some(base_mva) = take_f64_option(&mut obj, "base_mva")? {
+        options.base_mva = base_mva;
+    }
+    if let Some(convention) = take_string_option(&mut obj, "convention")? {
+        options.convention = match convention.as_str() {
+            "fortescue_power_invariant" | "FortescuePowerInvariant" => {
+                powerio_pkg::SequenceTransformConvention::FortescuePowerInvariant
+            }
+            _ => {
+                return Err(format!(
+                    "unknown convention `{convention}`; expected `fortescue_power_invariant`"
+                ));
+            }
+        };
+    }
+    reject_unknown_options(&obj)?;
+    Ok(options)
+}
+
+#[cfg(feature = "pkg")]
+unsafe fn finish_package(
+    errbuf: *mut c_char,
+    errlen: usize,
+    panic_msg: &str,
+    f: impl FnOnce() -> Result<powerio_pkg::CompilerPackage, String>,
+) -> *mut PioPackage {
+    unsafe {
+        match catch_unwind(AssertUnwindSafe(f)) {
+            Ok(Ok(package)) => Box::into_raw(Box::new(PioPackage { package })),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, panic_msg);
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Parse a `.pio.json` package file into an opaque package handle. This reads
+/// only the package envelope; case format names still enter through
+/// [`pio_parse_file`] / [`pio_dist_parse_file`] and package constructors.
+/// Returns `NULL` on error and writes the message into `errbuf`. Free the handle
+/// with [`pio_package_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_parse_file(
+    path: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(errbuf, errlen, "panic while parsing package", || {
+            let path = required_cstr(path, "path")?;
+            let text = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+            powerio_pkg::CompilerPackage::from_json(&text).map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Parse in-memory `.pio.json` text into an opaque package handle. Returns
+/// `NULL` on error and writes the message into `errbuf`. Free the handle with
+/// [`pio_package_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_parse_str(
+    text: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(errbuf, errlen, "panic while parsing package", || {
+            let text = required_cstr(text, "text")?;
+            powerio_pkg::CompilerPackage::from_json(text).map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Free a package handle returned by `pio_package_*`. NULL is a no-op; free
+/// exactly once.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_free(pkg: *mut PioPackage) {
+    unsafe {
+        guard((), || {
+            if !pkg.is_null() {
+                drop(Box::from_raw(pkg));
+            }
+        });
+    }
+}
+
+/// Serialize a package handle to compact `.pio.json`. Returns an owned C string
+/// (free with [`pio_string_free`]) or `NULL` on error.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_to_json(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let pkg = pkg
+                .as_ref()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            pkg.package.to_json().map_err(|e| e.to_string())
+        }));
+        match result {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while serializing package");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Wrap a balanced [`PioNetwork`] handle in a `.pio.json` package. The C handle
+/// name is historical; the payload is `powerio::BalancedNetwork`. `options_json`
+/// may be NULL or `{}`. The optional key `include_solver_metadata` attaches
+/// compact normalized solver table metadata.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_from_balanced_network(
+    net: *const PioNetwork,
+    options_json: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(
+            errbuf,
+            errlen,
+            "panic while packaging balanced network",
+            || {
+                let net = network_ref(net).ok_or_else(|| "network handle is NULL".to_string())?;
+                let options = parse_balanced_package_options(options_json)?;
+                let mut package = powerio_pkg::CompilerPackage::from_balanced(net.net.clone());
+                if options.include_solver_metadata {
+                    package
+                        .attach_normalized_solver_table_metadata()
+                        .map_err(|e| e.to_string())?;
+                }
+                Ok(package)
+            },
+        )
+    }
+}
+
+/// Wrap a multiconductor [`PioDistNetwork`] handle in a `.pio.json` package. The
+/// C handle name is historical; the payload is
+/// `powerio_dist::MulticonductorNetwork`. `options_json` may be NULL or `{}`.
+#[cfg(all(feature = "pkg", feature = "dist"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_from_multiconductor_network(
+    net: *const PioDistNetwork,
+    options_json: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(
+            errbuf,
+            errlen,
+            "panic while packaging multiconductor network",
+            || {
+                let net = net
+                    .as_ref()
+                    .ok_or_else(|| "distribution network handle is NULL".to_string())?;
+                parse_empty_package_options(options_json)?;
+                Ok(powerio_pkg::CompilerPackage::from_multiconductor(
+                    net.net.clone(),
+                ))
+            },
+        )
+    }
+}
+
+/// Run the package semantic validation profile in place. Returns `0` on
+/// success, `-1` on error.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_validate(
+    pkg: *mut PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> i32 {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let pkg = pkg
+                .as_mut()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            pkg.package.run_sane_validation();
+            Ok::<_, String>(())
+        }));
+        match result {
+            Ok(Ok(())) => 0,
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                -1
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while validating package");
+                -1
+            }
+        }
+    }
+}
+
+/// Return the package validation summary as JSON. The returned string is owned
+/// by the library; free it with [`pio_string_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_validation_json(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let pkg = pkg
+                .as_ref()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            serde_json::to_string(&pkg.package.validation).map_err(|e| e.to_string())
+        }));
+        match result {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while reading package validation");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Return the package structured diagnostics array as JSON. The returned string
+/// is owned by the library; free it with [`pio_string_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_diagnostics_json(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let pkg = pkg
+                .as_ref()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            serde_json::to_string(&pkg.package.diagnostics).map_err(|e| e.to_string())
+        }));
+        match result {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while reading package diagnostics");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Return the multiconductor-to-balanced lowering preflight report as JSON.
+/// `options_json` may be NULL or `{}`; accepted keys are `base_mva` and
+/// `convention`. Returns `NULL` if the package is not multiconductor or the
+/// options are invalid.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_multiconductor_to_balanced_preflight_json(
+    pkg: *const PioPackage,
+    options_json: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let pkg = pkg
+                .as_ref()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            let options = parse_lowering_options(options_json)?;
+            let net = pkg.package.as_multiconductor().ok_or_else(|| {
+                format!(
+                    "multiconductor preflight requires a multiconductor package, got {:?}",
+                    pkg.package.model_kind()
+                )
+            })?;
+            let report = powerio_pkg::check_multiconductor_to_balanced_lowering(net, options);
+            serde_json::to_string(&report).map_err(|e| e.to_string())
+        }));
+        match result {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while preflighting package lowering");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Lower a multiconductor package to a new balanced package. Call
+/// [`pio_package_multiconductor_to_balanced_preflight_json`] first when the
+/// caller needs structured blockers for unsupported inputs. `options_json` uses
+/// the same defaults and keys as the preflight function.
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_lower_multiconductor_to_balanced(
+    pkg: *const PioPackage,
+    options_json: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(errbuf, errlen, "panic while lowering package", || {
+            let pkg = pkg
+                .as_ref()
+                .ok_or_else(|| "package handle is NULL".to_string())?;
+            let options = parse_lowering_options(options_json)?;
+            pkg.package
+                .lower_multiconductor_to_balanced(options)
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Distribution surface (`dist` feature). The multiconductor model behind its own
 // opaque `PioDistNetwork` handle and the `pio_dist_*` entry points. It is gated
 // on the `dist` feature / `PIO_DIST` define, exactly like `arrow`/`gridfm`; a
@@ -1046,13 +1514,6 @@ pub unsafe extern "C" fn pio_to_arrow(
 // schema is a draft: C signature changes bump `PIO_DIST_ABI_VERSION`, and the
 // JSON payloads (bmopf-json, powerio-dist-json) carry their own meta.version.
 // ---------------------------------------------------------------------------
-
-/// Like [`cstr`] but a NULL or non-UTF-8 pointer is an error naming the offending
-/// parameter. The dist entry points take mostly required strings.
-#[cfg(feature = "dist")]
-fn required_cstr<'a>(p: *const c_char, name: &str) -> Result<&'a str, String> {
-    unsafe { cstr(p) }.ok_or_else(|| format!("{name} is NULL or not UTF-8"))
-}
 
 /// Finish a handle-returning dist entry point: run `f` (the handle payload or an
 /// error message) under the panic guard and box the payload into an owned handle,
@@ -1412,6 +1873,46 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "pkg")]
+    unsafe fn package_json_text(pkg: *const PioPackage) -> String {
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let s = pio_package_to_json(pkg, err.as_mut_ptr(), err.len());
+            assert!(
+                !s.is_null(),
+                "package to json failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+            let text = CStr::from_ptr(s).to_str().unwrap().to_owned();
+            pio_string_free(s);
+            text
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    unsafe fn package_json(pkg: *const PioPackage) -> serde_json::Value {
+        unsafe { serde_json::from_str(&package_json_text(pkg)).unwrap() }
+    }
+
+    #[cfg(feature = "pkg")]
+    unsafe fn package_report_json(
+        f: unsafe extern "C" fn(*const PioPackage, *mut c_char, usize) -> *mut c_char,
+        pkg: *const PioPackage,
+    ) -> serde_json::Value {
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let s = f(pkg, err.as_mut_ptr(), err.len());
+            assert!(
+                !s.is_null(),
+                "package report failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+            let text = CStr::from_ptr(s).to_str().unwrap().to_owned();
+            pio_string_free(s);
+            serde_json::from_str(&text).unwrap()
+        }
+    }
+
     #[test]
     fn version_surface() {
         // The ABI version is the load-time compatibility check; the version
@@ -1563,6 +2064,7 @@ mod tests {
             "#define PIO_ARROW_TABLE_SOLVER_HVDC 14",
             "typedef struct PioDistNetwork PioDistNetwork;",
             "typedef struct PioNetwork PioNetwork;",
+            "typedef struct PioPackage PioPackage;",
             "uint32_t pio_abi_version(void);",
             "uint32_t pio_dist_abi_version(void);",
             "int32_t pio_has_feature(const char *feature);",
@@ -1596,6 +2098,17 @@ mod tests {
             "size_t pio_bus_demand(const PioNetwork *net, double *pd, double *qd, size_t cap);",
             "size_t pio_bus_shunt(const PioNetwork *net, double *gs, double *bs, size_t cap);",
             "int32_t pio_to_arrow(const PioNetwork *net, int32_t table, struct ArrowArray *out_array, struct ArrowSchema *out_schema, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_parse_file(const char *path, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_parse_str(const char *text, char *errbuf, size_t errlen);",
+            "void pio_package_free(PioPackage *pkg);",
+            "char *pio_package_to_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_from_balanced_network(const PioNetwork *net, const char *options_json, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net, const char *options_json, char *errbuf, size_t errlen);",
+            "int32_t pio_package_validate(PioPackage *pkg, char *errbuf, size_t errlen);",
+            "char *pio_package_validation_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
+            "char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
+            "char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg, const char *options_json, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg, const char *options_json, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_parse_file(const char *path, const char *from, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_parse_str(const char *text, const char *format, char *errbuf, size_t errlen);",
             "void pio_dist_network_free(PioDistNetwork *net);",
@@ -2280,6 +2793,296 @@ mpc.branch = [
         unsafe { copy_to_buf(buf.as_mut_ptr(), buf.len(), "aé€") };
         let s = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
         assert_eq!(s, "aé€");
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
+    fn package_feature_is_reported() {
+        let pkg = CString::new("pkg").unwrap();
+        let nope = CString::new("nope").unwrap();
+        unsafe {
+            assert_eq!(pio_has_feature(pkg.as_ptr()), 1);
+            assert_eq!(pio_has_feature(nope.as_ptr()), 0);
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
+    fn package_parse_free_to_json_and_reports() {
+        let net = case9();
+        let options = CString::new(r#"{"include_solver_metadata":true}"#).unwrap();
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let pkg = pio_package_from_balanced_network(
+                net,
+                options.as_ptr(),
+                err.as_mut_ptr(),
+                err.len(),
+            );
+            assert!(
+                !pkg.is_null(),
+                "package constructor failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+            let v = package_json(pkg);
+            assert_eq!(v["model_kind"], serde_json::json!("balanced"));
+            assert_eq!(v["model"]["kind"], serde_json::json!("balanced"));
+            assert_eq!(
+                v["derived"]["normalized_solver_tables"]["row_counts"]["buses"],
+                serde_json::json!(9)
+            );
+
+            let json = CString::new(package_json_text(pkg)).unwrap();
+            let parsed = pio_package_parse_str(json.as_ptr(), err.as_mut_ptr(), err.len());
+            assert!(
+                !parsed.is_null(),
+                "package parse_str failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("case9.pio.json");
+            std::fs::write(&path, CStr::from_ptr(json.as_ptr()).to_bytes()).unwrap();
+            let path = CString::new(path.to_str().unwrap()).unwrap();
+            let parsed_file = pio_package_parse_file(path.as_ptr(), err.as_mut_ptr(), err.len());
+            assert!(
+                !parsed_file.is_null(),
+                "package parse_file failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+
+            assert_eq!(
+                pio_package_validate(parsed_file, err.as_mut_ptr(), err.len()),
+                0
+            );
+            let validation = package_report_json(pio_package_validation_json, parsed_file);
+            assert_eq!(validation["status"], serde_json::json!("ok"));
+            assert!(
+                validation["passes"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|p| p["name"] == "balanced.structure")
+            );
+            let diagnostics = package_report_json(pio_package_diagnostics_json, parsed_file);
+            assert!(diagnostics.as_array().unwrap().is_empty());
+
+            pio_package_free(parsed_file);
+            pio_package_free(parsed);
+            pio_package_free(pkg);
+            pio_network_free(net);
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
+    fn package_rejects_unknown_balanced_option() {
+        let net = case9();
+        let options = CString::new(r#"{"include_sovler_metadata":true}"#).unwrap();
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let pkg = pio_package_from_balanced_network(
+                net,
+                options.as_ptr(),
+                err.as_mut_ptr(),
+                err.len(),
+            );
+            assert!(pkg.is_null());
+            let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+            assert!(msg.contains("unknown option"), "got: {msg}");
+            pio_network_free(net);
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
+    fn package_rejects_non_utf8_options() {
+        let net = case9();
+        let options = [0xff_u8, 0];
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let pkg = pio_package_from_balanced_network(
+                net,
+                options.as_ptr().cast::<c_char>(),
+                err.as_mut_ptr(),
+                err.len(),
+            );
+            assert!(pkg.is_null());
+            let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+            assert!(msg.contains("options_json is not UTF-8"), "got: {msg}");
+            pio_network_free(net);
+        }
+    }
+
+    #[cfg(all(feature = "pkg", feature = "dist"))]
+    mod package_dist {
+        use super::*;
+
+        fn strings(values: &[&str]) -> Vec<String> {
+            values.iter().map(|v| (*v).to_owned()).collect()
+        }
+
+        fn zero_matrix(n: usize) -> powerio_dist::Mat {
+            vec![vec![0.0; n]; n]
+        }
+
+        fn diagonal_matrix(n: usize, value: f64) -> powerio_dist::Mat {
+            let mut matrix = zero_matrix(n);
+            for (idx, row) in matrix.iter_mut().enumerate() {
+                row[idx] = value;
+            }
+            matrix
+        }
+
+        fn phase_reference(terminals: &[&str], grounded: &[&str]) -> (Vec<f64>, Vec<f64>) {
+            let phase_angles = [
+                0.0,
+                -2.0 * std::f64::consts::PI / 3.0,
+                2.0 * std::f64::consts::PI / 3.0,
+            ];
+            let mut magnitudes = vec![0.0; terminals.len()];
+            let mut angles = vec![0.0; terminals.len()];
+            let mut active = 0;
+            for (idx, terminal) in terminals.iter().enumerate() {
+                if grounded.contains(terminal) || *terminal == "0" {
+                    continue;
+                }
+                magnitudes[idx] = 240.0;
+                if active < phase_angles.len() {
+                    angles[idx] = phase_angles[active];
+                }
+                active += 1;
+            }
+            (magnitudes, angles)
+        }
+
+        fn preflight_network(terminals: &[&str], grounded: &[&str]) -> powerio_dist::DistNetwork {
+            use powerio_dist::{
+                DistBus, DistLine, DistLineCode, DistNetwork, Extras, VoltageSource,
+            };
+
+            let n = terminals.len();
+            let terminal_map = strings(terminals);
+            let (v_magnitude, v_angle) = phase_reference(terminals, grounded);
+            let mut net = DistNetwork::default();
+            for id in ["sourcebus", "loadbus"] {
+                net.buses.push(DistBus {
+                    id: id.to_owned(),
+                    terminals: terminal_map.clone(),
+                    grounded: strings(grounded),
+                    v_min: None,
+                    v_max: None,
+                    vpn_min: None,
+                    vpn_max: None,
+                    vpp_min: None,
+                    vpp_max: None,
+                    vsym_min: None,
+                    vsym_max: None,
+                    extras: Extras::new(),
+                });
+            }
+            net.linecodes.push(DistLineCode {
+                name: "lc".to_owned(),
+                n_conductors: n,
+                r_series: diagonal_matrix(n, 0.01),
+                x_series: diagonal_matrix(n, 0.10),
+                g_from: zero_matrix(n),
+                b_from: zero_matrix(n),
+                g_to: zero_matrix(n),
+                b_to: zero_matrix(n),
+                i_max: None,
+                s_max: None,
+                extras: Extras::new(),
+            });
+            net.lines.push(DistLine {
+                name: "l1".to_owned(),
+                bus_from: "sourcebus".to_owned(),
+                bus_to: "loadbus".to_owned(),
+                terminal_map_from: terminal_map.clone(),
+                terminal_map_to: terminal_map.clone(),
+                linecode: "lc".to_owned(),
+                length: 1.0,
+                extras: Extras::new(),
+            });
+            net.sources.push(VoltageSource {
+                name: "source".to_owned(),
+                bus: "sourcebus".to_owned(),
+                terminal_map,
+                v_magnitude,
+                v_angle,
+                extras: Extras::new(),
+            });
+            net
+        }
+
+        #[test]
+        fn multiconductor_package_preflight_and_lowering() {
+            let dist = PioDistNetwork {
+                net: preflight_network(&["1", "2", "3"], &[]),
+            };
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            unsafe {
+                let pkg = pio_package_from_multiconductor_network(
+                    &dist,
+                    std::ptr::null(),
+                    err.as_mut_ptr(),
+                    err.len(),
+                );
+                assert!(
+                    !pkg.is_null(),
+                    "multiconductor package constructor failed: {}",
+                    CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+                );
+                let v = package_json(pkg);
+                assert_eq!(v["model_kind"], serde_json::json!("multiconductor"));
+
+                let preflight_opts = CString::new(r#"{"base_mva":50.0}"#).unwrap();
+                let report = pio_package_multiconductor_to_balanced_preflight_json(
+                    pkg,
+                    preflight_opts.as_ptr(),
+                    err.as_mut_ptr(),
+                    err.len(),
+                );
+                assert!(
+                    !report.is_null(),
+                    "preflight failed: {}",
+                    CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+                );
+                let report_json: serde_json::Value =
+                    serde_json::from_str(CStr::from_ptr(report).to_str().unwrap()).unwrap();
+                assert_eq!(report_json["status"], serde_json::json!("ok"));
+                assert_eq!(report_json["base_mva"], serde_json::json!(50.0));
+                pio_string_free(report);
+
+                let lower_opts =
+                    CString::new(r#"{"base_mva":75.0,"convention":"fortescue_power_invariant"}"#)
+                        .unwrap();
+                let lowered = pio_package_lower_multiconductor_to_balanced(
+                    pkg,
+                    lower_opts.as_ptr(),
+                    err.as_mut_ptr(),
+                    err.len(),
+                );
+                assert!(
+                    !lowered.is_null(),
+                    "lowering failed: {}",
+                    CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+                );
+                let lowered_json = package_json(lowered);
+                assert_eq!(lowered_json["model_kind"], serde_json::json!("balanced"));
+                assert_eq!(
+                    lowered_json["model"]["balanced_network"]["base_mva"],
+                    serde_json::json!(75.0)
+                );
+                assert_eq!(
+                    lowered_json["lowering_history"][0]["pass"],
+                    serde_json::json!("multiconductor-to-balanced")
+                );
+
+                pio_package_free(lowered);
+                pio_package_free(pkg);
+            }
+        }
     }
 
     #[cfg(feature = "arrow")]

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1067,119 +1067,11 @@ const _: fn() = || {
 };
 
 #[cfg(feature = "pkg")]
-#[derive(Default)]
-struct BalancedPackageOptions {
-    include_solver_metadata: bool,
-}
-
-#[cfg(feature = "pkg")]
-fn json_object_from_options(
-    options_json: *const c_char,
-    name: &str,
-) -> Result<serde_json::Map<String, serde_json::Value>, String> {
-    let Some(text) = optional_cstr(options_json, name)? else {
-        return Ok(serde_json::Map::new());
-    };
-    if text.trim().is_empty() {
-        return Ok(serde_json::Map::new());
+fn lowering_options(base_mva: f64) -> powerio_pkg::MulticonductorToBalancedOptions {
+    powerio_pkg::MulticonductorToBalancedOptions {
+        base_mva,
+        ..Default::default()
     }
-    let value: serde_json::Value =
-        serde_json::from_str(text).map_err(|e| format!("{name} is not valid JSON: {e}"))?;
-    match value {
-        serde_json::Value::Object(obj) => Ok(obj),
-        _ => Err(format!("{name} must be a JSON object")),
-    }
-}
-
-#[cfg(feature = "pkg")]
-fn take_bool_option(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    key: &str,
-) -> Result<Option<bool>, String> {
-    match obj.remove(key) {
-        Some(serde_json::Value::Bool(value)) => Ok(Some(value)),
-        Some(_) => Err(format!("option `{key}` must be a boolean")),
-        None => Ok(None),
-    }
-}
-
-#[cfg(feature = "pkg")]
-fn take_f64_option(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    key: &str,
-) -> Result<Option<f64>, String> {
-    match obj.remove(key) {
-        Some(serde_json::Value::Number(value)) => value
-            .as_f64()
-            .ok_or_else(|| format!("option `{key}` must be a finite number"))
-            .map(Some),
-        Some(_) => Err(format!("option `{key}` must be a number")),
-        None => Ok(None),
-    }
-}
-
-#[cfg(feature = "pkg")]
-fn take_string_option(
-    obj: &mut serde_json::Map<String, serde_json::Value>,
-    key: &str,
-) -> Result<Option<String>, String> {
-    match obj.remove(key) {
-        Some(serde_json::Value::String(value)) => Ok(Some(value)),
-        Some(_) => Err(format!("option `{key}` must be a string")),
-        None => Ok(None),
-    }
-}
-
-#[cfg(feature = "pkg")]
-fn reject_unknown_options(obj: &serde_json::Map<String, serde_json::Value>) -> Result<(), String> {
-    match obj.keys().next() {
-        Some(key) => Err(format!("unknown option `{key}`")),
-        None => Ok(()),
-    }
-}
-
-#[cfg(feature = "pkg")]
-fn parse_balanced_package_options(
-    options_json: *const c_char,
-) -> Result<BalancedPackageOptions, String> {
-    let mut obj = json_object_from_options(options_json, "options_json")?;
-    let include_solver_metadata =
-        take_bool_option(&mut obj, "include_solver_metadata")?.unwrap_or(false);
-    reject_unknown_options(&obj)?;
-    Ok(BalancedPackageOptions {
-        include_solver_metadata,
-    })
-}
-
-#[cfg(feature = "pkg")]
-fn parse_empty_package_options(options_json: *const c_char) -> Result<(), String> {
-    let obj = json_object_from_options(options_json, "options_json")?;
-    reject_unknown_options(&obj)
-}
-
-#[cfg(feature = "pkg")]
-fn parse_lowering_options(
-    options_json: *const c_char,
-) -> Result<powerio_pkg::MulticonductorToBalancedOptions, String> {
-    let mut obj = json_object_from_options(options_json, "options_json")?;
-    let mut options = powerio_pkg::MulticonductorToBalancedOptions::default();
-    if let Some(base_mva) = take_f64_option(&mut obj, "base_mva")? {
-        options.base_mva = base_mva;
-    }
-    if let Some(convention) = take_string_option(&mut obj, "convention")? {
-        options.convention = match convention.as_str() {
-            "fortescue_power_invariant" | "FortescuePowerInvariant" => {
-                powerio_pkg::SequenceTransformConvention::FortescuePowerInvariant
-            }
-            _ => {
-                return Err(format!(
-                    "unknown convention `{convention}`; expected `fortescue_power_invariant`"
-                ));
-            }
-        };
-    }
-    reject_unknown_options(&obj)?;
-    Ok(options)
 }
 
 #[cfg(feature = "pkg")]
@@ -1288,14 +1180,14 @@ pub unsafe extern "C" fn pio_package_to_json(
 }
 
 /// Wrap a balanced [`PioNetwork`] handle in a `.pio.json` package. The C handle
-/// name is historical; the payload is `powerio::BalancedNetwork`. `options_json`
-/// may be NULL or `{}`. The optional key `include_solver_metadata` attaches
-/// compact normalized solver table metadata.
+/// name is historical; the payload is `powerio::BalancedNetwork`.
+/// `include_solver_metadata != 0` attaches compact normalized solver table
+/// metadata.
 #[cfg(feature = "pkg")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_from_balanced_network(
     net: *const PioNetwork,
-    options_json: *const c_char,
+    include_solver_metadata: i32,
     errbuf: *mut c_char,
     errlen: usize,
 ) -> *mut PioPackage {
@@ -1306,9 +1198,8 @@ pub unsafe extern "C" fn pio_package_from_balanced_network(
             "panic while packaging balanced network",
             || {
                 let net = network_ref(net).ok_or_else(|| "network handle is NULL".to_string())?;
-                let options = parse_balanced_package_options(options_json)?;
                 let mut package = powerio_pkg::CompilerPackage::from_balanced(net.net.clone());
-                if options.include_solver_metadata {
+                if include_solver_metadata != 0 {
                     package
                         .attach_normalized_solver_table_metadata()
                         .map_err(|e| e.to_string())?;
@@ -1321,12 +1212,11 @@ pub unsafe extern "C" fn pio_package_from_balanced_network(
 
 /// Wrap a multiconductor [`PioDistNetwork`] handle in a `.pio.json` package. The
 /// C handle name is historical; the payload is
-/// `powerio_dist::MulticonductorNetwork`. `options_json` may be NULL or `{}`.
+/// `powerio_dist::MulticonductorNetwork`.
 #[cfg(all(feature = "pkg", feature = "dist"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_from_multiconductor_network(
     net: *const PioDistNetwork,
-    options_json: *const c_char,
     errbuf: *mut c_char,
     errlen: usize,
 ) -> *mut PioPackage {
@@ -1339,7 +1229,6 @@ pub unsafe extern "C" fn pio_package_from_multiconductor_network(
                 let net = net
                     .as_ref()
                     .ok_or_else(|| "distribution network handle is NULL".to_string())?;
-                parse_empty_package_options(options_json)?;
                 Ok(powerio_pkg::CompilerPackage::from_multiconductor(
                     net.net.clone(),
                 ))
@@ -1440,14 +1329,13 @@ pub unsafe extern "C" fn pio_package_diagnostics_json(
 }
 
 /// Return the multiconductor-to-balanced lowering preflight report as JSON.
-/// `options_json` may be NULL or `{}`; accepted keys are `base_mva` and
-/// `convention`. Returns `NULL` if the package is not multiconductor or the
-/// options are invalid.
+/// `base_mva` is the three phase system power base used for the balanced
+/// per-unit projection. Returns `NULL` if the package is not multiconductor.
 #[cfg(feature = "pkg")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_multiconductor_to_balanced_preflight_json(
     pkg: *const PioPackage,
-    options_json: *const c_char,
+    base_mva: f64,
     errbuf: *mut c_char,
     errlen: usize,
 ) -> *mut c_char {
@@ -1456,14 +1344,16 @@ pub unsafe extern "C" fn pio_package_multiconductor_to_balanced_preflight_json(
             let pkg = pkg
                 .as_ref()
                 .ok_or_else(|| "package handle is NULL".to_string())?;
-            let options = parse_lowering_options(options_json)?;
             let net = pkg.package.as_multiconductor().ok_or_else(|| {
                 format!(
                     "multiconductor preflight requires a multiconductor package, got {:?}",
                     pkg.package.model_kind()
                 )
             })?;
-            let report = powerio_pkg::check_multiconductor_to_balanced_lowering(net, options);
+            let report = powerio_pkg::check_multiconductor_to_balanced_lowering(
+                net,
+                lowering_options(base_mva),
+            );
             serde_json::to_string(&report).map_err(|e| e.to_string())
         }));
         match result {
@@ -1482,13 +1372,13 @@ pub unsafe extern "C" fn pio_package_multiconductor_to_balanced_preflight_json(
 
 /// Lower a multiconductor package to a new balanced package. Call
 /// [`pio_package_multiconductor_to_balanced_preflight_json`] first when the
-/// caller needs structured blockers for unsupported inputs. `options_json` uses
-/// the same defaults and keys as the preflight function.
+/// caller needs structured blockers for unsupported inputs. `base_mva` is the
+/// three phase system power base used for the balanced per-unit projection.
 #[cfg(feature = "pkg")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_lower_multiconductor_to_balanced(
     pkg: *const PioPackage,
-    options_json: *const c_char,
+    base_mva: f64,
     errbuf: *mut c_char,
     errlen: usize,
 ) -> *mut PioPackage {
@@ -1497,9 +1387,8 @@ pub unsafe extern "C" fn pio_package_lower_multiconductor_to_balanced(
             let pkg = pkg
                 .as_ref()
                 .ok_or_else(|| "package handle is NULL".to_string())?;
-            let options = parse_lowering_options(options_json)?;
             pkg.package
-                .lower_multiconductor_to_balanced(options)
+                .lower_multiconductor_to_balanced(lowering_options(base_mva))
                 .map_err(|e| e.to_string())
         })
     }
@@ -2102,13 +1991,13 @@ mod tests {
             "PioPackage *pio_package_parse_str(const char *text, char *errbuf, size_t errlen);",
             "void pio_package_free(PioPackage *pkg);",
             "char *pio_package_to_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
-            "PioPackage *pio_package_from_balanced_network(const PioNetwork *net, const char *options_json, char *errbuf, size_t errlen);",
-            "PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net, const char *options_json, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_from_balanced_network(const PioNetwork *net, int32_t include_solver_metadata, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net, char *errbuf, size_t errlen);",
             "int32_t pio_package_validate(PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_validation_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
-            "char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg, const char *options_json, char *errbuf, size_t errlen);",
-            "PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg, const char *options_json, char *errbuf, size_t errlen);",
+            "char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg, double base_mva, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg, double base_mva, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_parse_file(const char *path, const char *from, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_parse_str(const char *text, const char *format, char *errbuf, size_t errlen);",
             "void pio_dist_network_free(PioDistNetwork *net);",
@@ -2810,15 +2699,9 @@ mpc.branch = [
     #[test]
     fn package_parse_free_to_json_and_reports() {
         let net = case9();
-        let options = CString::new(r#"{"include_solver_metadata":true}"#).unwrap();
         let mut err = [0 as c_char; PIO_ERRBUF_MIN];
         unsafe {
-            let pkg = pio_package_from_balanced_network(
-                net,
-                options.as_ptr(),
-                err.as_mut_ptr(),
-                err.len(),
-            );
+            let pkg = pio_package_from_balanced_network(net, 1, err.as_mut_ptr(), err.len());
             assert!(
                 !pkg.is_null(),
                 "package constructor failed: {}",
@@ -2876,40 +2759,19 @@ mpc.branch = [
 
     #[cfg(feature = "pkg")]
     #[test]
-    fn package_rejects_unknown_balanced_option() {
+    fn package_balanced_constructor_omits_solver_metadata_by_default() {
         let net = case9();
-        let options = CString::new(r#"{"include_sovler_metadata":true}"#).unwrap();
         let mut err = [0 as c_char; PIO_ERRBUF_MIN];
         unsafe {
-            let pkg = pio_package_from_balanced_network(
-                net,
-                options.as_ptr(),
-                err.as_mut_ptr(),
-                err.len(),
+            let pkg = pio_package_from_balanced_network(net, 0, err.as_mut_ptr(), err.len());
+            assert!(
+                !pkg.is_null(),
+                "package constructor failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
             );
-            assert!(pkg.is_null());
-            let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
-            assert!(msg.contains("unknown option"), "got: {msg}");
-            pio_network_free(net);
-        }
-    }
-
-    #[cfg(feature = "pkg")]
-    #[test]
-    fn package_rejects_non_utf8_options() {
-        let net = case9();
-        let options = [0xff_u8, 0];
-        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
-        unsafe {
-            let pkg = pio_package_from_balanced_network(
-                net,
-                options.as_ptr().cast::<c_char>(),
-                err.as_mut_ptr(),
-                err.len(),
-            );
-            assert!(pkg.is_null());
-            let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
-            assert!(msg.contains("options_json is not UTF-8"), "got: {msg}");
+            let v = package_json(pkg);
+            assert!(v["derived"].get("normalized_solver_tables").is_none());
+            pio_package_free(pkg);
             pio_network_free(net);
         }
     }
@@ -3022,12 +2884,8 @@ mpc.branch = [
             };
             let mut err = [0 as c_char; PIO_ERRBUF_MIN];
             unsafe {
-                let pkg = pio_package_from_multiconductor_network(
-                    &dist,
-                    std::ptr::null(),
-                    err.as_mut_ptr(),
-                    err.len(),
-                );
+                let pkg =
+                    pio_package_from_multiconductor_network(&dist, err.as_mut_ptr(), err.len());
                 assert!(
                     !pkg.is_null(),
                     "multiconductor package constructor failed: {}",
@@ -3036,10 +2894,9 @@ mpc.branch = [
                 let v = package_json(pkg);
                 assert_eq!(v["model_kind"], serde_json::json!("multiconductor"));
 
-                let preflight_opts = CString::new(r#"{"base_mva":50.0}"#).unwrap();
                 let report = pio_package_multiconductor_to_balanced_preflight_json(
                     pkg,
-                    preflight_opts.as_ptr(),
+                    50.0,
                     err.as_mut_ptr(),
                     err.len(),
                 );
@@ -3054,12 +2911,9 @@ mpc.branch = [
                 assert_eq!(report_json["base_mva"], serde_json::json!(50.0));
                 pio_string_free(report);
 
-                let lower_opts =
-                    CString::new(r#"{"base_mva":75.0,"convention":"fortescue_power_invariant"}"#)
-                        .unwrap();
                 let lowered = pio_package_lower_multiconductor_to_balanced(
                     pkg,
-                    lower_opts.as_ptr(),
+                    75.0,
                     err.as_mut_ptr(),
                     err.len(),
                 );
@@ -3078,6 +2932,39 @@ mpc.branch = [
                     lowered_json["lowering_history"][0]["pass"],
                     serde_json::json!("multiconductor-to-balanced")
                 );
+
+                let invalid_report = pio_package_multiconductor_to_balanced_preflight_json(
+                    pkg,
+                    0.0,
+                    err.as_mut_ptr(),
+                    err.len(),
+                );
+                assert!(
+                    !invalid_report.is_null(),
+                    "invalid-base preflight failed: {}",
+                    CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+                );
+                let invalid_report_json: serde_json::Value =
+                    serde_json::from_str(CStr::from_ptr(invalid_report).to_str().unwrap()).unwrap();
+                assert_eq!(invalid_report_json["status"], serde_json::json!("error"));
+                assert!(
+                    invalid_report_json["diagnostics"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .any(|d| d["code"] == "LOWER.MULTI_TO_BALANCED.INVALID_BASE_MVA")
+                );
+                pio_string_free(invalid_report);
+
+                let invalid_lowered = pio_package_lower_multiconductor_to_balanced(
+                    pkg,
+                    0.0,
+                    err.as_mut_ptr(),
+                    err.len(),
+                );
+                assert!(invalid_lowered.is_null());
+                let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+                assert!(msg.contains("base_mva must be positive"), "got: {msg}");
 
                 pio_package_free(lowered);
                 pio_package_free(pkg);

--- a/scripts/capi-smoke.sh
+++ b/scripts/capi-smoke.sh
@@ -7,7 +7,7 @@ tmp="${TMPDIR:-/tmp}/powerio-capi-smoke-$$"
 mkdir -p "$tmp"
 trap 'rm -rf "$tmp"' EXIT
 
-cargo build -p powerio-capi --release --features arrow,gridfm,dist
+cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
 cargo run -p powerio-cli -- gridfm tests/data/case9.m -o "$tmp/gridfm" >/dev/null
 cp tests/data/case9.m "$tmp/case9.m"
 
@@ -22,13 +22,13 @@ else
     lib_path="$PWD/target/release"
 fi
 
-cc -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST \
+cc -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG \
    -I powerio-capi/include powerio-capi/examples/smoke.c \
    -L target/release -lpowerio_capi -o "$tmp/pio_smoke"
 env "$lib_env=$lib_path" "$tmp/pio_smoke" \
    "$tmp/case9.m" "$tmp/gridfm/case9/raw"
 
-c++ -std=c++17 -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST \
+c++ -std=c++17 -DPIO_ARROW -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG \
     -I powerio-capi/include powerio-capi/examples/header_cpp.cpp \
     -L target/release -lpowerio_capi -o "$tmp/pio_header_cpp"
 env "$lib_env=$lib_path" "$tmp/pio_header_cpp"

--- a/scripts/dev-capi.sh
+++ b/scripts/dev-capi.sh
@@ -7,8 +7,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-# --features arrow so the sibling PowerIO.jl build gets pio_to_arrow; the
-# base ABI is identical with or without it.
+# --features arrow so the sibling PowerIO.jl build gets pio_to_arrow. The
+# default features already include the dist and package surfaces.
 cargo build -p powerio-capi --release --features arrow >&2
 
 case "$(uname -s)" in


### PR DESCRIPTION
## Summary
- add the default `pkg` feature and opaque `PioPackage` C ABI surface for `.pio.json` packages
- add package parse/free/to-json, balanced and multiconductor constructors, validation/diagnostics JSON, multiconductor preflight, and lowering entry points
- regenerate `powerio.h` and update C smoke tests, docs, scripts, and release/CI feature sets

Follows #164 and unblocks the Rust-backed package calls needed by eigenergy/PowerIO.jl#46.

## Verification
- `cargo fmt --all --check`
- `cargo test -p powerio-capi`
- `cargo test -p powerio-capi --features arrow,gridfm,dist,pkg`
- `cargo test -p powerio-capi --no-default-features`
- `cargo clippy -p powerio-capi --all-targets --features arrow,gridfm,dist,pkg -- -D warnings`
- `cargo clippy -p powerio-capi --all-targets --no-default-features -- -D warnings`
- `scripts/capi-header-parity.sh`
- `scripts/capi-smoke.sh`
- `POWERIO_CAPI=/Users/sam/Research/powerio/target/release/libpowerio_capi.dylib julia --project=/Users/sam/Research/PowerIO.jl -e 'using Pkg; Pkg.test()'`\n