### PR TITLE
[codex] fix BMOPF generator export

### DIFF
--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -12,8 +12,8 @@ use serde_json::{Map, Value, json};
 
 use crate::convert::Conversion;
 use crate::model::{
-    Configuration, DistGenerator, DistLoadVoltageModel, DistNetwork, DistSourceFormat,
-    DistTransformer, Mat, Winding, WindingConn,
+    Configuration, DistGenerator, DistLoadVoltageModel, DistNetwork, DistTransformer, Mat, Winding,
+    WindingConn,
 };
 
 /// The `$schema` stamped into every document's `meta`: the canonical bmopf-report
@@ -281,25 +281,7 @@ impl Writer {
         }
         let mut gens = Map::new();
         for g in &net.generators {
-            if fixed_generation_as_negative_load(net, g) {
-                let load_name = unique_load_name(&loads, &g.name);
-                let mut o = Map::new();
-                let p_nom: Vec<f64> = g.p_nom.iter().map(|&p| -p).collect();
-                let q_nom: Vec<f64> = g.q_nom.iter().map(|&q| -q).collect();
-                o.insert("configuration".into(), json!(config_str(g.configuration)));
-                o.insert("p_nom".into(), self.nums(&p_nom, "load p_nom"));
-                o.insert("q_nom".into(), self.nums(&q_nom, "load q_nom"));
-                o.insert("bus".into(), json!(g.bus));
-                o.insert("terminal_map".into(), json!(g.terminal_map));
-                self.warn(format!(
-                    "generator {}: fixed P/Q generation encoded as BMOPF negative load `{load_name}`",
-                    g.name
-                ));
-                self.extras_dropped(&g.extras, &format!("generator {}", g.name));
-                loads.insert(load_name, Value::Object(o));
-            } else {
-                gens.insert(g.name.clone(), self.generator(g));
-            }
+            gens.insert(g.name.clone(), self.generator(g));
         }
         if !loads.is_empty() {
             doc.insert("load".into(), Value::Object(loads));
@@ -803,23 +785,6 @@ impl Writer {
     }
 }
 
-fn unique_load_name(loads: &Map<String, Value>, desired: &str) -> String {
-    if !loads.contains_key(desired) {
-        return desired.to_string();
-    }
-    let base = format!("generator_{desired}");
-    if !loads.contains_key(&base) {
-        return base;
-    }
-    for i in 2.. {
-        let candidate = format!("{base}_{i}");
-        if !loads.contains_key(&candidate) {
-            return candidate;
-        }
-    }
-    unreachable!("unbounded suffix search returns before overflow")
-}
-
 fn collect_bus_usage(value: &Value, refs: &mut BTreeMap<String, BTreeSet<String>>) {
     match value {
         Value::Object(o) => {
@@ -885,27 +850,6 @@ fn prune_string_array(
         ));
     }
     *values = kept;
-}
-
-fn fixed_generation(g: &DistGenerator) -> bool {
-    let has_setpoint = !g.p_nom.is_empty() || !g.q_nom.is_empty();
-    has_setpoint
-        && fixed_bounds(g.p_min.as_deref(), g.p_max.as_deref(), &g.p_nom)
-        && fixed_bounds(g.q_min.as_deref(), g.q_max.as_deref(), &g.q_nom)
-}
-
-fn fixed_generation_as_negative_load(net: &DistNetwork, g: &DistGenerator) -> bool {
-    g.cost.is_none()
-        && net.source_format != Some(DistSourceFormat::BmopfJson)
-        && fixed_generation(g)
-}
-
-fn fixed_bounds(lo: Option<&[f64]>, hi: Option<&[f64]>, nom: &[f64]) -> bool {
-    match (lo, hi) {
-        (None, None) => true,
-        (Some(lo), Some(hi)) => lo == nom && hi == nom,
-        _ => false,
-    }
 }
 
 enum Kind {

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -290,28 +290,39 @@ fn ten_conductor_linecode_is_schema_valid() {
 }
 
 #[test]
-fn fixed_generators_emit_as_negative_loads() {
+fn dss_fixed_generator_emits_as_bmopf_generator() {
     let v = schema_validator();
     let net = parse_dss_str(
-        "New Circuit.c\n\
-         New Generator.g bus1=b.1 phases=1 kv=2.4 kw=100 kvar=20",
+        "Clear\n\
+         New Circuit.generator_case basekv=12.47 bus1=sourcebus\n\
+         New Generator.g1 bus1=sourcebus.1 phases=1 kv=7.2 kw=10 kvar=2",
     );
     let out = write_bmopf_json(&net);
     assert_eq!(errors(&v, &out.text), Vec::<String>::new());
     assert!(
+        out.warnings.iter().all(|w| !w.contains("negative load")),
+        "obsolete fixed generator warning: {:?}",
+        out.warnings
+    );
+    assert!(
         out.warnings
             .iter()
-            .any(|w| w.contains("generator g") && w.contains("negative load")),
-        "missing fixed generator warning: {:?}",
+            .any(|w| w == "generator g1: no generation cost in the source; emitted cost 0"),
+        "missing zero cost warning: {:?}",
         out.warnings
     );
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     assert!(
-        doc.get("generator").is_none(),
-        "fixed generator was emitted"
+        doc.get("load").and_then(|loads| loads.get("g1")).is_none(),
+        "fixed generator was emitted as a load"
     );
-    assert_eq!(doc["load"]["g"]["p_nom"], serde_json::json!([-100_000.0]));
-    assert_eq!(doc["load"]["g"]["q_nom"], serde_json::json!([-20_000.0]));
+    let g = &doc["generator"]["g1"];
+    assert!(g.is_object(), "BMOPF generator g1 missing: {doc}");
+    assert_eq!(g["p_min"], serde_json::json!([10_000.0]));
+    assert_eq!(g["p_max"], serde_json::json!([10_000.0]));
+    assert_eq!(g["q_min"], serde_json::json!([2_000.0]));
+    assert_eq!(g["q_max"], serde_json::json!([2_000.0]));
+    assert_eq!(g["cost"], serde_json::json!([0.0]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix the BMOPF writer so fixed OpenDSS generators remain in the BMOPF `generator` table instead of being converted into negative loads.

## Details

The old BMOPF writer special cased fixed P/Q generators with no cost and emitted them as negative loads. That made generators disappear from the `.dss -> bmopf` generator table. The writer now routes all distribution generators through the existing BMOPF generator path, which represents fixed dispatch with pinned `p_min`/`p_max` and `q_min`/`q_max` bounds and emits zero cost when the source has no cost.

A regression test covers the minimal DSS generator case and asserts `generator.g1` exists, `load.g1` does not, and the pinned bounds are preserved.

## Validation

- `cargo test -p powerio-dist --test bmopf`
- `cargo test -p powerio-dist`
- `cargo test -p powerio-capi --features arrow,gridfm,dist,pkg`
- `cargo fmt --all --check`