### PR TITLE
[codex] prep v0.4.0 release

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -37,7 +37,7 @@ jobs:
           set -o pipefail
           actual="$(cargo metadata --no-deps --format-version 1 \
             | jq -r '[.packages[] | select(.publish == null) | .name] | sort | join(" ")')"
-          if [ "$actual" != "powerio powerio-cli powerio-dist powerio-matrix" ]; then
+          if [ "$actual" != "powerio powerio-cli powerio-dist powerio-matrix powerio-pkg" ]; then
             echo "publishable workspace members ($actual) do not match the publish list in crates.yml" >&2
             exit 1
           fi
@@ -73,7 +73,7 @@ jobs:
         # skip-existing), so a re-run after a partial publish only publishes
         # what's missing.
         run: |
-          for crate in powerio powerio-matrix powerio-dist powerio-cli; do
+          for crate in powerio powerio-dist powerio-pkg powerio-matrix powerio-cli; do
             resp="$RUNNER_TEMP/$crate.json"
             code="$(curl -sS -A "$UA" --max-time 30 -o "$resp" -w '%{http_code}' \
               "https://crates.io/api/v1/crates/$crate/$VERSION")" || code=unreachable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,10 @@
 name: Docs
 
 # Build the workspace rustdoc and publish it to GitHub Pages. This renders all
-# five library crates, including powerio-capi and powerio-py (publish = false),
+# six library crates, including powerio-capi and powerio-py (publish = false),
 # whose //! docs docs.rs would never host. docs.rs takes over for the published
-# crates (powerio, powerio-matrix, powerio-dist) once they reach crates.io.
+# crates (powerio, powerio-matrix, powerio-dist, powerio-pkg) once they reach
+# crates.io.
 # PRs build the docs too (so a broken intra-doc link fails review, not main),
 # but only push to main / dispatch deploys to Pages; see the `deploy` gate.
 on:
@@ -44,7 +45,7 @@ jobs:
     - name: Build docs
       env:
         RUSTDOCFLAGS: "-D warnings"
-      run: cargo doc --no-deps --all-features -p powerio -p powerio-matrix -p powerio-dist -p powerio-capi -p powerio-py
+      run: cargo doc --no-deps --all-features -p powerio -p powerio-matrix -p powerio-dist -p powerio-pkg -p powerio-capi -p powerio-py
     - name: Build Python API docs
       run: |
         python -m pip install --upgrade pip
@@ -119,13 +120,15 @@ jobs:
             <dt>released / docs.rs</dt>
             <dd><a href="https://docs.rs/powerio">powerio</a>
                 <a href="https://docs.rs/powerio-matrix">powerio-matrix</a>
-                <a href="https://docs.rs/powerio-dist">powerio-dist</a></dd>
+                <a href="https://docs.rs/powerio-dist">powerio-dist</a>
+                <a href="https://docs.rs/powerio-pkg">powerio-pkg</a></dd>
           </div>
           <div>
             <dt>development / main</dt>
             <dd><a href="powerio/index.html">powerio</a>
                 <a href="powerio_matrix/index.html">powerio-matrix</a>
                 <a href="powerio_dist/index.html">powerio-dist</a>
+                <a href="powerio_pkg/index.html">powerio-pkg</a>
                 <a href="powerio_capi/index.html">powerio-capi</a>
                 <a href="python/powerio.html">python</a></dd>
           </div>

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,11 +75,11 @@ jobs:
     # Deny the workspace pedantic lints on the non-extension crates. The PyO3
     # ext crates are linted in the Python workflow with their feature enabled.
     - name: Clippy
-      run: cargo clippy --all-targets -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -p powerio-dist -- -D warnings
+      run: cargo clippy --all-targets -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -p powerio-dist -p powerio-pkg -- -D warnings
     # Bare `cargo test` only covers the default-members; name the C ABI crate
     # explicitly so its end-to-end ABI tests run in CI too.
     - name: Run tests
-      run: cargo test -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -p powerio-dist --verbose
+      run: cargo test -p powerio -p powerio-matrix -p powerio-cli -p powerio-capi -p powerio-dist -p powerio-pkg --verbose
     # The gridfm Parquet export is behind a cargo feature; exercise it (and its
     # clippy) explicitly so coverage doesn't depend on CLI feature unification.
     - name: Clippy + tests (gridfm feature)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.0
 
 - `powerio-pkg`: `.pio.json` reads now enforce the envelope compatibility rule:
   same major `schema_version` values load, while incompatible major versions
@@ -13,6 +13,10 @@
 - Converter tests now compare stable per element values across writable legacy
   formats, not only counts and totals. PSLF export now warns when transformer
   charging admittance is dropped.
+- `powerio-dist` BMOPF: OpenDSS fixed P/Q generators now emit as BMOPF
+  `generator.*` entries with pinned P/Q bounds instead of negative `load.*`
+  entries. The old negative load warning is gone; generators without source
+  costs keep the existing cost 0 warning.
 - Python API: removed the one release `powerio.Case` and
   `powerio.dist.DistCase` compatibility aliases. Use `powerio.Network` /
   `powerio.BalancedNetwork` and `powerio.dist.MulticonductorNetwork` /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,18 +35,19 @@ version. Additive symbols don't bump it. The history is in
 
 ## Releasing
 
-The release version lives in `[workspace.package]` plus the two intra-workspace
-dependency pins in `[workspace.dependencies]`; a bump touches exactly those
-three lines of the root Cargo.toml (Cargo.lock follows on the next build). Then:
+The release version lives in `[workspace.package]` plus the four workspace
+dependency pins in `[workspace.dependencies]`; a bump touches exactly those five
+lines of the root Cargo.toml (Cargo.lock follows on the next build). Then:
 
 1. Merge the bump, tag the commit `vX.Y.Z`, push the tag. The release-binaries
    workflow builds the C ABI tarballs and stages a draft GitHub release.
 2. Publish the draft release. The release event fires the PyPI publish
-   (python.yml) and the crates.io publish (crates.yml: powerio, powerio-matrix,
-   powerio-cli, in dependency order). Both deploy through reviewer-protected
-   environments (`pypi`, `crates-io`; the protection lives in the repo
-   settings). PyPI skips already-uploaded files and crates.io skips versions
-   already in the index, so a partial failure is recovered by re-running.
+   (python.yml) and the crates.io publish (crates.yml: powerio, powerio-dist,
+   powerio-pkg, powerio-matrix, powerio-cli, in dependency order). Both deploy
+   through reviewer protected environments (`pypi`, `crates-io`; the protection
+   lives in the repo settings). PyPI skips already-uploaded files and crates.io
+   skips versions already in the index, so a partial failure is recovered by
+   re-running.
 3. Follow up in PowerIO.jl: regenerate Artifacts.toml from the new tag and
    register the new version (see its CONTRIBUTING.md). A breaking C ABI change
    bumps `PIO_ABI_VERSION` first; see "C ABI changes" above.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "powerio",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "approx",
  "arrow",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -31,10 +31,10 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.3.3" }
-powerio-matrix = { path = "powerio-matrix", version = "0.3.3" }
-powerio-dist = { path = "powerio-dist", version = "0.3.3" }
-powerio-pkg = { path = "powerio-pkg", version = "0.3.3" }
+powerio = { path = "powerio", version = "0.4.0" }
+powerio-matrix = { path = "powerio-matrix", version = "0.4.0" }
+powerio-dist = { path = "powerio-dist", version = "0.4.0" }
+powerio-pkg = { path = "powerio-pkg", version = "0.4.0" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -148,7 +148,7 @@ bindings, or MCP operations.
 {
   "schema": "https://powerio.dev/schema/pio-package/0.1",
   "schema_version": "0.1.0",
-  "producer": { "tool": "powerio", "version": "0.3.3" },
+  "producer": { "tool": "powerio", "version": "0.4.0" },
   "model_kind": "multiconductor",
   "model": {
     "kind": "multiconductor",

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -3,7 +3,7 @@
 The advertised MCP surface is semantic and format neutral:
 
 ``convert``, ``save``, ``summary``, ``parse``, ``normalize``, ``matrix``,
-``diagnostics``, ``capabilities``, ``display``.
+``diagnostics``, ``display``.
 
 Network tools route balanced transmission models, multiconductor distribution
 models, PyPSA CSV folders, and gridfm datasets through the lower level powerio
@@ -1050,60 +1050,6 @@ def _display_impl(path: str, from_format: Optional[str] = None) -> dict:
     }
 
 
-def _capabilities_impl() -> dict:
-    source_formats = {
-        "transmission": [
-            "matpower",
-            "powermodels-json",
-            "egret-json",
-            "psse",
-            "psse34",
-            "psse35",
-            "powerworld",
-            "pandapower-json",
-            "powerio-json",
-            "pypsa-csv",
-            "pslf",
-            "pwb",
-            "gridfm",
-        ],
-        "distribution": ["dss", "pmd-json", "bmopf-json"],
-        "package": ["package", "pio-json", "pio-package"],
-    }
-    target_formats = {
-        "transmission": [
-            "matpower",
-            "powermodels-json",
-            "egret-json",
-            "psse",
-            "psse34",
-            "psse35",
-            "powerworld",
-            "pandapower-json",
-            "powerio-json",
-            "pypsa-csv",
-            "pslf",
-            "gridfm",
-        ],
-        "distribution": ["dss", "pmd-json", "bmopf-json"],
-    }
-    return {
-        "schema": "powerio.capabilities",
-        "schema_version": _SCHEMA_VERSION,
-        "model_kinds": ["balanced", "multiconductor"],
-        "source_formats": source_formats,
-        "target_formats": target_formats,
-        "matrix_kinds": sorted(set(_MATRIX_KIND_ALIASES.values())),
-        "transports": ["powerio-json", "bmopf-json", "package"],
-        "optional_features": {
-            "gridfm": bool(getattr(powerio._powerio, "_has_gridfm", False)),
-            "mcp": True,
-            "distribution": True,
-            "package": True,
-        },
-    }
-
-
 @mcp.tool(name="convert")
 def _convert_tool(
     to_format: str,
@@ -1232,12 +1178,6 @@ def _matrix_tool(
 def _diagnostics_tool(package_json: str, verbose: bool = False) -> dict:
     """Return package diagnostics as structured JSON plus a concise summary."""
     return _diagnostics_payload(package_json, verbose)
-
-
-@mcp.tool(name="capabilities")
-def _capabilities_tool() -> dict:
-    """List supported model kinds, formats, matrix kinds, and optional features."""
-    return _capabilities_impl()
 
 
 @mcp.tool(name="display")
@@ -1396,10 +1336,6 @@ def display(
 
 def diagnostics(package_json: str, verbose: bool = False) -> dict:
     return _diagnostics_payload(package_json, verbose)
-
-
-def capabilities() -> dict:
-    return _capabilities_impl()
 
 
 def compute_matrix(*args: Any, **kwargs: Any) -> dict:

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -35,7 +35,6 @@ def test_tool_surface_is_semantic():
         "normalize",
         "matrix",
         "diagnostics",
-        "capabilities",
         "display",
     }
     for name in ("parse", "summary", "normalize", "matrix", "display"):
@@ -178,7 +177,7 @@ def test_package_transport_routes_distribution_by_model_kind():
     assert summary["elements"]["buses"] > 0
 
 
-def test_package_diagnostics_and_capabilities():
+def test_package_diagnostics():
     parsed = server.parse(path=str(DATA / "case9.m"), transport="package")
     diag = server.diagnostics(parsed["package_json"])
     assert diag["schema"] == "powerio.diagnostics"
@@ -189,16 +188,6 @@ def test_package_diagnostics_and_capabilities():
 
     verbose = server.diagnostics(parsed["package_json"], verbose=True)
     assert verbose["diagnostics"] == json.loads(parsed["package_json"]).get("diagnostics", [])
-
-    caps = server.capabilities()
-    assert caps["schema"] == "powerio.capabilities"
-    assert "balanced" in caps["model_kinds"]
-    assert "multiconductor" in caps["model_kinds"]
-    assert "matpower" in caps["source_formats"]["transmission"]
-    assert "bmopf-json" in caps["target_formats"]["distribution"]
-    assert "bprime" in caps["matrix_kinds"]
-    assert caps["optional_features"]["package"] is True
-
 
 def test_minimal_bmopf_json_routes_without_format(tmp_path):
     parsed = server.parse(content=MINIMAL_BMOPF)


### PR DESCRIPTION
Prep v0.4.0 release metadata/workflows and remove the redundant MCP `capabilities` tool.

Checks run locally.