### PR TITLE
Declare the .pio.json payload schema and resolve operating point updates by identity

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -148,6 +148,22 @@ jobs:
         </dl>
         <footer><a href="https://github.com/eigenergy/powerio">github.com/eigenergy/powerio</a></footer>
         HTML
+    # The schema URLs stamped into .pio.json files (`schema`, `payload_schema`)
+    # are identifiers first, but the site serves them so they also resolve:
+    # each lands on the schema guide chapter. Relative targets keep the pages
+    # working under both powerio.dev and eigenergy.github.io/powerio.
+    - name: Schema identifier pages
+      run: |
+        for id in pio-package/0.1 pio-payload-balanced/1 pio-payload-multiconductor/1; do
+          mkdir -p "target/doc/schema/$id"
+          cat > "target/doc/schema/$id/index.html" <<HTML
+        <!doctype html>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0; url=../../../guide/pio-json-schema.html">
+        <title>PowerIO schema: $id</title>
+        <a href="../../../guide/pio-json-schema.html">PowerIO schema $id — see the .pio.json schema guide</a>
+        HTML
+        done
     - uses: actions/upload-pages-artifact@v5
       with:
         path: target/doc

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -6,6 +6,13 @@ name: Julia binding
 # it is public; while it is private, add a token with read access to it as the
 # POWERIO_JL_REPO_TOKEN secret. With neither, the job prints a skip notice and
 # passes, so missing external access never blocks a PR.
+#
+# Companion branches: a PR that moves the shared surface (JSON shapes, schema
+# versions, pio_* behavior) pushes a PowerIO.jl branch with the SAME name; this
+# job tests against that branch when it exists and falls back to PowerIO.jl
+# main. That breaks the lockstep deadlock where a powerio PR can only go green
+# after PowerIO.jl main changes, which can only be validated after the powerio
+# PR merges. Merge either side first; the companion branch keeps both green.
 on:
   push:
     branches: [ "main" ]
@@ -50,12 +57,27 @@ jobs:
       # reader, distribution surface, and package surface bind against real
       # symbols rather than skipping behind feature probes.
       run: cargo build -p powerio-capi --release --features arrow,gridfm,dist,pkg
+    - name: Resolve PowerIO.jl companion branch
+      id: powerio-jl-ref
+      if: steps.powerio-jl.outputs.available == 'true'
+      env:
+        BRANCH: ${{ github.head_ref || github.ref_name }}
+      run: |
+        if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] \
+          && git ls-remote --exit-code --heads \
+            https://github.com/eigenergy/PowerIO.jl.git "refs/heads/$BRANCH" >/dev/null 2>&1; then
+          echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "PowerIO.jl has a companion branch '$BRANCH'; testing against it instead of main."
+        else
+          echo "ref=main" >> "$GITHUB_OUTPUT"
+        fi
     - name: Check out PowerIO.jl
       if: steps.powerio-jl.outputs.available == 'true'
       uses: actions/checkout@v6
       with:
         repository: eigenergy/PowerIO.jl
         path: PowerIO.jl
+        ref: ${{ steps.powerio-jl-ref.outputs.ref }}
         # Falls back to the workflow token, which suffices once the repo is public.
         token: ${{ secrets.POWERIO_JL_REPO_TOKEN || github.token }}
     - uses: julia-actions/setup-julia@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.5.1
+
+- `.pio.json` payload schema declared (#173): new optional envelope fields
+  `payload_schema` and `payload_schema_version` name and version the IR payload
+  contract per model kind (`pio-payload-balanced/1`,
+  `pio-payload-multiconductor/1`, both `1.0.0`), independent of the envelope
+  `schema_version` (now `0.1.1`). A reader rejects a foreign payload major;
+  packages without the fields (0.5.0 and earlier) read unchanged. The JSON
+  shape of `model` is untouched.
+- Payload row identity: balanced IR elements gained `uid: Option<String>`
+  (serde additive). The GOC3 parser keeps source uids on buses, devices,
+  branches, and dc lines; package construction synthesizes `{table}:{row}` uids
+  for the rest, so every powerio built payload row has a stable identity.
+- Operating point updates resolve by identity: `ElementRef.source_uid` is
+  authoritative when the payload table carries uids — a present `row` must
+  agree with the resolved row, unknown or duplicated identities are rejected
+  (at materialization and by `pio_package_validate` via the
+  `VALIDATE.PACKAGE.OPERATING_IDENTITY` pass), and `row` may be omitted on the
+  wire (`ElementRef::by_source_uid`). Tables without uids keep the pre-0.5.1
+  row-only semantics, so existing packages materialize as before. Provenance
+  cleanup paths now come from the resolved row, not the wire row.
+- Python: network table dicts expose `uid`; unknown identities raise
+  `ValueError` from `Package.materialize_operating_point`. C ABI: no signature
+  changes; materialization reports identity failures through `errbuf`.
+- `powerio-pkg`: `ElementRef.row` is meaningful only when
+  `ElementRef::wire_row()` is `Some`; refs built by `by_source_uid` serialize
+  without `row`.
+
 ## 0.5.0
 
 - `powerio-pkg`: `NetworkPackage` is the one package type name (`CompilerPackage`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,3 +74,14 @@ writing bespoke fixtures; pin their bytes.
 ## PRs
 
 Conventional commit subjects (`feat:`, `fix:`, `refactor:`); squash merge.
+
+## Tandem changes with PowerIO.jl
+
+The `Julia binding` CI job builds this repo's C ABI and runs PowerIO.jl's test
+suite against it. A PR that moves the shared surface (JSON shapes, schema
+versions, `pio_*` behavior) fails that job against PowerIO.jl main by
+construction. Push a PowerIO.jl branch with the **same name** as the powerio
+branch; the job tests against the companion branch when it exists. Open both
+PRs, merge in either order, and keep PowerIO.jl test assertions on the shared
+surface at contract strength (same major, shape present) rather than byte
+equality, so additive powerio changes do not fail the tandem job.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "powerio",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "approx",
  "arrow",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -31,10 +31,10 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.5.0" }
-powerio-matrix = { path = "powerio-matrix", version = "0.5.0" }
-powerio-dist = { path = "powerio-dist", version = "0.5.0" }
-powerio-pkg = { path = "powerio-pkg", version = "0.5.0" }
+powerio = { path = "powerio", version = "0.5.1" }
+powerio-matrix = { path = "powerio-matrix", version = "0.5.1" }
+powerio-dist = { path = "powerio-dist", version = "0.5.1" }
+powerio-pkg = { path = "powerio-pkg", version = "0.5.1" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -9,8 +9,9 @@ artifacts.
   envelope — explicit model kind, provenance, source maps, structured
   diagnostics, validation, operating points, and lowering.
 - [PIO JSON schema](https://eigenergy.github.io/powerio/guide/pio-json-schema.html): the `.pio.json` field reference and
-  the stability policy. The envelope is versioned; the nested IR payloads still
-  follow the Rust models.
+  the stability policy. The envelope and the IR payload are versioned
+  independently (`schema_version` vs `payload_schema_version`); the payload
+  shape follows the Rust models.
 - [v0.4 release direction](https://eigenergy.github.io/powerio/guide/v0.4-release-direction.html): the design direction
   for explicit `MulticonductorNetwork` to `BalancedNetwork` lowering.
 

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -89,10 +89,13 @@ reject a package where they do not.
 
 ### Payload stability
 
-The envelope is the versioned, documented surface. The nested `balanced_network`
-/ `multiconductor_network` payloads are direct serde snapshots of the live
-PowerIO Rust IR. They can change whenever the Rust models change, until a v1
-payload schema is declared. See
+The envelope and the payload are versioned independently. The nested
+`balanced_network` / `multiconductor_network` payloads are serde snapshots of
+the PowerIO Rust IR, declared by the package's `payload_schema` /
+`payload_schema_version` fields: additive IR growth bumps the payload minor,
+moves or removals bump its major, and a reader rejects a foreign major before
+computing on payload fields. Payload rows carry stable `uid` identities that
+operating point updates resolve against. See
 [the PIO JSON schema guide](https://eigenergy.github.io/powerio/guide/pio-json-schema.html).
 
 ### Provenance and source maps

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -16,26 +16,27 @@ A `.pio.json` file has two parts with different stability promises.
    under the versioning policy below.
 
 2. **The payload** — the `model` field's `balanced_network` /
-   `multiconductor_network` object. This is a direct serde snapshot of the live
-   PowerIO Rust IR (`powerio::Network` / `powerio_dist::DistNetwork`). It can
-   grow whenever the IR grows. Adding a typed field to a model appears in the
-   payload with no envelope version change. Until a v1 payload schema exists,
-   tools that need a stable contract should read the envelope (model kind,
-   summary, diagnostics, provenance) and treat the payload as opaque or pinned
-   to a producer version.
+   `multiconductor_network` object: the serde snapshot of the PowerIO Rust IR
+   (`powerio::Network` / `powerio_dist::DistNetwork`). The payload is a declared
+   contract of its own, named by the top-level `payload_schema` URL and
+   versioned by `payload_schema_version`. A consumer that computes on payload
+   fields pins the payload version; a tool that routes or audits packages pins
+   the envelope version and can keep treating the payload as opaque.
 
-`schema_version` versions the envelope only. The payload carries no separate
-version yet; pin to `producer.version` if you depend on payload fields.
+The two versions are independent because they change at different rates and
+break different consumers: the payload grows whenever the IR grows (a minor
+`payload_schema_version` bump), while the envelope bookkeeping barely moves.
 
-For distribution models, the payload follows the same multiconductor model used
-by the BMOPF reader and writer. The surrounding `.pio.json` object is the
-PowerIO package envelope: it adds model kind, provenance, source maps,
-diagnostics, validation, and lowering metadata around that model. Use the
-`bmopf-json` writer when a standalone BMOPF exchange file is needed.
+The payload is PowerIO's own IR schema for both model kinds. Interchange
+formats stay at the converter boundary: for distribution models the
+multiconductor payload is the same model the BMOPF reader and writer translate
+to and from, and `powerio convert --to bmopf-json` emits a standalone BMOPF
+exchange file when one is needed. The BMOPF schema itself (bmopf-report) never
+defines the payload.
 
 ## Versioning policy (envelope)
 
-- `schema_version` is semver. The current value is `0.1.0`; the `schema` URL is
+- `schema_version` is semver. The current value is `0.1.1`; the `schema` URL is
   `https://powerio.dev/schema/pio-package/0.1`.
 - Optional additive envelope fields (a reader that ignores them loses nothing
   it relied on before) land without a version change; `operating_points` landed
@@ -48,6 +49,35 @@ diagnostics, validation, and lowering metadata around that model. Use the
 - A reader accepts same major `schema_version` values and rejects a different
   major version before using the payload.
 - Every package states `producer.version` and `schema_version`.
+
+## Versioning policy (payload)
+
+- `payload_schema` names the payload contract per model kind:
+  `https://powerio.dev/schema/pio-payload-balanced/1` and
+  `https://powerio.dev/schema/pio-payload-multiconductor/1`. The URLs are
+  identifiers, not fetch locations (the JSON Schema `$id` convention).
+- `payload_schema_version` is semver, currently `1.0.0` for both kinds.
+  Additive optional fields bump the minor; field moves or removals bump the
+  major.
+- A reader rejects a `payload_schema_version` with a different major (or one
+  that does not parse as semver) before computing on payload fields. Absent
+  fields — every package written before 0.1.1 — are accepted; such payloads
+  predate the declared contract.
+- The payload field tables are the rustdoc of `powerio::Network` and
+  `powerio_dist::DistNetwork`; the serde snapshot of those structs is the
+  normative shape.
+
+## Row identity
+
+Every row of the balanced payload tables (`buses`, `loads`, `shunts`,
+`branches`, `switches`, `generators`, `storage`, `hvdc`, `transformers_3w`)
+carries a `uid` string: the source record uid where the format defines one
+(GOC3), and a `{table}:{row}` value synthesized at package build otherwise. A
+synthesized uid records the row the element had when the package was built and
+sticks to the element from then on. Uids are unique per table; a duplicate is a
+validation error. Operating point updates resolve against these identities
+(below). Rows in packages written before 0.1.1 carry no `uid`, which is what
+keeps their row-addressed operating points valid.
 
 ## Explicit model kind
 
@@ -76,6 +106,8 @@ later families can be added).
 | `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
 | `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
 | `model_kind` | enum | yes | `balanced` \| `multiconductor`; authoritative |
+| `payload_schema` | string (URL) | no | declared payload contract for `model_kind`; absent on pre-0.1.1 packages |
+| `payload_schema_version` | string (semver) | no | payload version; a different major is rejected on read |
 | `model` | object | yes | `{kind, <kind>_network}`; follows the Rust model payload |
 | `origin` | object | yes | tagged by `kind`: `in_memory` \| `file` \| `folder` \| `binary_file` \| `derived` \| `composite` |
 | `sources` | array | no | declared source artifacts: `{id, kind, path?, format?, hash?}` |
@@ -90,9 +122,18 @@ later families can be added).
 ### Operating points
 
 `operating_points` records a time axis and an ordered list of payload field
-updates. A point names a table, zero based row, optional source UID, and the
+updates. A point names a table, a row identity and/or a zero based row, and the
 fields to overwrite. Materializing a point clones the static payload, applies
 those field updates, and clears `operating_points` in the returned package.
+
+Updates resolve by identity first. When the referenced table carries `uid`
+values, `element.source_uid` is authoritative: it selects the row, a present
+`element.row` must agree with the resolved row, and an unknown or duplicated
+uid is an error (reported by validation and fatal to materialization). A
+producer that knows the identity can omit `row` entirely. When the table
+carries no uids (packages written before 0.1.1), `source_uid` is advisory and
+`row` addresses the update alone. An update may not overwrite `uid` itself, and
+an element ref with neither `row` nor `source_uid` does not parse.
 
 The block shape is:
 
@@ -105,8 +146,8 @@ The block shape is:
 | `points[].index` | integer | zero based period index; addresses `time_axis.duration_hours` and `time_axis.labels` |
 | `points[].updates[]` | array | row field updates to apply for this point |
 | `updates[].element.table` | string | payload table name, such as `generators`, `loads`, `branches`, or `hvdc` |
-| `updates[].element.row` | integer | zero based row in that table |
-| `updates[].element.source_uid` | string | optional source record UID |
+| `updates[].element.row` | integer | zero based row; optional when `source_uid` is present, then a consistency check |
+| `updates[].element.source_uid` | string | the target row's payload identity (`uid`); authoritative when the table carries uids |
 | `updates[].fields` | object | field names and JSON values to overwrite |
 | `metadata` | object | optional series or point metadata |
 
@@ -196,9 +237,11 @@ bindings, or MCP operations.
 ```json
 {
   "schema": "https://powerio.dev/schema/pio-package/0.1",
-  "schema_version": "0.1.0",
-  "producer": { "tool": "powerio", "version": "0.5.0" },
+  "schema_version": "0.1.1",
+  "producer": { "tool": "powerio", "version": "0.5.1" },
   "model_kind": "multiconductor",
+  "payload_schema": "https://powerio.dev/schema/pio-payload-multiconductor/1",
+  "payload_schema_version": "1.0.0",
   "model": {
     "kind": "multiconductor",
     "multiconductor_network": {

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -148,8 +148,11 @@ from the payload.
 
 `pkg.operating_points()` returns a Python dict for the replayable operating
 point series, or `None`. `pkg.materialize_operating_point(i)` returns a new
-static `Package` with one point applied. GOC3 packages populate this series
-from the source time series while the static payload holds the first interval.
+static `Package` with one point applied; updates resolve by the payload rows'
+`uid` identities, and an unknown identity or a row that contradicts one raises
+`ValueError`. GOC3 packages populate this series from the source time series
+while the static payload holds the first interval. Network table dicts
+(`net.buses`, `net.loads`, ...) expose each row's `uid`.
 `pkg.validate()`, `pkg.validation()`, and `pkg.diagnostics()` expose the
 package validation profile, and multiconductor packages lower through
 `pkg.multiconductor_to_balanced_preflight()` and

--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -139,7 +139,9 @@ compiler package handle, distinct from the parsed network handles:
 - `pio_package_operating_points_json` returns the replayable operating point
   series, or JSON `null` when the package has none.
 - `pio_package_materialize_operating_point` returns a new static package with
-  one operating point applied.
+  one operating point applied. Updates resolve by the payload rows' `uid`
+  identities; an unknown identity, an ambiguous (duplicated) uid, or a row that
+  contradicts a resolved identity returns `NULL` with the message in `errbuf`.
 - `pio_package_multiconductor_to_balanced_preflight_json` reports structured
   blockers before lowering, and `pio_package_lower_multiconductor_to_balanced`
   returns a new balanced package when the input is ready.

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -2709,6 +2709,50 @@ mpc.branch = [
 
     #[cfg(feature = "pkg")]
     #[test]
+    fn package_materialize_reports_unknown_identity() {
+        use powerio_pkg::{
+            ElementRef, ElementUpdate, NetworkPackage, OperatingPoint, OperatingPointSeries,
+            TimeAxis,
+        };
+
+        let case = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data")
+            .join("case9.m");
+        let net = powerio::parse_str(&std::fs::read_to_string(case).unwrap(), "matpower")
+            .unwrap()
+            .network;
+        let mut point = OperatingPoint::new(0);
+        point.updates.push(ElementUpdate::new(
+            ElementRef::by_source_uid("generators", "no-such-uid"),
+            std::collections::BTreeMap::from([("pg".to_owned(), serde_json::json!(1.0))]),
+        ));
+        let package = NetworkPackage::from_balanced(net).with_operating_points(
+            OperatingPointSeries::new(TimeAxis::new(1).with_duration_hours(vec![1.0]), vec![point]),
+        );
+        let json = CString::new(package.to_json().unwrap()).unwrap();
+
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let pkg = pio_package_parse_str(json.as_ptr(), err.as_mut_ptr(), err.len());
+            assert!(
+                !pkg.is_null(),
+                "package parse_str failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+            let materialized =
+                pio_package_materialize_operating_point(pkg, 0, err.as_mut_ptr(), err.len());
+            assert!(materialized.is_null(), "unknown identity must fail");
+            let message = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+            assert!(
+                message.contains("unknown identity"),
+                "unexpected error: {message}"
+            );
+            pio_package_free(pkg);
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
     fn package_parse_free_to_json_and_reports() {
         let net = case9();
         let mut err = [0 as c_char; PIO_ERRBUF_MIN];
@@ -2720,9 +2764,17 @@ mpc.branch = [
                 CStr::from_ptr(err.as_ptr()).to_str().unwrap()
             );
             let v = package_json(pkg);
-            assert_eq!(v["schema_version"], serde_json::json!("0.1.0"));
+            assert_eq!(v["schema_version"], serde_json::json!("0.1.1"));
             assert_eq!(v["model_kind"], serde_json::json!("balanced"));
             assert_eq!(v["model"]["kind"], serde_json::json!("balanced"));
+            assert_eq!(
+                v["payload_schema"],
+                serde_json::json!(powerio_pkg::PIO_PAYLOAD_BALANCED_SCHEMA_URL)
+            );
+            assert_eq!(
+                v["payload_schema_version"],
+                serde_json::json!(powerio_pkg::PIO_PAYLOAD_BALANCED_SCHEMA_VERSION)
+            );
             assert_eq!(
                 v["derived"]["normalized_solver_tables"]["row_counts"]["buses"],
                 serde_json::json!(9)

--- a/powerio-pkg/README.md
+++ b/powerio-pkg/README.md
@@ -29,9 +29,12 @@ It serializes to `.pio.json`. Binary `.pio` is out of scope until the JSON
 package stabilizes.
 
 Operating points are overlays, not separate payloads. Each point names table
-rows and fields to update on the one static payload. GOC3 package construction
-extracts the time series into this block while the balanced payload holds the
-first interval.
+rows and fields to update on the one static payload. Payload rows carry stable
+`uid` identities (source uids where the format has them, synthesized
+`{table}:{row}` values otherwise); an update's `source_uid` resolves against
+them and is authoritative, with the wire `row` as a fallback and consistency
+check. GOC3 package construction extracts the time series into this block while
+the balanced payload holds the first interval.
 
 See `docs/src/compiler-ir.md` and `docs/src/pio-json-schema.md` in the
 repository root.

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -61,6 +61,8 @@ pub use operating::{ElementRef, ElementUpdate, OperatingPoint, OperatingPointSer
 pub use package::{
     DerivedMetadata, NetworkPackage, NormalizedSolverTableMetadata, NormalizedSolverTableRowCounts,
     NormalizedSolverTableSourceRows, PIO_PACKAGE_SCHEMA_URL, PIO_PACKAGE_SCHEMA_VERSION,
+    PIO_PAYLOAD_BALANCED_SCHEMA_URL, PIO_PAYLOAD_BALANCED_SCHEMA_VERSION,
+    PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL, PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION,
 };
 pub use provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,

--- a/powerio-pkg/src/model.rs
+++ b/powerio-pkg/src/model.rs
@@ -25,10 +25,11 @@ pub enum ModelKind {
 /// The one IR payload a package carries, tagged by `kind` in JSON so the payload
 /// is self-describing in addition to the top-level `model_kind`.
 ///
-/// The payload is a direct serde snapshot of the live PowerIO Rust IR
-/// ([`powerio::Network`] / [`powerio_dist::DistNetwork`]). It is experimental: it
-/// grows whenever the IR does, with no envelope version change. Only the envelope
-/// is versioned. See `docs/src/pio-json-schema.md`.
+/// The payload is the serde snapshot of the PowerIO Rust IR
+/// ([`powerio::Network`] / [`powerio_dist::DistNetwork`]), declared by the
+/// package's `payload_schema` / `payload_schema_version` fields and versioned
+/// independently of the envelope: additive IR growth bumps the payload minor
+/// with no envelope version change. See `docs/src/pio-json-schema.md`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ModelPayload {

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -140,16 +140,26 @@ impl OperatingPoint {
 }
 
 /// A row in one table of the static payload.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `source_uid` is the row's payload identity: when the referenced table
+/// carries `uid` values, a present `source_uid` resolves the target row and a
+/// present `row` must agree with it. In a table without uids (packages written
+/// before payload identity existed), `source_uid` is advisory and `row`
+/// addresses the update alone. On the wire, `row` may be omitted when
+/// `source_uid` is given.
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ElementRef {
     /// Payload table name, such as `loads`, `generators`, `branches`, or `hvdc`.
     pub table: String,
-    /// Zero based row index in `table`.
+    /// Zero based row index in `table`. Meaningful only when the wire carried
+    /// one; read [`ElementRef::wire_row`] before trusting it.
     pub row: usize,
-    /// Optional source record UID for diagnostics and provenance.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The row's payload identity (its `uid` field), when the producer knows it.
     pub source_uid: Option<String>,
+    /// Whether the wire carried `row`. Refs built by
+    /// [`ElementRef::by_source_uid`] have no truthful row to serialize.
+    row_present: bool,
 }
 
 impl ElementRef {
@@ -159,6 +169,18 @@ impl ElementRef {
             table: table.into(),
             row,
             source_uid: None,
+            row_present: true,
+        }
+    }
+
+    /// Address a row by payload identity alone; no `row` is serialized.
+    #[must_use]
+    pub fn by_source_uid(table: impl Into<String>, uid: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            row: 0,
+            source_uid: Some(uid.into()),
+            row_present: false,
         }
     }
 
@@ -166,6 +188,53 @@ impl ElementRef {
     pub fn with_source_uid(mut self, uid: impl Into<String>) -> Self {
         self.source_uid = Some(uid.into());
         self
+    }
+
+    /// The wire `row`, when one was given.
+    #[must_use]
+    pub fn wire_row(&self) -> Option<usize> {
+        self.row_present.then_some(self.row)
+    }
+}
+
+impl Serialize for ElementRef {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let len = 1 + usize::from(self.row_present) + usize::from(self.source_uid.is_some());
+        let mut state = serializer.serialize_struct("ElementRef", len)?;
+        state.serialize_field("table", &self.table)?;
+        if self.row_present {
+            state.serialize_field("row", &self.row)?;
+        }
+        if let Some(uid) = &self.source_uid {
+            state.serialize_field("source_uid", uid)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for ElementRef {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Wire {
+            table: String,
+            #[serde(default)]
+            row: Option<usize>,
+            #[serde(default)]
+            source_uid: Option<String>,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        if wire.row.is_none() && wire.source_uid.is_none() {
+            return Err(serde::de::Error::custom(
+                "element ref needs `row` or `source_uid`",
+            ));
+        }
+        Ok(Self {
+            table: wire.table,
+            row_present: wire.row.is_some(),
+            row: wire.row.unwrap_or(0),
+            source_uid: wire.source_uid,
+        })
     }
 }
 
@@ -423,10 +492,14 @@ fn json_error(message: impl Into<String>) -> serde_json::Error {
     <serde_json::Error as serde::de::Error>::custom(message.into())
 }
 
+/// Apply one operating point to the payload and return the updated model plus
+/// the JSON Pointer paths of every field written, computed from the resolved
+/// rows so stale provenance cleanup follows identity resolution, never a stale
+/// wire row.
 pub(crate) fn apply_operating_point_to_model(
     model: &ModelPayload,
     point: &OperatingPoint,
-) -> serde_json::Result<ModelPayload> {
+) -> serde_json::Result<(ModelPayload, BTreeSet<String>)> {
     let mut value = serde_json::to_value(model)?;
     let root = value.as_object_mut().ok_or_else(|| {
         <serde_json::Error as serde::de::Error>::custom("model payload did not serialize to object")
@@ -441,32 +514,66 @@ pub(crate) fn apply_operating_point_to_model(
             ))
         })?;
 
+    let mut indexes = HashMap::new();
+    let mut resolved_rows = Vec::with_capacity(point.updates.len());
     for update in &point.updates {
-        apply_update(payload, update)?;
+        let row = resolve_update(payload, &mut indexes, update).map_err(json_error)?;
+        apply_update_fields(payload, &update.element.table, row, &update.fields)?;
+        resolved_rows.push(row);
     }
 
-    let updated = serde_json::from_value(value)?;
-    validate_update_fields_survived(&updated, &point.updates)?;
-    Ok(updated)
-}
-
-pub(crate) fn operating_point_update_paths(
-    model: &ModelPayload,
-    point: &OperatingPoint,
-) -> BTreeSet<String> {
-    let payload_key = payload_key(model);
-    point
+    let updated_paths = point
         .updates
         .iter()
-        .flat_map(|update| {
+        .zip(&resolved_rows)
+        .flat_map(|(update, row)| {
             update.fields.keys().map(move |field| {
                 format!(
-                    "/model/{payload_key}/{}/{}/{}",
-                    update.element.table, update.element.row, field
+                    "/model/{payload_key}/{}/{row}/{}",
+                    update.element.table, field
                 )
             })
         })
-        .collect()
+        .collect();
+
+    let updated = serde_json::from_value(value)?;
+    validate_update_fields_survived(&updated, &point.updates, &resolved_rows)?;
+    Ok((updated, updated_paths))
+}
+
+/// Dry run identity resolution over a whole series, returning `(point_position,
+/// update_position, message)` for every update that fails to resolve. The
+/// payload is serialized once and the per table indexes are shared across the
+/// series.
+pub(crate) fn check_series_identities(
+    model: &ModelPayload,
+    series: &OperatingPointSeries,
+) -> Vec<(usize, usize, String)> {
+    let payload_key = payload_key(model);
+    let payload = match serde_json::to_value(model) {
+        Ok(Value::Object(mut root)) => match root.remove(payload_key) {
+            Some(Value::Object(payload)) => payload,
+            _ => {
+                return vec![(
+                    0,
+                    0,
+                    format!("model payload missing `{payload_key}` object"),
+                )];
+            }
+        },
+        _ => return vec![(0, 0, "model payload did not serialize to object".to_owned())],
+    };
+
+    let mut indexes = HashMap::new();
+    let mut findings = Vec::new();
+    for (point_pos, point) in series.points.iter().enumerate() {
+        for (update_pos, update) in point.updates.iter().enumerate() {
+            if let Err(message) = resolve_update(&payload, &mut indexes, update) {
+                findings.push((point_pos, update_pos, message));
+            }
+        }
+    }
+    findings
 }
 
 fn payload_key(model: &ModelPayload) -> &'static str {
@@ -476,31 +583,132 @@ fn payload_key(model: &ModelPayload) -> &'static str {
     }
 }
 
-fn apply_update(
-    payload: &mut serde_json::Map<String, Value>,
+/// The uid -> row index for one payload table.
+struct IdentityIndex {
+    by_uid: HashMap<String, usize>,
+    /// Uids on more than one row; resolving through one is ambiguous.
+    duplicates: BTreeSet<String>,
+    /// Whether any row carries a uid. A table with none keeps the row-only
+    /// semantics packages had before payload identity existed.
+    has_uids: bool,
+}
+
+fn table_identity_index(table: &[Value]) -> IdentityIndex {
+    let mut by_uid = HashMap::with_capacity(table.len());
+    let mut duplicates = BTreeSet::new();
+    let mut has_uids = false;
+    for (row, value) in table.iter().enumerate() {
+        let Some(uid) = value.get("uid").and_then(Value::as_str) else {
+            continue;
+        };
+        has_uids = true;
+        if by_uid.insert(uid.to_owned(), row).is_some() {
+            duplicates.insert(uid.to_owned());
+        }
+    }
+    IdentityIndex {
+        by_uid,
+        duplicates,
+        has_uids,
+    }
+}
+
+/// Resolve one update to its payload row, first rejecting any update that would
+/// rewrite `uid`. Identity is immutable: letting a field write change it would
+/// invalidate the per table indexes mid application.
+fn resolve_update(
+    payload: &Map<String, Value>,
+    indexes: &mut HashMap<String, IdentityIndex>,
     update: &ElementUpdate,
+) -> Result<usize, String> {
+    if update.fields.contains_key("uid") {
+        return Err(format!(
+            "operating point update on table `{}` must not overwrite `uid`",
+            update.element.table
+        ));
+    }
+    resolve_update_row(payload, indexes, &update.element)
+}
+
+/// Resolve one element ref to a payload row. A `source_uid` that resolves in a
+/// uid bearing table is authoritative and a present wire `row` must agree with
+/// it; an unknown or duplicated uid in such a table is an error; a table without
+/// uids falls back to the wire row.
+fn resolve_update_row(
+    payload: &Map<String, Value>,
+    indexes: &mut HashMap<String, IdentityIndex>,
+    element: &ElementRef,
+) -> Result<usize, String> {
+    let table_name = element.table.as_str();
+    let Some(table) = payload.get(table_name).and_then(Value::as_array) else {
+        return Err(format!(
+            "operating point table `{table_name}` is not present or is not an array"
+        ));
+    };
+    let index = indexes
+        .entry(table_name.to_owned())
+        .or_insert_with(|| table_identity_index(table));
+    let resolved = match element.source_uid.as_deref() {
+        Some(uid) if index.duplicates.contains(uid) => {
+            return Err(format!(
+                "payload table `{table_name}` carries uid `{uid}` on more than one row; \
+                 identity resolution is ambiguous"
+            ));
+        }
+        Some(uid) => match index.by_uid.get(uid) {
+            Some(&row) => {
+                if let Some(wire_row) = element.wire_row()
+                    && wire_row != row
+                {
+                    return Err(format!(
+                        "update for table `{table_name}` names uid `{uid}` (row {row}) \
+                         but carries row {wire_row}"
+                    ));
+                }
+                row
+            }
+            None if index.has_uids => {
+                return Err(format!(
+                    "unknown identity: table `{table_name}` has no row with uid `{uid}`"
+                ));
+            }
+            None => element.wire_row().ok_or_else(|| {
+                format!(
+                    "update for table `{table_name}` names uid `{uid}`, but the payload rows \
+                     carry no uids and the update has no row to fall back on"
+                )
+            })?,
+        },
+        None => element.wire_row().ok_or_else(|| {
+            format!("update for table `{table_name}` has neither row nor source_uid")
+        })?,
+    };
+    if resolved >= table.len() {
+        return Err(format!(
+            "operating point table `{table_name}` has no row {resolved}"
+        ));
+    }
+    Ok(resolved)
+}
+
+fn apply_update_fields(
+    payload: &mut serde_json::Map<String, Value>,
+    table_name: &str,
+    row: usize,
+    fields: &BTreeMap<String, Value>,
 ) -> serde_json::Result<()> {
-    let table_name = update.element.table.as_str();
-    let table = payload
+    let row_object = payload
         .get_mut(table_name)
         .and_then(Value::as_array_mut)
-        .ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "operating point table `{table_name}` is not present or is not an array"
-            ))
-        })?;
-    let row = table
-        .get_mut(update.element.row)
+        .and_then(|table| table.get_mut(row))
         .and_then(Value::as_object_mut)
         .ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "operating point table `{table_name}` has no object row {}",
-                update.element.row
+            json_error(format!(
+                "operating point table `{table_name}` has no object row {row}"
             ))
         })?;
-
-    for (field, value) in &update.fields {
-        row.insert(field.clone(), value.clone());
+    for (field, value) in fields {
+        row_object.insert(field.clone(), value.clone());
     }
     Ok(())
 }
@@ -508,6 +716,7 @@ fn apply_update(
 fn validate_update_fields_survived(
     model: &ModelPayload,
     updates: &[ElementUpdate],
+    resolved_rows: &[usize],
 ) -> serde_json::Result<()> {
     let value = serde_json::to_value(model)?;
     let root = value.as_object().ok_or_else(|| {
@@ -523,31 +732,25 @@ fn validate_update_fields_survived(
             ))
         })?;
 
-    for update in updates {
+    for (update, &resolved_row) in updates.iter().zip(resolved_rows) {
         let table_name = update.element.table.as_str();
-        let table = payload
+        let row = payload
             .get(table_name)
             .and_then(Value::as_array)
-            .ok_or_else(|| {
-                <serde_json::Error as serde::de::Error>::custom(format!(
-                    "operating point table `{table_name}` is not present after typed materialization"
-                ))
-            })?;
-        let row = table
-            .get(update.element.row)
+            .and_then(|table| table.get(resolved_row))
             .and_then(Value::as_object)
             .ok_or_else(|| {
-                <serde_json::Error as serde::de::Error>::custom(format!(
-                    "operating point table `{table_name}` has no object row {} after typed materialization",
-                    update.element.row
+                json_error(format!(
+                    "operating point table `{table_name}` has no object row {resolved_row} \
+                     after typed materialization"
                 ))
             })?;
 
         for field in update.fields.keys() {
             if !row.contains_key(field) {
-                return Err(<serde_json::Error as serde::de::Error>::custom(format!(
-                    "operating point field `{field}` is not present on table `{table_name}` row {}",
-                    update.element.row
+                return Err(json_error(format!(
+                    "operating point field `{field}` is not present on table `{table_name}` \
+                     row {resolved_row}"
                 )));
             }
         }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -18,8 +18,8 @@ use crate::lowering::{
 };
 use crate::model::{ModelKind, ModelPayload};
 use crate::operating::{
-    OperatingPointSeries, apply_operating_point_to_model, goc3_operating_points_from_str,
-    operating_point_update_paths,
+    OperatingPointSeries, apply_operating_point_to_model, check_series_identities,
+    goc3_operating_points_from_str,
 };
 use crate::provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
@@ -33,7 +33,30 @@ pub const PIO_PACKAGE_SCHEMA_URL: &str = "https://powerio.dev/schema/pio-package
 /// The package schema version (semver). Keep additive optional fields within
 /// the current version when older readers can ignore them; field moves bump the
 /// major (or ship a migration pass).
-pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.1.0";
+pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.1.1";
+
+/// The declared schema URL for the balanced payload (`model.balanced_network`).
+///
+/// Payload schema URLs are identifiers, not fetch locations (the same
+/// convention as JSON Schema `$id`). The payload contract they name is the
+/// serde snapshot documented in `docs/src/pio-json-schema.md`.
+pub const PIO_PAYLOAD_BALANCED_SCHEMA_URL: &str =
+    "https://powerio.dev/schema/pio-payload-balanced/1";
+
+/// The balanced payload schema version (semver). Additive optional fields bump
+/// the minor; field moves or removals bump the major. Versioned independently
+/// of the envelope: [`PIO_PACKAGE_SCHEMA_VERSION`] covers the package
+/// bookkeeping, this covers the network tables a consumer computes on.
+pub const PIO_PAYLOAD_BALANCED_SCHEMA_VERSION: &str = "1.0.0";
+
+/// The declared schema URL for the multiconductor payload
+/// (`model.multiconductor_network`).
+pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL: &str =
+    "https://powerio.dev/schema/pio-payload-multiconductor/1";
+
+/// The multiconductor payload schema version (semver); the same policy as
+/// [`PIO_PAYLOAD_BALANCED_SCHEMA_VERSION`].
+pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.0.0";
 
 fn default_schema_url() -> String {
     PIO_PACKAGE_SCHEMA_URL.to_owned()
@@ -41,6 +64,20 @@ fn default_schema_url() -> String {
 
 fn default_schema_version() -> String {
     PIO_PACKAGE_SCHEMA_VERSION.to_owned()
+}
+
+/// The declared payload schema URL and version for a model kind.
+fn payload_schema_for(kind: ModelKind) -> (&'static str, &'static str) {
+    match kind {
+        ModelKind::Balanced => (
+            PIO_PAYLOAD_BALANCED_SCHEMA_URL,
+            PIO_PAYLOAD_BALANCED_SCHEMA_VERSION,
+        ),
+        ModelKind::Multiconductor => (
+            PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL,
+            PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION,
+        ),
+    }
 }
 
 /// Optional derived metadata: matrix statistics, solver table metadata, and
@@ -170,6 +207,17 @@ pub struct NetworkPackage {
     pub created_at: Option<String>,
     /// Explicit model kind. Authoritative; never inferred from field presence.
     pub model_kind: ModelKind,
+    /// The declared schema URL for the payload family named by `model_kind`.
+    /// `None` on packages written before the payload contract was declared.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_schema: Option<String>,
+    /// The declared payload schema version (semver), independent of the
+    /// envelope `schema_version`: the envelope versions the package
+    /// bookkeeping, this versions the network tables. A reader rejects a
+    /// different major before computing on payload fields; `None` (legacy
+    /// packages) is accepted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_schema_version: Option<String>,
     pub model: ModelPayload,
     /// Replayable operating states over the static payload. The package
     /// constructors and setters omit empty series for static single state cases.
@@ -197,6 +245,8 @@ impl NetworkPackage {
     /// recording whether source was retained; the path is not captured here).
     /// GOC3 sources also lift their time series into `operating_points`.
     pub fn from_balanced(net: BalancedNetwork) -> Self {
+        let mut net = net;
+        ensure_balanced_payload_uids(&mut net);
         let origin = balanced_origin(&net);
         let summary = balanced_summary(&net);
         let sources = balanced_sources(&net);
@@ -228,6 +278,7 @@ impl NetworkPackage {
             None
         };
         let validation = ValidationSummary::from_diagnostics(&diagnostics);
+        let (payload_schema, payload_schema_version) = payload_schema_for(ModelKind::Balanced);
         Self {
             schema: default_schema_url(),
             schema_version: default_schema_version(),
@@ -235,6 +286,8 @@ impl NetworkPackage {
             package_id: None,
             created_at: None,
             model_kind: ModelKind::Balanced,
+            payload_schema: Some(payload_schema.to_owned()),
+            payload_schema_version: Some(payload_schema_version.to_owned()),
             model: ModelPayload::balanced(net),
             operating_points,
             origin,
@@ -273,6 +326,8 @@ impl NetworkPackage {
             .collect();
         let validation = ValidationSummary::from_diagnostics(&diagnostics);
 
+        let (payload_schema, payload_schema_version) =
+            payload_schema_for(ModelKind::Multiconductor);
         Self {
             schema: default_schema_url(),
             schema_version: default_schema_version(),
@@ -280,6 +335,8 @@ impl NetworkPackage {
             package_id: None,
             created_at: None,
             model_kind: ModelKind::Multiconductor,
+            payload_schema: Some(payload_schema.to_owned()),
+            payload_schema_version: Some(payload_schema_version.to_owned()),
             model: ModelPayload::multiconductor(net),
             operating_points: None,
             origin,
@@ -351,7 +408,10 @@ impl NetworkPackage {
                 "package has no operating point {index}"
             ))
         })?;
-        let updated_paths = operating_point_update_paths(&self.model, point);
+        // Applying resolves each update's row (identity first, wire row as
+        // fallback), so the stale provenance paths come from the same
+        // resolution rather than the wire row values.
+        let (updated_model, updated_paths) = apply_operating_point_to_model(&self.model, point)?;
         let had_normalized_solver_tables = self.derived.normalized_solver_tables.is_some();
         let options = materialize_operating_point_options(index);
         // Built field by field rather than cloned: cloning would deep copy the
@@ -368,7 +428,11 @@ impl NetworkPackage {
             package_id: None,
             created_at: self.created_at.clone(),
             model_kind: self.model_kind,
-            model: apply_operating_point_to_model(&self.model, point)?,
+            // The payload content derives from the parent, so the derived
+            // package restates the parent's declared payload contract.
+            payload_schema: self.payload_schema.clone(),
+            payload_schema_version: self.payload_schema_version.clone(),
+            model: updated_model,
             operating_points: None,
             origin: Origin::Derived {
                 parent_package_id: self.package_id.clone(),
@@ -472,6 +536,16 @@ impl NetworkPackage {
             return Err(<serde_json::Error as serde::de::Error>::custom(
                 "model_kind does not match model.kind",
             ));
+        }
+        if let Some(version) = pkg.payload_schema_version.as_deref() {
+            let supported = supported_payload_schema_major(pkg.model_kind);
+            if schema_major(version) != Some(supported) {
+                return Err(<serde_json::Error as serde::de::Error>::custom(format!(
+                    "unsupported payload_schema_version {version}; this reader supports \
+                     major version {supported} for {:?} payloads",
+                    pkg.model_kind
+                )));
+            }
         }
         Ok(pkg)
     }
@@ -614,12 +688,19 @@ impl NetworkPackage {
         self.diagnostics
             .retain(|d| !is_sane_validation_code(d.code.as_str()));
 
-        let (mut diagnostics, passes) = match &self.model {
+        let (mut diagnostics, mut passes) = match &self.model {
             ModelPayload::Balanced { balanced_network } => sane_validate_balanced(balanced_network),
             ModelPayload::Multiconductor {
                 multiconductor_network,
             } => sane_validate_multiconductor(multiconductor_network),
         };
+
+        if let Some(series) = &self.operating_points {
+            let (identity_diagnostics, identity_pass) =
+                validate_operating_identity(&self.model, series);
+            diagnostics.extend(identity_diagnostics);
+            passes.push(identity_pass);
+        }
 
         attach_source_refs(&mut diagnostics, &self.source_maps);
         self.diagnostics.extend(diagnostics);
@@ -687,14 +768,75 @@ fn supported_schema_major() -> u64 {
     schema_major(PIO_PACKAGE_SCHEMA_VERSION).expect("package schema version has a major number")
 }
 
-const SANE_VALIDATION_CODES: [&str; 6] = [
+fn supported_payload_schema_major(kind: ModelKind) -> u64 {
+    schema_major(payload_schema_for(kind).1).expect("payload schema version has a major number")
+}
+
+/// Give every payload row a stable identity: keep source uids (GOC3) and
+/// synthesize `{table}:{row}` for the rest, so identity based operating point
+/// updates can resolve against any powerio built package. Synthesized values
+/// record the row an element had at package build; they stay put if rows
+/// reorder later, which is the point.
+fn ensure_balanced_payload_uids(net: &mut BalancedNetwork) {
+    macro_rules! fill {
+        ($table:ident) => {
+            for (row, element) in net.$table.iter_mut().enumerate() {
+                if element.uid.is_none() {
+                    element.uid = Some(format!(concat!(stringify!($table), ":{}"), row));
+                }
+            }
+        };
+    }
+    fill!(buses);
+    fill!(loads);
+    fill!(shunts);
+    fill!(branches);
+    fill!(switches);
+    fill!(generators);
+    fill!(storage);
+    fill!(hvdc);
+    fill!(transformers_3w);
+}
+
+const SANE_VALIDATION_CODES: [&str; 7] = [
     "VALIDATE.BALANCED.STRUCTURE",
     "VALIDATE.BALANCED.VALUE_DOMAIN",
     "VALIDATE.MULTI.STRUCTURE",
     "VALIDATE.MULTI.TERMINAL_MAP",
     "VALIDATE.MULTI.UNTYPED_OBJECT",
     "VALIDATE.MULTI.NO_VOLTAGE_SOURCE",
+    "VALIDATE.PACKAGE.OPERATING_IDENTITY",
 ];
+
+/// Check every operating point update against the payload's identity index:
+/// unknown `source_uid`, a wire `row` that contradicts the resolved row,
+/// ambiguous (duplicate) payload uids, and rows out of range all become Error
+/// diagnostics, so `pio_package_validate` rejects a package whose updates
+/// reference unknown identities without materializing it.
+fn validate_operating_identity(
+    model: &ModelPayload,
+    series: &OperatingPointSeries,
+) -> (Vec<StructuredDiagnostic>, ValidationPass) {
+    let diagnostics: Vec<StructuredDiagnostic> = check_series_identities(model, series)
+        .into_iter()
+        .map(|(point_pos, update_pos, message)| {
+            StructuredDiagnostic::new(
+                "VALIDATE.PACKAGE.OPERATING_IDENTITY",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Validate,
+                message,
+            )
+            .with_element_path(format!(
+                "/operating_points/points/{point_pos}/updates/{update_pos}"
+            ))
+        })
+        .collect();
+    let status = validation_status(&diagnostics);
+    (
+        diagnostics,
+        ValidationPass::new("package.operating_identity", status),
+    )
+}
 
 fn is_sane_validation_code(code: &str) -> bool {
     SANE_VALIDATION_CODES.contains(&code)

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -6,9 +6,11 @@ use powerio_pkg::{
     Confidence, DiagnosticCode, DiagnosticSeverity, DiagnosticStage, ElementRef, ElementUpdate,
     MappingKind, ModelKind, MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,
     NetworkPackage, OperatingPoint, OperatingPointSeries, Origin, PIO_PACKAGE_SCHEMA_URL,
-    PIO_PACKAGE_SCHEMA_VERSION, SequenceTransformConvention, SourceDescriptor, SourceMapEntry,
-    SourceRef, StructuredDiagnostic, TimeAxis, ValidationStatus,
-    check_multiconductor_to_balanced_lowering, lower_multiconductor_to_balanced,
+    PIO_PACKAGE_SCHEMA_VERSION, PIO_PAYLOAD_BALANCED_SCHEMA_URL,
+    PIO_PAYLOAD_BALANCED_SCHEMA_VERSION, PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL,
+    SequenceTransformConvention, SourceDescriptor, SourceMapEntry, SourceRef, StructuredDiagnostic,
+    TimeAxis, ValidationStatus, check_multiconductor_to_balanced_lowering,
+    lower_multiconductor_to_balanced,
 };
 
 const MATPOWER_SRC: &str = "\
@@ -79,9 +81,14 @@ fn multiconductor_package() -> NetworkPackage {
 }
 
 fn balanced_package_with_gen() -> NetworkPackage {
-    let net = powerio::parse_str(MATPOWER_WITH_GEN_SRC, "matpower")
+    let mut net = powerio::parse_str(MATPOWER_WITH_GEN_SRC, "matpower")
         .expect("parse matpower with gen")
         .network;
+    // Source uids the sample operating point updates resolve against; every
+    // other row gets a synthesized `{table}:{row}` uid at package build.
+    net.loads[0].uid = Some("load_1".to_owned());
+    net.generators[0].uid = Some("gen_1".to_owned());
+    net.branches[0].uid = Some("branch_1".to_owned());
     NetworkPackage::from_balanced(net)
 }
 
@@ -523,7 +530,7 @@ fn materialize_operating_point_reports_invalid_table_or_row() {
         .expect_err("invalid row must fail");
     assert!(
         err.to_string()
-            .contains("operating point table `loads` has no object row 99")
+            .contains("operating point table `loads` has no row 99")
     );
 }
 
@@ -1668,4 +1675,288 @@ fn load_voltage_model_survives_package_roundtrip() {
         v["model"]["multiconductor_network"]["loads"][0]["voltage_model"]["model"],
         serde_json::json!("zip")
     );
+}
+
+// --- declared payload schema and row identity ------------------------------
+
+fn single_point_series(point: OperatingPoint) -> OperatingPointSeries {
+    OperatingPointSeries::new(TimeAxis::new(1).with_duration_hours(vec![1.0]), vec![point])
+}
+
+#[test]
+fn package_declares_payload_schema_and_synthesizes_row_identity() {
+    let pkg = balanced_package();
+    assert_eq!(
+        pkg.payload_schema.as_deref(),
+        Some(PIO_PAYLOAD_BALANCED_SCHEMA_URL)
+    );
+    assert_eq!(
+        pkg.payload_schema_version.as_deref(),
+        Some(PIO_PAYLOAD_BALANCED_SCHEMA_VERSION)
+    );
+    // MATPOWER has no source uids, so every row gets a synthesized identity.
+    let net = pkg.as_balanced().unwrap();
+    assert_eq!(net.buses[0].uid.as_deref(), Some("buses:0"));
+    assert_eq!(net.buses[1].uid.as_deref(), Some("buses:1"));
+    assert_eq!(net.branches[0].uid.as_deref(), Some("branches:0"));
+
+    let v = serde_json::to_value(&pkg).unwrap();
+    assert_eq!(
+        v["schema_version"],
+        serde_json::json!(PIO_PACKAGE_SCHEMA_VERSION)
+    );
+    assert_eq!(
+        v["model"]["balanced_network"]["buses"][0]["uid"],
+        serde_json::json!("buses:0")
+    );
+    assert_json_roundtrips(&pkg);
+
+    let multi = multiconductor_package();
+    assert_eq!(
+        multi.payload_schema.as_deref(),
+        Some(PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL)
+    );
+}
+
+#[test]
+fn identity_only_update_resolves_without_row() {
+    let mut point = OperatingPoint::new(0);
+    point.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("loads", "load_1"),
+        fields(&[("p", serde_json::json!(33.0))]),
+    ));
+    let pkg = balanced_package_with_gen().with_operating_points(single_point_series(point));
+
+    // The wire form omits `row` entirely.
+    let v = serde_json::to_value(&pkg).unwrap();
+    let element = &v["operating_points"]["points"][0]["updates"][0]["element"];
+    assert!(element.get("row").is_none());
+    assert_eq!(element["source_uid"], serde_json::json!("load_1"));
+
+    let back = NetworkPackage::from_json(&pkg.to_json_pretty().unwrap()).unwrap();
+    let materialized = back.materialize_operating_point(0).unwrap();
+    assert_close(materialized.as_balanced().unwrap().loads[0].p, 33.0);
+}
+
+#[test]
+fn row_identity_mismatch_is_rejected() {
+    let mut point = OperatingPoint::new(0);
+    point.updates.push(ElementUpdate::new(
+        ElementRef::new("generators", 7).with_source_uid("gen_1"),
+        fields(&[("pg", serde_json::json!(1.0))]),
+    ));
+    let pkg = balanced_package_with_gen().with_operating_points(single_point_series(point));
+    let err = pkg
+        .materialize_operating_point(0)
+        .expect_err("row/uid mismatch must fail");
+    assert!(
+        err.to_string()
+            .contains("names uid `gen_1` (row 0) but carries row 7"),
+        "{err}"
+    );
+}
+
+#[test]
+fn unknown_identity_is_rejected_and_reported_by_validation() {
+    let mut point = OperatingPoint::new(0);
+    point.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("loads", "nope"),
+        fields(&[("p", serde_json::json!(1.0))]),
+    ));
+    let mut pkg = balanced_package_with_gen().with_operating_points(single_point_series(point));
+    let err = pkg
+        .materialize_operating_point(0)
+        .expect_err("unknown identity must fail");
+    assert!(err.to_string().contains("unknown identity"), "{err}");
+
+    // The same finding surfaces through validation without materializing.
+    pkg.run_sane_validation();
+    assert_eq!(pkg.validation.status, ValidationStatus::Error);
+    let diagnostic = pkg
+        .diagnostics
+        .iter()
+        .find(|d| d.code.as_str() == "VALIDATE.PACKAGE.OPERATING_IDENTITY")
+        .expect("identity diagnostic");
+    assert_eq!(
+        diagnostic.element_path.as_deref(),
+        Some("/operating_points/points/0/updates/0")
+    );
+}
+
+#[test]
+fn duplicate_payload_identities_are_rejected() {
+    let mut net = powerio::parse_str(MATPOWER_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+    net.buses[0].uid = Some("dup".to_owned());
+    net.buses[1].uid = Some("dup".to_owned());
+    let mut point = OperatingPoint::new(0);
+    point.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("buses", "dup"),
+        fields(&[("vm", serde_json::json!(1.02))]),
+    ));
+    let pkg = NetworkPackage::from_balanced(net).with_operating_points(single_point_series(point));
+    let err = pkg
+        .materialize_operating_point(0)
+        .expect_err("duplicate identity must fail");
+    assert!(err.to_string().contains("more than one row"), "{err}");
+}
+
+#[test]
+fn update_must_not_overwrite_uid() {
+    let mut point = OperatingPoint::new(0);
+    point.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("loads", "load_1"),
+        fields(&[("uid", serde_json::json!("other"))]),
+    ));
+    let pkg = balanced_package_with_gen().with_operating_points(single_point_series(point));
+    let err = pkg
+        .materialize_operating_point(0)
+        .expect_err("uid overwrite must fail");
+    assert!(
+        err.to_string().contains("must not overwrite `uid`"),
+        "{err}"
+    );
+}
+
+#[test]
+fn legacy_payload_without_uids_keeps_row_semantics() {
+    // A pre-0.1.1 package: payload rows carry no uids and the envelope has no
+    // payload schema declaration, while updates still carry advisory
+    // source_uid values. The wire row must keep addressing alone.
+    let pkg = balanced_package_with_gen().with_operating_points(sample_operating_points());
+    let mut v = serde_json::to_value(&pkg).unwrap();
+    let payload = v["model"]["balanced_network"].as_object_mut().unwrap();
+    for table in [
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "switches",
+        "generators",
+        "storage",
+        "hvdc",
+        "transformers_3w",
+    ] {
+        if let Some(rows) = payload.get_mut(table).and_then(|t| t.as_array_mut()) {
+            for row in rows {
+                row.as_object_mut().unwrap().remove("uid");
+            }
+        }
+    }
+    let root = v.as_object_mut().unwrap();
+    root.remove("payload_schema");
+    root.remove("payload_schema_version");
+    root.insert("schema_version".to_owned(), serde_json::json!("0.1.0"));
+
+    let legacy = NetworkPackage::from_json(&v.to_string()).unwrap();
+    assert!(legacy.payload_schema.is_none());
+    let materialized = legacy.materialize_operating_point(0).unwrap();
+    assert_close(materialized.as_balanced().unwrap().loads[0].p, 12.0);
+}
+
+#[test]
+fn payload_schema_version_gate() {
+    let pkg = balanced_package();
+    let mut v = serde_json::to_value(&pkg).unwrap();
+
+    v["payload_schema_version"] = serde_json::json!("1.9.3");
+    NetworkPackage::from_json(&v.to_string()).expect("same major accepted");
+
+    v["payload_schema_version"] = serde_json::json!("2.0.0");
+    let err = NetworkPackage::from_json(&v.to_string()).expect_err("major bump rejected");
+    assert!(
+        err.to_string()
+            .contains("unsupported payload_schema_version"),
+        "{err}"
+    );
+
+    v["payload_schema_version"] = serde_json::json!("not-semver");
+    let err = NetworkPackage::from_json(&v.to_string()).expect_err("invalid semver rejected");
+    assert!(
+        err.to_string()
+            .contains("unsupported payload_schema_version"),
+        "{err}"
+    );
+
+    v.as_object_mut().unwrap().remove("payload_schema_version");
+    NetworkPackage::from_json(&v.to_string()).expect("absent version accepted");
+}
+
+#[test]
+fn element_ref_wire_requires_row_or_identity() {
+    let err = serde_json::from_str::<ElementRef>(r#"{"table": "loads"}"#)
+        .expect_err("neither row nor identity");
+    assert!(err.to_string().contains("needs `row` or `source_uid`"));
+
+    let by_uid: ElementRef =
+        serde_json::from_str(r#"{"table": "loads", "source_uid": "l1"}"#).unwrap();
+    assert_eq!(by_uid, ElementRef::by_source_uid("loads", "l1"));
+    assert_eq!(by_uid.wire_row(), None);
+
+    let by_row: ElementRef = serde_json::from_str(r#"{"table": "loads", "row": 3}"#).unwrap();
+    assert_eq!(by_row, ElementRef::new("loads", 3));
+    assert_eq!(by_row.wire_row(), Some(3));
+}
+
+#[test]
+fn goc3_updates_resolve_by_identity_not_row_order() {
+    // The uid-less producer fixture from the row assignment test: `prod` is
+    // payload row 1 and row 0 is a synthesized identity. Identity alone finds
+    // the right row; a contradicting row or an unknown uid fails.
+    let src = GOC3_PACKAGE_SRC.replacen(
+        r#"{"uid": "prod", "bus": "bus_00""#,
+        r#"{"bus": "bus_00", "device_type": "producer", "initial_status": {"on_status": 1, "p": 0.0, "q": 0.0}},
+      {"uid": "prod", "bus": "bus_00""#,
+        1,
+    );
+    let net = powerio::parse_str(&src, "goc3-json")
+        .expect("parse goc3")
+        .network;
+    assert_eq!(net.generators[1].uid.as_deref(), Some("prod"));
+    let pkg = NetworkPackage::from_balanced(net);
+    let balanced = pkg.as_balanced().unwrap();
+    assert_eq!(balanced.generators[0].uid.as_deref(), Some("generators:0"));
+    assert_eq!(balanced.buses[0].uid.as_deref(), Some("bus_00"));
+
+    let mut by_identity = OperatingPoint::new(0);
+    by_identity.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("generators", "prod"),
+        fields(&[("pmax", serde_json::json!(123.0))]),
+    ));
+    let materialized = pkg
+        .clone()
+        .with_operating_points(single_point_series(by_identity))
+        .materialize_operating_point(0)
+        .expect("identity resolves");
+    let updated = materialized.as_balanced().unwrap();
+    assert_close(updated.generators[1].pmax, 123.0);
+    assert_close(updated.generators[0].pmax, 0.0);
+
+    let mut wrong_row = OperatingPoint::new(0);
+    wrong_row.updates.push(ElementUpdate::new(
+        ElementRef::new("generators", 0).with_source_uid("prod"),
+        fields(&[("pmax", serde_json::json!(123.0))]),
+    ));
+    let err = pkg
+        .clone()
+        .with_operating_points(single_point_series(wrong_row))
+        .materialize_operating_point(0)
+        .expect_err("row/uid mismatch must fail");
+    assert!(
+        err.to_string()
+            .contains("names uid `prod` (row 1) but carries row 0"),
+        "{err}"
+    );
+
+    let mut unknown = OperatingPoint::new(0);
+    unknown.updates.push(ElementUpdate::new(
+        ElementRef::by_source_uid("generators", "ghost"),
+        fields(&[("pmax", serde_json::json!(123.0))]),
+    ));
+    let err = pkg
+        .with_operating_points(single_point_series(unknown))
+        .materialize_operating_point(0)
+        .expect_err("unknown uid must fail");
+    assert!(err.to_string().contains("unknown identity"), "{err}");
 }

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -722,6 +722,7 @@ impl PyNetwork {
             d.set_item("zone", b.zone)?;
             d.set_item("vmax", b.vmax)?;
             d.set_item("vmin", b.vmin)?;
+            d.set_item("uid", b.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)
@@ -736,6 +737,7 @@ impl PyNetwork {
             d.set_item("p", l.p)?;
             d.set_item("q", l.q)?;
             d.set_item("in_service", l.in_service)?;
+            d.set_item("uid", l.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)
@@ -750,6 +752,7 @@ impl PyNetwork {
             d.set_item("g", s.g)?;
             d.set_item("b", s.b)?;
             d.set_item("in_service", s.in_service)?;
+            d.set_item("uid", s.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)
@@ -793,6 +796,7 @@ impl PyNetwork {
             d.set_item("qf", br.solution.map(|s| s.qf))?;
             d.set_item("pt", br.solution.map(|s| s.pt))?;
             d.set_item("qt", br.solution.map(|s| s.qt))?;
+            d.set_item("uid", br.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)
@@ -812,6 +816,7 @@ impl PyNetwork {
             d.set_item("qf", sw.qf)?;
             d.set_item("pt", sw.pt)?;
             d.set_item("qt", sw.qt)?;
+            d.set_item("uid", sw.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)
@@ -844,6 +849,7 @@ impl PyNetwork {
                 }
                 None => d.set_item("cost", py.None())?,
             }
+            d.set_item("uid", g.uid.as_deref())?;
             rows.push(d);
         }
         PyList::new(py, rows)

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -534,6 +534,7 @@ fn read_bus(key: &str, v: &Value) -> Result<Bus> {
         area: usize_or(v, "area", 0)?,
         zone: usize_or(v, "zone", 0)?,
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -545,6 +546,7 @@ fn read_load(v: &Value) -> Result<Load> {
         q: f(v, "q_load")?,
         voltage_model: None,
         in_service: flag(v, "in_service", true)?,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -556,6 +558,7 @@ fn read_shunt(v: &Value) -> Result<Shunt> {
         b: f(v, "bs")?,
         in_service: flag(v, "in_service", true)?,
         control: None,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -585,6 +588,7 @@ fn read_branch(v: &Value) -> Result<Branch> {
         angmax: f_or(v, "angle_diff_max", 360.0)?,
         control: None,
         solution: None,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -615,6 +619,7 @@ fn read_gen(v: &Value) -> Result<Generator> {
         cost,
         caps: Default::default(),
         regulated_bus: None,
+        uid: None,
     })
 }
 
@@ -638,6 +643,7 @@ fn read_dc_branch(v: &Value) -> Result<Hvdc> {
         loss0: f(v, "loss0")?,
         loss1: f_or(v, "loss_factor", 0.0)?,
         cost: None,
+        uid: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/format/goc3.rs
+++ b/powerio/src/format/goc3.rs
@@ -121,7 +121,7 @@ pub(crate) fn parse_goc3_source(
 
         match device.table {
             DeviceTable::Generators => {
-                let generator = read_producer(obj, ts, bus, base_mva);
+                let generator = read_producer(obj, ts, bus, base_mva, device.uid.clone());
                 generator_buses.insert(bus);
                 if reference_candidate
                     .as_ref()
@@ -131,7 +131,9 @@ pub(crate) fn parse_goc3_source(
                 }
                 generators.push(generator);
             }
-            DeviceTable::Loads => loads.push(read_consumer(obj, ts, bus, base_mva)),
+            DeviceTable::Loads => {
+                loads.push(read_consumer(obj, ts, bus, base_mva, device.uid.clone()));
+            }
         }
     }
 
@@ -213,7 +215,8 @@ fn read_buses(network: &Map<String, Value>) -> Result<(Vec<Bus>, Goc3BusMap)> {
             evlo: None,
             area: 1,
             zone: 1,
-            name: Some(uid),
+            name: Some(uid.clone()),
+            uid: Some(uid),
             extras: extras(
                 obj,
                 &["uid", "base_nom_volt", "vm_ub", "vm_lb", "initial_status"],
@@ -286,6 +289,7 @@ fn read_branches(
                 angmax: 360.0,
                 control: shifter_control(obj, transformer),
                 solution: None,
+                uid: item_uid(item, obj),
                 extras: extras(
                     obj,
                     &[
@@ -351,6 +355,7 @@ fn read_shunts(
                 b: number(obj, "bs").unwrap_or(0.0) * step * base_mva,
                 in_service: step != 0.0,
                 control: None,
+                uid: item_uid(item, obj),
                 extras: extras(
                     obj,
                     &[
@@ -373,6 +378,7 @@ fn read_producer(
     ts: Option<&Value>,
     bus: BusId,
     base_mva: f64,
+    uid: Option<String>,
 ) -> Generator {
     let initial = initial_status(obj);
     Generator {
@@ -389,10 +395,17 @@ fn read_producer(
         cost: cost_at(obj, ts, 0, base_mva),
         caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
         regulated_bus: None,
+        uid,
     }
 }
 
-fn read_consumer(obj: &Map<String, Value>, ts: Option<&Value>, bus: BusId, base_mva: f64) -> Load {
+fn read_consumer(
+    obj: &Map<String, Value>,
+    ts: Option<&Value>,
+    bus: BusId,
+    base_mva: f64,
+    uid: Option<String>,
+) -> Load {
     let initial = initial_status(obj);
     let p = initial
         .and_then(|s| number(s, "p"))
@@ -412,6 +425,7 @@ fn read_consumer(obj: &Map<String, Value>, ts: Option<&Value>, bus: BusId, base_
         q,
         voltage_model: None,
         in_service: initial_status_flag(obj, true),
+        uid,
         extras: extras(
             obj,
             &[
@@ -452,6 +466,7 @@ fn read_hvdc(network: &Map<String, Value>, base_mva: f64, buses: &Goc3BusMap) ->
                 loss0: 0.0,
                 loss1: 0.0,
                 cost: None,
+                uid: item_uid(item, obj),
                 extras: extras(
                     obj,
                     &[

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -159,6 +159,7 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
         area: row[bus_col::BUS_AREA] as usize,
         zone: row[bus_col::ZONE] as usize,
         name: None,
+        uid: None,
         extras: Extras::new(),
     };
     let (pd, qd) = (row[bus_col::PD], row[bus_col::QD]);
@@ -168,6 +169,7 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
         q: qd,
         voltage_model: None,
         in_service,
+        uid: None,
         extras: Extras::new(),
     });
     let (gs, bs) = (row[bus_col::GS], row[bus_col::BS]);
@@ -177,6 +179,7 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
         b: bs,
         in_service,
         control: None,
+        uid: None,
         extras: Extras::new(),
     });
     Ok((bus, load, shunt))
@@ -203,6 +206,7 @@ pub(super) fn branch_row(row: &[f64], i: usize) -> Result<Branch> {
         angmax: row[branch_col::ANGMAX],
         control: None,
         solution: None,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -235,6 +239,7 @@ pub(super) fn gen_row(row: &[f64], i: usize) -> Result<Generator> {
         cost: None,
         caps,
         regulated_bus: None,
+        uid: None,
     })
 }
 
@@ -291,6 +296,7 @@ pub(super) fn storage_row(row: &[f64], i: usize) -> Result<Storage> {
         p_loss: row[storage_col::P_LOSS],
         q_loss: row[storage_col::Q_LOSS],
         in_service: is_in_service(row[storage_col::STATUS]),
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -316,6 +322,7 @@ pub(super) fn hvdc_row(row: &[f64], i: usize) -> Result<Hvdc> {
         loss0: row[dcline_col::LOSS0],
         loss1: row[dcline_col::LOSS1],
         cost: None,
+        uid: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -120,6 +120,7 @@ pub(crate) fn parse_pandapower_source(
             area: 1,
             zone: row.usize_or("zone", 1),
             name: row.string("name"),
+            uid: None,
             extras: Extras::default(),
         });
     }
@@ -187,6 +188,7 @@ pub(crate) fn parse_pandapower_source(
                 q,
                 voltage_model,
                 in_service: row.bool_or("in_service", true),
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -214,6 +216,7 @@ pub(crate) fn parse_pandapower_source(
                 b: -row.f_or("q_mvar", 0.0) * step * v_ratio,
                 in_service: row.bool_or("in_service", true),
                 control: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -246,6 +249,7 @@ pub(crate) fn parse_pandapower_source(
                 cost: costs.get(&(CostElement::Gen, idx)).cloned(),
                 caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
                 regulated_bus: None,
+                uid: None,
             });
         }
     }
@@ -268,6 +272,7 @@ pub(crate) fn parse_pandapower_source(
                 cost: costs.get(&(CostElement::ExtGrid, idx)).cloned(),
                 caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
                 regulated_bus: None,
+                uid: None,
             });
         }
     }
@@ -293,6 +298,7 @@ pub(crate) fn parse_pandapower_source(
                 cost: costs.get(&(CostElement::Sgen, idx)).cloned(),
                 caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
                 regulated_bus: None,
+                uid: None,
             });
         }
     }
@@ -351,6 +357,7 @@ pub(crate) fn parse_pandapower_source(
                 angmax: 360.0,
                 control: None,
                 solution: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -486,6 +493,7 @@ pub(crate) fn parse_pandapower_source(
                 angmax: 360.0,
                 control: None,
                 solution: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -529,6 +537,7 @@ pub(crate) fn parse_pandapower_source(
                 p_loss: 0.0,
                 q_loss: 0.0,
                 in_service: row.bool_or("in_service", true),
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -562,6 +571,7 @@ pub(crate) fn parse_pandapower_source(
                 loss0: loss_mw,
                 loss1: loss_percent / 100.0,
                 cost: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -2611,6 +2621,7 @@ mod tests {
             q: 0.5,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         });
         let conv = write_pandapower_json(&net);
@@ -2808,6 +2819,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -2848,6 +2860,7 @@ mod tests {
             cost,
             caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
             regulated_bus: None,
+            uid: None,
         }
     }
 
@@ -2871,6 +2884,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -2910,6 +2924,7 @@ mod tests {
             q: 0.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         });
         net.generators.push(test_gen(3, None));
@@ -2967,6 +2982,7 @@ mod tests {
                 scaling: Some(0.5),
             }),
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         });
 

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -590,6 +590,7 @@ fn read_bus(v: &Value, ascale: f64) -> Result<Bus> {
         area: uid(v, "area"),
         zone: uid(v, "zone"),
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
+        uid: None,
         extras: extras_excluding(
             v,
             &[
@@ -617,6 +618,7 @@ fn read_load(v: &Value, pscale: f64) -> Load {
         q: f(v, "qd") * pscale,
         voltage_model: None,
         in_service: flag(v, "status"),
+        uid: None,
         extras: extras_excluding(v, &["load_bus", "pd", "qd", "status", "index", "source_id"]),
     }
 }
@@ -628,6 +630,7 @@ fn read_shunt(v: &Value, pscale: f64) -> Shunt {
         b: f(v, "bs") * pscale,
         in_service: flag(v, "status"),
         control: None,
+        uid: None,
         extras: extras_excluding(
             v,
             &["shunt_bus", "gs", "bs", "status", "index", "source_id"],
@@ -683,6 +686,7 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64) -> Branch {
             pt: f(v, "pt") * pscale,
             qt: f(v, "qt") * pscale,
         }),
+        uid: None,
         extras: extras_excluding(
             v,
             &[
@@ -740,6 +744,7 @@ fn read_switch(v: &Value, pscale: f64) -> Switch {
         qf: v.get("qf").and_then(Value::as_f64).map(|x| x * pscale),
         pt: v.get("pt").and_then(Value::as_f64).map(|x| x * pscale),
         qt: v.get("qt").and_then(Value::as_f64).map(|x| x * pscale),
+        uid: None,
         extras: extras_excluding(
             v,
             &[
@@ -789,6 +794,7 @@ fn read_gen(v: &Value, pscale: f64, base_mva: f64, per_unit: bool) -> Generator 
         cost,
         caps,
         regulated_bus: None,
+        uid: None,
     }
 }
 
@@ -857,6 +863,7 @@ fn read_hvdc(v: &Value, pscale: f64, base_mva: f64, per_unit: bool) -> Hvdc {
         loss0: f(v, "loss0") * pscale,
         loss1: f(v, "loss1"),
         cost: v.get("model").map(|_| read_cost(v, base_mva, per_unit)),
+        uid: None,
         extras: extras_excluding(
             v,
             &[
@@ -916,6 +923,7 @@ fn read_storage(v: &Value, pscale: f64) -> Storage {
         p_loss: f(v, "p_loss") * pscale,
         q_loss: f(v, "q_loss") * pscale,
         in_service: flag(v, "status"),
+        uid: None,
         extras: extras_excluding(
             v,
             &[

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -464,6 +464,7 @@ fn read_bus(r: &Row) -> Result<Bus> {
         area: uid_alias(r, &["AreaNum", "AreaNumber"])?,
         zone: uid_alias(r, &["ZoneNum", "ZoneNumber"])?,
         name,
+        uid: None,
         extras,
     })
 }
@@ -505,6 +506,7 @@ fn read_load(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Load> {
         q,
         voltage_model: None,
         in_service: on_alias(r, &["LoadStatus", "Status"])?,
+        uid: None,
         extras,
     })
 }
@@ -520,6 +522,7 @@ fn read_shunt(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Shunt> {
         b: f_alias(r, &["ShuntMVR", "SSNMVR", "MvarNom"], 0.0)?,
         in_service: on_alias(r, &["ShuntStatus", "SSStatus", "Status"])?,
         control: None,
+        uid: None,
         extras,
     })
 }
@@ -545,6 +548,7 @@ fn read_gen(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Generator> {
         cost: None,
         caps: Default::default(),
         regulated_bus: None,
+        uid: None,
     })
 }
 
@@ -600,6 +604,7 @@ fn read_branch(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Branch> {
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         extras,
     })
 }

--- a/powerio/src/format/powerworld/pwb.rs
+++ b/powerio/src/format/powerworld/pwb.rs
@@ -1150,6 +1150,7 @@ fn read_bus_head(b: &[u8], at: usize) -> Probe<(BusHead, usize)> {
         area,
         zone,
         name: Some(String::from_utf8_lossy(name).into_owned()),
+        uid: None,
         extras: Extras::new(),
     };
     let shunt = bus_tail_shunt(b, c.pos, BusId(num));
@@ -1184,6 +1185,7 @@ fn bus_tail_shunt(b: &[u8], after_head: usize, bus: BusId) -> Option<Shunt> {
         b: b_pu * MVA_BASE,
         in_service: true,
         control: None,
+        uid: None,
         extras,
     })
 }
@@ -1349,6 +1351,7 @@ fn read_load(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Load> {
         q,
         voltage_model: None,
         in_service,
+        uid: None,
         extras,
     })
 }
@@ -1424,6 +1427,7 @@ fn gen_from_block(bus: BusId, v: &[f64; 8], in_service: bool) -> Generator {
         cost: None,
         caps: Default::default(),
         regulated_bus: None,
+        uid: None,
     }
 }
 
@@ -1551,6 +1555,7 @@ fn read_shunt(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Shunt> {
         b: b_mvar,
         in_service: true,
         control: None,
+        uid: None,
         extras,
     })
 }
@@ -1782,6 +1787,7 @@ fn read_standard_branch_head(
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         extras,
     };
     Ok((br, c.pos, flags))
@@ -1867,6 +1873,7 @@ fn read_step_up_transformer_head(
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         extras,
     };
     Ok((

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -475,6 +475,7 @@ fn read_bus(rec: &Record) -> Result<Bus> {
         area: id_at(&rec.rhs, 4, 1, "bus area", rec)?,
         zone: id_at(&rec.rhs, 5, 1, "bus zone", rec)?,
         name,
+        uid: None,
         extras: extras(rec, "bus data", 3, 21),
     })
 }
@@ -517,6 +518,7 @@ fn read_branch(rec: &Record) -> Result<Branch> {
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         extras,
     })
 }
@@ -605,6 +607,7 @@ fn read_transformer(rec: &Record) -> Result<TransformerRecord> {
             mag_b: 0.0,
             in_service,
             name,
+            uid: None,
             extras,
         };
         return Ok(TransformerRecord::ThreeWinding(t3));
@@ -634,6 +637,7 @@ fn read_transformer(rec: &Record) -> Result<TransformerRecord> {
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         extras,
     }))
 }
@@ -675,6 +679,7 @@ fn read_generator(
         cost: None,
         caps: Default::default(),
         regulated_bus: None,
+        uid: None,
     })
 }
 
@@ -726,6 +731,7 @@ fn read_load(
             scaling: None,
         }),
         in_service: on_at(&rec.rhs, 0, true, "load status", rec)?,
+        uid: None,
         extras,
     })
 }
@@ -744,6 +750,7 @@ fn read_shunt(rec: &Record, base_mva: f64) -> Result<Shunt> {
         b: b_pu * base_mva,
         in_service: on_at(&rec.rhs, 0, true, "shunt status", rec)?,
         control: None,
+        uid: None,
         extras,
     })
 }
@@ -777,6 +784,7 @@ fn read_svd(
         b: b_pu * base_mva,
         in_service: on_at(&rec.rhs, 0, true, "svd status", rec)?,
         control: None,
+        uid: None,
         extras,
     })
 }
@@ -891,6 +899,7 @@ fn read_dc_lines(
                 loss0: 0.0,
                 loss1: 0.0,
                 cost: None,
+                uid: None,
                 extras,
             })
         })();
@@ -1802,6 +1811,7 @@ end
                     area: 1,
                     zone: 1,
                     name: None,
+                    uid: None,
                     extras: Extras::new(),
                 },
                 Bus {
@@ -1817,6 +1827,7 @@ end
                     area: 1,
                     zone: 1,
                     name: None,
+                    uid: None,
                     extras: Extras::new(),
                 },
             ],
@@ -1841,6 +1852,7 @@ end
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         });
 

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -1599,6 +1599,7 @@ fn read_bus(f: &[String]) -> Result<Bus> {
         area: id_at(f, 4, 0)?,
         zone: id_at(f, 5, 0)?,
         name,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -1692,6 +1693,7 @@ fn read_load(f: &[String], raw_rev: u32, warnings: &mut Vec<String>) -> Result<L
         q: ql + iq + yq,
         voltage_model,
         in_service: on_at(f, 2, true)?,
+        uid: None,
         extras,
     })
 }
@@ -1704,6 +1706,7 @@ fn read_shunt(f: &[String]) -> Result<Shunt> {
         b: num_at(f, 4, 0.0)?,
         in_service: on_at(f, 2, true)?,
         control: None,
+        uid: None,
         extras: device_extras(f, 1),
     })
 }
@@ -1751,6 +1754,7 @@ fn read_switched_shunt(f: &[String], rev: u32) -> Result<Shunt> {
         b: num_at(f, 9 + o2, 0.0)?,
         in_service: on_at(f, 3 + o, true)?,
         control: Some(control),
+        uid: None,
         // Keep the v35 shunt ID so it survives a round trip.
         extras: if rev >= 35 {
             device_extras(f, 1)
@@ -1817,6 +1821,7 @@ fn read_gen(f: &[String], raw_rev: u32) -> Result<Generator> {
         cost: None,
         caps: Default::default(),
         regulated_bus: (ireg != 0 && ireg != bus).then_some(BusId(ireg)),
+        uid: None,
     })
 }
 
@@ -1860,6 +1865,7 @@ fn read_branch(f: &[String], raw_rev: u32) -> Result<Branch> {
         angmax: 360.0,
         control: None,
         solution: None,
+        uid: None,
         // Capture CKT (field 2) so parallel circuits stay distinct on write-back.
         extras: device_extras(f, 2),
     })
@@ -1953,6 +1959,7 @@ fn read_transformer(
         angmax: 360.0,
         control,
         solution: None,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -2064,6 +2071,7 @@ fn read_transformer_3w(
             .get(10)
             .filter(|n| !n.is_empty())
             .map(|n| n.trim().to_string()),
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -2111,6 +2119,7 @@ fn read_dc_line(l1: &[String], rect: &[String], inv: &[String]) -> Result<Hvdc> 
         loss0: 0.0,
         loss1: 0.0,
         cost: None,
+        uid: None,
         extras,
     })
 }
@@ -2307,6 +2316,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -2336,6 +2346,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -2360,6 +2371,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -105,6 +105,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
             area: 1,
             zone: 1,
             name: bus_name,
+            uid: None,
             extras: Extras::default(),
         });
     }
@@ -119,6 +120,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 q: row.f("q_set").unwrap_or(0.0),
                 voltage_model: None,
                 in_service: row.bool("active").unwrap_or(true),
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -135,6 +137,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 b: row.f("b").unwrap_or(0.0) * zb * base_mva,
                 in_service: row.bool("active").unwrap_or(true),
                 control: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -190,6 +193,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 },
                 caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
                 regulated_bus: None,
+                uid: None,
             });
         }
     }
@@ -228,6 +232,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 angmax: row.f("v_ang_max").unwrap_or(360.0),
                 control: None,
                 solution: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -273,6 +278,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 angmax: 360.0,
                 control: None,
                 solution: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -302,6 +308,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 p_loss: 0.0,
                 q_loss: 0.0,
                 in_service: row.bool("active").unwrap_or(true),
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -334,6 +341,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 loss0: 0.0,
                 loss1: 1.0 - efficiency,
                 cost: None,
+                uid: None,
                 extras: Extras::default(),
             });
         }
@@ -1123,6 +1131,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: name.map(str::to_string),
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -1142,6 +1151,7 @@ mod tests {
             cost,
             caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
             regulated_bus: None,
+            uid: None,
         }
     }
 
@@ -1165,6 +1175,7 @@ mod tests {
             p_loss: 0.0,
             q_loss: 0.0,
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -1189,6 +1200,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -1213,6 +1225,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::default(),
         }
     }
@@ -1545,6 +1558,7 @@ mod tests {
             q: 1.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         }];
         let dir = tmp_dir("named-join");
@@ -1567,6 +1581,7 @@ mod tests {
             q: 1.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::default(),
         }];
         let dir = tmp_dir("dup-keys");

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -588,6 +588,7 @@ fn read_bus(value: &Value) -> Result<(Bus, Option<Shunt>)> {
             b,
             in_service: true,
             control: None,
+            uid: None,
             extras: Extras::new(),
         })
     } else {
@@ -608,6 +609,7 @@ fn read_bus(value: &Value) -> Result<(Bus, Option<Shunt>)> {
         name: string_map(obj, "name")
             .filter(|name| !name.is_empty())
             .map(str::to_string),
+        uid: None,
         extras: Extras::new(),
     };
     Ok((bus, shunt))
@@ -633,6 +635,7 @@ fn read_load(value: &Value) -> Result<Load> {
         q,
         voltage_model: read_load_voltage_model(obj, p, q)?,
         in_service: bool_map_or(obj, "in_service", true)?,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -679,6 +682,7 @@ fn read_fixed_shunt(value: &Value) -> Result<Shunt> {
         b: f_map_alias_or(obj, &["b_mvar", "susceptance_mvar"], 0.0)?,
         in_service: bool_map_or(obj, "in_service", true)?,
         control: None,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -714,6 +718,7 @@ fn read_branch(value: &Value) -> Result<Branch> {
         angmax: f_map_or(obj, "angle_diff_max_rad", std::f64::consts::TAU)? * normalize::RAD_TO_DEG,
         control: None,
         solution: read_branch_solution(obj)?,
+        uid: None,
         extras: Extras::new(),
     })
 }
@@ -815,6 +820,7 @@ fn read_generator(value: &Value) -> Result<(Option<Generator>, Option<Storage>)>
         },
         caps,
         regulated_bus: optional_usize(obj, "reg_bus")?.map(BusId),
+        uid: None,
     };
 
     let storage = match obj.get("storage") {
@@ -921,6 +927,7 @@ fn read_storage(
         p_loss: 0.0,
         q_loss: 0.0,
         in_service,
+        uid: None,
         extras: Extras::new(),
     };
     out.extras
@@ -995,6 +1002,7 @@ fn read_hvdc_link(value: &Value) -> Result<Hvdc> {
         loss1: f_map_or(from_terminal, "loss_linear", 0.0)?
             + f_map_or(to_terminal, "loss_linear", 0.0)?,
         cost: None,
+        uid: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/indexed.rs
+++ b/powerio/src/indexed.rs
@@ -420,6 +420,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -437,6 +438,7 @@ mod tests {
             q: 5.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         });
         net.loads.push(Load {
@@ -445,6 +447,7 @@ mod tests {
             q: 1.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         });
         net.shunts.push(Shunt {
@@ -453,6 +456,7 @@ mod tests {
             b: 0.4,
             in_service: true,
             control: None,
+            uid: None,
             extras: Extras::new(),
         });
         net.shunts.push(Shunt {
@@ -461,6 +465,7 @@ mod tests {
             b: 0.3,
             in_service: true,
             control: None,
+            uid: None,
             extras: Extras::new(),
         });
         net
@@ -501,6 +506,7 @@ mod tests {
             mag_b: 0.0,
             in_service: true,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -342,6 +342,12 @@ pub struct Bus {
     pub area: usize,
     pub zone: usize,
     pub name: Option<String>,
+    /// Stable row identity for `.pio.json` payloads and operating point updates:
+    /// the source record uid where the format defines one (GOC3), synthesized at
+    /// package build otherwise. `#[serde(default)]` so JSON written before the
+    /// field existed still deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -361,6 +367,7 @@ impl Bus {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -378,6 +385,9 @@ pub struct Load {
     #[serde(default)]
     pub voltage_model: Option<LoadVoltageModel>,
     pub in_service: bool,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -390,6 +400,7 @@ impl Load {
             q,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -476,6 +487,9 @@ pub struct Shunt {
     /// existed still deserializes.
     #[serde(default)]
     pub control: Option<SwitchedShuntControl>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -488,6 +502,7 @@ impl Shunt {
             b,
             in_service: true,
             control: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -597,6 +612,9 @@ pub struct Branch {
     /// Solved branch flow values, when present in a case snapshot.
     #[serde(default)]
     pub solution: Option<BranchSolution>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -727,6 +745,7 @@ impl Branch {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -795,6 +814,9 @@ pub struct Switch {
     pub pt: Option<f64>,
     #[serde(default)]
     pub qt: Option<f64>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -811,6 +833,7 @@ impl Switch {
             qf: None,
             pt: None,
             qt: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -915,6 +938,9 @@ pub struct Generator {
     /// JSON written before the field existed still deserializes.
     #[serde(default)]
     pub regulated_bus: Option<BusId>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
 }
 
 impl Generator {
@@ -934,6 +960,7 @@ impl Generator {
             cost: None,
             caps: default_caps(),
             regulated_bus: None,
+            uid: None,
         }
     }
 
@@ -1016,6 +1043,9 @@ pub struct Storage {
     pub p_loss: f64,
     pub q_loss: f64,
     pub in_service: bool,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -1041,6 +1071,7 @@ impl Storage {
             p_loss: 0.0,
             q_loss: 0.0,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -1075,6 +1106,9 @@ pub struct Hvdc {
     pub loss1: f64,
     #[serde(default)]
     pub cost: Option<GenCost>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -1100,6 +1134,7 @@ impl Hvdc {
             loss0: 0.0,
             loss1: 0.0,
             cost: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -1264,6 +1299,9 @@ pub struct Transformer3W {
     pub mag_b: f64,
     pub in_service: bool,
     pub name: Option<String>,
+    /// Stable row identity; see [`Bus::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
     pub extras: Extras,
 }
 
@@ -1279,6 +1317,7 @@ impl Transformer3W {
             mag_b: 0.0,
             in_service: true,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -1321,6 +1360,7 @@ impl Transformer3W {
             area: 0,
             zone: 0,
             name: self.name.clone(),
+            uid: self.uid.clone(),
             extras: Extras::new(),
         };
         let zs = self.star_impedances();
@@ -1343,6 +1383,7 @@ impl Transformer3W {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         };
         let branches = [
@@ -1493,7 +1534,7 @@ impl Network {
         }
         for (i, b) in self.buses.iter().enumerate() {
             #[rustfmt::skip]
-            let Bus { id: _, kind: _, vm, va, base_kv, vmax, vmin, evhi: _, evlo: _, area: _, zone: _, name: _, extras: _ } = b;
+            let Bus { id: _, kind: _, vm, va, base_kv, vmax, vmin, evhi: _, evlo: _, area: _, zone: _, name: _, uid: _, extras: _ } = b;
             let fields = [
                 ("vm", *vm),
                 ("va", *va),
@@ -1510,6 +1551,7 @@ impl Network {
                 q,
                 voltage_model,
                 in_service: _,
+                uid: _,
                 extras: _,
             } = l;
             out.extend(bad([("p", *p), ("q", *q)]).map(|f| format!("loads[{i}].{f}")));
@@ -1573,13 +1615,14 @@ impl Network {
                 b,
                 in_service: _,
                 control: _,
+                uid: _,
                 extras: _,
             } = s;
             out.extend(bad([("g", *g), ("b", *b)]).map(|f| format!("shunts[{i}].{f}")));
         }
         for (i, br) in self.branches.iter().enumerate() {
             #[rustfmt::skip]
-            let Branch { from: _, to: _, r, x, b, charging, rate_a, rate_b, rate_c, rating_sets, current_ratings, tap, shift, in_service: _, angmin, angmax, control: _, solution, extras: _ } = br;
+            let Branch { from: _, to: _, r, x, b, charging, rate_a, rate_b, rate_c, rating_sets, current_ratings, tap, shift, in_service: _, angmin, angmax, control: _, solution, uid: _, extras: _ } = br;
             let fields = [
                 ("r", *r),
                 ("x", *x),
@@ -1647,6 +1690,7 @@ impl Network {
                 qf,
                 pt,
                 qt,
+                uid: _,
                 extras: _,
             } = sw;
             for (field, value) in [
@@ -1664,7 +1708,7 @@ impl Network {
         }
         for (i, g) in self.generators.iter().enumerate() {
             #[rustfmt::skip]
-            let Generator { bus: _, pg, qg, pmax, pmin, qmax, qmin, vg, mbase, in_service: _, cost, caps, regulated_bus: _ } = g;
+            let Generator { bus: _, pg, qg, pmax, pmin, qmax, qmin, vg, mbase, in_service: _, cost, caps, regulated_bus: _, uid: _ } = g;
             let fields = [
                 ("pg", *pg),
                 ("qg", *qg),
@@ -1703,7 +1747,7 @@ impl Network {
         }
         for (i, s) in self.storage.iter().enumerate() {
             #[rustfmt::skip]
-            let Storage { bus: _, ps, qs, energy, energy_rating, charge_rating, discharge_rating, charge_efficiency, discharge_efficiency, thermal_rating, current_rating, qmin, qmax, r, x, p_loss, q_loss, in_service: _, extras: _ } = s;
+            let Storage { bus: _, ps, qs, energy, energy_rating, charge_rating, discharge_rating, charge_efficiency, discharge_efficiency, thermal_rating, current_rating, qmin, qmax, r, x, p_loss, q_loss, in_service: _, uid: _, extras: _ } = s;
             let fields = [
                 ("ps", *ps),
                 ("qs", *qs),
@@ -1728,7 +1772,7 @@ impl Network {
         }
         for (i, h) in self.hvdc.iter().enumerate() {
             #[rustfmt::skip]
-            let Hvdc { from: _, to: _, in_service: _, pf, pt, qf, qt, vf, vt, pmin, pmax, qminf, qmaxf, qmint, qmaxt, loss0, loss1, cost, extras: _ } = h;
+            let Hvdc { from: _, to: _, in_service: _, pf, pt, qf, qt, vf, vt, pmin, pmax, qminf, qmaxf, qmint, qmaxt, loss0, loss1, cost, uid: _, extras: _ } = h;
             let fields = [
                 ("pf", *pf),
                 ("pt", *pt),
@@ -1980,6 +2024,7 @@ impl Network {
                     b: t.mag_b * scale,
                     in_service: true,
                     control: None,
+                    uid: None,
                     extras: Extras::new(),
                 });
             }
@@ -2107,6 +2152,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -2138,6 +2184,7 @@ mod tests {
             mag_b: 0.0,
             in_service: true,
             name: Some("T1".into()),
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -2227,6 +2274,7 @@ mod tests {
                 mva_base: 100.0,
             }),
             solution: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -2264,6 +2312,7 @@ mod tests {
             cost: None,
             caps,
             regulated_bus: None,
+            uid: None,
         };
 
         // caps is a name-keyed object emitting only the present slots, not a
@@ -2309,6 +2358,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         };
         let branch = Branch {
@@ -2330,6 +2380,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         };
         // A non-finite generator capability reports at its exact key path
@@ -2348,6 +2399,7 @@ mod tests {
             cost: None,
             caps: GenCaps::default(),
             regulated_bus: None,
+            uid: None,
         };
         g.caps[8] = Some(f64::INFINITY); // ramp_30
         // Three distinct non-finite fields: a bus vm (NaN), a branch x (Inf), and
@@ -2402,6 +2454,7 @@ mod tests {
                     ShuntBlock { steps: 1, b: 50.0 },
                 ],
             }),
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -2450,6 +2503,7 @@ mod tests {
             cost: None,
             caps: Default::default(),
             regulated_bus: None,
+            uid: None,
         });
 
         let diags = net.validate_values();

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -534,6 +534,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         };
         let branch = Branch {
@@ -555,6 +556,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         };
         // Bus 3 is isolated, so to_normalized drops it.
@@ -582,6 +584,7 @@ mod tests {
             cost: None,
             caps: Default::default(),
             regulated_bus: None,
+            uid: None,
         });
         // A switched shunt on bus 2 whose control bus is the (dropped) isolated bus 3.
         net.shunts.push(Shunt {
@@ -597,6 +600,7 @@ mod tests {
                 rmpct: 100.0,
                 blocks: Vec::new(),
             }),
+            uid: None,
             extras: Extras::new(),
         });
 
@@ -626,6 +630,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         };
         let mkgen = |bus: usize, pmax: f64| Generator {
@@ -642,6 +647,7 @@ mod tests {
             cost: None,
             caps: Default::default(),
             regulated_bus: None,
+            uid: None,
         };
         let mut net = Network::in_memory("n", 100.0, vec![mkbus(1), mkbus(2)], Vec::new());
         net.generators = vec![mkgen(1, f64::NAN), mkgen(2, 10.0)];

--- a/powerio/src/operations.rs
+++ b/powerio/src/operations.rs
@@ -498,6 +498,7 @@ impl Network {
             angmax,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         });
         self.buses.retain(|b| b.id != m);
@@ -567,6 +568,7 @@ mod tests {
             area,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -591,6 +593,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -602,6 +605,7 @@ mod tests {
             q: 5.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -644,6 +648,7 @@ mod tests {
             mag_b: 0.0,
             in_service: true,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -663,6 +668,7 @@ mod tests {
             cost: None,
             caps: Default::default(),
             regulated_bus: Some(BusId(regulated)),
+            uid: None,
         }
     }
 

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -773,6 +773,7 @@ mod tests {
             area: 1,
             zone: 1,
             name: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -797,6 +798,7 @@ mod tests {
             angmax: 360.0,
             control: None,
             solution: None,
+            uid: None,
             extras: Extras::new(),
         }
     }
@@ -816,6 +818,7 @@ mod tests {
             cost: None,
             caps: [None; crate::network::GEN_EXTRA_KEYS.len()],
             regulated_bus: None,
+            uid: None,
         }
     }
 
@@ -864,6 +867,7 @@ mod tests {
             q: 5.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         });
         net.loads.push(Load {
@@ -872,6 +876,7 @@ mod tests {
             q: 99.0,
             voltage_model: None,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         });
         net.generators.push(generator(1, true));
@@ -934,6 +939,7 @@ mod tests {
             p_loss: 2.0,
             q_loss: 1.0,
             in_service: true,
+            uid: None,
             extras: Extras::new(),
         });
         net.hvdc.push(Hvdc {
@@ -955,6 +961,7 @@ mod tests {
             loss0: 1.5,
             loss1: 0.02,
             cost: None,
+            uid: None,
             extras: Extras::new(),
         });
 

--- a/powerio/tests/snapshot_schema.rs
+++ b/powerio/tests/snapshot_schema.rs
@@ -102,3 +102,19 @@ fn small_net() -> Network {
     net.source_format = SourceFormat::InMemory;
     net
 }
+
+#[test]
+fn uid_survives_snapshot_roundtrip_and_stays_off_the_wire_when_absent() {
+    let mut net = small_net();
+    net.generators[0].uid = Some("gen-a".to_owned());
+
+    let v: serde_json::Value = serde_json::from_str(&net.to_json().unwrap()).unwrap();
+    assert_eq!(v["generators"][0]["uid"], serde_json::json!("gen-a"));
+    // A row without a uid omits the key instead of writing null, so snapshots
+    // from parsers that never set it are byte-identical to the pre-uid vintage.
+    assert!(v["buses"][0].get("uid").is_none());
+
+    let parsed = Network::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
+    assert_eq!(parsed.generators[0].uid.as_deref(), Some("gen-a"));
+    assert_eq!(parsed.buses[0].uid, None);
+}

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -33,18 +33,21 @@ class Bus(TypedDict):
     zone: int
     vmax: float
     vmin: float
+    uid: Optional[str]
 
 class Load(TypedDict):
     bus: int
     p: float
     q: float
     in_service: bool
+    uid: Optional[str]
 
 class Shunt(TypedDict):
     bus: int
     g: float
     b: float
     in_service: bool
+    uid: Optional[str]
 
 class BranchRatingSet(TypedDict):
     name: str
@@ -65,6 +68,7 @@ class Branch(TypedDict):
     in_service: bool
     angmin: float
     angmax: float
+    uid: Optional[str]
 
 class Gen(TypedDict):
     bus: int
@@ -78,6 +82,7 @@ class Gen(TypedDict):
     mbase: float
     in_service: bool
     cost: Optional[GenCost]
+    uid: Optional[str]
 
 class Incidence(NamedTuple):
     A: Any  # scipy.sparse.csr_matrix, (n, m)

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -101,3 +101,30 @@ def test_package_from_network_constructors():
 def test_package_invalid_json_raises_value_error():
     with pytest.raises(ValueError):
         pio.Package.from_json("{}")
+
+
+def test_package_declares_payload_schema_and_row_identity():
+    import json
+
+    pkg = pio.Package.from_file(DATA / "case9.m")
+    doc = json.loads(pkg.to_json())
+    assert doc["schema_version"] == "0.1.1"
+    assert doc["payload_schema"].endswith("/pio-payload-balanced/1")
+    assert doc["payload_schema_version"] == "1.0.0"
+    # Every payload row carries an identity; case9 has no source uids, so they
+    # are synthesized from the build position.
+    assert doc["model"]["balanced_network"]["generators"][0]["uid"] == "generators:0"
+    assert pkg.as_balanced().generators[0]["uid"] == "generators:0"
+
+
+def test_package_materialize_rejects_unknown_identity():
+    import json
+
+    pkg = pio.Package.from_str(GOC3_SRC, from_="goc3-json")
+    doc = json.loads(pkg.to_json())
+    update = doc["operating_points"]["points"][0]["updates"][0]
+    update["element"]["source_uid"] = "no-such-uid"
+    del update["element"]["row"]
+    broken = pio.Package.from_json(json.dumps(doc))
+    with pytest.raises(ValueError, match="unknown identity"):
+        broken.materialize_operating_point(0)


### PR DESCRIPTION
Closes #173.

The `.pio.json` payload is now a declared contract. Two optional envelope fields, `payload_schema` and `payload_schema_version`, name and version the IR payload per model kind (`pio-payload-balanced/1`, `pio-payload-multiconductor/1`, both `1.0.0`), independent of the envelope `schema_version` (now `0.1.1`): the envelope versions the package bookkeeping, the payload versions the network tables a consumer computes on. A reader rejects a foreign payload major before touching payload fields. The JSON shape of `model` is unchanged and packages written by 0.5.0 read as before.

Payload rows get stable identity. Balanced IR elements gain `uid: Option<String>` (serde additive; absent keys omitted, so non-GOC3 snapshots are byte identical). The GOC3 parser keeps source uids on buses, dispatchable devices, branches, and dc lines instead of dropping them; package construction synthesizes `{table}:{row}` uids for rows without one.

Operating point updates resolve by identity. When the referenced table carries uids, `ElementRef.source_uid` is authoritative: it selects the row, a present `row` must agree with it, and unknown or duplicated identities are rejected both at materialization and by validation (`VALIDATE.PACKAGE.OPERATING_IDENTITY`, surfaced through `pio_package_validate`). `row` may be omitted on the wire (`ElementRef::by_source_uid`). Tables without uids keep row-only semantics, which is what keeps every existing package materializing unchanged. Provenance cleanup paths now come from the resolved row rather than the wire row, and an update may not overwrite `uid`.

Surfaces: no C ABI signature changes and no `PIO_ABI_VERSION` bump; identity failures return `NULL` with the message in `errbuf`. Python table dicts expose `uid` and `Package.materialize_operating_point` raises `ValueError` on unknown identities. PowerIO.jl needs only the routine artifact repin at release.

Tests: identity resolution matrix (uid-only update with `row` omitted, row/uid mismatch, unknown uid, duplicate uids, uid overwrite, legacy uid-less payload fallback), payload version gate (same major accepted, foreign major and invalid semver rejected, absent accepted), GOC3 uid-less row shift extended to prove identity lookup rather than extractor row alignment, a C ABI materialize failure test, Python shape and error tests, and a snapshot lock that `uid` stays off the wire when absent. 886 Rust and 91 Python tests pass; clippy and fmt clean; cbindgen header unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)