### PR TITLE
Document what the .pio.json format is and how it relates to BMOPF

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -144,12 +144,12 @@ jobs:
                 <a href="guide/python.html">python</a></dd>
           </div>
           <div>
-            <dt>.pio.json schema</dt>
+            <dt>.pio.json format</dt>
             <dd><a href="guide/pio-json-schema.html">field reference &amp; versioning</a>
                 <a href="guide/compiler-ir.html">compiler IR</a>
-                <a href="schema/pio-package/0.1/">pio-package/0.1</a>
-                <a href="schema/pio-payload-balanced/1/">pio-payload-balanced/1</a>
-                <a href="schema/pio-payload-multiconductor/1/">pio-payload-multiconductor/1</a></dd>
+                <a href="guide/pio-json-schema.html#pio-package">pio-package/0.1</a>
+                <a href="guide/pio-json-schema.html#pio-payload-balanced">pio-payload-balanced/1</a>
+                <a href="guide/pio-json-schema.html#pio-payload-multiconductor">pio-payload-multiconductor/1</a></dd>
           </div>
           <div>
             <dt>bindings</dt>
@@ -160,52 +160,29 @@ jobs:
         HTML
     # The schema URLs stamped into .pio.json files (`schema`, `payload_schema`)
     # are identifiers first, but the site serves them so they also resolve.
-    # Each page states what its URL names and links the field reference and the
-    # normative Rust type. Relative targets keep the pages working under both
-    # powerio.dev and eigenergy.github.io/powerio.
+    # Each redirects to its section of the format chapter. Relative targets
+    # keep the redirects working under both powerio.dev and
+    # eigenergy.github.io/powerio.
     - name: Schema identifier pages
       run: |
-        write_schema_page() {
+        redirect_schema_page() {
+          # A redirect to a missing anchor would land at the page top; fail
+          # the build instead.
+          anchor="${1%/*}"
+          grep -q "id=\"$anchor\"" target/doc/guide/pio-json-schema.html
+          target="../../../guide/pio-json-schema.html#$anchor"
           mkdir -p "target/doc/schema/$1"
           cat > "target/doc/schema/$1/index.html" <<HTML
         <!doctype html>
         <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta http-equiv="refresh" content="0; url=$target">
         <title>$1</title>
-        <style>body{font-family:Georgia,serif;max-width:600px;margin:5rem auto;padding:0 1.5rem;line-height:1.6}</style>
-        <h1><code>$1</code></h1>
-        <p>$2</p>
-        <p>Current version: <code>$3</code>. Additive optional fields bump the
-        minor version; field moves or removals bump the major. The
-        <a href="../../../guide/pio-json-schema.html">.pio.json schema guide</a>
-        is the field reference.</p>
-        $4
+        <a href="$target">$1</a>
         HTML
         }
-        write_schema_page pio-package/0.1 \
-          "The <code>.pio.json</code> package envelope: the versioned wrapper
-           (provenance, source maps, diagnostics, validation, operating points,
-           lowering history) around one network payload. Stamped as
-           <code>schema</code> on every package." \
-          "0.1.1" ""
-        write_schema_page pio-payload-balanced/1 \
-          "The balanced transmission payload: the serde snapshot of the
-           <code>powerio::Network</code> model under
-           <code>model.balanced_network</code>. Stamped as
-           <code>payload_schema</code> on balanced packages." \
-          "1.0.0" \
-          '<p>The normative shape is the Rust model:
-           <a href="../../../powerio/network/struct.Network.html">powerio::Network</a>.</p>'
-        write_schema_page pio-payload-multiconductor/1 \
-          "The multiconductor distribution payload: the serde snapshot of the
-           <code>powerio_dist::DistNetwork</code> model under
-           <code>model.multiconductor_network</code>. Stamped as
-           <code>payload_schema</code> on multiconductor packages. For a
-           standalone distribution exchange file, use the BMOPF writer instead
-           of this payload." \
-          "1.0.0" \
-          '<p>The normative shape is the Rust model:
-           <a href="../../../powerio_dist/model/struct.DistNetwork.html">powerio_dist::DistNetwork</a>.</p>'
+        redirect_schema_page pio-package/0.1
+        redirect_schema_page pio-payload-balanced/1
+        redirect_schema_page pio-payload-multiconductor/1
     - uses: actions/upload-pages-artifact@v5
       with:
         path: target/doc

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tests/data/local_pwb_corpus.tsv
 docs/book/
 docs/src/releasing*.md
 private/
+
+# Playwright MCP browser session artifacts
+.playwright-mcp/

--- a/.playwright-mcp/console-2026-07-02T17-43-45-684Z.log
+++ b/.playwright-mcp/console-2026-07-02T17-43-45-684Z.log
@@ -1,1 +1,0 @@
-[     223ms] [ERROR] Failed to load resource: the server responded with a status of 404 (File not found) @ http://127.0.0.1:8377/favicon.ico:0

--- a/.playwright-mcp/page-2026-07-02T17-43-45-919Z.yml
+++ b/.playwright-mcp/page-2026-07-02T17-43-45-919Z.yml
@@ -1,2 +1,0 @@
-- img [ref=e2]:
-  - generic [ref=e342]: compiler infrastructure for power systems

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,7 +4,7 @@
 
 - [Architecture](architecture.md)
   - [Compiler IR](compiler-ir.md)
-  - [PIO JSON Schema](pio-json-schema.md)
+  - [The .pio.json format](pio-json-schema.md)
 - [Format Fidelity](format-fidelity.md)
 - [Matrix Outputs](matrices.md)
 - [DC OPF Bundle](dcopf-bundle.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -4,14 +4,14 @@ PowerIO treats case IO as a compiler pipeline: source formats parse into typed
 models, passes derive normalized or lowered views, and writers emit target
 artifacts.
 
-- [Compiler IR](https://eigenergy.github.io/powerio/guide/compiler-ir.html): the IR layers, the `BalancedNetwork` and
+- [Compiler IR](compiler-ir.md): the IR layers, the `BalancedNetwork` and
   `MulticonductorNetwork` model families, and the `NetworkPackage` (`.pio.json`)
   envelope — explicit model kind, provenance, source maps, structured
   diagnostics, validation, operating points, and lowering.
-- [PIO JSON schema](https://eigenergy.github.io/powerio/guide/pio-json-schema.html): the `.pio.json` field reference and
-  the stability policy. The envelope and the IR payload are versioned
-  independently (`schema_version` vs `payload_schema_version`); the payload
-  shape follows the Rust models.
+- [The `.pio.json` format](pio-json-schema.md): what the package is for, the
+  field reference, and the stability policy. The envelope and the IR payload
+  are versioned independently (`schema_version` vs `payload_schema_version`);
+  the payload shape follows the Rust models.
 
 The package is implemented in the `powerio-pkg` crate.
 GOC3 package construction uses `operating_points` to preserve the source time

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -4,7 +4,7 @@ PowerIO is organized as a compiler for power system data: frontends parse source
 formats into typed IR, passes normalize and lower it, and backends emit target
 artifacts. The IR boundaries and the `.pio.json` package are below. The field
 reference for the package is in
-[the PIO JSON schema guide](https://eigenergy.github.io/powerio/guide/pio-json-schema.html).
+[the `.pio.json` format chapter](pio-json-schema.md).
 
 There is no flattened universal `Network` mega-struct. PowerIO keeps concrete
 model families separate. The package wraps one payload at a time with source,
@@ -41,7 +41,9 @@ sequence struct. The two families never merge into one struct.
 BMOPF JSON is the strict exchange format for the distribution family. The
 `.pio.json` package uses the same `MulticonductorNetwork` model and wraps it
 with compiler metadata: model kind, provenance, source maps, diagnostics,
-validation, and lowering history.
+validation, and lowering history. The two formats and the reasons they both
+exist are contrasted in
+[the `.pio.json` format chapter](pio-json-schema.md#interchange).
 
 ## The compiler package (`.pio.json`)
 
@@ -81,22 +83,16 @@ metadata for a compiler cache or sidecar artifact to verify table identity.
 
 ### Explicit model kind
 
-`model_kind` is a standalone field. A reader must never infer whether the payload
-is balanced or multiconductor from which field is present. The payload enum is
-also tagged by `kind`, so the payload is self-describing too;
-`NetworkPackage::kind_is_consistent` asserts the two agree, and a reader should
-reject a package where they do not.
+`model_kind` is a standalone, authoritative field: a reader branches on it
+rather than inferring the payload kind from which field is present. The reader
+requirements are in [the `.pio.json` format chapter](pio-json-schema.md).
 
 ### Payload stability
 
-The envelope and the payload are versioned independently. The nested
-`balanced_network` / `multiconductor_network` payloads are serde snapshots of
-the PowerIO Rust IR, declared by the package's `payload_schema` /
-`payload_schema_version` fields: additive IR growth bumps the payload minor,
-moves or removals bump its major, and a reader rejects a foreign major before
-computing on payload fields. Payload rows carry stable `uid` identities that
-operating point updates resolve against. See
-[the PIO JSON schema guide](https://eigenergy.github.io/powerio/guide/pio-json-schema.html).
+The envelope and the payload are versioned independently, declared by the
+package's `payload_schema` / `payload_schema_version` fields. Payload rows
+carry stable `uid` identities that operating point updates resolve against.
+The bump rules are in [the `.pio.json` format chapter](pio-json-schema.md).
 
 ### Provenance and source maps
 
@@ -150,9 +146,5 @@ rebuilt for the updated static payload.
 
 ## Versioning
 
-`schema_version` is semver. Optional additive envelope fields land without a
-version change (`operating_points` did); the minor bumps when a reader needs to
-depend on a field being present; field moves bump the major or ship a migration. Unknown future top-level fields are tolerated
-on read (ignored), so a package from a newer producer still deserializes when
-the `schema_version` major version matches. A different major version is
-rejected before payload use.
+The envelope and payload versioning policies are in
+[the `.pio.json` format chapter](pio-json-schema.md#pio-package).

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -1,43 +1,83 @@
-# The `.pio.json` schema
+# The `.pio.json` format
 
-`.pio.json` is the serialized form of `powerio_pkg::NetworkPackage`: a versioned
-envelope around one PowerIO IR payload. The envelope shape and stability policy
-are below. The crate is the implementation; `compiler-ir.md` is the architecture
-note.
+A `.pio.json` file is a compiled network case: one typed network model plus the
+record of how it was produced. The payload is the PowerIO IR serialized exactly
+as the Rust structs define it, either `powerio::Network` (balanced) or
+`powerio_dist::DistNetwork` (multiconductor). The envelope around it records
+provenance, source maps, structured diagnostics, validation results, lowering
+history, and optional operating points. `powerio_pkg::NetworkPackage` is the
+implementation; [Compiler IR](compiler-ir.md) is the architecture note.
+
+## Why a package format
+
+Source formats carry data, not interpretation. A MATPOWER or OpenDSS file
+states the case; it cannot state how a parser read it: which fields were
+defaulted or inferred, what validation found, or how a multiconductor model was
+lowered to a balanced one. The envelope records that work next to the model, so
+a downstream tool can audit a conversion instead of trusting it.
+
+The package is also the handoff object between PowerIO consumers. The CLI, the
+Julia bindings, and the Python bindings exchange one artifact whose model kind
+is explicit, instead of guessing what a bare network JSON contains.
+
+## Relation to interchange formats {#interchange}
+
+`.pio.json` is not an interchange format. Interchange formats (MATPOWER,
+PSS/E, BMOPF, GOC3) stay at the converter boundary: PowerIO reads and writes
+them, and the package records what happened in between.
+
+The nearest neighbor is BMOPF, and the differences are deliberate. BMOPF is an
+exchange schema for multiconductor distribution OPF cases, defined by the IEEE
+PES task force on benchmarking multiconductor OPF in
+[bmopf-report](https://github.com/frederikgeth/bmopf-report). Its contract is
+a JSON Schema 2020-12 document with `additionalProperties: false`, its units
+are SI, and independent tools validate instances against the schema file. It
+defines no transmission model and no provenance envelope, and it evolves under
+task force review.
+
+`.pio.json` is the output of one toolchain. It covers both IR families, wraps
+the payload in the compilation record above, and versions with PowerIO
+releases. Its contract is the Rust model that writes and reads it rather than
+a schema document: the payload is what the model serializes and the semver
+fields below govern change. Pinning the payload to an external draft
+schema would push every task force revision into every PowerIO consumer.
+
+The two formats meet at the multiconductor model. The BMOPF reader and writer
+translate to and from the same `DistNetwork` the multiconductor payload
+serializes, so crossing the boundary loses nothing the model can represent. To
+exchange a distribution case with tools outside PowerIO, write BMOPF
+(`powerio convert --to bmopf-json`). To carry a compiled case between PowerIO
+consumers with its provenance intact, use `.pio.json`.
 
 ## Two stability tiers
 
 A `.pio.json` file has two parts with different stability promises.
 
 1. **The envelope** — every field except `model`. This is the versioned,
-   documented surface: `schema`, `schema_version`, `producer`, `model_kind`,
-   `origin`, `sources`, `source_maps`, `diagnostics`, `validation`, `summary`,
-   `lowering_history`, `operating_points`, `derived`. Its shape changes only
-   under the versioning policy below.
+   documented surface; the envelope section below gives the policy and the
+   field table.
 
 2. **The payload** — the `model` field's `balanced_network` /
-   `multiconductor_network` object: the serde snapshot of the PowerIO Rust IR
-   (`powerio::Network` / `powerio_dist::DistNetwork`). The payload is a declared
-   contract of its own, named by the top-level `payload_schema` URL and
-   versioned by `payload_schema_version`. A consumer that computes on payload
-   fields pins the payload version; a tool that routes or audits packages pins
-   the envelope version and can keep treating the payload as opaque.
+   `multiconductor_network` object. The payload is a declared contract of its
+   own, named by the top-level `payload_schema` URL and versioned by
+   `payload_schema_version`. A consumer that computes on payload fields pins
+   the payload version; a tool that routes or audits packages pins the
+   envelope version and can keep treating the payload as opaque.
 
 The two versions are independent because they change at different rates and
 break different consumers: the payload grows whenever the IR grows (a minor
 `payload_schema_version` bump), while the envelope bookkeeping barely moves.
 
-The payload is PowerIO's own IR schema for both model kinds. Interchange
-formats stay at the converter boundary: for distribution models the
-multiconductor payload is the same model the BMOPF reader and writer translate
-to and from, and `powerio convert --to bmopf-json` emits a standalone BMOPF
-exchange file when one is needed. The BMOPF schema itself (bmopf-report) never
-defines the payload.
+The schema URLs are identifiers, not fetch locations (the JSON Schema `$id`
+convention). The site serves them anyway; each redirects to its section of
+this chapter.
 
-## Versioning policy (envelope)
+## The envelope: `pio-package/0.1` {#pio-package}
 
-- `schema_version` is semver. The current value is `0.1.1`; the `schema` URL is
-  `https://powerio.dev/schema/pio-package/0.1`.
+The `schema` field on every package names the envelope contract:
+`https://powerio.dev/schema/pio-package/0.1`. `schema_version` is semver; the
+current value is `0.1.1`.
+
 - Optional additive envelope fields (a reader that ignores them loses nothing
   it relied on before) land without a version change; `operating_points` landed
   this way. The minor version bumps when a reader needs to depend on a field
@@ -48,29 +88,89 @@ defines the payload.
   preserve them in an extras map instead of dropping them.
 - A reader accepts same major `schema_version` values and rejects a different
   major version before using the payload.
-- Every package states `producer.version` and `schema_version`.
 
-## Versioning policy (payload)
+### Envelope reference
 
-- `payload_schema` names the payload contract per model kind:
-  `https://powerio.dev/schema/pio-payload-balanced/1` and
-  `https://powerio.dev/schema/pio-payload-multiconductor/1`. The URLs are
-  identifiers, not fetch locations (the JSON Schema `$id` convention).
-- `payload_schema_version` is semver, currently `1.0.0` for both kinds.
-  Additive optional fields bump the minor; field moves or removals bump the
-  major.
-- A reader rejects a `payload_schema_version` with a different major (or one
-  that does not parse as semver) before computing on payload fields. Absent
-  fields — every package written before 0.1.1 — are accepted; such payloads
-  predate the declared contract.
-- The payload field tables are the rustdoc of `powerio::Network` and
-  `powerio_dist::DistNetwork`; the serde snapshot of those structs is the
-  normative shape.
+| field | type | required | notes |
+|---|---|---|---|
+| `schema` | string (URL) | yes | identifies the package format; defaults to the current URL on read |
+| `schema_version` | string (semver) | yes | envelope version; defaults to current on read |
+| `producer` | object | yes | `{tool, version, git_commit?, features[]}` |
+| `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
+| `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
+| `model_kind` | enum | yes | `balanced` \| `multiconductor`; authoritative |
+| `payload_schema` | string (URL) | no | declared payload contract for `model_kind`; absent on pre-0.1.1 packages |
+| `payload_schema_version` | string (semver) | no | payload version; a different major is rejected on read |
+| `model` | object | yes | `{kind, <kind>_network}`; the serialized Rust model payload |
+| `origin` | object | yes | tagged by `kind`: `in_memory` \| `file` \| `folder` \| `binary_file` \| `derived` \| `composite` |
+| `sources` | array | no | declared source artifacts: `{id, kind, path?, format?, hash?}` |
+| `source_maps` | array | no | `{element_path, source_ref, mapping_kind, confidence}` |
+| `diagnostics` | array | no | structured findings (see below) |
+| `validation` | object | yes | `{status, counts, passes[]}` |
+| `summary` | object | yes | `{elements{}, topology?, units?}` |
+| `lowering_history` | array | no | `LoweringRecord` per pass |
+| `operating_points` | object | no | replayable updates over the one static payload |
+| `derived` | object | no | optional matrix stats, normalized solver table metadata, and cache keys |
+
+## Explicit model kind
+
+`model_kind` is a standalone top-level field and is authoritative. A reader
+**must** branch on it and **must not** infer the payload kind from which field is
+present. The payload is additionally self-describing: `model` is tagged by
+`kind`, so `model.kind` and `model_kind` carry the same value.
+`NetworkPackage::kind_is_consistent` asserts the two agree; a reader should
+reject a package where they disagree.
+
+```json
+"model_kind": "balanced",
+"model": { "kind": "balanced", "balanced_network": { "...": "..." } }
+```
+
+`model_kind` values: `balanced`, `multiconductor` (the enum is non-exhaustive;
+later families can be added).
+
+## The payloads
+
+`payload_schema` names the payload contract per model kind and
+`payload_schema_version` versions it, currently `1.0.0` for both kinds.
+Additive optional fields bump the minor; field moves or removals bump the
+major. A reader rejects a different major (or a version that does not parse as
+semver) before computing on payload fields. Both fields are absent on packages
+written before envelope 0.1.1; such payloads predate the declared contract and
+are accepted.
+
+There is no separate schema document for the payloads. Each payload is what
+its Rust model serializes, and the model's rustdoc is the field reference. The
+balanced payload's wire form is additionally held to a committed golden file
+by `powerio/tests/snapshot_schema.rs`.
+
+### The balanced payload: `pio-payload-balanced/1` {#pio-payload-balanced}
+
+`https://powerio.dev/schema/pio-payload-balanced/1` names the serde form of
+`powerio::Network` under `model.balanced_network`, stamped when `model_kind`
+is `balanced`: the scalar positive-sequence transmission model. The tables are
+`buses`, `loads`, `shunts`, `branches`, `switches`, `generators`, `storage`,
+`hvdc`, `transformers_3w`, and `areas`, alongside `name`, `base_mva`,
+`base_frequency`, `source_format`, and optional solver metadata. Units follow the MATPOWER
+conventions: MW and MVAr power, per unit voltage magnitudes and impedances on
+the system base, degree angles. Every element carries an `extras` map for
+source format fields the model does not name. The field reference is the
+[`powerio::Network` rustdoc](../powerio/network/struct.Network.html).
+
+### The multiconductor payload: `pio-payload-multiconductor/1` {#pio-payload-multiconductor}
+
+`https://powerio.dev/schema/pio-payload-multiconductor/1` names the serde form
+of `powerio_dist::DistNetwork` under `model.multiconductor_network`, stamped
+when `model_kind` is `multiconductor`: the wire-coordinate distribution model,
+in SI units with radian angles. [Compiler IR](compiler-ir.md) describes the
+model family. The field reference is the
+[`powerio_dist::DistNetwork` rustdoc](../powerio_dist/model/struct.DistNetwork.html).
+For a standalone distribution exchange file, write BMOPF instead of extracting
+this payload ([relation to interchange formats](#interchange)).
 
 ## Row identity
 
-Every row of the balanced payload tables (`buses`, `loads`, `shunts`,
-`branches`, `switches`, `generators`, `storage`, `hvdc`, `transformers_3w`)
+Every row of every balanced payload table except `areas`
 carries a `uid` string: the source record uid where the format defines one
 (GOC3), and a `{table}:{row}` value synthesized at package build otherwise. A
 synthesized uid records the row the element had when the package was built and
@@ -93,33 +193,7 @@ reject a package where they disagree.
 "model": { "kind": "balanced", "balanced_network": { "...": "..." } }
 ```
 
-`model_kind` values: `balanced`, `multiconductor` (the enum is non-exhaustive;
-later families can be added).
-
-## Envelope reference
-
-| field | type | required | notes |
-|---|---|---|---|
-| `schema` | string (URL) | yes | identifies the package format; defaults to the current URL on read |
-| `schema_version` | string (semver) | yes | envelope version; defaults to current on read |
-| `producer` | object | yes | `{tool, version, git_commit?, features[]}` |
-| `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
-| `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
-| `model_kind` | enum | yes | `balanced` \| `multiconductor`; authoritative |
-| `payload_schema` | string (URL) | no | declared payload contract for `model_kind`; absent on pre-0.1.1 packages |
-| `payload_schema_version` | string (semver) | no | payload version; a different major is rejected on read |
-| `model` | object | yes | `{kind, <kind>_network}`; follows the Rust model payload |
-| `origin` | object | yes | tagged by `kind`: `in_memory` \| `file` \| `folder` \| `binary_file` \| `derived` \| `composite` |
-| `sources` | array | no | declared source artifacts: `{id, kind, path?, format?, hash?}` |
-| `source_maps` | array | no | `{element_path, source_ref, mapping_kind, confidence}` |
-| `diagnostics` | array | no | structured findings (see below) |
-| `validation` | object | yes | `{status, counts, passes[]}` |
-| `summary` | object | yes | `{elements{}, topology?, units?}` |
-| `lowering_history` | array | no | `LoweringRecord` per pass |
-| `operating_points` | object | no | replayable updates over the one static payload |
-| `derived` | object | no | optional matrix stats, normalized solver table metadata, and cache keys |
-
-### Operating points
+## Operating points
 
 `operating_points` records a time axis and an ordered list of payload field
 updates. A point names a table, a row identity and/or a zero based row, and the
@@ -173,7 +247,7 @@ package with `origin.kind = "derived"` and
 }
 ```
 
-### Derived metadata
+## Derived metadata
 
 `derived.normalized_solver_tables` records the compact identity metadata for
 `powerio::Network::to_normalized_solver_tables()` without embedding every table
@@ -192,7 +266,7 @@ The block carries:
 - `source_rows`: source row indices for rows that survived normalization, with
   `null` for synthetic rows such as 3-winding star buses and branches.
 
-### Diagnostics
+## Diagnostics
 
 Each diagnostic carries a stable dotted `code`, a `severity` (`debug`, `info`,
 `warning`, `error`, `fatal`; ordered worst-last), the `stage` it came from
@@ -202,7 +276,7 @@ a `details` object, a `suggested_action`, and a `safe_to_ignore` list. Code
 namespaces by leading segment: `PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`,
 `LOWER`, `EMIT`, `BINDING`, `PARTNER`, `PERF`.
 
-### Source maps
+## Source maps
 
 A `source_map` entry records where a canonical field came from: an `element_path`
 (a JSON pointer, or a best-effort locator in v0.1), a `source_ref` into a declared

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -31,16 +31,15 @@ exchange schema for multiconductor distribution OPF cases, defined by the IEEE
 PES task force on benchmarking multiconductor OPF in
 [bmopf-report](https://github.com/frederikgeth/bmopf-report). Its contract is
 a JSON Schema 2020-12 document with `additionalProperties: false`, its units
-are SI, and independent tools validate instances against the schema file. It
-defines no transmission model and no provenance envelope, and it evolves under
-task force review.
+are SI, and independent tools validate instances against the schema file. A
+transmission model and a provenance envelope are outside its scope.
 
-`.pio.json` is the output of one toolchain. It covers both IR families, wraps
-the payload in the compilation record above, and versions with PowerIO
-releases. Its contract is the Rust model that writes and reads it rather than
-a schema document: the payload is what the model serializes and the semver
-fields below govern change. Pinning the payload to an external draft
-schema would push every task force revision into every PowerIO consumer.
+`.pio.json` is the output of one toolchain. It covers both IR families and
+wraps the payload in the compilation record above. Its contract is the Rust
+model that writes and reads it rather than a schema document: the payload is
+what the model serializes and the semver fields below govern change. The two
+formats also version on different schedules: the payload with PowerIO
+releases, BMOPF with the task force.
 
 The two formats meet at the multiconductor model. The BMOPF reader and writer
 translate to and from the same `DistNetwork` the multiconductor payload


### PR DESCRIPTION
The schema identifier URLs served near-empty pages whose only substantive link was a raw rustdoc struct dump, and the schema chapter never said what the format is for or how it fits alongside the interchange formats.

- The chapter (`docs/src/pio-json-schema.md`) now opens with what a `.pio.json` file is (one IR payload plus the record of how it was produced), why the package format exists, and where each format fits: BMOPF is the exchange path for distribution cases, and `.pio.json` carries a compiled case between PowerIO consumers. The two are described by scope and version schedule; the payload contract is the Rust model, versioned by the semver fields and held to a committed golden by the snapshot test.
- Each identifier URL redirects to its section of the chapter (`#pio-package`, `#pio-payload-balanced`, `#pio-payload-multiconductor`) instead of serving a standalone stub, and the docs build fails if a redirect anchor goes missing from the chapter.
- `compiler-ir.md` no longer restates the versioning policy and reader requirements the chapter owns; it keeps the design points and links. Cross links between the chapters are relative instead of hardcoding the eigenergy.github.io origin.
- Fixes from review: the envelope field enumeration in "Two stability tiers" had drifted from the field table (dropped in favor of the table), the snapshot test claim is scoped to the balanced payload, and `source_format` was missing from the balanced payload field list.
- Removes two Playwright MCP session artifacts committed by 60e0126c and ignores `.playwright-mcp/`.

Verified locally: mdBook 0.5.2 builds with no warnings, all four anchors render, and the extracted redirect step emits correct pages and fails on a renamed anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)