### PR TITLE
Add design chapters for geographic data and the study block

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,8 @@
 - [Architecture](architecture.md)
   - [Compiler IR](compiler-ir.md)
   - [The .pio.json format](pio-json-schema.md)
+  - [Geographic and display data](geo-and-display.md)
+  - [The study block](study-block.md)
 - [Format Fidelity](format-fidelity.md)
 - [Matrix Outputs](matrices.md)
 - [DC OPF Bundle](dcopf-bundle.md)

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -1,6 +1,6 @@
 # Geographic and display data
 
-> **Status: design.** Nothing in this chapter ships in 0.5.x. The tracking
+> **Status: design.** Nothing in this chapter ships in 0.5.x or 0.6.x. The tracking
 > issues are linked at the end.
 
 Power system case files disagree about where equipment sits on a map, and most
@@ -25,7 +25,7 @@ Both model families gain the same optional fields:
 - `Network.geo: Option<GeoMeta>` and `DistNetwork.geo: Option<GeoMeta>`;
 - later, polyline routing: `Branch.route` and `DistLine.route`.
 
-The types are small and plain:
+The types are small:
 
 ```rust
 pub struct Location {
@@ -57,7 +57,7 @@ pub enum CoordinateSpace {
 }
 ```
 
-The coordinate space is a network property, not a bus property; a network with
+The coordinate space is a network property and is not a bus property. A network with
 per bus coordinate systems cannot be rendered. Per point `kind` exists so a
 partially hand placed network round trips: three buses pinned manually, the
 rest from a synthetic layout, and a renderer knows which points it may move.
@@ -68,9 +68,10 @@ defined in `powerio::geo` and mirrored in `powerio_dist::geo`, the same
 arrangement `Extras` already uses. A parity test in `powerio-pkg` serializes
 both and asserts identical JSON, so the copies cannot drift.
 
+Before this is implemented, it is worth considering whether a `powerio-geo` or `powerio-format` crate make be necessary.
+
 Because the fields are additive and skipped when absent, they ride the
-`.pio.json` payloads as a minor bump: both payload schemas go 1.0.0 to 1.1.0
-and the envelope is untouched.
+`.pio.json` payloads as a minor bump.
 
 ## Layer 2: the geographic document
 

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -1,0 +1,192 @@
+# Geographic and display data
+
+> **Status: design.** Nothing in this chapter ships in 0.5.x. The tracking
+> issues are linked at the end.
+
+Power system case files disagree about where equipment sits on a map, and most
+say nothing at all. PowerWorld aux exports carry substation latitude and
+longitude; OpenDSS distributes coordinates in a separate `Buscoords` file;
+pandapower has a `geo` column; MATPOWER, PSS/E, and the BMOPF exchange schema
+carry no geometry. Today PowerIO keeps what it happens to see in per element
+`extras` maps and loses it at most writers. Consumers that render networks
+re-derive coordinates from those maps per source format, which is parsing work
+that belongs here.
+
+This chapter specifies a canonical coordinate model in two layers: typed
+optional fields on the network models, and a standalone geographic document for
+interchange. Both are optional everywhere. A case without coordinates
+serializes byte identically to today, and no writer invents geometry.
+
+## Layer 1: typed model fields
+
+Both model families gain the same optional fields:
+
+- `Bus.location: Option<Location>` and `DistBus.location: Option<Location>`;
+- `Network.geo: Option<GeoMeta>` and `DistNetwork.geo: Option<GeoMeta>`;
+- later, polyline routing: `Branch.route` and `DistLine.route`.
+
+The types are small and plain:
+
+```rust
+pub struct Location {
+    /// x is longitude when the space is geographic (GeoJSON axis order).
+    pub x: f64,
+    /// y is latitude when the space is geographic.
+    pub y: f64,
+    /// Per point provenance when it differs from the network default.
+    pub kind: Option<CoordsKind>,
+}
+
+pub enum CoordsKind { Source, Synthetic, Manual, Derived }
+
+pub struct GeoMeta {
+    pub space: CoordinateSpace,
+    /// Default provenance for points without their own `kind`.
+    pub kind: Option<CoordsKind>,
+}
+
+pub enum CoordinateSpace {
+    /// x = lon, y = lat, decimal degrees. `crs` defaults to EPSG:4326.
+    Geographic { crs: Option<String> },
+    /// Planar projected coordinates, `crs` when known.
+    Projected { crs: Option<String> },
+    /// Drawing coordinates with no earth referent (.pwd, hand diagrams).
+    Diagram { canvas: Option<Canvas> },
+    /// The source did not declare a space (bare OpenDSS buscoords).
+    Unknown,
+}
+```
+
+The coordinate space is a network property, not a bus property; a network with
+per bus coordinate systems cannot be rendered. Per point `kind` exists so a
+partially hand placed network round trips: three buses pinned manually, the
+rest from a synthetic layout, and a renderer knows which points it may move.
+
+`powerio_dist` cannot depend on `powerio`, and `powerio-pkg` depends on both,
+so no shared crate can sit below the two models. The types are therefore
+defined in `powerio::geo` and mirrored in `powerio_dist::geo`, the same
+arrangement `Extras` already uses. A parity test in `powerio-pkg` serializes
+both and asserts identical JSON, so the copies cannot drift.
+
+Because the fields are additive and skipped when absent, they ride the
+`.pio.json` payloads as a minor bump: both payload schemas go 1.0.0 to 1.1.0
+and the envelope is untouched.
+
+## Layer 2: the geographic document
+
+Coordinates also arrive and leave as files of their own: a `Buscoords` CSV next
+to a DSS master, a GeoJSON export from a GIS tool, a layout computed by a
+renderer for a case that had no geometry. The container for these is
+`GeoLayer`, surfaced as a `DisplayData::Geo` variant beside the existing
+PowerWorld `.pwd` display path.
+
+The canonical wire form is a GeoJSON FeatureCollection with one foreign member:
+
+```json
+{
+  "type": "FeatureCollection",
+  "powerio_geo": { "version": "0.1.0", "space": "geographic", "kind": "source" },
+  "features": [
+    { "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-80.05, 34.20] },
+      "properties": { "target": "bus", "id": "312", "uid": "buses:11" } },
+    { "type": "Feature",
+      "geometry": { "type": "LineString", "coordinates": [[-80.05, 34.20], [-80.10, 34.30]] },
+      "properties": { "target": "branch", "uid": "branches:4", "from": "312", "to": "410" } }
+  ]
+}
+```
+
+When the space is geographic this is valid RFC 7946 GeoJSON, so GIS tools open
+it directly. The suggested extension is `.geo.json`.
+
+Reading is tolerant; writing is canonical. The reader accepts headerless
+buscoords CSV (`bus,x,y`), CSV and JSON records with aliased field names
+(`bus_i`/`bus`/`id`, `lat`/`latitude`/`y`, `lon`/`lng`/`longitude`/`x`, branch
+endpoint pairs), and GeoJSON Point and LineString features. Writers emit only
+the canonical form above.
+
+Features reference elements by an `ElementKey` of up to three fields, matched
+in order: `uid`, then `id`, then case insensitive `name`. Ids are strings on
+the wire, so one document format serves balanced integer bus ids,
+multiconductor string ids, and BMOPF ids. Branch paths additionally fall back
+to the unordered `(from, to)` bus pair. Positional branch indices are accepted
+on read as a legacy alias and never written; the durable identity is the
+payload `uid`.
+
+## Harvest and emit
+
+Readers promote coordinates out of `extras` into `location` and stamp the
+space. Promotion removes the raw keys: `location` is the single source of
+truth, and byte level round trips of an unmodified case already go through the
+retained source text, not through extras.
+
+| Format | Read | Space |
+| --- | --- | --- |
+| PowerWorld aux | `Latitude:1`/`Longitude:1` bus fields (`SubNum` stays in extras; it is identity, not geometry) | geographic |
+| OpenDSS | `Buscoords` | unknown, with a range check diagnostic that suggests geographic when every point fits lon/lat bounds |
+| BMOPF JSON | out of schema `longitude`/`latitude` (the BMOPFTools sideload convention) | geographic |
+| pandapower | bus `geo` GeoJSON Point strings | geographic |
+| PyPSA | `buses.csv` x/y | geographic |
+| MATPOWER, PSS/E, PowerModels, egret, GOC3, PSLF, Surge | nothing to read; `location` stays `None` | — |
+
+Writers emit from `location`:
+
+- **OpenDSS**: a companion `Buscoords` CSV.
+- **BMOPF JSON**: dropped by default with a structured warning, because the
+  schema sets `additionalProperties: false` and the writer promises schema
+  valid output. `BmopfWriteOptions::sideload_coordinates` opts in to emitting
+  `longitude`/`latitude` per bus, matching the BMOPFTools convention. This
+  default flips if the task force adopts coordinate fields upstream.
+- **pandapower**: the bus `geo` column, replacing today's null.
+- **PowerWorld aux**: `Latitude:1`/`Longitude:1` bus columns.
+- **GeoJSON**: the canonical `GeoLayer` document.
+- Formats with no geometry concept warn that locations were dropped, the same
+  contract `base_frequency` uses. `powerio geo extract` writes the sidecar as
+  the escape hatch.
+
+## PowerWorld `.pwd` promotion
+
+The `.pwd` reader already decodes substation symbols in diagram coordinates.
+Two additions connect it to the geo model: `geo_layer_from_pwd` produces a
+`GeoLayer` in diagram space with substation targets, and
+`apply_substation_points` joins those points onto buses through the `SubNum`
+extras key. The auto generated PowerWorld layouts equal a Mercator projection
+of geography, so `pwd_mercator_to_lonlat` ships as a documented, approximate
+inverse for consumers that want to place a diagram on a map.
+
+## API surface
+
+Rust (and therefore wasm consumers):
+
+- `powerio::geo::{Location, CoordsKind, CoordinateSpace, GeoMeta, GeoLayer}`;
+- `parse_display_bytes(bytes, "geojson")` returning `DisplayData::Geo`;
+- `Network::geo_layer()` and `Network::apply_geo_layer(&GeoLayer) -> GeoApplyReport`
+  (matched and unmatched counts, notes); the multiconductor equivalents attach
+  through `powerio-pkg`, which sees both model crates;
+- `powerio geo extract | apply | convert` in the CLI.
+
+C ABI: `pio_geo_parse`, `pio_geo_extract`, `pio_geo_apply`, and `pio_dist_geo_*`
+counterparts, all string in and string out. No new object lifetimes and no ABI
+bump; format names stay strings.
+
+## What PowerIO does not do
+
+PowerIO stores and transports coordinates; it does not compute them. Synthetic
+layout (force placement of a coordinate free case) is renderer math and stays
+in the consumer. A consumer that computes a layout can write it back with
+`kind = synthetic` so the provenance survives.
+
+## Phasing
+
+1. Typed fields plus the OpenDSS and BMOPF harvest and emit paths (payload
+   1.1.0).
+2. Balanced harvest and emit: PowerWorld aux, pandapower, PyPSA, fidelity
+   warnings.
+3. `GeoLayer`, `DisplayData::Geo`, branch routing, the CLI subcommand
+   (payload 1.2.0).
+4. `.pwd` promotion and the Mercator helper.
+5. C ABI and Python bindings.
+
+Tracking issues: filed per phase; see the pull request that introduced this
+chapter.

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -188,5 +188,8 @@ in the consumer. A consumer that computes a layout can write it back with
 4. `.pwd` promotion and the Mercator helper.
 5. C ABI and Python bindings.
 
-Tracking issues: filed per phase; see the pull request that introduced this
-chapter.
+Tracking issues: [#180](https://github.com/eigenergy/powerio/issues/180)
+(typed fields), [#183](https://github.com/eigenergy/powerio/issues/183)
+(balanced formats), [#184](https://github.com/eigenergy/powerio/issues/184)
+(GeoLayer and `.pwd`), [#185](https://github.com/eigenergy/powerio/issues/185)
+(bindings).

--- a/docs/src/study-block.md
+++ b/docs/src/study-block.md
@@ -1,0 +1,124 @@
+# The study block
+
+> **Status: design.** Nothing in this chapter ships in 0.5.x. The tracking
+> issues are linked at the end.
+
+Interactive tools hold a base case plus an ordered log of edits, and replay the
+log to reconstruct the current operating point. tellegen's `Study` works this
+way: every commit re-solves from a fresh copy of the base, so the state is
+always the base plus the whole log, never accumulated drift. That object has
+no on disk form today. This chapter specifies one: an additive `study` block in
+the `.pio.json` envelope, so a saved study is an ordinary package that any
+PowerIO consumer can validate, replay, materialize, and convert.
+
+## Why not operating points
+
+The package already carries `operating_points`, and the two mechanisms look
+similar from a distance. They differ in both axes that matter:
+
+- an `ElementUpdate` overwrites fields on one existing payload row, while an
+  interactive edit is a delta, and the most common one (add demand at a bus) is
+  legal at a bus with no load rows at all;
+- operating points are independent overlays on the base (materializing point k
+  ignores point k−1), while commits are cumulative (state k is the base plus
+  commits 0 through k).
+
+Retrofitting deltas and a cumulative axis onto the series would change a
+contract GO Challenge 3 consumers already rely on. The study block is its own
+envelope field and reuses the operating point machinery where it fits: element
+addressing and identity resolution through `ElementRef`.
+
+## Shape
+
+```json
+"study": {
+  "label": "congestion sweep",
+  "created_at": "2026-07-03T18:20:00Z",
+  "commits": [
+    { "edits": [
+        { "kind": "demand_delta",
+          "bus": { "table": "buses", "source_uid": "buses:1" }, "p_mw": 50.0 },
+        { "kind": "rating_delta",
+          "branch": { "table": "branches", "source_uid": "branches:2" },
+          "delta_mw": -210.0 }
+    ]}
+  ],
+  "app": { "tellegen": { "formulation": "dcopf", "options": { "shed": false } } }
+}
+```
+
+`StudyBlock` carries optional `label`, `author`, `created_at`, an optional
+`base_operating_point` (a study over a materialized snapshot of this package's
+series), the ordered `commits`, an `app` map, and free `metadata`. Each
+`StudyCommit` carries optional `label` and `created_at`, its `edits`, and
+`metadata`. The block is additive: packages without one are unchanged, and the
+envelope version does not move, the same rule `operating_points` landed under.
+
+## The edit vocabulary
+
+`StudyEdit` is a tagged enum that grows additively:
+
+- `demand_delta { bus, p_mw, q_mvar? }` adds to the total demand at a bus.
+  Bus level on purpose: it is defined at a bus with zero load rows.
+- `rating_delta { branch, delta_mw }` adds to a branch thermal rating.
+- `set_fields { update }` wraps an `ElementUpdate` for absolute overwrites of
+  one row, the escape hatch for future edits that are naturally absolute
+  (service status, setpoints).
+- An unrecognized `kind` is preserved verbatim on read and refused loudly at
+  materialization. Reading never fails on an unknown edit; silently dropping
+  one would silently change the operating point.
+
+Element references are `ElementRef`s resolved identity first, exactly as in
+operating point updates. Producers should write `source_uid` and let `row` be
+the legacy fallback. Package validation dry runs every reference in every
+commit, mirroring the operating point identity check.
+
+## Materialization
+
+`NetworkPackage::materialize_study_commit(k)` folds commits 0 through k into
+cumulative deltas, applies them to a clone of the payload, clears the block,
+and records the transformation in `lowering_history`. The result is a static
+package: convert it, build matrices from it, or hand it to a solver.
+
+Lowering `demand_delta` to concrete load rows is the one semantic decision.
+The delta distributes proportionally across the in service load rows at the
+bus, preserving each load's share and power factor. At a bus with no in
+service load (or zero total demand) a synthetic load row is appended with
+uid `study:load:{bus_uid}` and metadata marking it synthetic.
+
+The v1 block is defined for balanced payloads; a study on a multiconductor
+payload is a clean validation error until there is a consumer.
+
+## The app namespace
+
+A study is replayed by a solver, and solver vocabulary (formulation names,
+options) is not PowerIO's to define or validate. The `app` map gives each tool
+a namespace that PowerIO round trips verbatim: tellegen keeps its formulation
+and solve options under `app["tellegen"]`. A consumer that only wants the
+network states ignores the map entirely.
+
+## Identity
+
+Edits address rows by payload `uid`, so the uid contract tightens from
+implementation detail to public guarantee:
+
+- parsing the same bytes yields the same uids;
+- synthesized uids are `{table}:{row}` at package build, and source defined
+  uids are never overwritten;
+- uids survive the network JSON round trip.
+
+`ensure_payload_uids` becomes public so a consumer can stamp uids on a parsed
+network before building its own edit state, instead of inventing positional
+ids. Consumers should key interactive state by uid and treat row order as a
+display concern.
+
+## API surface
+
+- `NetworkPackage::study()`, `with_study`, `clear_study`,
+  `materialize_study_commit(k)`;
+- `powerio study materialize --commit k --to <format>` in the CLI;
+- C ABI: `pio_package_study_json` and `pio_package_materialize_study_commit`,
+  additive symbols beside the operating point calls, no ABI bump.
+
+Tracking issues: filed per phase; see the pull request that introduced this
+chapter.

--- a/docs/src/study-block.md
+++ b/docs/src/study-block.md
@@ -120,5 +120,6 @@ display concern.
 - C ABI: `pio_package_study_json` and `pio_package_materialize_study_commit`,
   additive symbols beside the operating point calls, no ABI bump.
 
-Tracking issues: filed per phase; see the pull request that introduced this
-chapter.
+Tracking issues: [#181](https://github.com/eigenergy/powerio/issues/181)
+(block, materialization, uid contract),
+[#185](https://github.com/eigenergy/powerio/issues/185) (bindings).


### PR DESCRIPTION
Two design chapters under Architecture, specifying planned work (nothing ships yet):

- **Geographic and display data**: typed optional `Location`/`GeoMeta` fields on both model families (mirrored across `powerio`/`powerio-dist`, parity tested from `powerio-pkg`), a `GeoLayer` GeoJSON document surfaced as `DisplayData::Geo`, the harvest/emit matrix per format, and `.pwd` promotion. Payload schemas bump 1.0.0 → 1.1.0 when the fields land.
- **The study block**: an additive `study` envelope field persisting a base case plus an ordered commit log of typed delta edits, materializable at any commit. Documents why operating points don't fit (absolute row overwrites, independent points vs cumulative commits) and the uid identity contract it relies on.

Implementation issues are filed per phase and linked from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)