### PR TITLE
Package payload inverses, JSON classifier entry point, directed boundary errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   serialization rather than a byte-exact echo; the multiconductor payload's
   parse warnings ride along.
 - C ABI: `pio_dist_to_json` / `pio_dist_from_json` serialize a distribution
-  handle to its model JSON and back in one call each -- the same object a
+  handle to its model JSON and back in one call each: the same object a
   `.pio.json` document carries under `model.multiconductor_network`, without
   the surrounding document. Bindings materialize element tables with this
   instead of building a throwaway package; it is not a case format (the
@@ -22,6 +22,14 @@
   `.pio.json` envelopes: `transmission:<format>`, `distribution:<format>`,
   `package`, `ambiguous`, or `unknown`, size-then-fill. Bindings can route a
   bare `.json` before choosing a parser instead of matching error text.
+- The JSON classifier reports a `.pio.json` envelope as its own outcome
+  (`routing::JsonClass`), so every consumer handles it: the CLI, the Python
+  readers, and the Python `classify_json_text` now name the package surface
+  for an envelope instead of a generic cannot-infer error (or, for the Python
+  string reader, a MATPOWER syntax error). Envelope detection requires
+  `model_kind` to be `balanced` or `multiconductor`, so a case document
+  carrying those key names with other values still classifies as a case, and
+  classification parses the document once.
 - Directed errors at the transmission boundary: a `.dss` path, a distribution
   `from` token (`dss`/`pmd`/`bmopf`), and a `.pio.json` envelope handed to the
   balanced parser now name the surface that reads them instead of a generic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.6.0
 
+- Breaking (#175): `ElementRef.row` is `Option<usize>`, the honest form of the
+  0.5.1 wire semantics. `None` addresses by identity alone (refs built with
+  `by_source_uid`); the private wire-presence shim (`wire_row()`) is gone, and
+  `row` itself says whether the wire carried one. The `.pio.json` wire format
+  is unchanged. The other break collected in #175, keyed-object addressing for
+  multiconductor operating point updates, needs design and moves to the 1.0
+  window (#196).
 - C ABI: the package payload extraction inverses land as additive symbols (no
   ABI version change; probe the symbols like the other feature surfaces):
   `pio_package_to_balanced_network` and `pio_package_to_multiconductor_network`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   payload retains no source text, so a same-format write is a fresh
   serialization rather than a byte-exact echo; the multiconductor payload's
   parse warnings ride along.
+- C ABI: `pio_dist_to_json` / `pio_dist_from_json` serialize a distribution
+  handle to its model JSON and back in one call each -- the same object a
+  `.pio.json` document carries under `model.multiconductor_network`, without
+  the surrounding document. Bindings materialize element tables with this
+  instead of building a throwaway package; it is not a case format (the
+  converter, CLI, and inference do not know it), so BMOPF JSON remains the
+  distribution JSON exchanged with other tools.
 - C ABI: `pio_classify_str` classifies in-memory JSON by the same top level
   markers the transmission parser's `.json` sniffing uses, and recognizes
   `.pio.json` envelopes: `transmission:<format>`, `distribution:<format>`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+- C ABI: the package payload extraction inverses land as additive symbols (no
+  ABI version change; probe the symbols like the other feature surfaces):
+  `pio_package_to_balanced_network` and `pio_package_to_multiconductor_network`
+  materialize an owned network handle from a parsed `.pio.json` package handle,
+  the inverses of the `pio_package_from_*` constructors. A handle built from a
+  payload retains no source text, so a same-format write is a fresh
+  serialization rather than a byte-exact echo; the multiconductor payload's
+  parse warnings ride along.
+- C ABI: `pio_classify_str` classifies in-memory JSON by the same top level
+  markers the transmission parser's `.json` sniffing uses, and recognizes
+  `.pio.json` envelopes: `transmission:<format>`, `distribution:<format>`,
+  `package`, `ambiguous`, or `unknown`, size-then-fill. Bindings can route a
+  bare `.json` before choosing a parser instead of matching error text.
+- Directed errors at the transmission boundary: a `.dss` path, a distribution
+  `from` token (`dss`/`pmd`/`bmopf`), and a `.pio.json` envelope handed to the
+  balanced parser now name the surface that reads them instead of a generic
+  unknown-format message.
+
 ## 0.5.1
 
 - `.pio.json` payload schema declared (#173): new optional envelope fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   payload retains no source text, so a same-format write is a fresh
   serialization rather than a byte-exact echo; the multiconductor payload's
   parse warnings ride along.
+- C ABI: `pio_to_json` / `pio_from_json` are the function form of the balanced
+  model JSON (byte identical to the `powerio-json` writer); the format token
+  remains as a compatibility alias for file based workflows. This is the
+  additive half of #194; retiring the token waits for 1.0.
 - C ABI: `pio_dist_to_json` / `pio_dist_from_json` serialize a distribution
   handle to its model JSON and back in one call each: the same object a
   `.pio.json` document carries under `model.multiconductor_network`, without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.6.0
 
 - C ABI: the package payload extraction inverses land as additive symbols (no
   ABI version change; probe the symbols like the other feature surfaces):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2005,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "powerio",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "jsonschema",
  "serde",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "approx",
  "arrow",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -31,10 +31,10 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.5.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.5.1" }
-powerio-dist = { path = "powerio-dist", version = "0.5.1" }
-powerio-pkg = { path = "powerio-pkg", version = "0.5.1" }
+powerio = { path = "powerio", version = "0.6.0" }
+powerio-matrix = { path = "powerio-matrix", version = "0.6.0" }
+powerio-dist = { path = "powerio-dist", version = "0.6.0" }
+powerio-pkg = { path = "powerio-pkg", version = "0.6.0" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -311,7 +311,7 @@ bindings, or MCP operations.
 {
   "schema": "https://powerio.dev/schema/pio-package/0.1",
   "schema_version": "0.1.1",
-  "producer": { "tool": "powerio", "version": "0.5.1" },
+  "producer": { "tool": "powerio", "version": "0.6.0" },
   "model_kind": "multiconductor",
   "payload_schema": "https://powerio.dev/schema/pio-payload-multiconductor/1",
   "payload_schema_version": "1.0.0",

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -294,6 +294,24 @@ PioNetwork *pio_parse_str(const char *text,
                           char *errbuf,
                           size_t errlen);
 
+/**
+ * Classify in-memory JSON case `text` by its top level markers, without
+ * parsing the case. Writes one of
+ *
+ * - `transmission:<format>` (e.g. `transmission:powermodels-json`)
+ * - `distribution:<format>` (e.g. `distribution:pmd-json`)
+ * - `package` (a `.pio.json` envelope; read it with the package entry points)
+ * - `ambiguous` (strong markers from both domains; pass an explicit format)
+ * - `unknown` (no recognized marker, or not a JSON object)
+ *
+ * into the caller `outbuf` (truncated to fit, always NUL-terminated) and
+ * returns the total byte length of the classification string -- the
+ * size-then-fill idiom of [`pio_warnings`]. Returns 0 for NULL `text`. The
+ * markers are the same ones the transmission parser's `.json` sniffing uses,
+ * so a binding can route a bare `.json` before choosing a parser.
+ */
+size_t pio_classify_str(const char *text, char *outbuf, size_t outlen);
+
 #if defined(PIO_GRIDFM)
 /**
  * Read one scenario of a dataset directory in the named `from` format into a
@@ -641,6 +659,33 @@ PioPackage *pio_package_from_balanced_network(const PioNetwork *net,
 PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net,
                                                     char *errbuf,
                                                     size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Materialize the balanced payload of a package handle as an owned network
+ * handle -- the inverse of [`pio_package_from_balanced_network`]. Errors when
+ * the package holds a different model kind. The handle is built from the
+ * payload alone: it retains no source text, so a same-format write is a fresh
+ * serialization rather than a byte-exact echo, and it carries no parse
+ * warnings. Free with [`pio_network_free`].
+ */
+PioNetwork *pio_package_to_balanced_network(const PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if (defined(PIO_PKG) && defined(PIO_DIST))
+/**
+ * Materialize the multiconductor payload of a package handle as an owned
+ * distribution network handle -- the inverse of
+ * [`pio_package_from_multiconductor_network`]. Errors when the package holds
+ * a different model kind. The handle retains no source text (`source` never
+ * enters the payload), so a same-format write is a fresh serialization; the
+ * payload's parse warnings ride along and stay readable via
+ * [`pio_dist_warnings`]. Free with [`pio_dist_network_free`].
+ */
+PioDistNetwork *pio_package_to_multiconductor_network(const PioPackage *pkg,
+                                                      char *errbuf,
+                                                      size_t errlen);
 #endif
 
 #if defined(PIO_PKG)

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -312,6 +312,25 @@ PioNetwork *pio_parse_str(const char *text,
  */
 size_t pio_classify_str(const char *text, char *outbuf, size_t outlen);
 
+/**
+ * Serialize `net` to its model JSON: the same object a `.pio.json` package
+ * carries under `model.balanced_network`, without the surrounding document,
+ * and the same text the `powerio-json` format token writes. This is the
+ * bindings' data transport; the token remains as a compatibility alias for
+ * file based workflows. Returns an owned C string (free with
+ * [`pio_string_free`]), `NULL` on error.
+ */
+char *pio_to_json(const PioNetwork *net, char *errbuf, size_t errlen);
+
+/**
+ * Parse model JSON produced by [`pio_to_json`] (or lifted from a `.pio.json`
+ * document's `model.balanced_network`) back into an owned handle, the
+ * inverse of [`pio_to_json`] and the function form of parsing under the
+ * `powerio-json` token. Returns `NULL` on error. Free with
+ * [`pio_network_free`].
+ */
+PioNetwork *pio_from_json(const char *text, char *errbuf, size_t errlen);
+
 #if defined(PIO_GRIDFM)
 /**
  * Read one scenario of a dataset directory in the named `from` format into a

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -814,6 +814,30 @@ size_t pio_dist_warnings(const PioDistNetwork *net, char *warnbuf, size_t warnle
 
 #if defined(PIO_DIST)
 /**
+ * Serialize `net` to its model JSON: the same object a `.pio.json` package
+ * carries under `model.multiconductor_network`, without the surrounding
+ * document. This is the bindings' data transport, not a case format -- the
+ * converter, CLI, and format inference do not know it; distribution cases
+ * exchanged with other tools are BMOPF JSON ([`pio_dist_to_format`]).
+ * Returns an owned C string (free with [`pio_string_free`]), `NULL` on error.
+ */
+char *pio_dist_to_json(const PioDistNetwork *net, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_DIST)
+/**
+ * Parse model JSON produced by [`pio_dist_to_json`] (or lifted from a
+ * `.pio.json` document's `model.multiconductor_network`) back into an owned
+ * handle -- the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
+ * no source text, so a same-format write is a fresh serialization; the model
+ * JSON's `warnings` ride along. Returns `NULL` on error. Free with
+ * [`pio_dist_network_free`].
+ */
+PioDistNetwork *pio_dist_from_json(const char *text, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_DIST)
+/**
  * Serialize `net` to distribution format `to` (`dss`, `pmd`, or `bmopf`).
  * Writing back to the format the handle was parsed from echoes the source text
  * byte for byte; a cross-format write reports every fidelity loss in `warnbuf`

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -305,8 +305,8 @@ PioNetwork *pio_parse_str(const char *text,
  * - `unknown` (no recognized marker, or not a JSON object)
  *
  * into the caller `outbuf` (truncated to fit, always NUL-terminated) and
- * returns the total byte length of the classification string -- the
- * size-then-fill idiom of [`pio_warnings`]. Returns 0 for NULL `text`. The
+ * returns the total byte length of the classification string (the
+ * size-then-fill idiom of [`pio_warnings`]). Returns 0 for NULL `text`. The
  * markers are the same ones the transmission parser's `.json` sniffing uses,
  * so a binding can route a bare `.json` before choosing a parser.
  */
@@ -664,7 +664,7 @@ PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net,
 #if defined(PIO_PKG)
 /**
  * Materialize the balanced payload of a package handle as an owned network
- * handle -- the inverse of [`pio_package_from_balanced_network`]. Errors when
+ * handle: the inverse of [`pio_package_from_balanced_network`]. Errors when
  * the package holds a different model kind. The handle is built from the
  * payload alone: it retains no source text, so a same-format write is a fresh
  * serialization rather than a byte-exact echo, and it carries no parse
@@ -676,12 +676,12 @@ PioNetwork *pio_package_to_balanced_network(const PioPackage *pkg, char *errbuf,
 #if (defined(PIO_PKG) && defined(PIO_DIST))
 /**
  * Materialize the multiconductor payload of a package handle as an owned
- * distribution network handle -- the inverse of
+ * distribution network handle: the inverse of
  * [`pio_package_from_multiconductor_network`]. Errors when the package holds
- * a different model kind. The handle retains no source text (`source` never
- * enters the payload), so a same-format write is a fresh serialization; the
- * payload's parse warnings ride along and stay readable via
- * [`pio_dist_warnings`]. Free with [`pio_dist_network_free`].
+ * a different model kind. The handle retains no source text, so a
+ * same-format write is a fresh serialization; the payload's parse warnings
+ * ride along and stay readable via [`pio_dist_warnings`]. Free with
+ * [`pio_dist_network_free`].
  */
 PioDistNetwork *pio_package_to_multiconductor_network(const PioPackage *pkg,
                                                       char *errbuf,
@@ -816,7 +816,7 @@ size_t pio_dist_warnings(const PioDistNetwork *net, char *warnbuf, size_t warnle
 /**
  * Serialize `net` to its model JSON: the same object a `.pio.json` package
  * carries under `model.multiconductor_network`, without the surrounding
- * document. This is the bindings' data transport, not a case format -- the
+ * document. This is the bindings' data transport, not a case format: the
  * converter, CLI, and format inference do not know it; distribution cases
  * exchanged with other tools are BMOPF JSON ([`pio_dist_to_format`]).
  * Returns an owned C string (free with [`pio_string_free`]), `NULL` on error.
@@ -828,7 +828,7 @@ char *pio_dist_to_json(const PioDistNetwork *net, char *errbuf, size_t errlen);
 /**
  * Parse model JSON produced by [`pio_dist_to_json`] (or lifted from a
  * `.pio.json` document's `model.multiconductor_network`) back into an owned
- * handle -- the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
+ * handle: the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
  * no source text, so a same-format write is a fresh serialization; the model
  * JSON's `warnings` ride along. Returns `NULL` on error. Free with
  * [`pio_dist_network_free`].

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -119,7 +119,8 @@ fn finish_cstring(s: String, errbuf: *mut c_char, errlen: usize) -> *mut c_char 
 /// message) under the panic guard and hand back an owned C string, or write
 /// the error (`panic_msg` if `f` panicked) into `errbuf` and return NULL. The
 /// shared tail of the string-returning functions that carry no warning buffer.
-#[cfg(any(feature = "dist", feature = "pkg"))]
+/// Used by the always built `pio_to_json` as well as the dist and pkg
+/// surfaces, so it carries no feature gate.
 unsafe fn finish_string(
     errbuf: *mut c_char,
     errlen: usize,
@@ -391,6 +392,49 @@ fn classify_label(text: &str) -> String {
         }
         JsonClass::Case(Detection::Ambiguous) => "ambiguous".to_string(),
         JsonClass::Case(Detection::Unknown) => "unknown".to_string(),
+    }
+}
+
+/// Serialize `net` to its model JSON: the same object a `.pio.json` package
+/// carries under `model.balanced_network`, without the surrounding document,
+/// and the same text the `powerio-json` format token writes. This is the
+/// bindings' data transport; the token remains as a compatibility alias for
+/// file based workflows. Returns an owned C string (free with
+/// [`pio_string_free`]), `NULL` on error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_to_json(
+    net: *const PioNetwork,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        finish_string(errbuf, errlen, "panic while serializing model JSON", || {
+            let net = net
+                .as_ref()
+                .ok_or_else(|| "network handle is NULL".to_string())?;
+            net.net.to_json().map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Parse model JSON produced by [`pio_to_json`] (or lifted from a `.pio.json`
+/// document's `model.balanced_network`) back into an owned handle, the
+/// inverse of [`pio_to_json`] and the function form of parsing under the
+/// `powerio-json` token. Returns `NULL` on error. Free with
+/// [`pio_network_free`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_from_json(
+    text: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioNetwork {
+    unsafe {
+        finish_network(errbuf, errlen, "panic while parsing model JSON", || {
+            let text = required_cstr(text, "text")?;
+            Network::from_json(text)
+                .map(|net| (net, Vec::new()))
+                .map_err(|e| e.to_string())
+        })
     }
 }
 
@@ -2166,6 +2210,8 @@ mod tests {
             "PioNetwork *pio_parse_file(const char *path, const char *from, char *errbuf, size_t errlen);",
             "PioNetwork *pio_parse_str(const char *text, const char *format, char *errbuf, size_t errlen);",
             "size_t pio_classify_str(const char *text, char *outbuf, size_t outlen);",
+            "char *pio_to_json(const PioNetwork *net, char *errbuf, size_t errlen);",
+            "PioNetwork *pio_from_json(const char *text, char *errbuf, size_t errlen);",
             "PioNetwork *pio_read_dir(const char *dir, const char *from, int64_t scenario, char *errbuf, size_t errlen);",
             "ptrdiff_t pio_scenario_ids(const char *dir, const char *from, int64_t *out, size_t cap, char *errbuf, size_t errlen);",
             "size_t pio_warnings(const PioNetwork *net, char *warnbuf, size_t warnlen);",
@@ -3603,6 +3649,29 @@ mpc.branch = [
             assert_eq!(unsafe { pio_has_feature(dist.as_ptr()) }, 1);
             let nope = CString::new("nope").unwrap();
             assert_eq!(unsafe { pio_has_feature(nope.as_ptr()) }, 0);
+        }
+    }
+
+    /// The balanced model JSON pair: one call out, one call back, byte
+    /// identical to the `powerio-json` token writer.
+    #[test]
+    fn balanced_model_json_round_trip_matches_token_writer() {
+        let net = case9();
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        let json = unsafe { pio_to_json(net, err.as_mut_ptr(), err.len()) };
+        assert!(!json.is_null());
+        let text = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_owned();
+        unsafe { pio_string_free(json) };
+        assert_eq!(text, unsafe { to_format(net, "powerio-json") });
+
+        let c = CString::new(text).unwrap();
+        let back = unsafe { pio_from_json(c.as_ptr(), err.as_mut_ptr(), err.len()) };
+        assert!(!back.is_null());
+        unsafe {
+            assert_eq!(pio_n_buses(back), pio_n_buses(net));
+            close(pio_base_mva(back), pio_base_mva(net));
+            pio_network_free(back);
+            pio_network_free(net);
         }
     }
 

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -256,7 +256,8 @@ fn optional_cstr<'a>(p: *const c_char, name: &str) -> Result<Option<&'a str>, St
 
 /// Like [`cstr`] but a NULL or non-UTF-8 pointer is an error naming the
 /// offending parameter. Entry points use this for required strings.
-#[cfg(any(feature = "dist", feature = "pkg"))]
+/// Used by the always-built `pio_classify_str` as well as the dist and pkg
+/// surfaces, so it carries no feature gate.
 fn required_cstr<'a>(p: *const c_char, name: &str) -> Result<&'a str, String> {
     unsafe { cstr(p) }.ok_or_else(|| format!("{name} is NULL or not UTF-8"))
 }
@@ -3546,9 +3547,7 @@ mpc.branch = [
             let text = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_owned();
             unsafe { pio_string_free(json) };
             let c = CString::new(text).unwrap();
-            let reread = unsafe {
-                pio_package_parse_str(c.as_ptr(), err.as_mut_ptr(), err.len())
-            };
+            let reread = unsafe { pio_package_parse_str(c.as_ptr(), err.as_mut_ptr(), err.len()) };
             assert!(!reread.is_null());
             unsafe { pio_package_free(pkg) };
             reread
@@ -3558,25 +3557,21 @@ mpc.branch = [
         fn balanced_wrap_extract_across_json() {
             let net = case9();
             let mut err = [0 as c_char; PIO_ERRBUF_MIN];
-            let pkg = unsafe {
-                pio_package_from_balanced_network(net, 0, err.as_mut_ptr(), err.len())
-            };
+            let pkg =
+                unsafe { pio_package_from_balanced_network(net, 0, err.as_mut_ptr(), err.len()) };
             assert!(!pkg.is_null());
             let pkg = unsafe { envelope_round_trip(pkg) };
 
             // Wrong-kind extraction refuses with a directed message.
             #[cfg(feature = "dist")]
             unsafe {
-                let wrong =
-                    pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len());
+                let wrong = pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len());
                 assert!(wrong.is_null());
                 let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
                 assert!(msg.contains("balanced"), "got: {msg}");
             }
 
-            let back = unsafe {
-                pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len())
-            };
+            let back = unsafe { pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len()) };
             assert!(
                 !back.is_null(),
                 "{}",
@@ -3612,9 +3607,8 @@ mpc.branch = [
             };
             assert!(!pkg.is_null());
             let pkg = unsafe { envelope_round_trip(pkg) };
-            let back = unsafe {
-                pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len())
-            };
+            let back =
+                unsafe { pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len()) };
             assert!(
                 !back.is_null(),
                 "{}",

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -315,6 +315,55 @@ pub unsafe extern "C" fn pio_parse_str(
     }
 }
 
+/// Classify in-memory JSON case `text` by its top level markers, without
+/// parsing the case. Writes one of
+///
+/// - `transmission:<format>` (e.g. `transmission:powermodels-json`)
+/// - `distribution:<format>` (e.g. `distribution:pmd-json`)
+/// - `package` (a `.pio.json` envelope; read it with the package entry points)
+/// - `ambiguous` (strong markers from both domains; pass an explicit format)
+/// - `unknown` (no recognized marker, or not a JSON object)
+///
+/// into the caller `outbuf` (truncated to fit, always NUL-terminated) and
+/// returns the total byte length of the classification string -- the
+/// size-then-fill idiom of [`pio_warnings`]. Returns 0 for NULL `text`. The
+/// markers are the same ones the transmission parser's `.json` sniffing uses,
+/// so a binding can route a bare `.json` before choosing a parser.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_classify_str(
+    text: *const c_char,
+    outbuf: *mut c_char,
+    outlen: usize,
+) -> usize {
+    unsafe {
+        guard(0, || {
+            let Ok(text) = required_cstr(text, "text") else {
+                return 0;
+            };
+            let label = classify_label(text);
+            copy_to_buf(outbuf, outlen, &label);
+            label.len()
+        })
+    }
+}
+
+fn classify_label(text: &str) -> String {
+    use powerio::format::routing::{self, Detection, SourceFormat};
+    if routing::looks_like_package_envelope(text) {
+        return "package".to_string();
+    }
+    match routing::classify_json_text(text) {
+        Detection::Known(SourceFormat::Transmission(f)) => {
+            format!("transmission:{}", f.name())
+        }
+        Detection::Known(SourceFormat::Distribution(f)) => {
+            format!("distribution:{}", f.name())
+        }
+        Detection::Ambiguous => "ambiguous".to_string(),
+        _ => "unknown".to_string(),
+    }
+}
+
 /// Read one scenario of a dataset directory in the named `from` format into a
 /// network handle: the directory sibling of [`pio_parse_file`]. `gridfm` (the
 /// gridfm-datakit Parquet layout; `dir` resolves leniently: the `raw/` leaf,
@@ -1265,6 +1314,73 @@ pub unsafe extern "C" fn pio_package_from_multiconductor_network(
     }
 }
 
+/// Materialize the balanced payload of a package handle as an owned network
+/// handle -- the inverse of [`pio_package_from_balanced_network`]. Errors when
+/// the package holds a different model kind. The handle is built from the
+/// payload alone: it retains no source text, so a same-format write is a fresh
+/// serialization rather than a byte-exact echo, and it carries no parse
+/// warnings. Free with [`pio_network_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_to_balanced_network(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioNetwork {
+    unsafe {
+        finish_network(
+            errbuf,
+            errlen,
+            "panic while extracting balanced network",
+            || {
+                let pkg = pkg
+                    .as_ref()
+                    .ok_or_else(|| "package handle is NULL".to_string())?;
+                let net = pkg.package.model.as_balanced().ok_or_else(|| {
+                    "package holds a multiconductor model, not balanced; use \
+                     pio_package_to_multiconductor_network"
+                        .to_string()
+                })?;
+                Ok((net.clone(), Vec::new()))
+            },
+        )
+    }
+}
+
+/// Materialize the multiconductor payload of a package handle as an owned
+/// distribution network handle -- the inverse of
+/// [`pio_package_from_multiconductor_network`]. Errors when the package holds
+/// a different model kind. The handle retains no source text (`source` never
+/// enters the payload), so a same-format write is a fresh serialization; the
+/// payload's parse warnings ride along and stay readable via
+/// [`pio_dist_warnings`]. Free with [`pio_dist_network_free`].
+#[cfg(all(feature = "pkg", feature = "dist"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_to_multiconductor_network(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioDistNetwork {
+    unsafe {
+        finish_handle(
+            errbuf,
+            errlen,
+            "panic while extracting multiconductor network",
+            || {
+                let pkg = pkg
+                    .as_ref()
+                    .ok_or_else(|| "package handle is NULL".to_string())?;
+                let net = pkg.package.model.as_multiconductor().ok_or_else(|| {
+                    "package holds a balanced model, not multiconductor; use \
+                     pio_package_to_balanced_network"
+                        .to_string()
+                })?;
+                Ok(PioDistNetwork { net: net.clone() })
+            },
+        )
+    }
+}
+
 /// Run the package semantic validation profile in place. Returns `0` on
 /// success, `-1` on error.
 ///
@@ -1970,6 +2086,7 @@ mod tests {
             "const char *pio_version(void);",
             "PioNetwork *pio_parse_file(const char *path, const char *from, char *errbuf, size_t errlen);",
             "PioNetwork *pio_parse_str(const char *text, const char *format, char *errbuf, size_t errlen);",
+            "size_t pio_classify_str(const char *text, char *outbuf, size_t outlen);",
             "PioNetwork *pio_read_dir(const char *dir, const char *from, int64_t scenario, char *errbuf, size_t errlen);",
             "ptrdiff_t pio_scenario_ids(const char *dir, const char *from, int64_t *out, size_t cap, char *errbuf, size_t errlen);",
             "size_t pio_warnings(const PioNetwork *net, char *warnbuf, size_t warnlen);",
@@ -2003,6 +2120,8 @@ mod tests {
             "char *pio_package_to_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "PioPackage *pio_package_from_balanced_network(const PioNetwork *net, int32_t include_solver_metadata, char *errbuf, size_t errlen);",
             "PioPackage *pio_package_from_multiconductor_network(const PioDistNetwork *net, char *errbuf, size_t errlen);",
+            "PioNetwork *pio_package_to_balanced_network(const PioPackage *pkg, char *errbuf, size_t errlen);",
+            "PioDistNetwork *pio_package_to_multiconductor_network(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "int32_t pio_package_validate(PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_validation_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
@@ -3375,6 +3494,164 @@ mpc.branch = [
             assert_eq!(unsafe { pio_has_feature(dist.as_ptr()) }, 1);
             let nope = CString::new("nope").unwrap();
             assert_eq!(unsafe { pio_has_feature(nope.as_ptr()) }, 0);
+        }
+    }
+
+    /// `pio_classify_str` labels: same markers as the `.json` sniffing.
+    #[test]
+    fn classify_str_labels() {
+        fn classify(text: &str) -> String {
+            let c = CString::new(text).unwrap();
+            let mut out = [0 as c_char; 64];
+            let n = unsafe { pio_classify_str(c.as_ptr(), out.as_mut_ptr(), out.len()) };
+            let label = unsafe { CStr::from_ptr(out.as_ptr()) }.to_str().unwrap();
+            assert_eq!(n, label.len(), "size-then-fill length disagrees");
+            label.to_string()
+        }
+        assert_eq!(
+            classify(r#"{"baseMVA": 100.0, "bus": {}}"#),
+            "transmission:powermodels-json"
+        );
+        assert_eq!(
+            classify(r#"{"data_model": "ENGINEERING"}"#),
+            "distribution:pmd-json"
+        );
+        assert_eq!(
+            classify(r#"{"line": {}, "bus": {}}"#),
+            "distribution:bmopf-json"
+        );
+        assert_eq!(
+            classify(r#"{"model_kind": "balanced", "model": {}}"#),
+            "package"
+        );
+        assert_eq!(classify("not json"), "unknown");
+        assert_eq!(classify(r#"{"nothing": 1}"#), "unknown");
+        assert_eq!(
+            unsafe { pio_classify_str(std::ptr::null(), std::ptr::null_mut(), 0) },
+            0
+        );
+    }
+
+    /// The package inverse pair: wrap a handle, cross the JSON envelope, and
+    /// extract an owned handle again -- the binding materialization path.
+    #[cfg(feature = "pkg")]
+    mod package_inverse {
+        use super::*;
+        use std::ffi::CStr;
+
+        unsafe fn envelope_round_trip(pkg: *mut PioPackage) -> *mut PioPackage {
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            let json = unsafe { pio_package_to_json(pkg, err.as_mut_ptr(), err.len()) };
+            assert!(!json.is_null());
+            let text = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_owned();
+            unsafe { pio_string_free(json) };
+            let c = CString::new(text).unwrap();
+            let reread = unsafe {
+                pio_package_parse_str(c.as_ptr(), err.as_mut_ptr(), err.len())
+            };
+            assert!(!reread.is_null());
+            unsafe { pio_package_free(pkg) };
+            reread
+        }
+
+        #[test]
+        fn balanced_wrap_extract_across_json() {
+            let net = case9();
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            let pkg = unsafe {
+                pio_package_from_balanced_network(net, 0, err.as_mut_ptr(), err.len())
+            };
+            assert!(!pkg.is_null());
+            let pkg = unsafe { envelope_round_trip(pkg) };
+
+            // Wrong-kind extraction refuses with a directed message.
+            #[cfg(feature = "dist")]
+            unsafe {
+                let wrong =
+                    pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len());
+                assert!(wrong.is_null());
+                let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+                assert!(msg.contains("balanced"), "got: {msg}");
+            }
+
+            let back = unsafe {
+                pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len())
+            };
+            assert!(
+                !back.is_null(),
+                "{}",
+                unsafe { CStr::from_ptr(err.as_ptr()) }.to_str().unwrap()
+            );
+            unsafe {
+                assert_eq!(pio_n_buses(back), pio_n_buses(net));
+                assert_eq!(pio_n_gens(back), pio_n_gens(net));
+                close(pio_base_mva(back), pio_base_mva(net));
+                pio_package_free(pkg);
+                pio_network_free(back);
+                pio_network_free(net);
+            }
+        }
+
+        #[cfg(feature = "dist")]
+        #[test]
+        fn multiconductor_wrap_extract_across_json() {
+            let path = CString::new(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../tests/data/dist/micro/fourwire_linecode.dss")
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            let net = unsafe {
+                pio_dist_parse_file(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len())
+            };
+            assert!(!net.is_null());
+            let pkg = unsafe {
+                pio_package_from_multiconductor_network(net, err.as_mut_ptr(), err.len())
+            };
+            assert!(!pkg.is_null());
+            let pkg = unsafe { envelope_round_trip(pkg) };
+            let back = unsafe {
+                pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len())
+            };
+            assert!(
+                !back.is_null(),
+                "{}",
+                unsafe { CStr::from_ptr(err.as_ptr()) }.to_str().unwrap()
+            );
+
+            // The extracted model writes the same BMOPF text as the original:
+            // nothing the model represents is lost crossing the envelope.
+            unsafe fn bmopf(net: *const PioDistNetwork) -> String {
+                let to = CString::new("bmopf").unwrap();
+                let mut warn = [0 as c_char; 4096];
+                let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+                let s = unsafe {
+                    pio_dist_to_format(
+                        net,
+                        to.as_ptr(),
+                        warn.as_mut_ptr(),
+                        warn.len(),
+                        err.as_mut_ptr(),
+                        err.len(),
+                    )
+                };
+                assert!(!s.is_null());
+                let text = unsafe { CStr::from_ptr(s) }.to_str().unwrap().to_owned();
+                unsafe { pio_string_free(s) };
+                text
+            }
+            unsafe {
+                assert_eq!(bmopf(back), bmopf(net));
+                let wrong = pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len());
+                assert!(wrong.is_null());
+                let msg = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+                assert!(msg.contains("multiconductor"), "got: {msg}");
+                pio_package_free(pkg);
+                pio_dist_network_free(back);
+                pio_dist_network_free(net);
+            }
         }
     }
 }

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -115,6 +115,32 @@ fn finish_cstring(s: String, errbuf: *mut c_char, errlen: usize) -> *mut c_char 
     }
 }
 
+/// Finish a `*mut c_char` entry point: run `f` (the string payload or an error
+/// message) under the panic guard and hand back an owned C string, or write
+/// the error (`panic_msg` if `f` panicked) into `errbuf` and return NULL. The
+/// shared tail of the string-returning functions that carry no warning buffer.
+#[cfg(any(feature = "dist", feature = "pkg"))]
+unsafe fn finish_string(
+    errbuf: *mut c_char,
+    errlen: usize,
+    panic_msg: &str,
+    f: impl FnOnce() -> Result<String, String>,
+) -> *mut c_char {
+    unsafe {
+        match catch_unwind(AssertUnwindSafe(f)) {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, panic_msg);
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
 /// Run `f` at the FFI boundary, catching any panic so it can't unwind across
 /// `extern "C"` (UB). Returns `fallback` if `f` panics.
 unsafe fn guard<R>(fallback: R, f: impl FnOnce() -> R) -> R {
@@ -326,8 +352,8 @@ pub unsafe extern "C" fn pio_parse_str(
 /// - `unknown` (no recognized marker, or not a JSON object)
 ///
 /// into the caller `outbuf` (truncated to fit, always NUL-terminated) and
-/// returns the total byte length of the classification string -- the
-/// size-then-fill idiom of [`pio_warnings`]. Returns 0 for NULL `text`. The
+/// returns the total byte length of the classification string (the
+/// size-then-fill idiom of [`pio_warnings`]). Returns 0 for NULL `text`. The
 /// markers are the same ones the transmission parser's `.json` sniffing uses,
 /// so a binding can route a bare `.json` before choosing a parser.
 #[unsafe(no_mangle)]
@@ -337,6 +363,9 @@ pub unsafe extern "C" fn pio_classify_str(
     outlen: usize,
 ) -> usize {
     unsafe {
+        // Terminate up front so every early return, including a panic inside
+        // the guard, leaves outbuf a valid empty string.
+        copy_to_buf(outbuf, outlen, "");
         guard(0, || {
             let Ok(text) = required_cstr(text, "text") else {
                 return 0;
@@ -349,19 +378,19 @@ pub unsafe extern "C" fn pio_classify_str(
 }
 
 fn classify_label(text: &str) -> String {
-    use powerio::format::routing::{self, Detection, SourceFormat};
-    if routing::looks_like_package_envelope(text) {
-        return "package".to_string();
-    }
+    use powerio::format::routing::{self, Detection, Domain, JsonClass};
     match routing::classify_json_text(text) {
-        Detection::Known(SourceFormat::Transmission(f)) => {
-            format!("transmission:{}", f.name())
+        JsonClass::Package => "package".to_string(),
+        JsonClass::Case(Detection::Known(format)) => {
+            let domain = match format.domain() {
+                Domain::Transmission => "transmission",
+                Domain::Distribution => "distribution",
+                _ => return "unknown".to_string(),
+            };
+            format!("{domain}:{}", format.name())
         }
-        Detection::Known(SourceFormat::Distribution(f)) => {
-            format!("distribution:{}", f.name())
-        }
-        Detection::Ambiguous => "ambiguous".to_string(),
-        _ => "unknown".to_string(),
+        JsonClass::Case(Detection::Ambiguous) => "ambiguous".to_string(),
+        JsonClass::Case(Detection::Unknown) => "unknown".to_string(),
     }
 }
 
@@ -1217,23 +1246,12 @@ unsafe fn finish_package_json(
     f: impl FnOnce(&PioPackage) -> Result<String, String>,
 ) -> *mut c_char {
     unsafe {
-        let result = catch_unwind(AssertUnwindSafe(|| {
+        finish_string(errbuf, errlen, panic_msg, || {
             let pkg = pkg
                 .as_ref()
                 .ok_or_else(|| "package handle is NULL".to_string())?;
             f(pkg)
-        }));
-        match result {
-            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
-            Ok(Err(msg)) => {
-                copy_to_buf(errbuf, errlen, &msg);
-                std::ptr::null_mut()
-            }
-            Err(_) => {
-                copy_to_buf(errbuf, errlen, panic_msg);
-                std::ptr::null_mut()
-            }
-        }
+        })
     }
 }
 
@@ -1316,7 +1334,7 @@ pub unsafe extern "C" fn pio_package_from_multiconductor_network(
 }
 
 /// Materialize the balanced payload of a package handle as an owned network
-/// handle -- the inverse of [`pio_package_from_balanced_network`]. Errors when
+/// handle: the inverse of [`pio_package_from_balanced_network`]. Errors when
 /// the package holds a different model kind. The handle is built from the
 /// payload alone: it retains no source text, so a same-format write is a fresh
 /// serialization rather than a byte-exact echo, and it carries no parse
@@ -1338,23 +1356,36 @@ pub unsafe extern "C" fn pio_package_to_balanced_network(
                     .as_ref()
                     .ok_or_else(|| "package handle is NULL".to_string())?;
                 let net = pkg.package.model.as_balanced().ok_or_else(|| {
-                    "package holds a multiconductor model, not balanced; use \
-                     pio_package_to_multiconductor_network"
-                        .to_string()
+                    if cfg!(feature = "dist") {
+                        "package holds a multiconductor model, not balanced; use \
+                         pio_package_to_multiconductor_network"
+                            .to_string()
+                    } else {
+                        "package holds a multiconductor model, not balanced; extracting \
+                         it needs a build with the `dist` feature \
+                         (pio_package_to_multiconductor_network)"
+                            .to_string()
+                    }
                 })?;
-                Ok((net.clone(), Vec::new()))
+                let mut net = net.clone();
+                // An in-memory package still holds the payload's #[serde(skip)]
+                // source text; drop it so extraction behaves the same whether
+                // or not the package crossed JSON, and a same-format write is
+                // the promised fresh serialization.
+                net.source = None;
+                Ok((net, Vec::new()))
             },
         )
     }
 }
 
 /// Materialize the multiconductor payload of a package handle as an owned
-/// distribution network handle -- the inverse of
+/// distribution network handle: the inverse of
 /// [`pio_package_from_multiconductor_network`]. Errors when the package holds
-/// a different model kind. The handle retains no source text (`source` never
-/// enters the payload), so a same-format write is a fresh serialization; the
-/// payload's parse warnings ride along and stay readable via
-/// [`pio_dist_warnings`]. Free with [`pio_dist_network_free`].
+/// a different model kind. The handle retains no source text, so a
+/// same-format write is a fresh serialization; the payload's parse warnings
+/// ride along and stay readable via [`pio_dist_warnings`]. Free with
+/// [`pio_dist_network_free`].
 #[cfg(all(feature = "pkg", feature = "dist"))]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_to_multiconductor_network(
@@ -1376,7 +1407,13 @@ pub unsafe extern "C" fn pio_package_to_multiconductor_network(
                      pio_package_to_balanced_network"
                         .to_string()
                 })?;
-                Ok(PioDistNetwork { net: net.clone() })
+                let mut net = net.clone();
+                // Same in-memory strip as the balanced inverse: source and the
+                // defaulted provenance are #[serde(skip)], so dropping them
+                // here matches what a JSON crossing produces.
+                net.source = None;
+                net.defaulted = Default::default();
+                Ok(PioDistNetwork { net })
             },
         )
     }
@@ -1523,33 +1560,27 @@ pub unsafe extern "C" fn pio_package_multiconductor_to_balanced_preflight_json(
     errlen: usize,
 ) -> *mut c_char {
     unsafe {
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            let pkg = pkg
-                .as_ref()
-                .ok_or_else(|| "package handle is NULL".to_string())?;
-            let net = pkg.package.as_multiconductor().ok_or_else(|| {
-                format!(
-                    "multiconductor preflight requires a multiconductor package, got {:?}",
-                    pkg.package.model_kind()
-                )
-            })?;
-            let report = powerio_pkg::check_multiconductor_to_balanced_lowering(
-                net,
-                lowering_options(base_mva),
-            );
-            serde_json::to_string(&report).map_err(|e| e.to_string())
-        }));
-        match result {
-            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
-            Ok(Err(msg)) => {
-                copy_to_buf(errbuf, errlen, &msg);
-                std::ptr::null_mut()
-            }
-            Err(_) => {
-                copy_to_buf(errbuf, errlen, "panic while preflighting package lowering");
-                std::ptr::null_mut()
-            }
-        }
+        finish_string(
+            errbuf,
+            errlen,
+            "panic while preflighting package lowering",
+            || {
+                let pkg = pkg
+                    .as_ref()
+                    .ok_or_else(|| "package handle is NULL".to_string())?;
+                let net = pkg.package.as_multiconductor().ok_or_else(|| {
+                    format!(
+                        "multiconductor preflight requires a multiconductor package, got {:?}",
+                        pkg.package.model_kind()
+                    )
+                })?;
+                let report = powerio_pkg::check_multiconductor_to_balanced_lowering(
+                    net,
+                    lowering_options(base_mva),
+                );
+                serde_json::to_string(&report).map_err(|e| e.to_string())
+            },
+        )
     }
 }
 
@@ -1718,7 +1749,7 @@ pub unsafe extern "C" fn pio_dist_warnings(
 
 /// Serialize `net` to its model JSON: the same object a `.pio.json` package
 /// carries under `model.multiconductor_network`, without the surrounding
-/// document. This is the bindings' data transport, not a case format -- the
+/// document. This is the bindings' data transport, not a case format: the
 /// converter, CLI, and format inference do not know it; distribution cases
 /// exchanged with other tools are BMOPF JSON ([`pio_dist_to_format`]).
 /// Returns an owned C string (free with [`pio_string_free`]), `NULL` on error.
@@ -1730,29 +1761,18 @@ pub unsafe extern "C" fn pio_dist_to_json(
     errlen: usize,
 ) -> *mut c_char {
     unsafe {
-        let result = catch_unwind(AssertUnwindSafe(|| {
+        finish_string(errbuf, errlen, "panic while serializing model JSON", || {
             let net = net
                 .as_ref()
                 .ok_or_else(|| "distribution network handle is NULL".to_string())?;
             serde_json::to_string(&net.net).map_err(|e| e.to_string())
-        }));
-        match result {
-            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
-            Ok(Err(msg)) => {
-                copy_to_buf(errbuf, errlen, &msg);
-                std::ptr::null_mut()
-            }
-            Err(_) => {
-                copy_to_buf(errbuf, errlen, "panic while serializing model JSON");
-                std::ptr::null_mut()
-            }
-        }
+        })
     }
 }
 
 /// Parse model JSON produced by [`pio_dist_to_json`] (or lifted from a
 /// `.pio.json` document's `model.multiconductor_network`) back into an owned
-/// handle -- the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
+/// handle: the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
 /// no source text, so a same-format write is a fresh serialization; the model
 /// JSON's `warnings` ride along. Returns `NULL` on error. Free with
 /// [`pio_dist_network_free`].
@@ -3318,18 +3338,46 @@ mpc.branch = [
     }
 
     #[cfg(feature = "dist")]
+    fn fourwire() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data/dist/micro/fourwire_linecode.dss")
+    }
+
+    #[cfg(feature = "dist")]
+    fn fourwire_cstr() -> CString {
+        CString::new(fourwire().to_str().unwrap()).unwrap()
+    }
+
+    /// Write `net` as BMOPF JSON. Shared by the round trip tests that compare
+    /// a handle's output before and after crossing an envelope.
+    #[cfg(feature = "dist")]
+    unsafe fn bmopf(net: *const PioDistNetwork) -> String {
+        let to = CString::new("bmopf").unwrap();
+        let mut warn = [0 as c_char; 4096];
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        let s = unsafe {
+            pio_dist_to_format(
+                net,
+                to.as_ptr(),
+                warn.as_mut_ptr(),
+                warn.len(),
+                err.as_mut_ptr(),
+                err.len(),
+            )
+        };
+        assert!(!s.is_null());
+        let text = unsafe { std::ffi::CStr::from_ptr(s) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        unsafe { pio_string_free(s) };
+        text
+    }
+
+    #[cfg(feature = "dist")]
     mod dist {
         use super::*;
         use std::ffi::CStr;
-
-        fn fourwire() -> std::path::PathBuf {
-            std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../tests/data/dist/micro/fourwire_linecode.dss")
-        }
-
-        fn fourwire_cstr() -> CString {
-            CString::new(fourwire().to_str().unwrap()).unwrap()
-        }
 
         #[test]
         fn dist_abi_version_is_separate() {
@@ -3594,7 +3642,7 @@ mpc.branch = [
     }
 
     /// The package inverse pair: wrap a handle, cross the JSON envelope, and
-    /// extract an owned handle again -- the binding materialization path.
+    /// extract an owned handle again, the binding materialization path.
     #[cfg(feature = "pkg")]
     mod package_inverse {
         use super::*;
@@ -3620,6 +3668,17 @@ mpc.branch = [
             let pkg =
                 unsafe { pio_package_from_balanced_network(net, 0, err.as_mut_ptr(), err.len()) };
             assert!(!pkg.is_null());
+
+            // An in-memory extraction (no JSON crossing) sheds the retained
+            // source text too: same-format writes are fresh serializations,
+            // never byte echoes of the wrapped handle's source.
+            unsafe {
+                let mem = pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len());
+                assert!(!mem.is_null());
+                assert!((*mem).net.source.is_none());
+                pio_network_free(mem);
+            }
+
             let pkg = unsafe { envelope_round_trip(pkg) };
 
             // Wrong-kind extraction refuses with a directed message.
@@ -3650,13 +3709,7 @@ mpc.branch = [
         #[cfg(feature = "dist")]
         #[test]
         fn dist_model_json_round_trip_matches_package_field() {
-            let path = CString::new(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../tests/data/dist/micro/fourwire_linecode.dss")
-                    .to_str()
-                    .unwrap(),
-            )
-            .unwrap();
+            let path = fourwire_cstr();
             let mut err = [0 as c_char; PIO_ERRBUF_MIN];
             let net = unsafe {
                 pio_dist_parse_file(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len())
@@ -3672,25 +3725,6 @@ mpc.branch = [
             let back = unsafe { pio_dist_from_json(c.as_ptr(), err.as_mut_ptr(), err.len()) };
             assert!(!back.is_null());
 
-            unsafe fn bmopf(net: *const PioDistNetwork) -> String {
-                let to = CString::new("bmopf").unwrap();
-                let mut warn = [0 as c_char; 4096];
-                let mut err = [0 as c_char; PIO_ERRBUF_MIN];
-                let s = unsafe {
-                    pio_dist_to_format(
-                        net,
-                        to.as_ptr(),
-                        warn.as_mut_ptr(),
-                        warn.len(),
-                        err.as_mut_ptr(),
-                        err.len(),
-                    )
-                };
-                assert!(!s.is_null());
-                let text = unsafe { CStr::from_ptr(s) }.to_str().unwrap().to_owned();
-                unsafe { pio_string_free(s) };
-                text
-            }
             unsafe { assert_eq!(bmopf(back), bmopf(net)) };
 
             // The model JSON is the same object the .pio.json document carries
@@ -3718,13 +3752,7 @@ mpc.branch = [
         #[cfg(feature = "dist")]
         #[test]
         fn multiconductor_wrap_extract_across_json() {
-            let path = CString::new(
-                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-                    .join("../tests/data/dist/micro/fourwire_linecode.dss")
-                    .to_str()
-                    .unwrap(),
-            )
-            .unwrap();
+            let path = fourwire_cstr();
             let mut err = [0 as c_char; PIO_ERRBUF_MIN];
             let net = unsafe {
                 pio_dist_parse_file(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len())
@@ -3734,6 +3762,17 @@ mpc.branch = [
                 pio_package_from_multiconductor_network(net, err.as_mut_ptr(), err.len())
             };
             assert!(!pkg.is_null());
+
+            // Same in-memory strip check as the balanced side: source and the
+            // defaulted provenance never survive extraction.
+            unsafe {
+                let mem = pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len());
+                assert!(!mem.is_null());
+                assert!((*mem).net.source.is_none());
+                assert!((*mem).net.defaulted.is_empty());
+                pio_dist_network_free(mem);
+            }
+
             let pkg = unsafe { envelope_round_trip(pkg) };
             let back =
                 unsafe { pio_package_to_multiconductor_network(pkg, err.as_mut_ptr(), err.len()) };
@@ -3745,25 +3784,6 @@ mpc.branch = [
 
             // The extracted model writes the same BMOPF text as the original:
             // nothing the model represents is lost crossing the envelope.
-            unsafe fn bmopf(net: *const PioDistNetwork) -> String {
-                let to = CString::new("bmopf").unwrap();
-                let mut warn = [0 as c_char; 4096];
-                let mut err = [0 as c_char; PIO_ERRBUF_MIN];
-                let s = unsafe {
-                    pio_dist_to_format(
-                        net,
-                        to.as_ptr(),
-                        warn.as_mut_ptr(),
-                        warn.len(),
-                        err.as_mut_ptr(),
-                        err.len(),
-                    )
-                };
-                assert!(!s.is_null());
-                let text = unsafe { CStr::from_ptr(s) }.to_str().unwrap().to_owned();
-                unsafe { pio_string_free(s) };
-                text
-            }
             unsafe {
                 assert_eq!(bmopf(back), bmopf(net));
                 let wrong = pio_package_to_balanced_network(pkg, err.as_mut_ptr(), err.len());

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1583,8 +1583,9 @@ pub unsafe extern "C" fn pio_package_lower_multiconductor_to_balanced(
 // on the `dist` feature / `PIO_DIST` define, exactly like `arrow`/`gridfm`; a
 // runtime consumer probes it with `pio_has_feature("dist")`, then checks
 // `pio_dist_abi_version()`. The surface is EXPERIMENTAL while the IEEE BMOPF
-// schema is a draft: C signature changes bump `PIO_DIST_ABI_VERSION`, and the
-// JSON payloads (bmopf-json, powerio-dist-json) carry their own meta.version.
+// schema is a draft: C signature changes bump `PIO_DIST_ABI_VERSION`. BMOPF
+// JSON carries its own meta.version; the model JSON of `pio_dist_to_json` is
+// versioned by the pio-payload-multiconductor identifier in powerio-pkg.
 // ---------------------------------------------------------------------------
 
 /// Finish a handle-returning dist entry point: run `f` (the handle payload or an
@@ -1711,6 +1712,63 @@ pub unsafe extern "C" fn pio_dist_warnings(
             let msg = c.net.warnings.join("\n");
             copy_to_buf(warnbuf, warnlen, &msg);
             msg.len()
+        })
+    }
+}
+
+/// Serialize `net` to its model JSON: the same object a `.pio.json` package
+/// carries under `model.multiconductor_network`, without the surrounding
+/// document. This is the bindings' data transport, not a case format -- the
+/// converter, CLI, and format inference do not know it; distribution cases
+/// exchanged with other tools are BMOPF JSON ([`pio_dist_to_format`]).
+/// Returns an owned C string (free with [`pio_string_free`]), `NULL` on error.
+#[cfg(feature = "dist")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_dist_to_json(
+    net: *const PioDistNetwork,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let net = net
+                .as_ref()
+                .ok_or_else(|| "distribution network handle is NULL".to_string())?;
+            serde_json::to_string(&net.net).map_err(|e| e.to_string())
+        }));
+        match result {
+            Ok(Ok(text)) => finish_cstring(text, errbuf, errlen),
+            Ok(Err(msg)) => {
+                copy_to_buf(errbuf, errlen, &msg);
+                std::ptr::null_mut()
+            }
+            Err(_) => {
+                copy_to_buf(errbuf, errlen, "panic while serializing model JSON");
+                std::ptr::null_mut()
+            }
+        }
+    }
+}
+
+/// Parse model JSON produced by [`pio_dist_to_json`] (or lifted from a
+/// `.pio.json` document's `model.multiconductor_network`) back into an owned
+/// handle -- the inverse of [`pio_dist_to_json`]. The rebuilt handle retains
+/// no source text, so a same-format write is a fresh serialization; the model
+/// JSON's `warnings` ride along. Returns `NULL` on error. Free with
+/// [`pio_dist_network_free`].
+#[cfg(feature = "dist")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_dist_from_json(
+    text: *const c_char,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioDistNetwork {
+    unsafe {
+        finish_handle(errbuf, errlen, "panic while parsing model JSON", || {
+            let text = required_cstr(text, "text")?;
+            serde_json::from_str::<powerio_dist::DistNetwork>(text)
+                .map(|net| PioDistNetwork { net })
+                .map_err(|e| format!("model JSON: {e}"))
         })
     }
 }
@@ -2134,6 +2192,8 @@ mod tests {
             "PioDistNetwork *pio_dist_parse_str(const char *text, const char *format, char *errbuf, size_t errlen);",
             "void pio_dist_network_free(PioDistNetwork *net);",
             "size_t pio_dist_warnings(const PioDistNetwork *net, char *warnbuf, size_t warnlen);",
+            "char *pio_dist_to_json(const PioDistNetwork *net, char *errbuf, size_t errlen);",
+            "PioDistNetwork *pio_dist_from_json(const char *text, char *errbuf, size_t errlen);",
             "char *pio_dist_to_format(const PioDistNetwork *net, const char *to, char *warnbuf, size_t warnlen, char *errbuf, size_t errlen);",
             "char *pio_dist_convert_file(const char *path, const char *from, const char *to, char *warnbuf, size_t warnlen, char *errbuf, size_t errlen);",
             "char *pio_dist_convert_str(const char *text, const char *from, const char *to, char *warnbuf, size_t warnlen, char *errbuf, size_t errlen);",
@@ -3584,6 +3644,74 @@ mpc.branch = [
                 pio_package_free(pkg);
                 pio_network_free(back);
                 pio_network_free(net);
+            }
+        }
+
+        #[cfg(feature = "dist")]
+        #[test]
+        fn dist_model_json_round_trip_matches_package_field() {
+            let path = CString::new(
+                std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../tests/data/dist/micro/fourwire_linecode.dss")
+                    .to_str()
+                    .unwrap(),
+            )
+            .unwrap();
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            let net = unsafe {
+                pio_dist_parse_file(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len())
+            };
+            assert!(!net.is_null());
+
+            // One call out, one call back: bmopf output survives unchanged.
+            let json = unsafe { pio_dist_to_json(net, err.as_mut_ptr(), err.len()) };
+            assert!(!json.is_null());
+            let text = unsafe { CStr::from_ptr(json) }.to_str().unwrap().to_owned();
+            unsafe { pio_string_free(json) };
+            let c = CString::new(text.clone()).unwrap();
+            let back = unsafe { pio_dist_from_json(c.as_ptr(), err.as_mut_ptr(), err.len()) };
+            assert!(!back.is_null());
+
+            unsafe fn bmopf(net: *const PioDistNetwork) -> String {
+                let to = CString::new("bmopf").unwrap();
+                let mut warn = [0 as c_char; 4096];
+                let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+                let s = unsafe {
+                    pio_dist_to_format(
+                        net,
+                        to.as_ptr(),
+                        warn.as_mut_ptr(),
+                        warn.len(),
+                        err.as_mut_ptr(),
+                        err.len(),
+                    )
+                };
+                assert!(!s.is_null());
+                let text = unsafe { CStr::from_ptr(s) }.to_str().unwrap().to_owned();
+                unsafe { pio_string_free(s) };
+                text
+            }
+            unsafe { assert_eq!(bmopf(back), bmopf(net)) };
+
+            // The model JSON is the same object the .pio.json document carries
+            // under model.multiconductor_network.
+            let pkg = unsafe {
+                pio_package_from_multiconductor_network(net, err.as_mut_ptr(), err.len())
+            };
+            assert!(!pkg.is_null());
+            let pkg_json = unsafe { pio_package_to_json(pkg, err.as_mut_ptr(), err.len()) };
+            assert!(!pkg_json.is_null());
+            let doc: serde_json::Value =
+                serde_json::from_str(unsafe { CStr::from_ptr(pkg_json) }.to_str().unwrap())
+                    .unwrap();
+            let direct: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(doc["model"]["multiconductor_network"], direct);
+
+            unsafe {
+                pio_string_free(pkg_json);
+                pio_package_free(pkg);
+                pio_dist_network_free(back);
+                pio_dist_network_free(net);
             }
         }
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
-use powerio_matrix::format::routing::{Detection, SourceFormat as DetectedFormat};
+use powerio_matrix::format::routing::{Detection, JsonClass, SourceFormat as DetectedFormat};
 use powerio_matrix::io::gridfm::{GridfmOptions, numbered_snapshots, write_gridfm_batch};
 use powerio_matrix::matrix::{BuildOptions, DcConvention, Scheme, Units, sddm_check};
 use powerio_matrix::opf_pipeline::{DcOpfOptions, write_dcopf_bundle};
@@ -1208,17 +1208,23 @@ fn infer_input_family(input: &Path) -> anyhow::Result<Option<bool>> {
     let text = std::fs::read_to_string(input)
         .with_context(|| format!("reading JSON format markers from {}", input.display()))?;
     match powerio_matrix::format::routing::classify_json_text(&text) {
-        Detection::Known(DetectedFormat::Distribution(_)) => Ok(Some(true)),
-        Detection::Known(DetectedFormat::Transmission(_)) => Ok(Some(false)),
-        Detection::Ambiguous => anyhow::bail!(
+        JsonClass::Package => anyhow::bail!(
+            "{} is a .pio.json package envelope, not a case file; the `package` \
+             subcommand writes envelopes, and the bindings read them \
+             (powerio.Package.from_json in Python, read_package in Julia)",
+            input.display()
+        ),
+        JsonClass::Case(Detection::Known(DetectedFormat::Distribution(_))) => Ok(Some(true)),
+        JsonClass::Case(Detection::Known(DetectedFormat::Transmission(_))) => Ok(Some(false)),
+        JsonClass::Case(Detection::Ambiguous) => anyhow::bail!(
             "ambiguous JSON markers in {}; pass --from to choose a format",
             input.display()
         ),
-        Detection::Unknown => anyhow::bail!(
+        JsonClass::Case(Detection::Unknown) => anyhow::bail!(
             "cannot infer JSON format for {}; pass --from to choose a format",
             input.display()
         ),
-        Detection::Known(_) => anyhow::bail!(
+        JsonClass::Case(Detection::Known(_)) => anyhow::bail!(
             "unrecognized JSON format family in {}; pass --from to choose a format",
             input.display()
         ),

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -147,19 +147,19 @@ impl OperatingPoint {
 /// before payload identity existed), `source_uid` is advisory and `row`
 /// addresses the update alone. On the wire, `row` may be omitted when
 /// `source_uid` is given.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[non_exhaustive]
 pub struct ElementRef {
     /// Payload table name, such as `loads`, `generators`, `branches`, or `hvdc`.
     pub table: String,
-    /// Zero based row index in `table`. Meaningful only when the wire carried
-    /// one; read [`ElementRef::wire_row`] before trusting it.
-    pub row: usize,
+    /// Zero based row index in `table`, when the producer addressed one.
+    /// `None` on refs built by [`ElementRef::by_source_uid`], which address by
+    /// identity alone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub row: Option<usize>,
     /// The row's payload identity (its `uid` field), when the producer knows it.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_uid: Option<String>,
-    /// Whether the wire carried `row`. Refs built by
-    /// [`ElementRef::by_source_uid`] have no truthful row to serialize.
-    row_present: bool,
 }
 
 impl ElementRef {
@@ -167,9 +167,8 @@ impl ElementRef {
     pub fn new(table: impl Into<String>, row: usize) -> Self {
         Self {
             table: table.into(),
-            row,
+            row: Some(row),
             source_uid: None,
-            row_present: true,
         }
     }
 
@@ -178,9 +177,8 @@ impl ElementRef {
     pub fn by_source_uid(table: impl Into<String>, uid: impl Into<String>) -> Self {
         Self {
             table: table.into(),
-            row: 0,
+            row: None,
             source_uid: Some(uid.into()),
-            row_present: false,
         }
     }
 
@@ -188,28 +186,6 @@ impl ElementRef {
     pub fn with_source_uid(mut self, uid: impl Into<String>) -> Self {
         self.source_uid = Some(uid.into());
         self
-    }
-
-    /// The wire `row`, when one was given.
-    #[must_use]
-    pub fn wire_row(&self) -> Option<usize> {
-        self.row_present.then_some(self.row)
-    }
-}
-
-impl Serialize for ElementRef {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        use serde::ser::SerializeStruct;
-        let len = 1 + usize::from(self.row_present) + usize::from(self.source_uid.is_some());
-        let mut state = serializer.serialize_struct("ElementRef", len)?;
-        state.serialize_field("table", &self.table)?;
-        if self.row_present {
-            state.serialize_field("row", &self.row)?;
-        }
-        if let Some(uid) = &self.source_uid {
-            state.serialize_field("source_uid", uid)?;
-        }
-        state.end()
     }
 }
 
@@ -231,8 +207,7 @@ impl<'de> Deserialize<'de> for ElementRef {
         }
         Ok(Self {
             table: wire.table,
-            row_present: wire.row.is_some(),
-            row: wire.row.unwrap_or(0),
+            row: wire.row,
             source_uid: wire.source_uid,
         })
     }
@@ -657,7 +632,7 @@ fn resolve_update_row(
         }
         Some(uid) => match index.by_uid.get(uid) {
             Some(&row) => {
-                if let Some(wire_row) = element.wire_row()
+                if let Some(wire_row) = element.row
                     && wire_row != row
                 {
                     return Err(format!(
@@ -672,14 +647,14 @@ fn resolve_update_row(
                     "unknown identity: table `{table_name}` has no row with uid `{uid}`"
                 ));
             }
-            None => element.wire_row().ok_or_else(|| {
+            None => element.row.ok_or_else(|| {
                 format!(
                     "update for table `{table_name}` names uid `{uid}`, but the payload rows \
                      carry no uids and the update has no row to fall back on"
                 )
             })?,
         },
-        None => element.wire_row().ok_or_else(|| {
+        None => element.row.ok_or_else(|| {
             format!("update for table `{table_name}` has neither row nor source_uid")
         })?,
     };

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -343,7 +343,11 @@ fn goc3_operating_points_follow_parser_row_assignment() {
     let series = pkg.operating_points().expect("operating points");
     let update = &series.points[1].updates[0];
     assert_eq!(update.element.table, "generators");
-    assert_eq!(update.element.row, 1, "uid-less producer occupies row 0");
+    assert_eq!(
+        update.element.row,
+        Some(1),
+        "uid-less producer occupies row 0"
+    );
     assert_eq!(update.element.source_uid.as_deref(), Some("prod"));
 
     let materialized = pkg.materialize_operating_point(1).expect("materialize");
@@ -1892,11 +1896,11 @@ fn element_ref_wire_requires_row_or_identity() {
     let by_uid: ElementRef =
         serde_json::from_str(r#"{"table": "loads", "source_uid": "l1"}"#).unwrap();
     assert_eq!(by_uid, ElementRef::by_source_uid("loads", "l1"));
-    assert_eq!(by_uid.wire_row(), None);
+    assert_eq!(by_uid.row, None);
 
     let by_row: ElementRef = serde_json::from_str(r#"{"table": "loads", "row": 3}"#).unwrap();
     assert_eq!(by_row, ElementRef::new("loads", 3));
-    assert_eq!(by_row.wire_row(), Some(3));
+    assert_eq!(by_row.row, Some(3));
 }
 
 #[test]

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -400,11 +400,16 @@ fn looks_like_distribution_input(input: &Path) -> PyResult<bool> {
             input.display()
         ))
     })?;
-    use powerio_matrix::format::routing::{Detection, Domain};
+    use powerio_matrix::format::routing::{Detection, Domain, JsonClass};
     match powerio_matrix::format::routing::classify_json_text(&text) {
-        Detection::Known(format) => Ok(format.domain() == Domain::Distribution),
-        Detection::Unknown => Ok(false),
-        Detection::Ambiguous => Err(PyValueError::new_err(format!(
+        JsonClass::Package => Err(PyValueError::new_err(format!(
+            "{} is a .pio.json package envelope, not a case; read it with \
+             powerio.Package.from_json",
+            input.display()
+        ))),
+        JsonClass::Case(Detection::Known(format)) => Ok(format.domain() == Domain::Distribution),
+        JsonClass::Case(Detection::Unknown) => Ok(false),
+        JsonClass::Case(Detection::Ambiguous) => Err(PyValueError::new_err(format!(
             "ambiguous JSON markers in {}; pass from_",
             input.display()
         ))),
@@ -494,13 +499,19 @@ fn build_package_from_str(text: &str, from_: Option<&str>) -> PyResult<NetworkPa
     let source_format = if let Some(format) = from_ {
         Some(format.to_owned())
     } else {
-        use powerio_matrix::format::routing::Detection;
+        use powerio_matrix::format::routing::{Detection, JsonClass};
         match powerio_matrix::format::routing::classify_json_text(text) {
-            Detection::Known(format) => Some(format.name().to_owned()),
-            Detection::Ambiguous => {
+            JsonClass::Package => {
+                return Err(PyValueError::new_err(
+                    "text is a .pio.json package envelope, not a case; read it with \
+                     powerio.Package.from_json",
+                ));
+            }
+            JsonClass::Case(Detection::Known(format)) => Some(format.name().to_owned()),
+            JsonClass::Case(Detection::Ambiguous) => {
                 return Err(PyValueError::new_err("ambiguous JSON markers; pass from_"));
             }
-            Detection::Unknown => None,
+            JsonClass::Case(Detection::Unknown) => None,
         }
     };
 
@@ -1525,21 +1536,24 @@ impl PyPackage {
 }
 
 /// Classify top level JSON markers. Returns `(status, domain, format)` where
-/// `status` is `known`, `unknown`, or `ambiguous`.
+/// `status` is `known`, `package` (a `.pio.json` envelope), `unknown`, or
+/// `ambiguous`.
 #[pyfunction]
 fn classify_json_text(text: &str) -> (String, Option<String>, Option<String>) {
+    use powerio_matrix::format::routing::{Detection, Domain, JsonClass};
     match powerio_matrix::format::routing::classify_json_text(text) {
-        powerio_matrix::format::routing::Detection::Known(format) => (
+        JsonClass::Package => ("package".into(), None, None),
+        JsonClass::Case(Detection::Known(format)) => (
             "known".into(),
             Some(match format.domain() {
-                powerio_matrix::format::routing::Domain::Transmission => "transmission".into(),
-                powerio_matrix::format::routing::Domain::Distribution => "distribution".into(),
+                Domain::Transmission => "transmission".into(),
+                Domain::Distribution => "distribution".into(),
                 _ => "unknown".into(),
             }),
             Some(format.name().into()),
         ),
-        powerio_matrix::format::routing::Detection::Unknown => ("unknown".into(), None, None),
-        powerio_matrix::format::routing::Detection::Ambiguous => ("ambiguous".into(), None, None),
+        JsonClass::Case(Detection::Unknown) => ("unknown".into(), None, None),
+        JsonClass::Case(Detection::Ambiguous) => ("ambiguous".into(), None, None),
     }
 }
 

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -1215,10 +1215,7 @@ mod tests {
     #[test]
     fn dss_extension_error_names_the_distribution_surface() {
         let err = parse_file("feeder.dss", None).unwrap_err();
-        assert!(
-            err.to_string().contains("distribution"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("distribution"), "got: {err}");
     }
 
     #[test]

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -36,7 +36,7 @@ use serde_json::{Map, Value};
 use crate::gen_cost::{GenCostPatch, MissingGenCostPolicy};
 use crate::network::{Branch, BranchRatingSet, Bus, BusId, BusType, Network, SourceFormat};
 use crate::{Error, Result};
-use routing::{Detection, SourceFormat as DetectedFormat, TransmissionFormat};
+use routing::{Detection, JsonClass, SourceFormat as DetectedFormat, TransmissionFormat};
 
 mod egret;
 mod goc3;
@@ -443,15 +443,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
                 Some("raw") => Some(TargetFormat::Psse { rev: 33 }),
                 Some("aux") => Some(TargetFormat::PowerWorld),
                 Some("json") => None,
-                Some("dss") => {
-                    return Err(Error::UnknownFormat(
-                        "\"dss\" is an OpenDSS distribution case; this parser reads only \
-                         balanced transmission formats -- use the distribution surface \
-                         (powerio_dist::parse_file, pio_dist_parse_file in C, or the \
-                         format-routed parse_file in the bindings)"
-                            .into(),
-                    ));
-                }
+                Some("dss") => return Err(unknown_source_format("dss")),
                 other => {
                     return Err(Error::UnknownFormat(format!(
                         "cannot infer from file extension {other:?}; \
@@ -534,8 +526,8 @@ pub(crate) fn reject_empty_case(net: &Network, format: &'static str) -> Result<(
 fn unknown_source_format(name: &str) -> Error {
     if let Some(dist) = routing::distribution_format_from_name(name) {
         return Error::UnknownFormat(format!(
-            "`{}` is a distribution format; this parser reads only balanced transmission \
-             formats -- use the distribution surface (powerio_dist::parse_file, \
+            "`{}` is a distribution format, and this parser reads only balanced \
+             transmission formats; use the distribution surface (powerio_dist::parse_file, \
              pio_dist_parse_file in C, or the format-routed parse_file in the bindings)",
             dist.name()
         ));
@@ -547,25 +539,26 @@ fn unknown_source_format(name: &str) -> Error {
 /// isn't always given. Classification lives here so the CLI and bindings use
 /// the same top level markers as the Rust parsers.
 fn sniff_json(text: &str) -> Result<TargetFormat> {
-    if routing::looks_like_package_envelope(text) {
-        return Err(Error::UnknownFormat(
-            "JSON is a .pio.json package envelope, not a case format; read it with the \
-             package entry points (pio_package_parse_str / read_package in the bindings)"
-                .into(),
-        ));
-    }
     match routing::classify_json_text(text) {
-        Detection::Known(DetectedFormat::Transmission(format)) => transmission_json_target(format),
-        Detection::Known(DetectedFormat::Distribution(format)) => {
+        JsonClass::Package => Err(Error::UnknownFormat(
+            "JSON is a .pio.json package envelope, not a case format; read it with the \
+             package entry points (pio_package_parse_str in C, powerio.Package.from_json \
+             in Python, read_package in Julia)"
+                .into(),
+        )),
+        JsonClass::Case(Detection::Known(DetectedFormat::Transmission(format))) => {
+            transmission_json_target(format)
+        }
+        JsonClass::Case(Detection::Known(DetectedFormat::Distribution(format))) => {
             Err(Error::UnknownFormat(format!(
                 "JSON looks like distribution `{}`; use the distribution parser or pass an explicit transmission format",
                 format.name()
             )))
         }
-        Detection::Ambiguous => Err(Error::UnknownFormat(
+        JsonClass::Case(Detection::Ambiguous) => Err(Error::UnknownFormat(
             "ambiguous JSON markers; pass an explicit source format".into(),
         )),
-        Detection::Unknown => Err(Error::UnknownFormat(
+        JsonClass::Case(Detection::Unknown) => Err(Error::UnknownFormat(
             "cannot infer JSON format; pass an explicit source format".into(),
         )),
     }

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -434,7 +434,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
             if display_format_from_name(f).is_some() {
                 return Err(display_file_guidance());
             }
-            Some(target_format_from_name(f).ok_or_else(|| Error::UnknownFormat(f.to_string()))?)
+            Some(target_format_from_name(f).ok_or_else(|| unknown_source_format(f))?)
         }
         None => {
             // Everything but `.json` (sniffed below) resolves without the text.
@@ -443,6 +443,15 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
                 Some("raw") => Some(TargetFormat::Psse { rev: 33 }),
                 Some("aux") => Some(TargetFormat::PowerWorld),
                 Some("json") => None,
+                Some("dss") => {
+                    return Err(Error::UnknownFormat(
+                        "\"dss\" is an OpenDSS distribution case; this parser reads only \
+                         balanced transmission formats -- use the distribution surface \
+                         (powerio_dist::parse_file, pio_dist_parse_file in C, or the \
+                         format-routed parse_file in the bindings)"
+                            .into(),
+                    ));
+                }
                 other => {
                     return Err(Error::UnknownFormat(format!(
                         "cannot infer from file extension {other:?}; \
@@ -518,10 +527,33 @@ pub(crate) fn reject_empty_case(net: &Network, format: &'static str) -> Result<(
     Ok(())
 }
 
+/// An unrecognized source format token. When the token names a distribution
+/// format (`dss`, `pmd`, `bmopf`), the error points at the distribution
+/// surface instead of echoing the token: this parser reads only balanced
+/// transmission formats.
+fn unknown_source_format(name: &str) -> Error {
+    if let Some(dist) = routing::distribution_format_from_name(name) {
+        return Error::UnknownFormat(format!(
+            "`{}` is a distribution format; this parser reads only balanced transmission \
+             formats -- use the distribution surface (powerio_dist::parse_file, \
+             pio_dist_parse_file in C, or the format-routed parse_file in the bindings)",
+            dist.name()
+        ));
+    }
+    Error::UnknownFormat(name.to_string())
+}
+
 /// The JSON formats share the `.json` extension, so an explicit source format
 /// isn't always given. Classification lives here so the CLI and bindings use
 /// the same top level markers as the Rust parsers.
 fn sniff_json(text: &str) -> Result<TargetFormat> {
+    if routing::looks_like_package_envelope(text) {
+        return Err(Error::UnknownFormat(
+            "JSON is a .pio.json package envelope, not a case format; read it with the \
+             package entry points (pio_package_parse_str / read_package in the bindings)"
+                .into(),
+        ));
+    }
     match routing::classify_json_text(text) {
         Detection::Known(DetectedFormat::Transmission(format)) => transmission_json_target(format),
         Detection::Known(DetectedFormat::Distribution(format)) => {
@@ -568,8 +600,7 @@ pub fn parse_str(text: &str, format: &str) -> Result<Parsed> {
         reject_empty_case(&network, "PSLF .epc")?;
         return Ok(Parsed { network, warnings });
     }
-    let fmt =
-        target_format_from_name(format).ok_or_else(|| Error::UnknownFormat(format.to_string()))?;
+    let fmt = target_format_from_name(format).ok_or_else(|| unknown_source_format(format))?;
     read_source(Arc::new(text.to_owned()), fmt, None)
 }
 
@@ -1180,6 +1211,35 @@ fn collect_null_keys(value: &Value, out: &mut BTreeSet<String>) {
 mod tests {
     use super::*;
     use crate::network::SourceFormat;
+
+    #[test]
+    fn dss_extension_error_names_the_distribution_surface() {
+        let err = parse_file("feeder.dss", None).unwrap_err();
+        assert!(
+            err.to_string().contains("distribution"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn distribution_from_token_error_names_the_distribution_surface() {
+        for token in ["dss", "pmd", "bmopf"] {
+            let err = parse_str("anything", token).unwrap_err();
+            assert!(
+                err.to_string().contains("distribution surface"),
+                "{token}: {err}"
+            );
+        }
+        // A genuinely unknown token still echoes plainly.
+        let err = parse_str("anything", "nonesuch").unwrap_err();
+        assert!(err.to_string().contains("nonesuch"));
+    }
+
+    #[test]
+    fn package_envelope_json_error_names_the_package_reader() {
+        let err = sniff_json(r#"{"model_kind":"balanced","model":{}}"#).unwrap_err();
+        assert!(err.to_string().contains(".pio.json"), "got: {err}");
+    }
 
     #[test]
     fn source_format_strings_round_trip_to_a_target() {

--- a/powerio/src/format/routing.rs
+++ b/powerio/src/format/routing.rs
@@ -285,8 +285,12 @@ mod tests {
             r#"{"model_kind":"multiconductor","model":{"kind":"multiconductor"}}"#
         ));
         // A payload alone is not an envelope, and neither is a case document.
-        assert!(!looks_like_package_envelope(r#"{"buses":[],"linecodes":[]}"#));
-        assert!(!looks_like_package_envelope(r#"{"baseMVA":100.0,"bus":{}}"#));
+        assert!(!looks_like_package_envelope(
+            r#"{"buses":[],"linecodes":[]}"#
+        ));
+        assert!(!looks_like_package_envelope(
+            r#"{"baseMVA":100.0,"bus":{}}"#
+        ));
         assert!(!looks_like_package_envelope("not json"));
     }
 

--- a/powerio/src/format/routing.rs
+++ b/powerio/src/format/routing.rs
@@ -167,6 +167,17 @@ pub fn classify_json_text(text: &str) -> Detection<JsonFormat> {
     shape.classify()
 }
 
+/// True when `text` is a `.pio.json` package envelope (top level `model_kind`
+/// and `model`). A package is not a converter-boundary format, so envelope
+/// detection stays out of [`SourceFormat`]; callers route an envelope to the
+/// package reader instead of a case parser.
+pub fn looks_like_package_envelope(text: &str) -> bool {
+    let Ok(shape) = JsonShape::try_from(text) else {
+        return false;
+    };
+    shape.has("model_kind") && shape.has("model")
+}
+
 fn canonical_key(name: &str) -> String {
     name.to_ascii_lowercase()
         .chars()
@@ -265,7 +276,19 @@ impl JsonShape {
 mod tests {
     use super::{
         Detection, DistributionFormat, SourceFormat, TransmissionFormat, classify_json_text,
+        looks_like_package_envelope,
     };
+
+    #[test]
+    fn package_envelope_predicate() {
+        assert!(looks_like_package_envelope(
+            r#"{"model_kind":"multiconductor","model":{"kind":"multiconductor"}}"#
+        ));
+        // A payload alone is not an envelope, and neither is a case document.
+        assert!(!looks_like_package_envelope(r#"{"buses":[],"linecodes":[]}"#));
+        assert!(!looks_like_package_envelope(r#"{"baseMVA":100.0,"bus":{}}"#));
+        assert!(!looks_like_package_envelope("not json"));
+    }
 
     #[test]
     fn classifies_pmd_json() {

--- a/powerio/src/format/routing.rs
+++ b/powerio/src/format/routing.rs
@@ -155,27 +155,41 @@ pub fn distribution_format_from_name(name: &str) -> Option<DistributionFormat> {
     }
 }
 
-/// Classify a JSON document across the transmission and distribution domains.
-///
-/// Unknown means there is no recognized top level marker. Ambiguous means a
-/// document contains strong markers from both domains, so the caller must ask
-/// the user for an explicit format.
-pub fn classify_json_text(text: &str) -> Detection<JsonFormat> {
-    let Ok(shape) = JsonShape::try_from(text) else {
-        return Detection::Unknown;
-    };
-    shape.classify()
+/// Top level classification of bare JSON text: a `.pio.json` package envelope
+/// or a case document with its format detection. The envelope outcome lives in
+/// the classifier's result rather than a separate predicate, so every consumer
+/// handles it, and one parse answers both questions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JsonClass {
+    /// A `.pio.json` package envelope. A package is not a converter boundary
+    /// format, so it stays out of [`SourceFormat`]; callers route it to the
+    /// package reader instead of a case parser.
+    Package,
+    /// A case document and its format detection.
+    Case(Detection<JsonFormat>),
 }
 
-/// True when `text` is a `.pio.json` package envelope (top level `model_kind`
-/// and `model`). A package is not a converter-boundary format, so envelope
-/// detection stays out of [`SourceFormat`]; callers route an envelope to the
-/// package reader instead of a case parser.
-pub fn looks_like_package_envelope(text: &str) -> bool {
+/// Classify a JSON document: a `.pio.json` package envelope, or a case
+/// document across the transmission and distribution domains.
+///
+/// An envelope is recognized by a top level `model_kind` of `"balanced"` or
+/// `"multiconductor"` plus a `model` key; the value check keeps a case
+/// document that happens to carry those key names from being misrouted.
+/// For a case, Unknown means there is no recognized top level marker, and
+/// Ambiguous means the document contains strong markers from both domains, so
+/// the caller must ask the user for an explicit format.
+pub fn classify_json_text(text: &str) -> JsonClass {
     let Ok(shape) = JsonShape::try_from(text) else {
-        return false;
+        return JsonClass::Case(Detection::Unknown);
     };
-    shape.has("model_kind") && shape.has("model")
+    if matches!(
+        shape.string("model_kind"),
+        Some("balanced" | "multiconductor")
+    ) && shape.has("model")
+    {
+        return JsonClass::Package;
+    }
+    JsonClass::Case(shape.classify())
 }
 
 fn canonical_key(name: &str) -> String {
@@ -275,30 +289,47 @@ impl JsonShape {
 #[cfg(test)]
 mod tests {
     use super::{
-        Detection, DistributionFormat, SourceFormat, TransmissionFormat, classify_json_text,
-        looks_like_package_envelope,
+        Detection, DistributionFormat, JsonClass, SourceFormat, TransmissionFormat,
+        classify_json_text,
     };
 
     #[test]
-    fn package_envelope_predicate() {
-        assert!(looks_like_package_envelope(
-            r#"{"model_kind":"multiconductor","model":{"kind":"multiconductor"}}"#
-        ));
-        // A payload alone is not an envelope, and neither is a case document.
-        assert!(!looks_like_package_envelope(
-            r#"{"buses":[],"linecodes":[]}"#
-        ));
-        assert!(!looks_like_package_envelope(
-            r#"{"baseMVA":100.0,"bus":{}}"#
-        ));
-        assert!(!looks_like_package_envelope("not json"));
+    fn classifies_package_envelope() {
+        assert_eq!(
+            classify_json_text(
+                r#"{"model_kind":"multiconductor","model":{"kind":"multiconductor"}}"#
+            ),
+            JsonClass::Package
+        );
+        assert_eq!(
+            classify_json_text(r#"{"model_kind":"balanced","model":{}}"#),
+            JsonClass::Package
+        );
+        // A payload alone is not an envelope, and neither is a case document,
+        // even one that carries the envelope key names with case-file values.
+        assert_eq!(
+            classify_json_text(r#"{"buses":[],"linecodes":[]}"#),
+            JsonClass::Case(Detection::Unknown)
+        );
+        assert_eq!(
+            classify_json_text(r#"{"baseMVA":100.0,"bus":{},"model":"ACP","model_kind":"opf"}"#),
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::PowerModelsJson
+            )))
+        );
+        assert_eq!(
+            classify_json_text("not json"),
+            JsonClass::Case(Detection::Unknown)
+        );
     }
 
     #[test]
     fn classifies_pmd_json() {
         assert_eq!(
             classify_json_text(r#"{"data_model":"ENGINEERING","bus":{}}"#),
-            Detection::Known(SourceFormat::Distribution(DistributionFormat::PmdJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Distribution(
+                DistributionFormat::PmdJson
+            )))
         );
     }
 
@@ -306,7 +337,9 @@ mod tests {
     fn classifies_full_bmopf_json() {
         assert_eq!(
             classify_json_text(r#"{"bus":{},"linecode":{},"voltage_source":{}}"#),
-            Detection::Known(SourceFormat::Distribution(DistributionFormat::BmopfJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Distribution(
+                DistributionFormat::BmopfJson
+            )))
         );
     }
 
@@ -314,7 +347,9 @@ mod tests {
     fn classifies_minimal_bmopf_json() {
         assert_eq!(
             classify_json_text(r#"{"bus":{"a":{"terminal_names":["1"]}}}"#),
-            Detection::Known(SourceFormat::Distribution(DistributionFormat::BmopfJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Distribution(
+                DistributionFormat::BmopfJson
+            )))
         );
     }
 
@@ -324,9 +359,9 @@ mod tests {
             classify_json_text(
                 r#"{"baseMVA":100.0,"bus":{},"branch":{},"gen":{},"load":{},"switch":{}}"#
             ),
-            Detection::Known(SourceFormat::Transmission(
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
                 TransmissionFormat::PowerModelsJson
-            ))
+            )))
         );
     }
 
@@ -334,7 +369,9 @@ mod tests {
     fn classifies_powerio_json() {
         assert_eq!(
             classify_json_text(r#"{"base_mva":100.0,"buses":[],"branches":[]}"#),
-            Detection::Known(SourceFormat::Transmission(TransmissionFormat::PowerioJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::PowerioJson
+            )))
         );
     }
 
@@ -342,9 +379,9 @@ mod tests {
     fn classifies_pandapower_json() {
         assert_eq!(
             classify_json_text(r#"{"_class":"pandapowerNet","_object":{}}"#),
-            Detection::Known(SourceFormat::Transmission(
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
                 TransmissionFormat::PandapowerJson
-            ))
+            )))
         );
     }
 
@@ -352,7 +389,9 @@ mod tests {
     fn classifies_egret_json() {
         assert_eq!(
             classify_json_text(r#"{"elements":{},"system":{}}"#),
-            Detection::Known(SourceFormat::Transmission(TransmissionFormat::EgretJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::EgretJson
+            )))
         );
     }
 
@@ -362,7 +401,9 @@ mod tests {
             classify_json_text(
                 r#"{"network":{"bus":[],"simple_dispatchable_device":[]},"time_series_input":{}}"#
             ),
-            Detection::Known(SourceFormat::Transmission(TransmissionFormat::Goc3Json))
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::Goc3Json
+            )))
         );
     }
 
@@ -383,7 +424,9 @@ mod tests {
             classify_json_text(
                 r#"{"format":"surge-json","schema_version":"0.1.0","network":{"buses":[]}}"#
             ),
-            Detection::Known(SourceFormat::Transmission(TransmissionFormat::SurgeJson))
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::SurgeJson
+            )))
         );
     }
 
@@ -400,14 +443,17 @@ mod tests {
 
     #[test]
     fn unknown_json_has_no_signal() {
-        assert_eq!(classify_json_text(r#"{"name":"case"}"#), Detection::Unknown);
+        assert_eq!(
+            classify_json_text(r#"{"name":"case"}"#),
+            JsonClass::Case(Detection::Unknown)
+        );
     }
 
     #[test]
     fn mixed_transmission_and_distribution_markers_are_ambiguous() {
         assert_eq!(
             classify_json_text(r#"{"baseMVA":100.0,"voltage_source":{}}"#),
-            Detection::Ambiguous
+            JsonClass::Case(Detection::Ambiguous)
         );
     }
 }

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -275,6 +275,11 @@ def _format_from_json_class(
     where = f" in {path}" if path is not None else ""
     if status == "known" and domain is not None and format is not None:
         return domain, format
+    if status == "package":
+        raise ValueError(
+            f"JSON{where} is a .pio.json package envelope, not a case; "
+            "pass it as `json_format=\"package\"` or read it as a package"
+        )
     if status == "ambiguous":
         raise ValueError(
             f"ambiguous JSON markers{where}; pass `from_format` or `json_format`"


### PR DESCRIPTION
## Summary

Three additive C ABI capabilities that let the language bindings treat the multiconductor model as first-class data, without adding a bare payload format token (the payload stays enveloped, per the [interchange positioning](docs/src/pio-json-schema.md#interchange); BMOPF remains the exchange format):

- **`pio_package_to_balanced_network` / `pio_package_to_multiconductor_network`** — materialize an owned network handle from a parsed `.pio.json` package handle, the inverses of the `pio_package_from_*` constructors. A handle built from a payload retains no source text, so a same-format write is a fresh serialization rather than a byte-exact echo; the multiconductor payload's parse warnings ride along and stay readable via `pio_dist_warnings`.
- **`pio_classify_str`** — exposes the cross-domain JSON classification the `.json` sniffing already uses. The classifier reports a `.pio.json` envelope as its own outcome (`routing::JsonClass`), so every consumer handles it: the CLI, the Python readers, and the Python `classify_json_text` name the package surface for an envelope instead of a generic cannot-infer error. Returns `transmission:<format>`, `distribution:<format>`, `package`, `ambiguous`, or `unknown`, size-then-fill. Bindings route a bare `.json` on the returned family instead of matching error text.
- **Directed boundary errors** — a `.dss` path, a distribution `from` token (`dss`/`pmd`/`bmopf`), and a `.pio.json` envelope handed to the transmission parser now name the surface that reads them instead of a generic unknown-format message.

Plus the 0.6.0 break window items from #175:

- **Breaking: `ElementRef.row` is `Option<usize>`** — the honest form of the 0.5.1 wire semantics. `None` addresses by identity alone (`by_source_uid`); the private wire-presence shim (`wire_row()`) is gone. The `.pio.json` wire format is unchanged. The other break collected in #175, keyed-object addressing for multiconductor operating point updates, needs design and moves to the 1.0 window (#196).
- `pio_to_json` / `pio_from_json`: the function form of the balanced model JSON; the `powerio-json` format token remains as a compatibility alias (the additive half of #194).

No ABI version changes: the C surface is additive; consumers probe the new symbols like the other feature surfaces. Header regenerated with cbindgen; the header/source symbol sync tests pin the new declarations.

Closes #175

## Test plan

- [x] `cargo test --workspace --all-features` green
- [x] New tests: classify labels across pm/pmd/bmopf/envelope/garbage; balanced and multiconductor wrap → envelope JSON → extract round trips (counts and BMOPF text equality across the crossing, plus the in-memory source strip); wrong-kind extraction errors; envelope classification; the three directed errors
- [x] Release cdylib builds with `arrow,gridfm,dist,pkg`; pkg-only build checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)