### PR TITLE
Add wasm32 CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,18 @@ jobs:
         cargo clippy -p powerio-matrix --all-targets --features gridfm -- -D warnings
         cargo test -p powerio-matrix --features gridfm --verbose
 
+  wasm32:
+    name: wasm32 check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+    - uses: Swatinem/rust-cache@v2
+    - name: Check wasm32 parser crates
+      run: cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg
+
   c-abi:
     name: C ABI (core no-default + C smoke test)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope

Add a Rust CI job that checks the browser parser target:

`cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`

The job installs the wasm target explicitly and runs on pull requests to `main`, so wasm hostile dependencies or cfgs fail before merge.

## Acceptance Criteria

- CI checks `powerio`, `powerio-dist`, and `powerio-pkg` on `wasm32-unknown-unknown`.
- The check is independent of Python, CLI, matrix, and C ABI crates.
- Any wasm compile failures exposed by the check are fixed in this PR.

## Out Of Scope

- No public Rust, C, Python, or package model API changes.
- No wasm packaging, wasm bindgen wrapper, or browser demo work.

Fixes #186

Merge order: 1 of 14. Base: `main`.
