### PR TITLE
Preserve transformer neutral impedance

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,6 +14,7 @@ on:
     branches: [ "main" ]
     paths:
       - "powerio/**"
+      - "powerio-dist/**"
       - "powerio-matrix/**"
       - "powerio-capi/**"
       - "powerio-py/**"

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -644,6 +644,10 @@ impl Reader<'_> {
             "r_series_to",
             "x_series_from",
             "x_series_to",
+            "r_neutral_from",
+            "x_neutral_from",
+            "r_neutral_to",
+            "x_neutral_to",
             "tap",
             "tap_min",
             "tap_max",
@@ -708,6 +712,8 @@ impl Reader<'_> {
                 s_rating: s,
                 r_pct: r_from_pct,
                 tap: first_float(o.get("tap")).unwrap_or(1.0),
+                r_neutral: first_float(o.get("r_neutral_from")),
+                x_neutral: first_float(o.get("x_neutral_from")),
             },
             Winding {
                 bus: string(o.get("bus_to")),
@@ -717,6 +723,8 @@ impl Reader<'_> {
                 s_rating: s,
                 r_pct: r_to_pct,
                 tap: 1.0,
+                r_neutral: first_float(o.get("r_neutral_to")),
+                x_neutral: first_float(o.get("x_neutral_to")),
             },
         ];
         expand_center_tap_windings(subtype, &mut windings);
@@ -797,6 +805,8 @@ impl Reader<'_> {
                     s_rating: s,
                     r_pct,
                     tap: 1.0,
+                    r_neutral: None,
+                    x_neutral: None,
                 });
             }
         }
@@ -859,6 +869,8 @@ fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>) {
         s_rating: to.s_rating,
         r_pct: to.r_pct * 2.0,
         tap: to.tap,
+        r_neutral: to.r_neutral,
+        x_neutral: to.x_neutral,
     };
     let other_half = Winding {
         bus: to.bus,
@@ -868,6 +880,8 @@ fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>) {
         s_rating: to.s_rating,
         r_pct: to.r_pct * 2.0,
         tap: to.tap,
+        r_neutral: None,
+        x_neutral: None,
     };
     windings.push(half);
     windings.push(other_half);

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -33,11 +33,15 @@ const RAW_BMOPF_TOP_LEVEL: &[&str] = &[
 
 const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 4] =
     ["g_no_load", "b_no_load", "%noloadloss", "%imag"];
-const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 6] = [
+const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 10] = [
     "tap_min",
     "tap_max",
     "g_no_load",
     "b_no_load",
+    "r_neutral_from",
+    "x_neutral_from",
+    "r_neutral_to",
+    "x_neutral_to",
     "%noloadloss",
     "%imag",
 ];
@@ -671,6 +675,7 @@ impl Writer {
         o.insert("x_series_to".into(), json!(0.0));
         o.insert("terminal_map_from".into(), json!(from.terminal_map));
         o.insert("terminal_map_to".into(), json!(to.terminal_map));
+        self.transformer_neutral_fields(&mut o, t, from, to);
         self.transformer_tap_fields(&mut o, t, from);
         if emit_no_load {
             self.transformer_no_load_fields(&mut o, t, from, s);
@@ -712,6 +717,8 @@ impl Writer {
         let r_pct_new = (w2.r_pct * w2.v_ref * w2.v_ref * (from.s_rating / w2.s_rating)
             + w3.r_pct * w3.v_ref * w3.v_ref * (from.s_rating / w3.s_rating))
             / (v_new * v_new);
+        let r_neutral = self.center_tap_neutral(t, "r_neutral", w2.r_neutral, w3.r_neutral);
+        let x_neutral = self.center_tap_neutral(t, "x_neutral", w2.x_neutral, w3.x_neutral);
         let to = Winding {
             bus: w2.bus.clone(),
             terminal_map: {
@@ -724,6 +731,8 @@ impl Writer {
             s_rating: from.s_rating,
             r_pct: r_pct_new,
             tap: 1.0,
+            r_neutral,
+            x_neutral,
         };
         self.warn(format!(
             "transformer {}: center tap secondary collapsed to one winding; the \
@@ -783,6 +792,7 @@ impl Writer {
         );
         o.insert("terminal_map_from".into(), json!(from.terminal_map));
         o.insert("terminal_map_to".into(), json!(to.terminal_map));
+        self.transformer_neutral_fields(&mut o, t, from, to);
         self.transformer_tap_fields(&mut o, t, from);
         self.transformer_no_load_fields(&mut o, t, from, s);
         self.transformer_extras_dropped(t, &TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS);
@@ -854,6 +864,7 @@ impl Writer {
         if let Some(first) = t.windings.first() {
             self.transformer_no_load_fields(&mut o, t, first, s);
         }
+        self.warn_unrepresented_neutral_fields(t, "n_winding BMOPF");
         self.taps_dropped(t);
         self.transformer_extras_dropped(t, &TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS);
         o.into()
@@ -880,13 +891,16 @@ impl Writer {
                     s_rating: w.s_rating / 3.0,
                     r_pct: w.r_pct,
                     tap: w.tap,
+                    r_neutral: if k == 0 { w.r_neutral } else { None },
+                    x_neutral: if k == 0 { w.x_neutral } else { None },
                 }
             };
             let f = per(from);
             let to_1 = per(to);
             let mut t1 = t.clone();
             t1.windings = vec![f.clone(), to_1.clone()];
-            let v = self.two_winding(&t1, &f, &to_1, 1.0, false, false);
+            split_no_load_extras(&mut t1, t.phases);
+            let v = self.two_winding(&t1, &f, &to_1, 1.0, true, false);
             out.push((format!("{}_{}", t.name, k + 1), v));
         }
         self.warn(format!(
@@ -927,6 +941,67 @@ impl Writer {
                 self.warn(format!(
                     "transformer {}: non-from-side tap {} has no BMOPF field; dropped",
                     t.name, w.tap
+                ));
+            }
+        }
+    }
+
+    fn transformer_neutral_fields(
+        &mut self,
+        o: &mut Map<String, Value>,
+        t: &DistTransformer,
+        from: &Winding,
+        to: &Winding,
+    ) {
+        self.transformer_neutral_field(o, t, "r_neutral_from", from.r_neutral);
+        self.transformer_neutral_field(o, t, "x_neutral_from", from.x_neutral);
+        self.transformer_neutral_field(o, t, "r_neutral_to", to.r_neutral);
+        self.transformer_neutral_field(o, t, "x_neutral_to", to.x_neutral);
+    }
+
+    fn transformer_neutral_field(
+        &mut self,
+        o: &mut Map<String, Value>,
+        t: &DistTransformer,
+        key: &str,
+        value: Option<f64>,
+    ) {
+        let Some(v) = value else {
+            return;
+        };
+        if v.is_finite() && v >= 0.0 {
+            o.insert(key.into(), json!(v));
+        } else {
+            self.warn(format!(
+                "transformer {}: {key}={v} is not a nonnegative finite BMOPF neutral impedance; dropped",
+                t.name
+            ));
+        }
+    }
+
+    fn center_tap_neutral(
+        &mut self,
+        t: &DistTransformer,
+        field: &str,
+        a: Option<f64>,
+        b: Option<f64>,
+    ) -> Option<f64> {
+        if let (Some(a), Some(b)) = (a, b) {
+            self.warn(format!(
+                "transformer {}: center tap secondary has two {field} values ({a}, {b}); emitted the first",
+                t.name
+            ));
+        }
+        a.or(b)
+    }
+
+    fn warn_unrepresented_neutral_fields(&mut self, t: &DistTransformer, target: &str) {
+        for (idx, w) in t.windings.iter().enumerate() {
+            if w.r_neutral.is_some() || w.x_neutral.is_some() {
+                self.warn(format!(
+                    "transformer {} winding {}: neutral impedance has no {target} field; dropped",
+                    t.name,
+                    idx + 1
                 ));
             }
         }
@@ -1191,6 +1266,15 @@ fn extras_number(extras: &crate::model::Extras, key: &str) -> Option<f64> {
         .or_else(|| v.as_i64().map(|v| v as f64))
         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
         .filter(|v| v.is_finite())
+}
+
+fn split_no_load_extras(t: &mut DistTransformer, phases: usize) {
+    let phases = phases.max(1) as f64;
+    for key in ["g_no_load", "b_no_load"] {
+        if let Some(v) = extras_number(&t.extras, key) {
+            t.extras.insert(key.into(), json!(v / phases));
+        }
+    }
 }
 
 fn n_winding_phase_count(w: &Winding) -> usize {

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -1063,7 +1063,7 @@ impl Reader<'_> {
                 }
                 "bus" => windings[active].bus = Some(v.to_bus_spec()),
                 "conn" => windings[active].conn_delta = conn_is_delta(&v.text),
-                "kv" | "kva" | "tap" | "%r" => {
+                "kv" | "kva" | "tap" | "%r" | "rneut" | "xneut" => {
                     let parsed = self.f64_prop(Some(v));
                     let w = &mut windings[active];
                     match name.as_str() {
@@ -1076,7 +1076,10 @@ impl Reader<'_> {
                             w.kva_specified = true;
                         }
                         "tap" => w.tap = parsed.unwrap_or(w.tap),
-                        _ => w.r_pct = parsed.unwrap_or(w.r_pct),
+                        "%r" => w.r_pct = parsed.unwrap_or(w.r_pct),
+                        "rneut" => w.r_neutral = parsed,
+                        "xneut" => w.x_neutral = parsed,
+                        _ => unreachable!("matched transformer scalar property"),
                     }
                 }
                 "buses" | "conns" => {
@@ -1200,6 +1203,8 @@ impl Reader<'_> {
                 s_rating: w.kva * 1e3,
                 r_pct: w.r_pct,
                 tap: w.tap,
+                r_neutral: w.r_neutral,
+                x_neutral: w.x_neutral,
             });
         }
         out
@@ -1764,6 +1769,8 @@ struct WindingRaw {
     kva: f64,
     tap: f64,
     r_pct: f64,
+    r_neutral: Option<f64>,
+    x_neutral: Option<f64>,
     kv_specified: bool,
     kva_specified: bool,
 }
@@ -1777,6 +1784,8 @@ impl Default for WindingRaw {
             kva: dd::transformer::KVA,
             tap: dd::transformer::TAP,
             r_pct: dd::transformer::PCT_R,
+            r_neutral: None,
+            x_neutral: None,
             kv_specified: false,
             kva_specified: false,
         }

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -894,6 +894,19 @@ impl DssWriter {
             }
             s.push_str(&self.extras_tail("transformer", &t.name, &t.extras));
             self.line_out(&s);
+            for (idx, w) in t.windings.iter().enumerate() {
+                if w.r_neutral.is_none() && w.x_neutral.is_none() {
+                    continue;
+                }
+                let mut edit = format!("~ wdg={}", idx + 1);
+                if let Some(r) = w.r_neutral {
+                    let _ = write!(edit, " rneut={}", num(r));
+                }
+                if let Some(x) = w.x_neutral {
+                    let _ = write!(edit, " xneut={}", num(x));
+                }
+                self.line_out(&edit);
+            }
         }
         self.out.push('\n');
     }
@@ -1845,6 +1858,8 @@ mod tests {
                     s_rating: 25e3,
                     r_pct: 0.5,
                     tap: 1.0,
+                    r_neutral: None,
+                    x_neutral: None,
                 },
                 Winding {
                     bus: "b2".into(),
@@ -1854,6 +1869,8 @@ mod tests {
                     s_rating: 25e3,
                     r_pct: 0.5,
                     tap: 1.0,
+                    r_neutral: None,
+                    x_neutral: None,
                 },
             ],
             xsc_pct: Vec::new(),

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -397,6 +397,10 @@ pub struct Winding {
     /// Winding resistance, percent of the winding base.
     pub r_pct: f64,
     pub tap: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r_neutral: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub x_neutral: Option<f64>,
 }
 
 impl Winding {
@@ -416,6 +420,8 @@ impl Winding {
             s_rating,
             r_pct: 0.0,
             tap: 1.0,
+            r_neutral: None,
+            x_neutral: None,
         }
     }
 }

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -289,6 +289,8 @@ fn build_windings(
             s_rating: nums.sm_nom.get(w).copied().unwrap_or(f64::NAN) * 1e3,
             r_pct: nums.rw.get(w).copied().unwrap_or(0.0) * 100.0,
             tap: nums.tm_set.get(w).copied().unwrap_or(1.0),
+            r_neutral: None,
+            x_neutral: None,
         });
     }
     (windings, phases, unrolled)

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use powerio_dist::dss::{parse_dss_file, parse_dss_str};
 use powerio_dist::{
-    Configuration, DistLineCode, DistNetwork, DistTransformer, Winding, WindingConn,
+    Configuration, DistBus, DistLineCode, DistNetwork, DistTransformer, Winding, WindingConn,
     parse_bmopf_file, parse_bmopf_str, write_bmopf_json, write_dss,
 };
 
@@ -703,6 +703,69 @@ fn dss_noloadloss_derives_bmopf_no_load_fields() {
 }
 
 #[test]
+fn transformer_neutral_impedance_round_trips_dss_and_bmopf() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.neutral basekv=7.2 pu=1.0 phases=1 bus1=src.1\n\
+         New Transformer.t1 phases=1 windings=2 buses=(src.1.0, load.1.0) \
+         kvs=(7.2 0.24) kvas=(25 25) %Rs=(1 1) xhl=2\n\
+         ~ wdg=1 rneut=5 xneut=6\n\
+         ~ wdg=2 rneut=7 xneut=8\n",
+    );
+    let t = &net.transformers[0];
+    assert_eq!(t.windings[0].r_neutral, Some(5.0));
+    assert_eq!(t.windings[0].x_neutral, Some(6.0));
+    assert_eq!(t.windings[1].r_neutral, Some(7.0));
+    assert_eq!(t.windings[1].x_neutral, Some(8.0));
+
+    let dss = write_dss(&net).text;
+    assert!(!dss.contains("NaN"), "{dss}");
+    assert!(dss.contains("kvs=(7.2, 0.24)"), "{dss}");
+    assert!(dss.contains("~ wdg=1 rneut=5 xneut=6"), "{dss}");
+    assert!(dss.contains("~ wdg=2 rneut=7 xneut=8"), "{dss}");
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["single_phase"]["t1"];
+    assert_eq!(t["r_neutral_from"], serde_json::json!(5.0));
+    assert_eq!(t["x_neutral_from"], serde_json::json!(6.0));
+    assert_eq!(t["r_neutral_to"], serde_json::json!(7.0));
+    assert_eq!(t["x_neutral_to"], serde_json::json!(8.0));
+
+    let reparsed = parse_bmopf_str(&out.text).unwrap();
+    let rt = &reparsed.transformers[0];
+    assert_eq!(rt.windings[0].r_neutral, Some(5.0));
+    assert_eq!(rt.windings[0].x_neutral, Some(6.0));
+    assert_eq!(rt.windings[1].r_neutral, Some(7.0));
+    assert_eq!(rt.windings[1].x_neutral, Some(8.0));
+
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.neutral basekv=7.2 pu=1.0 phases=1 bus1=src.1\n\
+         New Transformer.t1 phases=1 windings=2 buses=(src.1.0, load.1.0) \
+         kvs=(7.2 0.24) kvas=(25 25) %Rs=(1 1) xhl=2\n\
+         ~ wdg=1 rneut=-1 xneut=-2\n",
+    );
+    let dss = write_dss(&net).text;
+    assert!(dss.contains("~ wdg=1 rneut=-1 xneut=-2"), "{dss}");
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    assert!(!out.text.contains("r_neutral_from"), "{out:?}");
+    assert!(!out.text.contains("x_neutral_from"), "{out:?}");
+    assert!(
+        out.warnings.iter().any(|w| w.contains("r_neutral_from=-1")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings.iter().any(|w| w.contains("x_neutral_from=-2")),
+        "{:?}",
+        out.warnings
+    );
+}
+
+#[test]
 fn dss_phase_to_phase_noloadloss_does_not_emit_bmopf_ground_shunt() {
     let net = parse_dss_str(
         "Clear\n\
@@ -755,6 +818,91 @@ fn wye_wye_3_extras_drop_warns_once_not_per_phase() {
         .filter(|w| w.contains("unknown_key"))
         .count();
     assert_eq!(count, 1, "{:?}", out.warnings);
+}
+
+#[test]
+fn wye_wye_3_neutral_grounding_decomposes_once_not_per_phase() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.wyewye basekv=7.2 pu=1.0 phases=3 bus1=src.1.2.3.0\n\
+         New Transformer.t phases=3 windings=2 buses=(src.1.2.3.0, load.1.2.3.0) \
+         conns=(wye wye) kvs=(12.47 0.48) kvas=(75 75) %Rs=(1 1) xhl=2 \
+         %noloadloss=0.3 %imag=0.6\n\
+         ~ wdg=1 rneut=5 xneut=6\n\
+         ~ wdg=2 rneut=7 xneut=8\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let sp = doc["transformer"]["single_phase"].as_object().unwrap();
+    assert_eq!(sp.len(), 3);
+    assert_eq!(sp["t_1"]["r_neutral_from"], serde_json::json!(5.0));
+    assert_eq!(sp["t_1"]["x_neutral_from"], serde_json::json!(6.0));
+    assert_eq!(sp["t_1"]["r_neutral_to"], serde_json::json!(7.0));
+    assert_eq!(sp["t_1"]["x_neutral_to"], serde_json::json!(8.0));
+    let expected_g = 0.3 / 100.0 * (75_000.0 / 3.0) / ((12_470.0 / 3f64.sqrt()).powi(2));
+    let expected_b = 0.6 / 100.0 * (75_000.0 / 3.0) / ((12_470.0 / 3f64.sqrt()).powi(2));
+    for name in ["t_1", "t_2", "t_3"] {
+        let t = &sp[name];
+        let g = t["g_no_load"].as_f64().unwrap();
+        assert!((g - expected_g).abs() < 1e-18, "{name} g_no_load = {g}");
+        let b = t["b_no_load"].as_f64().unwrap();
+        assert!((b - expected_b).abs() < 1e-18, "{name} b_no_load = {b}");
+    }
+    for name in ["t_2", "t_3"] {
+        let t = &sp[name];
+        assert!(t.get("r_neutral_from").is_none(), "{name}: {t}");
+        assert!(t.get("x_neutral_from").is_none(), "{name}: {t}");
+        assert!(t.get("r_neutral_to").is_none(), "{name}: {t}");
+        assert!(t.get("x_neutral_to").is_none(), "{name}: {t}");
+    }
+}
+
+#[test]
+fn wye_wye_3_raw_no_load_splits_across_decomposition() {
+    let from = Winding::new(
+        "a",
+        vec!["1".into(), "2".into(), "3".into(), "n".into()],
+        WindingConn::Wye,
+        7200.0,
+        30_000.0,
+    );
+    let to = Winding::new(
+        "b",
+        vec!["1".into(), "2".into(), "3".into(), "n".into()],
+        WindingConn::Wye,
+        240.0,
+        30_000.0,
+    );
+    let mut t = DistTransformer::new("t", vec![from, to], vec![4.0], 3);
+    t.extras
+        .insert("g_no_load".into(), serde_json::json!(0.000_009));
+    t.extras
+        .insert("b_no_load".into(), serde_json::json!(-0.000_012));
+
+    let mut net = DistNetwork::default();
+    net.buses = vec![
+        DistBus::new("a", vec!["1".into(), "2".into(), "3".into(), "n".into()]),
+        DistBus::new("b", vec!["1".into(), "2".into(), "3".into(), "n".into()]),
+    ];
+    net.transformers.push(t);
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let sp = doc["transformer"]["single_phase"].as_object().unwrap();
+    assert_eq!(sp.len(), 3);
+    let mut g_sum = 0.0;
+    let mut b_sum = 0.0;
+    for name in ["t_1", "t_2", "t_3"] {
+        let t = &sp[name];
+        assert_eq!(t["g_no_load"], serde_json::json!(0.000_003));
+        assert_eq!(t["b_no_load"], serde_json::json!(-0.000_004));
+        g_sum += t["g_no_load"].as_f64().unwrap();
+        b_sum += t["b_no_load"].as_f64().unwrap();
+    }
+    assert!((g_sum - 0.000_009).abs() < 1e-18);
+    assert!((b_sum + 0.000_012).abs() < 1e-18);
 }
 
 #[test]
@@ -1008,6 +1156,60 @@ fn bmopf_center_tap_rebuilds_dss_grounded_center() {
         doc["transformer"]["center_tap"]["ct"]["terminal_map_to"],
         serde_json::json!(["1", "2", "4"])
     );
+}
+
+#[test]
+fn bmopf_center_tap_neutral_grounding_rebuilds_once() {
+    let text = r#"{
+        "bus": {
+            "src": {"terminal_names": ["1", "2"], "perfectly_grounded_terminals": ["2"]},
+            "lv": {"terminal_names": ["1", "2", "3"], "perfectly_grounded_terminals": ["3"]}
+        },
+        "voltage_source": {
+            "source": {
+                "v_magnitude": [7200.0, 0.0],
+                "v_angle": [0.0, 0.0],
+                "bus": "src",
+                "terminal_map": ["1", "2"]
+            }
+        },
+        "transformer": {
+            "center_tap": {
+                "ct": {
+                    "bus_from": "src",
+                    "bus_to": "lv",
+                    "terminal_map_from": ["1", "2"],
+                    "terminal_map_to": ["1", "2", "3"],
+                    "s_rating": 25000.0,
+                    "v_nom_from": 7200.0,
+                    "v_nom_to": 240.0,
+                    "r_series_from": 12.4416,
+                    "r_series_to": 0.013824,
+                    "x_series_from": 42.2784,
+                    "x_series_to": 0.0,
+                    "r_neutral_to": 5.0,
+                    "x_neutral_to": 6.0
+                }
+            }
+        }
+    }"#;
+    let net = parse_bmopf_str(text).unwrap();
+    let t = &net.transformers[0];
+    assert_eq!(t.windings[1].r_neutral, Some(5.0));
+    assert_eq!(t.windings[1].x_neutral, Some(6.0));
+    assert_eq!(t.windings[2].r_neutral, None);
+    assert_eq!(t.windings[2].x_neutral, None);
+
+    let dss = write_dss(&net).text;
+    assert_eq!(dss.matches("rneut=5").count(), 1, "{dss}");
+    assert_eq!(dss.matches("xneut=6").count(), 1, "{dss}");
+
+    let out = write_bmopf_json(&parse_dss_str(&dss));
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["center_tap"]["ct"];
+    assert_eq!(t["r_neutral_to"], serde_json::json!(5.0));
+    assert_eq!(t["x_neutral_to"], serde_json::json!(6.0));
 }
 
 #[test]

--- a/tests/data/dist/bmopf/draft_bmopf_schema.json
+++ b/tests/data/dist/bmopf/draft_bmopf_schema.json
@@ -53,6 +53,10 @@
                         "version": { "type": "string" }
                     },
                     "additionalProperties": false
+                },
+                "provenance": {
+                    "type": "object",
+                    "description": "Free-form conversion/audit provenance written by tooling (e.g. BMOPFTools' fidelity-loss inventory, migration notes, earth-terminal routing). Round-trips to the in-memory _meta block."
                 }
             },
             "additionalProperties": false
@@ -137,6 +141,10 @@
                             "$ref": "#/$defs/nonnegative_number"
                         },
                         "description": "Maximum symmetric component voltage values [V]"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": ["terminal_names"]
@@ -170,6 +178,20 @@
                     "bus_to": {
                         "type": "string",
                         "description": "'to' bus for the element"
+                    },
+                    "i_max": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-conductor current-magnitude limit [A]; overrides the linecode's i_max for this line"
+                    },
+                    "s_max": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-phase apparent-power limit [VA]; overrides the linecode's s_max for this line"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -208,6 +230,10 @@
                     },
                     "bus": {
                         "$ref": "#/$defs/bus_type"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -230,6 +256,10 @@
                     },
                     "terminal_map": {
                         "$ref": "#/$defs/terminal_map_type"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "patternProperties": {
@@ -347,6 +377,10 @@
                     "gamma_q": {
                         "type": "array",
                         "items": {"type": "number", "description": "Reactive-power voltage exponent (exponential model)"}
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -422,6 +456,10 @@
                     },
                     "terminal_map": {
                         "$ref": "#/$defs/terminal_map_type"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -742,6 +780,10 @@
                         "type": "array",
                         "description": "Maximum permitted current passing through each conductor of the switch [A]",
                         "items": { "$ref": "#/$defs/nonnegative_number" }
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -930,6 +972,26 @@
                 },
                 "required": ["dc_bus", "terminal_map"]
             }
+        },
+        "time_series": {
+            "type": "object",
+            "description": "Named time-series profiles. Components reference a profile via their own time_series map (parameter name -> profile id); get_snapshot multiplies the static parameter by values[t_index].",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "time": {
+                        "type": "array",
+                        "items": { "type": "number" },
+                        "description": "Optional time stamps for the steps"
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": { "type": "number" },
+                        "description": "Multiplicative scale factors applied to the referenced static parameter"
+                    }
+                },
+                "required": ["values"]
+            }
         }
     },
     "required": [
@@ -1037,6 +1099,10 @@
                     "type": "integer",
                     "enum": [1, -1],
                     "description": "DELTA only: coil rotation / vector-group sense. +1 connects coil k across phases k->k+1, -1 across k->k-1 (OpenDSS's standard delta). Ignored for WYE."
+                },
+                "i_max": {
+                    "$ref": "#/$defs/nonnegative_number",
+                    "description": "Optional per-winding current-magnitude limit [A], applied to each phase coil current of this winding"
                 }
             },
             "required": ["bus", "terminal_map", "v_nom", "configuration"]
@@ -1103,6 +1169,22 @@
                         "$ref": "#/$defs/nonnegative_number",
                         "description": "Transformer series reactance on the 'to' side [Ohm]"
                     },
+                    "r_neutral_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding resistance on the 'from' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS rneut); stand-alone transformer property, external groundings stay on buses/shunts"
+                    },
+                    "x_neutral_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding reactance on the 'from' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS xneut)"
+                    },
+                    "r_neutral_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding resistance on the 'to' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS rneut); stand-alone transformer property, external groundings stay on buses/shunts"
+                    },
+                    "x_neutral_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding reactance on the 'to' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS xneut)"
+                    },
                     "bus_from": {
                         "type": "string",
                         "description": "'from' bus for the element"
@@ -1144,6 +1226,20 @@
                     "tap_max": {
                         "$ref": "#/$defs/nonnegative_number",
                         "description": "Upper bound on the continuous tap multiplier (see tap_min)."
+                    },
+                    "i_max_from": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-conductor 'from'-side current limit [A]"
+                    },
+                    "i_max_to": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-conductor 'to'-side current limit [A]"
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [
@@ -1169,11 +1265,53 @@
                     },
                     "r_series": {
                         "$ref": "#/$defs/nonnegative_number",
-                        "description": "Series resistance on the wye-connected winding [Ohm]"
+                        "description": "Legacy lumped series resistance on the wye-connected winding [Ohm]; migrated on parse to r_series_from (with r_series_to = 0)"
                     },
                     "x_series": {
                         "$ref": "#/$defs/nonnegative_number",
-                        "description": "Series reactance on the wye-connected winding [Ohm]"
+                        "description": "Legacy lumped series reactance on the wye-connected winding [Ohm]; migrated on parse to x_series_from (with x_series_to = 0)"
+                    },
+                    "r_series_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Transformer series resistance on the 'from'-side winding [Ohm]"
+                    },
+                    "x_series_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Transformer series reactance on the 'from'-side winding [Ohm]"
+                    },
+                    "r_series_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Transformer series resistance on the 'to'-side winding [Ohm]"
+                    },
+                    "x_series_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Transformer series reactance on the 'to'-side winding [Ohm]"
+                    },
+                    "r_neutral_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding resistance on the 'from' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS rneut); stand-alone transformer property, external groundings stay on buses/shunts"
+                    },
+                    "x_neutral_from": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding reactance on the 'from' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS xneut)"
+                    },
+                    "r_neutral_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding resistance on the 'to' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS rneut); stand-alone transformer property, external groundings stay on buses/shunts"
+                    },
+                    "x_neutral_to": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Winding neutral grounding reactance on the 'to' side [Ohm]: internal grounding branch from the winding's shared neutral terminal to earth (OpenDSS xneut)"
+                    },
+                    "i_max_from": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-conductor 'from'-side current limit [A]"
+                    },
+                    "i_max_to": {
+                        "type": "array",
+                        "items": { "$ref": "#/$defs/nonnegative_number" },
+                        "description": "Per-conductor 'to'-side current limit [A]"
                     },
                     "bus_from": {
                         "type": "string",
@@ -1216,6 +1354,10 @@
                     "tap_max": {
                         "$ref": "#/$defs/nonnegative_number",
                         "description": "Upper bound on the continuous tap multiplier (see tap_min)."
+                    },
+                    "time_series": {
+                        "type": "object",
+                        "description": "Map from parameter name to time_series id for time-varying scaling"
                     }
                 },
                 "required": [


### PR DESCRIPTION
## Summary

- Add typed transformer winding neutral impedance fields and carry OpenDSS `rneut` / `xneut` through DSS and BMOPF where the target schema has fields.
- Preserve BMOPF transformer core shunt fields through the three phase wye/wye decomposition path; split raw SI shunts across emitted single phase records.
- Refresh the vendored draft BMOPF schema to the current task force copy and run validation when `powerio-dist/**` changes.

## Tests

- `cargo test -p powerio-dist`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo clippy -p powerio-matrix --all-targets --features gridfm -- -D warnings`
- `cargo test -p powerio-matrix --features gridfm`
- `cargo clippy -p powerio-matrix --all-targets --features kkt -- -D warnings`
- `cargo test -p powerio-matrix --features kkt`
- `actionlint .github/workflows/validation.yml`
- `bash benchmarks/run_validation.sh`

## Out Of Scope

- No DER or IBR mapping; that is PR 4.
- No load `Vminpu`/`Vmaxpu` or 4-wire voltage oracle; that is PR 3.
- No C ABI or Python binding changes.

Addresses #197 findings 1, 6, 7, and 8.

Merge order: 2 of 14. Base: `main`.
