### PR TITLE
Map distribution IBR controls to OpenDSS

### DIFF
--- a/benchmarks/validate_opendss.py
+++ b/benchmarks/validate_opendss.py
@@ -14,6 +14,7 @@ from opendssdirect import dss
 
 FIXTURES = [
     Path("tests/data/dist/micro/fourwire_linecode.dss"),
+    Path("tests/data/dist/micro/ibr_pv_control.dss"),
     Path("tests/data/dist/micro/linecode_10x10.dss"),
     Path("tests/data/dist/micro/neutral_grounding_reactor.dss"),
     Path("tests/data/dist/micro/onephase_cvr_load.dss"),

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -11,14 +11,18 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
 use crate::model::{
-    Configuration, DistBus, DistGenerator, DistLine, DistLineCode, DistLoad, DistLoadVoltageModel,
-    DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer, Extras, Mat,
-    UntypedObject, VoltageSource, Winding, WindingConn, n_winding_impedance_base,
-    n_winding_phase_count, pair_keys,
+    ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
+    DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
+    DistLoadVoltageModel, DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer,
+    Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation, Mat, PowerFactorControl,
+    ReactivePowerReference, ReactivePowerUnit, UntypedObject, VoltVarControl, VoltWattControl,
+    VoltageSource, Winding, WindingConn, n_winding_impedance_base, n_winding_phase_count,
+    pair_keys,
 };
 
 pub fn parse_bmopf_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
@@ -105,6 +109,21 @@ fn strings(v: Option<&Value>) -> Vec<String> {
 
 fn string(v: Option<&Value>) -> String {
     v.and_then(Value::as_str).unwrap_or_default().to_string()
+}
+
+fn enum_field<T: DeserializeOwned>(
+    v: Option<&Value>,
+    what: &str,
+    warnings: &mut Vec<String>,
+) -> Option<T> {
+    let value = v?;
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Some(parsed),
+        Err(err) => {
+            warnings.push(format!("{what}: {err}; field ignored"));
+            None
+        }
+    }
 }
 
 /// Case insensitive on the recognized values (the dss reader's tolerance);
@@ -221,6 +240,8 @@ impl Reader<'_> {
                 "switch" => self.switches(items),
                 "load" => self.loads(items),
                 "generator" => self.generators(items),
+                "ibr" => self.ibrs(items),
+                "control_profile" => self.control_profiles(items),
                 "shunt" => self.shunts(items),
                 "voltage_source" => self.sources(items),
                 "transformer" => self.transformers(items),
@@ -239,6 +260,130 @@ impl Reader<'_> {
                     }
                 }
             }
+        }
+    }
+
+    fn ibrs(&mut self, items: &Map<String, Value>) {
+        const TYPED: &[&str] = &[
+            "bus",
+            "terminal_map",
+            "topology",
+            "prime_mover",
+            "s_max",
+            "i_max",
+            "p_avail",
+            "p_min",
+            "p_max",
+            "q_min",
+            "q_max",
+            "control_profile",
+            "voltage_aggregation",
+        ];
+        for (name, v) in items {
+            let Value::Object(o) = v else { continue };
+            let topology = enum_field::<IbrTopology>(
+                o.get("topology"),
+                &format!("ibr {name} topology"),
+                &mut self.net.warnings,
+            )
+            .unwrap_or(IbrTopology::SinglePhase);
+            let prime_mover = enum_field::<IbrPrimeMover>(
+                o.get("prime_mover"),
+                &format!("ibr {name} prime_mover"),
+                &mut self.net.warnings,
+            )
+            .unwrap_or(IbrPrimeMover::Generic);
+            let mut extras = Extras::new();
+            for (key, value) in o {
+                if !TYPED.contains(&key.as_str()) {
+                    extras.insert(key.clone(), value.clone());
+                }
+            }
+            self.net.ibrs.push(DistIbr {
+                name: name.clone(),
+                bus: string(o.get("bus")),
+                terminal_map: strings(o.get("terminal_map")),
+                topology,
+                prime_mover,
+                s_max: floats(o.get("s_max")).unwrap_or_default(),
+                i_max: floats(o.get("i_max")),
+                p_avail: first_float(o.get("p_avail")),
+                p_min: floats(o.get("p_min")),
+                p_max: floats(o.get("p_max")),
+                q_min: floats(o.get("q_min")),
+                q_max: floats(o.get("q_max")),
+                control_profile: o
+                    .get("control_profile")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                voltage_aggregation: enum_field::<IbrVoltageAggregation>(
+                    o.get("voltage_aggregation"),
+                    &format!("ibr {name} voltage_aggregation"),
+                    &mut self.net.warnings,
+                ),
+                extras,
+            });
+        }
+    }
+
+    fn control_profiles(&mut self, items: &Map<String, Value>) {
+        for (name, v) in items {
+            let Value::Object(o) = v else { continue };
+            let mut profile = DistControlProfile::new(name.clone());
+            if let Some(Value::Object(pf)) = o.get("power_factor") {
+                profile.power_factor =
+                    first_float(pf.get("pf")).map(|pf| PowerFactorControl { pf });
+            }
+            if let Some(Value::Object(vv)) = o.get("volt_var") {
+                profile.volt_var = Some(VoltVarControl {
+                    voltage_reference: enum_field::<ControlVoltageReference>(
+                        vv.get("voltage_reference"),
+                        &format!("control_profile {name} volt_var voltage_reference"),
+                        &mut self.net.warnings,
+                    ),
+                    breakpoints: floats(vv.get("breakpoints")).unwrap_or_default(),
+                    q_limits: floats(vv.get("q_limits")).unwrap_or_default(),
+                    q_unit: enum_field::<ReactivePowerUnit>(
+                        vv.get("q_unit"),
+                        &format!("control_profile {name} volt_var q_unit"),
+                        &mut self.net.warnings,
+                    ),
+                    q_ref: enum_field::<ReactivePowerReference>(
+                        vv.get("q_ref"),
+                        &format!("control_profile {name} volt_var q_ref"),
+                        &mut self.net.warnings,
+                    ),
+                    p_min_for_q: first_float(vv.get("p_min_for_q")),
+                    p_min_for_q_max: first_float(vv.get("p_min_for_q_max")),
+                });
+            }
+            if let Some(Value::Object(vw)) = o.get("volt_watt") {
+                profile.volt_watt = Some(VoltWattControl {
+                    voltage_reference: enum_field::<ControlVoltageReference>(
+                        vw.get("voltage_reference"),
+                        &format!("control_profile {name} volt_watt voltage_reference"),
+                        &mut self.net.warnings,
+                    ),
+                    breakpoints: floats(vw.get("breakpoints")).unwrap_or_default(),
+                    p_limits: floats(vw.get("p_limits")).unwrap_or_default(),
+                    p_unit: enum_field::<ActivePowerUnit>(
+                        vw.get("p_unit"),
+                        &format!("control_profile {name} volt_watt p_unit"),
+                        &mut self.net.warnings,
+                    ),
+                    p_ref: enum_field::<ActivePowerReference>(
+                        vw.get("p_ref"),
+                        &format!("control_profile {name} volt_watt p_ref"),
+                        &mut self.net.warnings,
+                    ),
+                });
+            }
+            for (key, value) in o {
+                if !matches!(key.as_str(), "power_factor" | "volt_var" | "volt_watt") {
+                    profile.extras.insert(key.clone(), value.clone());
+                }
+            }
+            self.net.control_profiles.push(profile);
         }
     }
 

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -12,7 +12,9 @@ use serde_json::{Map, Value, json};
 
 use crate::convert::Conversion;
 use crate::model::{
-    Configuration, DistGenerator, DistLoadVoltageModel, DistNetwork, DistTransformer, Mat, Winding,
+    ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference,
+    DistControlProfile, DistGenerator, DistIbr, DistLoadVoltageModel, DistNetwork, DistTransformer,
+    Mat, ReactivePowerReference, ReactivePowerUnit, VoltVarControl, VoltWattControl, Winding,
     WindingConn, n_winding_impedance_base, pair_keys,
 };
 
@@ -29,6 +31,26 @@ const RAW_BMOPF_TOP_LEVEL: &[&str] = &[
     "dc_line",
     "dc_load",
     "dc_source",
+];
+
+const IBR_EXTRA_FIELDS: &[&str] = &[
+    "dc_link_coupled",
+    "p_dc_min",
+    "p_dc_max",
+    "dc_bus",
+    "dc_terminal_map",
+    "dc_control",
+    "dc_v_set",
+    "dc_p_ref",
+    "dc_droop",
+    "dc_deadband",
+    "r_filter",
+    "x_filter",
+    "b_filter_shunt",
+    "grid_forming",
+    "v_ref_internal",
+    "cost",
+    "time_series",
 ];
 
 const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 4] =
@@ -198,6 +220,8 @@ impl Writer {
 
         self.branches(net, &mut doc);
         self.injections(net, &mut doc);
+        self.control_profiles(net, &mut doc);
+        self.ibrs(net, &mut doc);
 
         let transformers = self.transformers(net);
         if !transformers.is_empty() {
@@ -417,6 +441,155 @@ impl Writer {
             sources.insert(vs.name.clone(), Value::Object(o));
         }
         doc.insert("voltage_source".into(), Value::Object(sources));
+    }
+
+    fn control_profiles(&mut self, net: &DistNetwork, doc: &mut Map<String, Value>) {
+        if net.control_profiles.is_empty() {
+            return;
+        }
+        let mut profiles = Map::new();
+        for profile in &net.control_profiles {
+            profiles.insert(profile.name.clone(), self.control_profile(profile));
+        }
+        doc.insert("control_profile".into(), Value::Object(profiles));
+    }
+
+    fn control_profile(&mut self, profile: &DistControlProfile) -> Value {
+        let mut o = Map::new();
+        if let Some(pf) = &profile.power_factor {
+            o.insert(
+                "power_factor".into(),
+                json!({ "pf": self.num(pf.pf, "power factor") }),
+            );
+        }
+        if let Some(vv) = &profile.volt_var {
+            o.insert("volt_var".into(), self.volt_var(vv));
+        }
+        if let Some(vw) = &profile.volt_watt {
+            o.insert("volt_watt".into(), self.volt_watt(vw));
+        }
+        for (key, value) in &profile.extras {
+            if value.is_object() {
+                o.insert(key.clone(), value.clone());
+            } else {
+                self.warn(format!(
+                    "control_profile {}: extra `{key}` is not an object; dropped from the output",
+                    profile.name
+                ));
+            }
+        }
+        Value::Object(o)
+    }
+
+    fn volt_var(&mut self, vv: &VoltVarControl) -> Value {
+        let mut o = Map::new();
+        if let Some(v) = vv.voltage_reference {
+            o.insert("voltage_reference".into(), json_enum(v));
+        }
+        o.insert(
+            "breakpoints".into(),
+            self.nums(&vv.breakpoints, "volt_var breakpoints"),
+        );
+        o.insert(
+            "q_limits".into(),
+            self.nums(&vv.q_limits, "volt_var q_limits"),
+        );
+        if let Some(v) = vv.q_unit {
+            o.insert("q_unit".into(), json_enum::<ReactivePowerUnit>(v));
+        }
+        if let Some(v) = vv.q_ref {
+            o.insert("q_ref".into(), json_enum::<ReactivePowerReference>(v));
+        }
+        if let Some(v) = vv.p_min_for_q {
+            o.insert("p_min_for_q".into(), self.num(v, "volt_var p_min_for_q"));
+        }
+        if let Some(v) = vv.p_min_for_q_max {
+            o.insert(
+                "p_min_for_q_max".into(),
+                self.num(v, "volt_var p_min_for_q_max"),
+            );
+        }
+        Value::Object(o)
+    }
+
+    fn volt_watt(&mut self, vw: &VoltWattControl) -> Value {
+        let mut o = Map::new();
+        if let Some(v) = vw.voltage_reference {
+            o.insert(
+                "voltage_reference".into(),
+                json_enum::<ControlVoltageReference>(v),
+            );
+        }
+        o.insert(
+            "breakpoints".into(),
+            self.nums(&vw.breakpoints, "volt_watt breakpoints"),
+        );
+        o.insert(
+            "p_limits".into(),
+            self.nums(&vw.p_limits, "volt_watt p_limits"),
+        );
+        if let Some(v) = vw.p_unit {
+            o.insert("p_unit".into(), json_enum::<ActivePowerUnit>(v));
+        }
+        if let Some(v) = vw.p_ref {
+            o.insert("p_ref".into(), json_enum::<ActivePowerReference>(v));
+        }
+        Value::Object(o)
+    }
+
+    fn ibrs(&mut self, net: &DistNetwork, doc: &mut Map<String, Value>) {
+        if net.ibrs.is_empty() {
+            return;
+        }
+        let mut ibrs = Map::new();
+        for ibr in &net.ibrs {
+            ibrs.insert(ibr.name.clone(), self.ibr(ibr));
+        }
+        doc.insert("ibr".into(), Value::Object(ibrs));
+    }
+
+    fn ibr(&mut self, ibr: &DistIbr) -> Value {
+        let mut o = Map::new();
+        o.insert("bus".into(), json!(ibr.bus));
+        o.insert("terminal_map".into(), json!(ibr.terminal_map));
+        o.insert("topology".into(), json_enum(ibr.topology));
+        o.insert("prime_mover".into(), json_enum(ibr.prime_mover));
+        o.insert("s_max".into(), self.nums(&ibr.s_max, "ibr s_max"));
+        if let Some(v) = &ibr.i_max {
+            o.insert("i_max".into(), self.nums(v, "ibr i_max"));
+        }
+        if let Some(v) = ibr.p_avail {
+            o.insert("p_avail".into(), self.num(v, "ibr p_avail"));
+        }
+        if let Some(v) = &ibr.p_min {
+            o.insert("p_min".into(), self.nums(v, "ibr p_min"));
+        }
+        if let Some(v) = &ibr.p_max {
+            o.insert("p_max".into(), self.nums(v, "ibr p_max"));
+        }
+        if let Some(v) = &ibr.q_min {
+            o.insert("q_min".into(), self.nums(v, "ibr q_min"));
+        }
+        if let Some(v) = &ibr.q_max {
+            o.insert("q_max".into(), self.nums(v, "ibr q_max"));
+        }
+        if let Some(v) = &ibr.control_profile {
+            o.insert("control_profile".into(), json!(v));
+        }
+        if let Some(v) = ibr.voltage_aggregation {
+            o.insert("voltage_aggregation".into(), json_enum(v));
+        }
+        for (key, value) in &ibr.extras {
+            if IBR_EXTRA_FIELDS.contains(&key.as_str()) {
+                o.insert(key.clone(), value.clone());
+            } else {
+                self.warn(format!(
+                    "ibr {}: extra `{key}` has no place in the BMOPF schema; dropped from the output",
+                    ibr.name
+                ));
+            }
+        }
+        Value::Object(o)
     }
 
     fn load_voltage_model(
@@ -1311,6 +1484,10 @@ fn config_str(c: Configuration) -> &'static str {
         Configuration::Delta => "DELTA",
         Configuration::SinglePhase => "SINGLE_PHASE",
     }
+}
+
+fn json_enum<T: serde::Serialize>(value: T) -> Value {
+    serde_json::to_value(value).expect("enum serializes to a string")
 }
 
 #[cfg(test)]

--- a/powerio-dist/src/dss/defaults.rs
+++ b/powerio-dist/src/dss/defaults.rs
@@ -83,6 +83,15 @@ pub mod generator {
     pub const PF: f64 = 0.88;
 }
 
+pub mod pvsystem {
+    pub const PHASES: usize = 3;
+    pub const KV: f64 = 12.47;
+    pub const IRRADIANCE: f64 = 1.0;
+    pub const PMPP: f64 = 500.0;
+    pub const PCT_PMPP: f64 = 100.0;
+    pub const PF: f64 = 1.0;
+}
+
 /// Base frequency when no `Set DefaultBaseFrequency` appears.
 pub const BASE_FREQUENCY: f64 = 60.0;
 

--- a/powerio-dist/src/dss/prop.rs
+++ b/powerio-dist/src/dss/prop.rs
@@ -383,6 +383,105 @@ class!(
 );
 
 class!(
+    PVSYSTEM,
+    "pvsystem",
+    [
+        "phases",
+        "bus1",
+        "kv",
+        "irradiance",
+        "pmpp",
+        "%pmpp",
+        "temperature",
+        "pf",
+        "conn",
+        "kvar",
+        "kva",
+        "%cutin",
+        "%cutout",
+        "effcurve",
+        "ptcurve",
+        "daily",
+        "yearly",
+        "duty",
+        "tdaily",
+        "tyearly",
+        "tduty",
+        "class",
+        "user_model",
+        "user_data",
+        "debugtrace",
+        "varfollowinverter",
+        "duty_start",
+        "wattpriority",
+        "pfpriority",
+        "pctpmpp",
+        "pctcutin",
+        "pctcutout",
+        "kvarmax",
+        "kvarmaxabs",
+        "kvarlimit",
+        "kvarlimitneg",
+        "%pminnovars",
+        "%pminkvarmax",
+        "vminpu",
+        "vmaxpu",
+        // inherited
+        "spectrum",
+        "basefreq",
+        "enabled",
+        "like",
+    ]
+);
+
+class!(
+    XYCURVE,
+    "xycurve",
+    [
+        "npts", "points", "yarray", "xarray", "csvfile", "sngfile", "dblfile", "x", "y",
+        // inherited
+        "like",
+    ]
+);
+
+class!(
+    INVCONTROL,
+    "invcontrol",
+    [
+        "derlist",
+        "mode",
+        "combimode",
+        "vvc_curve1",
+        "hysteresis_offset",
+        "voltage_curvex_ref",
+        "avgwindowlen",
+        "volt_watt_curve",
+        "dbvmin",
+        "dbvmax",
+        "armingtime",
+        "deltaq_factor",
+        "voltagechange_tolerance",
+        "varchange_tolerance",
+        "voltwatt_curve",
+        "voltwattyaxis",
+        "rateofchange_mode",
+        "lpftau",
+        "riseFallLimit",
+        "deltaP_factor",
+        "eventlog",
+        "refreactivepower",
+        "activepchange_tolerance",
+        "monvoltagecalc",
+        "monbus",
+        "monbusesvbase",
+        // inherited
+        "basefreq",
+        "enabled",
+        "like",
+    ]
+);
+
+class!(
     SWTCONTROL,
     "swtcontrol",
     [
@@ -455,6 +554,9 @@ static CLASSES: &[&DssClass] = &[
     &CAPACITOR,
     &REACTOR,
     &GENERATOR,
+    &PVSYSTEM,
+    &XYCURVE,
+    &INVCONTROL,
     &SWTCONTROL,
     &REGCONTROL,
 ];

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -20,10 +20,29 @@ use super::lex::{BusSpec, Value, VarMap};
 use super::raw::{RawDss, RawObject, parse_raw_with};
 use crate::error::{Error, Result};
 use crate::model::{
-    Configuration, DistBus, DistGenerator, DistLine, DistLineCode, DistLoad, DistLoadVoltageModel,
-    DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer, Extras, Mat,
-    UntypedObject, VoltageSource, Winding, WindingConn, pair_keys, square_from_rows,
+    ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
+    DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
+    DistLoadVoltageModel, DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer,
+    Extras, IbrPrimeMover, IbrTopology, Mat, PowerFactorControl, ReactivePowerReference,
+    ReactivePowerUnit, UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, Winding,
+    WindingConn, pair_keys, square_from_rows,
 };
+
+const TYPED_DSS_CLASSES: &[&str] = &[
+    "linecode",
+    "vsource",
+    "line",
+    "transformer",
+    "load",
+    "capacitor",
+    "reactor",
+    "generator",
+    "pvsystem",
+    "xycurve",
+    "invcontrol",
+    "swtcontrol",
+    "regcontrol",
+];
 
 /// Parses a `.dss` file, following includes, into the canonical model.
 pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
@@ -59,6 +78,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
         buses: BTreeMap::new(),
         bus_order: Vec::new(),
         linecode_units: BTreeMap::new(),
+        xycurves: BTreeMap::new(),
         vars: &raw.vars,
     };
 
@@ -110,6 +130,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
         let g = rd.generator(obj);
         rd.net.generators.push(g);
     }
+    read_ibr_objects(&mut rd, raw);
     for obj in raw.of_class("swtcontrol") {
         rd.swtcontrol(obj);
     }
@@ -117,19 +138,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
         rd.regcontrol(obj);
     }
     for obj in &raw.objects {
-        if !matches!(
-            obj.class.as_str(),
-            "linecode"
-                | "vsource"
-                | "line"
-                | "transformer"
-                | "load"
-                | "capacitor"
-                | "reactor"
-                | "generator"
-                | "swtcontrol"
-                | "regcontrol"
-        ) {
+        if !TYPED_DSS_CLASSES.contains(&obj.class.as_str()) {
             rd.net.untyped.push(UntypedObject::from(obj));
         }
     }
@@ -232,6 +241,18 @@ fn finish_buses(mut rd: Reader, raw: &RawDss) -> DistNetwork {
     net
 }
 
+fn read_ibr_objects(rd: &mut Reader<'_>, raw: &RawDss) {
+    for obj in raw.of_class("pvsystem") {
+        rd.pvsystem(obj);
+    }
+    for obj in raw.of_class("xycurve") {
+        rd.xycurve(obj);
+    }
+    for obj in raw.of_class("invcontrol") {
+        rd.invcontrol(obj);
+    }
+}
+
 impl From<&RawObject> for UntypedObject {
     fn from(obj: &RawObject) -> Self {
         UntypedObject {
@@ -259,6 +280,7 @@ struct Reader<'a> {
     /// the linecode has no units. Lines need it: `ConvertLineUnits` couples
     /// the two sides' units.
     linecode_units: BTreeMap<String, Option<f64>>,
+    xycurves: BTreeMap<String, XyCurveRaw>,
     vars: &'a VarMap,
 }
 
@@ -336,6 +358,12 @@ const REACTOR_KVAR_SHUNT: KvarShuntSpec = KvarShuntSpec {
     default_kv: dd::reactor::KV,
     b_sign: -1.0,
 };
+
+#[derive(Clone, Debug)]
+struct XyCurveRaw {
+    x: Vec<f64>,
+    y: Vec<f64>,
+}
 
 impl Reader<'_> {
     fn warn(&mut self, msg: impl Into<String>) {
@@ -1556,6 +1584,318 @@ impl Reader<'_> {
         }
     }
 
+    // ----- PVSystem / InvControl ----------------------------------------
+
+    fn pvsystem(&mut self, obj: &RawObject) {
+        let props = Props::new(obj);
+        let phases = self.usize_or(
+            &props,
+            "phases",
+            "pvsystem",
+            &obj.name,
+            dd::pvsystem::PHASES,
+        );
+        if phases == 0 {
+            self.warn(format!(
+                "pvsystem {}: nonpositive `phases` value is not typed; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        let conn_delta = props.get("conn").is_some_and(|v| {
+            v.text.to_ascii_lowercase().starts_with('d') || v.text.eq_ignore_ascii_case("ll")
+        });
+        let spec = bus_spec(props.get("bus1"), "");
+        let nconds = if conn_delta && phases == 3 {
+            phases
+        } else {
+            phases + 1
+        };
+        let map = self.terminals(&spec, phases, nconds, nconds);
+        let kv = self.f64_or(&props, "kv", "pvsystem", &obj.name, dd::pvsystem::KV);
+        let irradiance = self.f64_or(
+            &props,
+            "irradiance",
+            "pvsystem",
+            &obj.name,
+            dd::pvsystem::IRRADIANCE,
+        );
+        let pmpp = self.f64_or(&props, "pmpp", "pvsystem", &obj.name, dd::pvsystem::PMPP);
+        let pct_pmpp = self
+            .f64_prop(props.get("%pmpp"))
+            .or_else(|| self.f64_prop(props.get("pctpmpp")))
+            .unwrap_or(dd::pvsystem::PCT_PMPP);
+        let kva = self
+            .f64_prop(props.get("kva"))
+            .unwrap_or(pmpp.max(f64::EPSILON));
+        let per_phase = |total_kw: f64| vec![total_kw * 1e3 / phases as f64; phases];
+        let p_avail = pmpp * irradiance * pct_pmpp / 100.0 * 1e3;
+        let q_max = self
+            .f64_prop(props.get("kvarmax"))
+            .map(per_phase)
+            .or_else(|| Some(vec![kva * 1e3 / phases as f64; phases]));
+        let q_min = self
+            .f64_prop(props.get("kvarmaxabs"))
+            .map(|v| vec![-v * 1e3 / phases as f64; phases])
+            .or_else(|| q_max.as_ref().map(|v| v.iter().map(|x| -*x).collect()));
+        let topology = if phases == 1 {
+            IbrTopology::SinglePhase
+        } else if conn_delta {
+            IbrTopology::ThreeLeg
+        } else {
+            IbrTopology::FourLeg
+        };
+        let pf = self.f64_prop(props.get("pf"));
+        let mut extras = extras_from_leftovers(&props);
+        self.stash_kv_and_phases(&props, &mut extras, kv, phases);
+        extras.remove("conn");
+        let mut ibr = DistIbr {
+            name: obj.name.clone(),
+            bus: spec.name,
+            terminal_map: map,
+            topology,
+            prime_mover: IbrPrimeMover::Pv,
+            s_max: vec![kva * 1e3 / phases as f64; phases],
+            i_max: None,
+            p_avail: Some(p_avail),
+            p_min: Some(vec![0.0; phases]),
+            p_max: Some(per_phase(pmpp * pct_pmpp / 100.0)),
+            q_min,
+            q_max,
+            control_profile: None,
+            voltage_aggregation: None,
+            extras,
+        };
+        if let Some(pf) = pf {
+            let profile = format!("{}_pf", obj.name);
+            ibr.control_profile = Some(profile.clone());
+            self.net.control_profiles.push(DistControlProfile {
+                name: profile,
+                power_factor: Some(PowerFactorControl { pf }),
+                volt_var: None,
+                volt_watt: None,
+                extras: Extras::new(),
+            });
+        }
+        self.net.ibrs.push(ibr);
+    }
+
+    fn xycurve(&mut self, obj: &RawObject) {
+        let props = Props::new(obj);
+        let x = props
+            .get("xarray")
+            .and_then(|v| v.to_vector(Some(self.vars)).ok())
+            .unwrap_or_default();
+        let y = props
+            .get("yarray")
+            .and_then(|v| v.to_vector(Some(self.vars)).ok())
+            .unwrap_or_default();
+        if x.is_empty() || y.is_empty() {
+            self.warn(format!(
+                "xycurve {}: xarray/yarray are incomplete; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        self.xycurves
+            .insert(obj.name.to_ascii_lowercase(), XyCurveRaw { x, y });
+    }
+
+    fn invcontrol(&mut self, obj: &RawObject) {
+        let props = Props::new(obj);
+        let derlist = props
+            .get("derlist")
+            .map(|v| dss_name_list(&v.text))
+            .unwrap_or_default();
+        let mode = props
+            .get("mode")
+            .map(|v| v.text.to_ascii_lowercase())
+            .unwrap_or_default();
+        let combimode = props
+            .get("combimode")
+            .map(|v| v.text.to_ascii_lowercase())
+            .unwrap_or_default();
+        let mon = props
+            .get("monvoltagecalc")
+            .map(|v| v.text.to_ascii_lowercase())
+            .unwrap_or_default();
+        let voltage_reference = if mon.contains("avg") {
+            ControlVoltageReference::PgAveraged
+        } else {
+            ControlVoltageReference::PgPerPhase
+        };
+        let mut profile = DistControlProfile::new(obj.name.clone());
+        profile.volt_var =
+            self.invcontrol_volt_var(obj, &props, &derlist, voltage_reference, &mode, &combimode);
+        profile.volt_watt =
+            self.invcontrol_volt_watt(&props, &derlist, voltage_reference, &mode, &combimode);
+        if profile.power_factor.is_none()
+            && profile.volt_var.is_none()
+            && profile.volt_watt.is_none()
+        {
+            self.warn(format!(
+                "invcontrol {}: control mode is not typed; kept untyped",
+                obj.name
+            ));
+            self.net.untyped.push(UntypedObject::from(obj));
+            return;
+        }
+        for der in derlist {
+            let name = der.rsplit_once('.').map_or(der.as_str(), |(_, name)| name);
+            if let Some(ibr) = self
+                .net
+                .ibrs
+                .iter_mut()
+                .find(|ibr| ibr.name.eq_ignore_ascii_case(name))
+            {
+                ibr.control_profile = Some(profile.name.clone());
+                if profile.volt_var.is_some() {
+                    ibr.extras.remove("%pminnovars");
+                    ibr.extras.remove("%pminkvarmax");
+                }
+            } else {
+                self.warn(format!(
+                    "invcontrol {}: DER `{der}` does not match a typed PVSystem",
+                    obj.name
+                ));
+            }
+        }
+        self.net.control_profiles.push(profile);
+    }
+
+    fn invcontrol_volt_var(
+        &mut self,
+        obj: &RawObject,
+        props: &Props<'_>,
+        derlist: &[String],
+        voltage_reference: ControlVoltageReference,
+        mode: &str,
+        combimode: &str,
+    ) -> Option<VoltVarControl> {
+        if !(mode.contains("voltvar") || combimode.contains("vv")) {
+            return None;
+        }
+        let curve_name = props.get("vvc_curve1").map(|v| v.text.clone())?;
+        let curve = self
+            .xycurves
+            .get(&curve_name.to_ascii_lowercase())
+            .cloned()?;
+        let base_v = self.control_base_voltage(derlist).unwrap_or_else(|| {
+            self.warn(format!(
+                "invcontrol {}: no rated voltage found for vvc_curve1; using 1 pu as 1 V",
+                obj.name
+            ));
+            1.0
+        });
+        let q_ref = props
+            .get("refreactivepower")
+            .map(|v| v.text.to_ascii_uppercase())
+            .filter(|s| s.contains("VARAVAL"))
+            .map_or(ReactivePowerReference::VarMax, |_| {
+                ReactivePowerReference::VarAvailable
+            });
+        let p_min_for_q = self
+            .ibr_extra_f64(derlist, "%pminnovars")
+            .or_else(|| self.f64_prop(props.get("%pminnovars")));
+        let p_min_for_q_max = self
+            .ibr_extra_f64(derlist, "%pminkvarmax")
+            .or_else(|| self.f64_prop(props.get("%pminkvarmax")));
+        Some(VoltVarControl {
+            voltage_reference: Some(voltage_reference),
+            breakpoints: curve.x.iter().map(|x| x * base_v).collect(),
+            q_limits: if curve.y.len() >= 4 {
+                vec![curve.y[3], curve.y[0]]
+            } else {
+                curve.y
+            },
+            q_unit: Some(ReactivePowerUnit::VaFraction),
+            q_ref: Some(q_ref),
+            p_min_for_q,
+            p_min_for_q_max,
+        })
+    }
+
+    fn invcontrol_volt_watt(
+        &mut self,
+        props: &Props<'_>,
+        derlist: &[String],
+        voltage_reference: ControlVoltageReference,
+        mode: &str,
+        combimode: &str,
+    ) -> Option<VoltWattControl> {
+        if !(mode.contains("voltwatt") || combimode.contains("vw")) {
+            return None;
+        }
+        let curve_name = props
+            .get("voltwatt_curve")
+            .or_else(|| props.get("volt_watt_curve"))
+            .map(|v| v.text.clone())?;
+        let curve = self
+            .xycurves
+            .get(&curve_name.to_ascii_lowercase())
+            .cloned()?;
+        let base_v = self.control_base_voltage(derlist).unwrap_or(1.0);
+        let p_ref = props
+            .get("voltwattyaxis")
+            .map(|v| v.text.to_ascii_uppercase())
+            .map_or(ActivePowerReference::SMax, |s| {
+                if s.contains("PAVAILABLE") {
+                    ActivePowerReference::PAvailable
+                } else if s.contains("PMPP") {
+                    ActivePowerReference::PMax
+                } else {
+                    ActivePowerReference::SMax
+                }
+            });
+        Some(VoltWattControl {
+            voltage_reference: Some(voltage_reference),
+            breakpoints: curve.x.iter().map(|x| x * base_v).collect(),
+            p_limits: if curve.y.len() >= 2 {
+                vec![curve.y[1], curve.y[0]]
+            } else {
+                curve.y
+            },
+            p_unit: Some(ActivePowerUnit::VaFraction),
+            p_ref: Some(p_ref),
+        })
+    }
+
+    fn ibr_extra_f64(&self, derlist: &[String], key: &str) -> Option<f64> {
+        derlist.iter().find_map(|der| {
+            let name = der.rsplit_once('.').map_or(der.as_str(), |(_, name)| name);
+            self.net
+                .ibrs
+                .iter()
+                .find(|ibr| ibr.name.eq_ignore_ascii_case(name))
+                .and_then(|ibr| ibr.extras.get(key))
+                .and_then(json_value_f64)
+        })
+    }
+
+    fn control_base_voltage(&self, derlist: &[String]) -> Option<f64> {
+        let der = derlist.first()?;
+        let name = der.rsplit_once('.').map_or(der.as_str(), |(_, name)| name);
+        let ibr = self
+            .net
+            .ibrs
+            .iter()
+            .find(|ibr| ibr.name.eq_ignore_ascii_case(name))?;
+        let kv = ibr
+            .extras
+            .get("kv")
+            .and_then(|v| {
+                v.as_f64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+            })
+            .unwrap_or(dd::pvsystem::KV);
+        Some(match ibr.topology {
+            IbrTopology::FourLeg => kv * 1e3 / 3f64.sqrt(),
+            IbrTopology::SinglePhase | IbrTopology::ThreeLeg => kv * 1e3,
+        })
+    }
+
     // ----- controls ------------------------------------------------------
 
     fn swtcontrol(&mut self, obj: &RawObject) {
@@ -1640,6 +1980,20 @@ fn explicit_single_terminal_ground_return(bus: &BusSpec, return_bus: &BusSpec) -
         && bus.nodes.len() == 1
         && return_bus.nodes.len() == 1
         && return_bus.nodes[0] <= 0
+}
+
+fn dss_name_list(text: &str) -> Vec<String> {
+    text.trim_matches(|c: char| matches!(c, '[' | ']' | '(' | ')'))
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn json_value_f64(value: &serde_json::Value) -> Option<f64> {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
 }
 
 /// The line to line branches of a delta bank over `n` terminals: a closed

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -17,7 +17,10 @@ use std::fmt::Write as _;
 
 use crate::convert::Conversion;
 use crate::model::{
-    Configuration, DistBus, DistLoadVoltageModel, DistNetwork, Extras, Mat, Winding, WindingConn,
+    ActivePowerReference, Configuration, ControlVoltageReference, DistBus, DistControlProfile,
+    DistIbr, DistLoadVoltageModel, DistNetwork, Extras, IbrPrimeMover, IbrTopology,
+    IbrVoltageAggregation, Mat, ReactivePowerReference, VoltVarControl, VoltWattControl, Winding,
+    WindingConn,
 };
 
 use super::read::delta_edges;
@@ -600,6 +603,7 @@ impl DssWriter {
         self.loads(net);
         self.shunts(net);
         self.generators(net);
+        self.ibrs(net);
 
         for u in &net.untyped {
             self.warn(format!(
@@ -1400,6 +1404,373 @@ impl DssWriter {
             self.line_out(&s);
         }
     }
+
+    fn ibrs(&mut self, net: &DistNetwork) {
+        for ibr in &net.ibrs {
+            self.check_name("pvsystem", &ibr.name);
+            if ibr_is_fixed_dispatch(ibr) {
+                self.write_fixed_ibr_generator(ibr);
+            } else {
+                self.write_pvsystem(ibr, net);
+            }
+        }
+        for ibr in &net.ibrs {
+            if !ibr_is_fixed_dispatch(ibr) {
+                self.write_ibr_controls(ibr, net);
+            }
+        }
+        if !net.ibrs.is_empty() {
+            self.out.push('\n');
+        }
+    }
+
+    fn write_fixed_ibr_generator(&mut self, ibr: &DistIbr) {
+        let phases = ibr_phases(ibr);
+        let configuration = ibr_configuration(ibr);
+        let conn = self.element_conn(&ibr.extras, configuration, &ibr.bus, &ibr.terminal_map);
+        let kv = self.ibr_kv(ibr, phases, configuration, "generator");
+        let kw = ibr
+            .p_min
+            .as_ref()
+            .map_or(0.0, |p| p.iter().sum::<f64>() / 1e3);
+        let kvar = ibr
+            .q_min
+            .as_ref()
+            .map_or(0.0, |q| q.iter().sum::<f64>() / 1e3);
+        let mut line = format!(
+            "New Generator.{} bus1={} phases={phases} conn={conn} kv={} kw={} kvar={} model=1 vminpu=0 vmaxpu=2",
+            ibr.name,
+            self.bus_ref(&ibr.bus, &ibr.terminal_map),
+            num(kv),
+            num(kw),
+            num(kvar),
+        );
+        if let Some(q) = &ibr.q_max {
+            let _ = write!(line, " maxkvar={}", num(q.iter().sum::<f64>() / 1e3));
+        }
+        if let Some(q) = &ibr.q_min {
+            let _ = write!(line, " minkvar={}", num(q.iter().sum::<f64>() / 1e3));
+        }
+        self.warn_ibr_dss_drops(ibr);
+        self.line_out(&line);
+    }
+
+    fn write_pvsystem(&mut self, ibr: &DistIbr, net: &DistNetwork) {
+        let phases = ibr_phases(ibr);
+        let configuration = ibr_configuration(ibr);
+        let conn = self.element_conn(&ibr.extras, configuration, &ibr.bus, &ibr.terminal_map);
+        let kv = self.ibr_kv(ibr, phases, configuration, "pvsystem");
+        let kva = ibr.s_max.iter().sum::<f64>() / 1e3;
+        let pmpp = ibr
+            .p_avail
+            .or_else(|| ibr.p_max.as_ref().map(|p| p.iter().sum()))
+            .unwrap_or(0.0)
+            / 1e3;
+        let mut line = format!(
+            "New PVSystem.{} bus1={} phases={phases} conn={conn} kv={} kVA={} Pmpp={} irradiance=1 %Pmpp=100 WattPriority=No VarFollowInverter=Yes",
+            ibr.name,
+            self.bus_ref(&ibr.bus, &ibr.terminal_map),
+            num(kv),
+            num(kva),
+            num(pmpp),
+        );
+        if let Some(q) = &ibr.q_max {
+            let _ = write!(line, " kvarMax={}", num(q.iter().sum::<f64>() / 1e3));
+        }
+        if let Some(q) = &ibr.q_min {
+            let _ = write!(
+                line,
+                " kvarMaxAbs={}",
+                num(q.iter().map(|v| v.abs()).sum::<f64>() / 1e3)
+            );
+        }
+        if let Some(profile) = ibr_profile(ibr, net) {
+            if let Some(pf) = &profile.power_factor {
+                let _ = write!(line, " pf={}", num(pf.pf));
+            }
+            if let Some(vv) = &profile.volt_var {
+                if let Some(v) = vv.p_min_for_q {
+                    let _ = write!(line, " %PminNoVars={}", num(v));
+                }
+                if let Some(v) = vv.p_min_for_q_max {
+                    let _ = write!(line, " %PminkvarMax={}", num(v));
+                }
+            }
+        }
+        self.warn_ibr_dss_drops(ibr);
+        self.line_out(&line);
+    }
+
+    fn write_ibr_controls(&mut self, ibr: &DistIbr, net: &DistNetwork) {
+        let Some(profile) = ibr_profile(ibr, net) else {
+            if let Some(name) = &ibr.control_profile {
+                self.warn(format!(
+                    "ibr {}: control_profile `{name}` not found; no InvControl emitted",
+                    ibr.name
+                ));
+            }
+            return;
+        };
+        let phases = ibr_phases(ibr);
+        let configuration = ibr_configuration(ibr);
+        let kv = self.ibr_kv(ibr, phases, configuration, "pvsystem");
+        let base_v = if phases >= 2 && configuration != Configuration::Delta {
+            kv * 1e3 / 3f64.sqrt()
+        } else {
+            kv * 1e3
+        };
+        let mut curves = Vec::new();
+        let mut has_vv = false;
+        let mut has_vw = false;
+        if let Some(vv) = &profile.volt_var
+            && let Some(curve) = self.volt_var_curve(ibr, vv, base_v)
+        {
+            curves.push(curve);
+            has_vv = true;
+        }
+        if let Some(vw) = &profile.volt_watt
+            && let Some(curve) = self.volt_watt_curve(ibr, vw, base_v)
+        {
+            curves.push(curve);
+            has_vw = true;
+        }
+        for line in &curves {
+            self.line_out(line);
+        }
+        if !has_vv && !has_vw {
+            return;
+        }
+        let mon = self.control_mon_voltage(ibr, profile);
+        let inv_name = format!("ivc_{}", ibr.name);
+        self.check_name("invcontrol", &inv_name);
+        let mut line = format!(
+            "New InvControl.{inv_name} DERList=[PVSystem.{}] voltage_curvex_ref=rated monVoltageCalc={mon}",
+            ibr.name
+        );
+        match (has_vv, has_vw) {
+            (true, true) => {
+                let _ = write!(
+                    line,
+                    " CombiMode=VV_VW vvc_curve1=vv_{} voltwatt_curve=vw_{}",
+                    ibr.name, ibr.name
+                );
+                if let Some(vv) = &profile.volt_var {
+                    let _ = write!(
+                        line,
+                        " RefReactivePower={}",
+                        reactive_reference(vv.q_ref.unwrap_or(ReactivePowerReference::VarMax))
+                    );
+                }
+                if let Some(vw) = &profile.volt_watt {
+                    let _ = write!(
+                        line,
+                        " VoltwattYAxis={}",
+                        active_reference(vw.p_ref.unwrap_or(ActivePowerReference::SMax))
+                    );
+                }
+            }
+            (true, false) => {
+                line.push_str(" mode=VOLTVAR");
+                let _ = write!(line, " vvc_curve1=vv_{}", ibr.name);
+                if let Some(vv) = &profile.volt_var {
+                    let _ = write!(
+                        line,
+                        " RefReactivePower={}",
+                        reactive_reference(vv.q_ref.unwrap_or(ReactivePowerReference::VarMax))
+                    );
+                }
+            }
+            (false, true) => {
+                line.push_str(" mode=VOLTWATT");
+                let _ = write!(line, " voltwatt_curve=vw_{}", ibr.name);
+                if let Some(vw) = &profile.volt_watt {
+                    let _ = write!(
+                        line,
+                        " VoltwattYAxis={}",
+                        active_reference(vw.p_ref.unwrap_or(ActivePowerReference::SMax))
+                    );
+                }
+            }
+            (false, false) => {}
+        }
+        self.line_out(&line);
+    }
+
+    fn volt_var_curve(
+        &mut self,
+        ibr: &DistIbr,
+        vv: &VoltVarControl,
+        base_v: f64,
+    ) -> Option<String> {
+        self.check_control_reference(ibr, vv.voltage_reference)?;
+        if !matches!(
+            vv.q_unit,
+            None | Some(crate::model::ReactivePowerUnit::VaFraction)
+        ) {
+            self.warn(format!(
+                "ibr {}: volt_var q_unit is absolute VAR; DSS export only maps VA_FRACTION",
+                ibr.name
+            ));
+            return None;
+        }
+        if vv.breakpoints.len() < 4 || vv.q_limits.len() < 2 || base_v <= 0.0 {
+            self.warn(format!(
+                "ibr {}: volt_var profile is incomplete; no XYcurve emitted",
+                ibr.name
+            ));
+            return None;
+        }
+        let xs: Vec<String> = vv
+            .breakpoints
+            .iter()
+            .take(4)
+            .map(|v| num(v / base_v))
+            .collect();
+        let ys = [num(vv.q_limits[1]), num(0.0), num(0.0), num(vv.q_limits[0])];
+        Some(format!(
+            "New XYcurve.vv_{} npts=4 Xarray=[{}] Yarray=[{}]",
+            ibr.name,
+            xs.join(" "),
+            ys.join(" ")
+        ))
+    }
+
+    fn volt_watt_curve(
+        &mut self,
+        ibr: &DistIbr,
+        vw: &VoltWattControl,
+        base_v: f64,
+    ) -> Option<String> {
+        self.check_control_reference(ibr, vw.voltage_reference)?;
+        if !matches!(
+            vw.p_unit,
+            None | Some(crate::model::ActivePowerUnit::VaFraction)
+        ) {
+            self.warn(format!(
+                "ibr {}: volt_watt p_unit is absolute W; DSS export only maps VA_FRACTION",
+                ibr.name
+            ));
+            return None;
+        }
+        if vw.breakpoints.len() < 2 || vw.p_limits.len() < 2 || base_v <= 0.0 {
+            self.warn(format!(
+                "ibr {}: volt_watt profile is incomplete; no XYcurve emitted",
+                ibr.name
+            ));
+            return None;
+        }
+        let xs: Vec<String> = vw
+            .breakpoints
+            .iter()
+            .take(2)
+            .map(|v| num(v / base_v))
+            .collect();
+        let ys = [num(vw.p_limits[1]), num(vw.p_limits[0])];
+        Some(format!(
+            "New XYcurve.vw_{} npts=2 Xarray=[{}] Yarray=[{}]",
+            ibr.name,
+            xs.join(" "),
+            ys.join(" ")
+        ))
+    }
+
+    fn check_control_reference(
+        &mut self,
+        ibr: &DistIbr,
+        reference: Option<ControlVoltageReference>,
+    ) -> Option<()> {
+        match reference.unwrap_or(ControlVoltageReference::PnPerPhase) {
+            ControlVoltageReference::PgPerPhase | ControlVoltageReference::PgAveraged => Some(()),
+            ControlVoltageReference::PnPerPhase | ControlVoltageReference::PnAveraged => {
+                self.warn(format!(
+                    "ibr {}: PN voltage control is approximated by OpenDSS phase-to-ground InvControl",
+                    ibr.name
+                ));
+                Some(())
+            }
+            ControlVoltageReference::PpPerPhase | ControlVoltageReference::PpAveraged => {
+                self.warn(format!(
+                    "ibr {}: PP voltage control is not representable by OpenDSS InvControl; skipped",
+                    ibr.name
+                ));
+                None
+            }
+        }
+    }
+
+    fn control_mon_voltage(&mut self, ibr: &DistIbr, profile: &DistControlProfile) -> &'static str {
+        let reference = profile
+            .volt_var
+            .as_ref()
+            .and_then(|vv| vv.voltage_reference)
+            .or_else(|| {
+                profile
+                    .volt_watt
+                    .as_ref()
+                    .and_then(|vw| vw.voltage_reference)
+            })
+            .unwrap_or(ControlVoltageReference::PnPerPhase);
+        let averaged = matches!(
+            ibr.voltage_aggregation,
+            Some(IbrVoltageAggregation::Average)
+        ) || matches!(
+            reference,
+            ControlVoltageReference::PgAveraged
+                | ControlVoltageReference::PnAveraged
+                | ControlVoltageReference::PpAveraged
+        );
+        if !averaged && ibr_phases(ibr) > 1 {
+            self.warn(format!(
+                "ibr {}: per phase InvControl needs split PVSystems; emitted AVG monitor",
+                ibr.name
+            ));
+        }
+        "AVG"
+    }
+
+    fn ibr_kv(
+        &mut self,
+        ibr: &DistIbr,
+        phases: usize,
+        configuration: Configuration,
+        class: &'static str,
+    ) -> f64 {
+        self.element_kv(
+            &ibr.extras,
+            ElementKv {
+                bus: &ibr.bus,
+                phases,
+                configuration,
+                name: &ibr.name,
+                class,
+                typed_kv: None,
+            },
+        )
+    }
+
+    fn warn_ibr_dss_drops(&mut self, ibr: &DistIbr) {
+        for key in ibr.extras.keys() {
+            if matches!(key.as_str(), "kv" | "phases") {
+                continue;
+            }
+            self.warn(format!(
+                "ibr {}: `{key}` has no OpenDSS export mapping; dropped",
+                ibr.name
+            ));
+        }
+        if ibr.i_max.is_some() {
+            self.warn(format!(
+                "ibr {}: i_max has no OpenDSS PVSystem current limit field; dropped",
+                ibr.name
+            ));
+        }
+        if !matches!(ibr.prime_mover, IbrPrimeMover::Pv | IbrPrimeMover::Generic) {
+            self.warn(format!(
+                "ibr {}: prime_mover {:?} has no dedicated OpenDSS export path; emitted with the generic inverter mapping",
+                ibr.name, ibr.prime_mover
+            ));
+        }
+    }
 }
 
 /// Drop the shunt keys the writer regenerates from the typed model so a stale
@@ -1407,6 +1778,49 @@ impl DssWriter {
 fn strip_shunt_extras(extras: &mut Extras) {
     for key in ["kv", "kvar", "phases", "conn"] {
         extras.remove(key);
+    }
+}
+
+fn ibr_is_fixed_dispatch(ibr: &DistIbr) -> bool {
+    ibr.control_profile.is_none()
+        && matches!((&ibr.p_min, &ibr.p_max), (Some(a), Some(b)) if a == b)
+        && matches!((&ibr.q_min, &ibr.q_max), (Some(a), Some(b)) if a == b)
+}
+
+fn ibr_profile<'a>(ibr: &DistIbr, net: &'a DistNetwork) -> Option<&'a DistControlProfile> {
+    let name = ibr.control_profile.as_ref()?;
+    net.control_profiles
+        .iter()
+        .find(|profile| profile.name.eq_ignore_ascii_case(name))
+}
+
+fn ibr_phases(ibr: &DistIbr) -> usize {
+    match ibr.topology {
+        IbrTopology::SinglePhase => 1,
+        IbrTopology::ThreeLeg | IbrTopology::FourLeg => 3,
+    }
+}
+
+fn ibr_configuration(ibr: &DistIbr) -> Configuration {
+    match ibr.topology {
+        IbrTopology::SinglePhase => Configuration::SinglePhase,
+        IbrTopology::ThreeLeg => Configuration::Delta,
+        IbrTopology::FourLeg => Configuration::Wye,
+    }
+}
+
+fn reactive_reference(reference: ReactivePowerReference) -> &'static str {
+    match reference {
+        ReactivePowerReference::VarMax => "VARMAX",
+        ReactivePowerReference::VarAvailable => "VARAVAL_WATTS",
+    }
+}
+
+fn active_reference(reference: ActivePowerReference) -> &'static str {
+    match reference {
+        ActivePowerReference::SMax => "KVARATINGPU",
+        ActivePowerReference::PAvailable => "PAVAILABLEPU",
+        ActivePowerReference::PMax => "PMPPPU",
     }
 }
 
@@ -1559,8 +1973,9 @@ mod tests {
     use super::super::read::parse_dss_str;
     use super::*;
     use crate::model::{
-        DistGenerator, DistLine, DistLineCode, DistLoad, DistShunt, DistSwitch, DistTransformer,
-        VoltageSource, Winding,
+        ControlVoltageReference, DistControlProfile, DistGenerator, DistIbr, DistLine,
+        DistLineCode, DistLoad, DistShunt, DistSwitch, DistTransformer, IbrPrimeMover, IbrTopology,
+        ReactivePowerReference, ReactivePowerUnit, VoltVarControl, VoltageSource, Winding,
     };
 
     fn strings(v: &[&str]) -> Vec<String> {
@@ -2609,5 +3024,129 @@ mod tests {
             .unwrap();
         assert!(line.contains("phases=2 conn=delta"), "{line}");
         assert_eq!(line.matches("phases=").count(), 1, "{line}");
+    }
+
+    #[test]
+    fn fixed_dispatch_ibr_exports_as_generator_model_one() {
+        let (b, vs) = three_phase_source(240.0);
+        let ibr = DistIbr {
+            name: "pv".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3", "4"]),
+            topology: IbrTopology::FourLeg,
+            prime_mover: IbrPrimeMover::Pv,
+            s_max: vec![10_000.0; 3],
+            i_max: None,
+            p_avail: Some(24_000.0),
+            p_min: Some(vec![8_000.0; 3]),
+            p_max: Some(vec![8_000.0; 3]),
+            q_min: Some(vec![0.0; 3]),
+            q_max: Some(vec![0.0; 3]),
+            control_profile: None,
+            voltage_aggregation: None,
+            extras: Extras::from([("kv".to_string(), serde_json::json!("0.416"))]),
+        };
+        let net = DistNetwork {
+            name: Some("fixed".into()),
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            ibrs: vec![ibr],
+            ..DistNetwork::default()
+        };
+
+        let out = write_dss(&net);
+
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.starts_with("New Generator.pv"))
+            .unwrap();
+        assert!(line.contains("model=1 vminpu=0 vmaxpu=2"), "{line}");
+        assert!(line.contains("kw=24"), "{line}");
+        assert!(!out.text.contains("PVSystem.pv"), "{}", out.text);
+    }
+
+    #[test]
+    fn volt_var_ibr_exports_pvsystem_xycurve_and_invcontrol() {
+        let (b, vs) = three_phase_source(240.0);
+        let base_v = 416.0 / 3f64.sqrt();
+        let ibr = DistIbr {
+            name: "pv".into(),
+            bus: "sb".into(),
+            terminal_map: strings(&["1", "2", "3", "4"]),
+            topology: IbrTopology::FourLeg,
+            prime_mover: IbrPrimeMover::Pv,
+            s_max: vec![10_000.0; 3],
+            i_max: None,
+            p_avail: Some(24_000.0),
+            p_min: Some(vec![0.0; 3]),
+            p_max: Some(vec![8_000.0; 3]),
+            q_min: Some(vec![-4_000.0; 3]),
+            q_max: Some(vec![4_000.0; 3]),
+            control_profile: Some("cp".into()),
+            voltage_aggregation: None,
+            extras: Extras::from([("kv".to_string(), serde_json::json!("0.416"))]),
+        };
+        let profile = DistControlProfile {
+            name: "cp".into(),
+            power_factor: None,
+            volt_var: Some(VoltVarControl {
+                voltage_reference: Some(ControlVoltageReference::PgAveraged),
+                breakpoints: [0.92, 0.98, 1.02, 1.08]
+                    .into_iter()
+                    .map(|v| v * base_v)
+                    .collect(),
+                q_limits: vec![-0.44, 0.44],
+                q_unit: Some(ReactivePowerUnit::VaFraction),
+                q_ref: Some(ReactivePowerReference::VarMax),
+                p_min_for_q: Some(10.0),
+                p_min_for_q_max: Some(50.0),
+            }),
+            volt_watt: None,
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            name: Some("controlled".into()),
+            base_frequency: 60.0,
+            buses: vec![b],
+            sources: vec![vs],
+            ibrs: vec![ibr],
+            control_profiles: vec![profile],
+            ..DistNetwork::default()
+        };
+
+        let out = write_dss(&net);
+
+        assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+        let pv = out
+            .text
+            .lines()
+            .find(|l| l.starts_with("New PVSystem.pv"))
+            .unwrap();
+        assert!(pv.contains("WattPriority=No VarFollowInverter=Yes"), "{pv}");
+        assert!(pv.contains("kvarMax=12"), "{pv}");
+        assert!(pv.contains("kvarMaxAbs=12"), "{pv}");
+        assert!(pv.contains("%PminNoVars=10"), "{pv}");
+        assert!(pv.contains("%PminkvarMax=50"), "{pv}");
+
+        let curve = out
+            .text
+            .lines()
+            .find(|l| l.starts_with("New XYcurve.vv_pv"))
+            .unwrap();
+        assert!(curve.contains("Xarray=[0.92 0.98 1.02 1.08]"), "{curve}");
+        assert!(curve.contains("Yarray=[0.44 0 0 -0.44]"), "{curve}");
+
+        let inv = out
+            .text
+            .lines()
+            .find(|l| l.starts_with("New InvControl.ivc_pv"))
+            .unwrap();
+        assert!(inv.contains("mode=VOLTVAR"), "{inv}");
+        assert!(inv.contains("vvc_curve1=vv_pv"), "{inv}");
+        assert!(inv.contains("RefReactivePower=VARMAX"), "{inv}");
+        assert!(inv.contains("monVoltageCalc=AVG"), "{inv}");
     }
 }

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -61,8 +61,11 @@ pub use dss::{
 };
 pub use error::{Error, Result};
 pub use model::{
-    Configuration, DistBus, DistGenerator, DistLine, DistLineCode, DistLoad, DistLoadVoltageModel,
-    DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer, Extras, Mat,
-    MulticonductorNetwork, UntypedObject, VoltageSource, Winding, WindingConn,
+    ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
+    DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
+    DistLoadVoltageModel, DistNetwork, DistShunt, DistSourceFormat, DistSwitch, DistTransformer,
+    Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation, Mat, MulticonductorNetwork,
+    PowerFactorControl, ReactivePowerReference, ReactivePowerUnit, UntypedObject, VoltVarControl,
+    VoltWattControl, VoltageSource, Winding, WindingConn,
 };
 pub use pmd::{parse_pmd_file, parse_pmd_str, write_pmd_json};

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -344,6 +344,183 @@ impl DistGenerator {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum IbrTopology {
+    SinglePhase,
+    ThreeLeg,
+    FourLeg,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum IbrPrimeMover {
+    Pv,
+    Battery,
+    Generic,
+    Statcom,
+    Dstatcom,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum IbrVoltageAggregation {
+    PerPhase,
+    Average,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DistIbr {
+    pub name: String,
+    pub bus: String,
+    pub terminal_map: Vec<String>,
+    pub topology: IbrTopology,
+    pub prime_mover: IbrPrimeMover,
+    /// Per phase apparent power nameplate ratings, volt amperes.
+    pub s_max: Vec<f64>,
+    /// Per conductor current limits, amperes.
+    pub i_max: Option<Vec<f64>>,
+    /// Available active power, watts.
+    pub p_avail: Option<f64>,
+    pub p_min: Option<Vec<f64>>,
+    pub p_max: Option<Vec<f64>>,
+    pub q_min: Option<Vec<f64>>,
+    pub q_max: Option<Vec<f64>>,
+    pub control_profile: Option<String>,
+    pub voltage_aggregation: Option<IbrVoltageAggregation>,
+    pub extras: Extras,
+}
+
+impl DistIbr {
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        bus: impl Into<String>,
+        terminal_map: Vec<String>,
+        topology: IbrTopology,
+        prime_mover: IbrPrimeMover,
+        s_max: Vec<f64>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            bus: bus.into(),
+            terminal_map,
+            topology,
+            prime_mover,
+            s_max,
+            i_max: None,
+            p_avail: None,
+            p_min: None,
+            p_max: None,
+            q_min: None,
+            q_max: None,
+            control_profile: None,
+            voltage_aggregation: None,
+            extras: Extras::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum ControlVoltageReference {
+    PnPerPhase,
+    PpPerPhase,
+    PpAveraged,
+    PgAveraged,
+    PnAveraged,
+    PgPerPhase,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum ReactivePowerUnit {
+    VaFraction,
+    Var,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum ActivePowerUnit {
+    VaFraction,
+    W,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum ReactivePowerReference {
+    VarMax,
+    VarAvailable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[non_exhaustive]
+pub enum ActivePowerReference {
+    PAvailable,
+    PMax,
+    SMax,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PowerFactorControl {
+    pub pf: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct VoltVarControl {
+    pub voltage_reference: Option<ControlVoltageReference>,
+    pub breakpoints: Vec<f64>,
+    pub q_limits: Vec<f64>,
+    pub q_unit: Option<ReactivePowerUnit>,
+    pub q_ref: Option<ReactivePowerReference>,
+    pub p_min_for_q: Option<f64>,
+    pub p_min_for_q_max: Option<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct VoltWattControl {
+    pub voltage_reference: Option<ControlVoltageReference>,
+    pub breakpoints: Vec<f64>,
+    pub p_limits: Vec<f64>,
+    pub p_unit: Option<ActivePowerUnit>,
+    pub p_ref: Option<ActivePowerReference>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct DistControlProfile {
+    pub name: String,
+    pub power_factor: Option<PowerFactorControl>,
+    pub volt_var: Option<VoltVarControl>,
+    pub volt_watt: Option<VoltWattControl>,
+    pub extras: Extras,
+}
+
+impl DistControlProfile {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            power_factor: None,
+            volt_var: None,
+            volt_watt: None,
+            extras: Extras::new(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DistShunt {
@@ -532,6 +709,10 @@ pub struct DistNetwork {
     pub transformers: Vec<DistTransformer>,
     pub loads: Vec<DistLoad>,
     pub generators: Vec<DistGenerator>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ibrs: Vec<DistIbr>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub control_profiles: Vec<DistControlProfile>,
     pub shunts: Vec<DistShunt>,
     /// BMOPF allows exactly one; the model allows any number and the BMOPF
     /// writer warns beyond the first.
@@ -578,6 +759,8 @@ impl Default for DistNetwork {
             transformers: Vec::new(),
             loads: Vec::new(),
             generators: Vec::new(),
+            ibrs: Vec::new(),
+            control_profiles: Vec::new(),
             shunts: Vec::new(),
             sources: Vec::new(),
             untyped: Vec::new(),

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -140,6 +140,8 @@ fn assert_model_eq(a: &DistNetwork, b: &DistNetwork) {
     assert_eq!(a.switches, b.switches);
     assert_eq!(a.loads, b.loads);
     assert_eq!(a.generators, b.generators);
+    assert_eq!(a.ibrs, b.ibrs);
+    assert_eq!(a.control_profiles, b.control_profiles);
     assert_eq!(a.shunts, b.shunts);
     assert_eq!(a.sources, b.sources);
     assert_eq!(a.transformers, b.transformers);
@@ -161,6 +163,7 @@ fn dss_fixtures_emit_valid_bmopf() {
         "micro/switch.dss",
         "micro/fourwire_linecode.dss",
         "micro/defaults_degenerate.dss",
+        "micro/ibr_pv_control.dss",
     ] {
         let net = parse_dss_file(fixture(case)).unwrap();
         let out = write_bmopf_json(&net);
@@ -431,7 +434,18 @@ fn raw_ibr_and_control_profile_tables_round_trip() {
             }
           },
           "control_profile": {
-            "cp": {"power_factor": {"pf": 0.98}}
+            "cp": {
+              "power_factor": {"pf": 0.98},
+              "volt_var": {
+                "voltage_reference": "PN_PER_PHASE",
+                "breakpoints": [216.0, 228.0, 252.0, 264.0],
+                "q_limits": [-0.44, 0.44],
+                "q_unit": "VA_FRACTION",
+                "q_ref": "VAR_MAX",
+                "p_min_for_q": 10.0,
+                "p_min_for_q_max": 50.0
+              }
+            }
           },
           "ibr": {
             "pv": {
@@ -447,12 +461,28 @@ fn raw_ibr_and_control_profile_tables_round_trip() {
     )
     .unwrap();
 
+    assert_eq!(net.ibrs.len(), 1);
+    assert_eq!(net.control_profiles.len(), 1);
+    let ibr = &net.ibrs[0];
+    assert_eq!(ibr.name, "pv");
+    assert_eq!(ibr.control_profile.as_deref(), Some("cp"));
+    let cp = &net.control_profiles[0];
+    let vv = cp.volt_var.as_ref().expect("volt var typed");
+    assert_eq!(vv.q_limits, vec![-0.44, 0.44]);
+    assert_eq!(vv.p_min_for_q, Some(10.0));
+    assert_eq!(vv.p_min_for_q_max, Some(50.0));
+
     let out = write_bmopf_json(&net);
 
     assert_eq!(errors(&v, &out.text), Vec::<String>::new());
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     assert_eq!(doc["ibr"]["pv"]["control_profile"], "cp");
     assert_eq!(doc["control_profile"]["cp"]["power_factor"]["pf"], 0.98);
+    assert_eq!(
+        doc["control_profile"]["cp"]["volt_var"]["voltage_reference"],
+        "PN_PER_PHASE"
+    );
+    assert_eq!(doc["control_profile"]["cp"]["volt_var"]["q_ref"], "VAR_MAX");
     assert!(
         out.warnings
             .iter()
@@ -460,6 +490,106 @@ fn raw_ibr_and_control_profile_tables_round_trip() {
         "{:?}",
         out.warnings
     );
+    let again = parse_bmopf_str(&out.text).unwrap();
+    assert_model_eq(&net, &again);
+}
+
+#[test]
+fn bmopf_fixed_dispatch_ibr_emits_dss_generator() {
+    let net = parse_bmopf_str(
+        r#"{
+          "bus": {
+            "b": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]}
+          },
+          "voltage_source": {
+            "source": {
+              "v_magnitude": [240.0, 240.0, 240.0, 0.0],
+              "v_angle": [0.0, -2.0943951023931953, 2.0943951023931953, 0.0],
+              "bus": "b",
+              "terminal_map": ["1", "2", "3", "n"]
+            }
+          },
+          "ibr": {
+            "pv": {
+              "bus": "b",
+              "terminal_map": ["1", "2", "3", "n"],
+              "topology": "FOUR_LEG",
+              "prime_mover": "PV",
+              "s_max": [10000.0, 10000.0, 10000.0],
+              "p_min": [8000.0, 8000.0, 8000.0],
+              "p_max": [8000.0, 8000.0, 8000.0],
+              "q_min": [0.0, 0.0, 0.0],
+              "q_max": [0.0, 0.0, 0.0]
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let out = write_dss(&net);
+
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    let line = out
+        .text
+        .lines()
+        .find(|l| l.starts_with("New Generator.pv"))
+        .unwrap();
+    assert!(line.contains("model=1 vminpu=0 vmaxpu=2"), "{line}");
+    assert!(line.contains("kw=24"), "{line}");
+    assert!(!out.text.contains("PVSystem.pv"), "{}", out.text);
+}
+
+#[test]
+fn bmopf_volt_var_ibr_emits_dss_pvsystem_control() {
+    let net = parse_bmopf_str(
+        r#"{
+          "bus": {
+            "b": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]}
+          },
+          "voltage_source": {
+            "source": {
+              "v_magnitude": [240.0, 240.0, 240.0, 0.0],
+              "v_angle": [0.0, -2.0943951023931953, 2.0943951023931953, 0.0],
+              "bus": "b",
+              "terminal_map": ["1", "2", "3", "n"]
+            }
+          },
+          "control_profile": {
+            "cp": {
+              "volt_var": {
+                "voltage_reference": "PG_AVERAGED",
+                "breakpoints": [220.8, 235.2, 244.8, 259.2],
+                "q_limits": [-0.44, 0.44],
+                "q_unit": "VA_FRACTION",
+                "q_ref": "VAR_MAX"
+              }
+            }
+          },
+          "ibr": {
+            "pv": {
+              "bus": "b",
+              "terminal_map": ["1", "2", "3", "n"],
+              "topology": "FOUR_LEG",
+              "prime_mover": "PV",
+              "s_max": [10000.0, 10000.0, 10000.0],
+              "p_avail": 24000.0,
+              "q_min": [-4000.0, -4000.0, -4000.0],
+              "q_max": [4000.0, 4000.0, 4000.0],
+              "control_profile": "cp"
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let out = write_dss(&net);
+
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    assert!(out.text.contains("New PVSystem.pv"), "{}", out.text);
+    assert!(out.text.contains("New XYcurve.vv_pv"), "{}", out.text);
+    assert!(out.text.contains("New InvControl.ivc_pv"), "{}", out.text);
+    assert!(out.text.contains("mode=VOLTVAR"), "{}", out.text);
+    assert!(out.text.contains("RefReactivePower=VARMAX"), "{}", out.text);
 }
 
 #[test]

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -8,7 +8,10 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use powerio_dist::dss::{parse_dss_file, write_dss};
-use powerio_dist::{Configuration, DistNetwork, WindingConn};
+use powerio_dist::{
+    Configuration, DistNetwork, IbrPrimeMover, IbrTopology, ReactivePowerReference,
+    ReactivePowerUnit, WindingConn,
+};
 
 fn fixture(rel: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -261,6 +264,60 @@ fn four_wire_line_keeps_the_neutral() {
     // The load on phase 1 returns through terminal 4, not ground.
     let la = net.loads.iter().find(|l| l.name == "la").unwrap();
     assert_eq!(la.terminal_map, vec!["1", "4"]);
+}
+
+#[test]
+fn pvsystem_and_invcontrol_type_to_ibr_profile() {
+    use powerio_dist::parse_dss_str;
+    let net = parse_dss_str(
+        "New Circuit.c basekv=0.416 phases=3 bus1=sourcebus\n\
+         New PVSystem.pv1 bus1=loadbus.1.2.3.4 phases=3 conn=wye kv=0.416 kva=30 pmpp=24 \
+             irradiance=1 %pmpp=100 kvarMax=12 kvarMaxAbs=9 WattPriority=No \
+             VarFollowInverter=Yes %PminNoVars=10 %PminkvarMax=50\n\
+         New XYcurve.vv npts=4 Xarray=[0.92 0.98 1.02 1.08] Yarray=[0.44 0 0 -0.44]\n\
+         New InvControl.ivc DERList=[PVSystem.pv1] mode=VOLTVAR vvc_curve1=vv \
+             RefReactivePower=VARMAX voltage_curvex_ref=rated monVoltageCalc=AVG\n",
+    );
+
+    assert_eq!(net.ibrs.len(), 1, "{:?}", net.warnings);
+    assert_eq!(net.control_profiles.len(), 1);
+    let ibr = &net.ibrs[0];
+    assert_eq!(ibr.name, "pv1");
+    assert_eq!(ibr.bus, "loadbus");
+    assert_eq!(ibr.terminal_map, vec!["1", "2", "3", "4"]);
+    assert_eq!(ibr.topology, IbrTopology::FourLeg);
+    assert_eq!(ibr.prime_mover, IbrPrimeMover::Pv);
+    assert_eq!(ibr.s_max, vec![10_000.0; 3]);
+    assert_eq!(ibr.p_avail, Some(24_000.0));
+    assert_eq!(ibr.p_max.as_deref(), Some(&[8_000.0, 8_000.0, 8_000.0][..]));
+    assert_eq!(ibr.q_max.as_deref(), Some(&[4_000.0, 4_000.0, 4_000.0][..]));
+    assert_eq!(
+        ibr.q_min.as_deref(),
+        Some(&[-3_000.0, -3_000.0, -3_000.0][..])
+    );
+    assert_eq!(ibr.control_profile.as_deref(), Some("ivc"));
+    assert!(!ibr.extras.contains_key("%pminnovars"));
+    assert!(!ibr.extras.contains_key("%pminkvarmax"));
+
+    let profile = &net.control_profiles[0];
+    let vv = profile.volt_var.as_ref().expect("volt var profile");
+    let base_v = 416.0 / 3f64.sqrt();
+    let expected = [0.92, 0.98, 1.02, 1.08].map(|v| v * base_v);
+    for (actual, expected) in vv.breakpoints.iter().zip(expected) {
+        assert!((actual - expected).abs() < 1e-9, "{actual} != {expected}");
+    }
+    assert_eq!(vv.q_limits, vec![-0.44, 0.44]);
+    assert_eq!(vv.q_unit, Some(ReactivePowerUnit::VaFraction));
+    assert_eq!(vv.q_ref, Some(ReactivePowerReference::VarMax));
+    assert_eq!(vv.p_min_for_q, Some(10.0));
+    assert_eq!(vv.p_min_for_q_max, Some(50.0));
+    assert!(
+        net.untyped
+            .iter()
+            .all(|o| !matches!(o.class.as_str(), "pvsystem" | "xycurve" | "invcontrol")),
+        "{:?}",
+        net.untyped
+    );
 }
 
 #[test]

--- a/tests/data/dist/README.md
+++ b/tests/data/dist/README.md
@@ -54,11 +54,12 @@ constructor defaults (`defaults_degenerate`), and a ten conductor linecode
 with double digit matrix indices (`linecode_10x10`), plus a four wire feeder
 whose neutral is grounded through an explicit reactor
 (`neutral_grounding_reactor`) and two single phase load model cases
-(`onephase_cvr_load`, `onephase_zip_load`). All thirteen solve in OpenDSS
-(opendssdirect 0.9.4). `benchmarks/validate_opendss.py` compares the twelve
-solve fidelity fixtures against their canonical regenerated decks; it excludes
-`defaults_degenerate` because that fixture intentionally relies on constructor
-defaults, including omitted load voltage bounds.
+(`onephase_cvr_load`, `onephase_zip_load`), plus one inverter based resource
+case with `PVSystem` and `InvControl` (`ibr_pv_control`). All fourteen solve in
+OpenDSS (opendssdirect 0.9.4). `benchmarks/validate_opendss.py` compares the
+thirteen solve fidelity fixtures against their canonical regenerated decks; it
+excludes `defaults_degenerate` because that fixture intentionally relies on
+constructor defaults, including omitted load voltage bounds.
 
 ## pmd/
 

--- a/tests/data/dist/micro/License.md
+++ b/tests/data/dist/micro/License.md
@@ -1,6 +1,6 @@
 # License
 
-The eight `.dss` cases in this directory are original works written for
+The fourteen `.dss` cases in this directory are original works written for
 powerio-dist (no upstream source). They are released under the Creative
 Commons Attribution 4.0 International license
 (<https://creativecommons.org/licenses/by/4.0/>).

--- a/tests/data/dist/micro/ibr_pv_control.dss
+++ b/tests/data/dist/micro/ibr_pv_control.dss
@@ -1,0 +1,25 @@
+! Three phase PVSystem with volt var InvControl.
+Clear
+Set DefaultBaseFrequency=60
+
+New Circuit.ibr_pv_control basekv=0.416 pu=1.0 phases=3 bus1=sourcebus MVAsc3=2000 MVAsc1=2100
+
+New Linecode.lc4 nphases=4 basefreq=60 units=km
+~ rmatrix = (0.211 | 0.049 0.211 | 0.049 0.049 0.211 | 0.049 0.049 0.049 0.211)
+~ xmatrix = (0.747 | 0.673 0.747 | 0.651 0.673 0.747 | 0.673 0.651 0.673 0.747)
+~ cmatrix = (10.0 | 0.0 10.0 | 0.0 0.0 10.0 | 0.0 0.0 0.0 10.0)
+~ normamps=185 emergamps=240
+
+New Line.l1 bus1=sourcebus.1.2.3.0 bus2=loadbus.1.2.3.4 phases=4 linecode=lc4 length=0.15 units=km
+
+New Load.la bus1=loadbus.1.4 phases=1 conn=wye kv=0.24 kw=8 pf=0.95 model=1 vminpu=0.8 vmaxpu=1.2
+New Load.lb bus1=loadbus.2.4 phases=1 conn=wye kv=0.24 kw=6 pf=0.95 model=1 vminpu=0.8 vmaxpu=1.2
+New Load.lc bus1=loadbus.3.4 phases=1 conn=wye kv=0.24 kw=10 pf=0.95 model=1 vminpu=0.8 vmaxpu=1.2
+
+New PVSystem.pv1 bus1=loadbus.1.2.3.4 phases=3 conn=wye kv=0.416 kVA=30 Pmpp=24 irradiance=1 %Pmpp=100 kvarMax=12 kvarMaxAbs=12 WattPriority=No VarFollowInverter=Yes %PminNoVars=10 %PminkvarMax=50
+New XYcurve.vv_pv1 npts=4 Xarray=[0.92 0.98 1.02 1.08] Yarray=[0.44 0 0 -0.44]
+New InvControl.ivc_pv1 DERList=[PVSystem.pv1] mode=VOLTVAR vvc_curve1=vv_pv1 RefReactivePower=VARMAX voltage_curvex_ref=rated monVoltageCalc=AVG
+
+Set VoltageBases=[0.416]
+Calcvoltagebases
+Solve


### PR DESCRIPTION
## Summary

- Adds typed `DistIbr` and `DistControlProfile` fields to the distribution model, with BMOPF read and write support for `ibr` and `control_profile`.
- Maps BMOPF IBRs to OpenDSS `Generator` for fixed dispatch and `PVSystem` plus `XYcurve` and `InvControl` for controlled PV style resources.
- Imports OpenDSS `PVSystem`, `XYcurve`, and `InvControl` back into typed IBR and control profile fields.
- Adds a public `ibr_pv_control.dss` micro fixture to the OpenDSS solve oracle.

## Issue #197 Map

| # | Finding | Covered by |
|---|---------|------------|
| 1 | Transformer winding `kv` exported as `NaN` | PR #199 |
| 2 | BMOPF `ibr` not exported | This PR |
| 3 | OpenDSS `PVSystem` / `Generator` not imported | This PR for `PVSystem`; `Generator` is already typed as `generator` |
| 4 | Loads exported without `Vminpu` / `Vmaxpu` | PR #200 |
| 5 | Three phase / four wire line snapshot drift | PR #200 |
| 6 | BMOPF transformer export drops core shunts, taps, and some leakage data | PR #199 |
| 7 | Three plus winding and non two bus transformers dropped from BMOPF export | PR #199 |
| 8 | Transformer `rneut` / `xneut` dropped from exports | PR #199 |

Closes #197.

## Scope Notes

- `PG_*` voltage references map exactly to OpenDSS `InvControl`.
- `PN_*` references export with a warning because OpenDSS measures phase to ground, not phase to neutral.
- `PP_*` references are skipped with a warning because native `InvControl` does not represent phase to phase monitoring.
- Per phase droop through split one phase `PVSystem` elements is intentionally out of scope for this PR.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio-dist`
- `cargo test`
- `cargo clippy --all-targets`
- `PYTHONPATH=/private/tmp/powerio-pr4-wheel-current-unpack /Users/sam/Research/powerio/.claude/worktrees/powerio-dist/.venv/bin/python benchmarks/validate_opendss.py`

Merge order: 4 of 14. Base: dist/opendss-solve-fidelity.