### PR TITLE
Validate emitted BMOPF JSON in CI

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,7 +11,6 @@ name: Validation
 # off doc-only PRs. The fixtures are all vendored, so no large-case fetch is needed.
 on:
   pull_request:
-    branches: [ "main" ]
     paths:
       - "powerio/**"
       - "powerio-dist/**"
@@ -19,6 +18,8 @@ on:
       - "powerio-capi/**"
       - "powerio-py/**"
       - "benchmarks/**"
+      - "tests/data/dist/**"
+      - "powerio-dist/examples/**"
       - ".github/workflows/validation.yml"
 
 permissions:
@@ -66,6 +67,6 @@ jobs:
     # The validation script also checks this, but keep the failure close to the
     # setup step.
     - name: Verify the oracle stack imports
-      run: .venv/bin/python -c "import egret, opendssdirect, pandapower, pypsa"
+      run: .venv/bin/python -c "import egret, jsonschema, opendssdirect, pandapower, pypsa"
     - name: Run the validation matrix
       run: bash benchmarks/run_validation.sh

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -15,5 +15,6 @@ matpowercaseframes<2   # pandapower's .m reader; 2.x's reader is broken (loadcas
 gridx-egret>=0.6       # validate_egret.py / validate_matrix.py: the egret oracle
 pypsa>=1.0             # validate_pypsa.py: PyPSA CSV folder import oracle
 opendssdirect.py>=0.9,<0.10  # validate_opendss.py: OpenDSS solve oracle
+jsonschema>=4.18       # validate_bmopf_schema.py: external BMOPF schema validator
 pillow>=12.2.0; python_version >= "3.10"
 pytest>=9.0.3; python_version >= "3.10"

--- a/benchmarks/run_validation.sh
+++ b/benchmarks/run_validation.sh
@@ -13,6 +13,8 @@
 #   pypsa   — powerio's PyPSA CSV folder output imported by PyPSA.
 #   OpenDSS — original micro distribution decks vs canonical DSS regeneration,
 #             compared by solved node voltage magnitude.
+#   BMOPF schema: distribution fixtures converted to canonical BMOPF JSON,
+#                  then checked by Python jsonschema against the task force schema.
 #
 # Then the read sides and the full conversion matrix:
 #   PSSE-read   — powerio reads a real PSS/E .raw, emits PowerModels JSON, compared
@@ -72,10 +74,10 @@ trap 'rm -rf "$TMP"' EXIT
 export PIO_RESULTS_TSV="$TMP/results.tsv"
 : > "$PIO_RESULTS_TSV"
 
-if ! "$PY" -c "import egret, opendssdirect, pandapower, pypsa" >/dev/null 2>&1; then
+if ! "$PY" -c "import egret, jsonschema, opendssdirect, pandapower, pypsa" >/dev/null 2>&1; then
     echo "error: validation oracle imports failed for $PY" >&2
     echo "hint: .venv/bin/python -m pip install -r benchmarks/requirements.txt" >&2
-    "$PY" -c "import egret, opendssdirect, pandapower, pypsa"
+    "$PY" -c "import egret, jsonschema, opendssdirect, pandapower, pypsa"
     exit 1
 fi
 
@@ -133,6 +135,10 @@ echo "=== PyPSA CSV converter ==="
 echo "=== OpenDSS distribution solve oracle ==="
 "$PY" benchmarks/validate_opendss.py || true
 
+# 4e. External schema validation of emitted BMOPF JSON.
+echo "=== BMOPF schema validation ==="
+"$PY" benchmarks/validate_bmopf_schema.py || true
+
 # 5. Full reader x writer matrix (its own batched process).
 echo "=== full reader x writer matrix (PowerModels + egret oracles) ==="
 if "$PY" benchmarks/validate_matrix.py; then
@@ -154,8 +160,11 @@ awk -F'\t' '
 # (fewer rows than legs run) means a phase crashed before recording — fail loudly.
 mark_fails=$(awk -F'\t' '$3 == "FAIL" { c++ } END { print c + 0 }' "$PIO_RESULTS_TSV")
 # 7 legs per .m case (PMjson, PMread, PSSE, Exa, pp, pp-json, pypsa)
-# + 1 per raw + 1 per egret + 12 OpenDSS micro fixtures + 1 matrix.
-expected=$((${#MCASES[@]} * 7 + ${#RAWCASES[@]} + ${#EGCASES[@]} + 12 + 1))
+# + 1 per raw + 1 per egret + every OpenDSS micro fixture
+# + every emitted BMOPF schema fixture + 1 matrix.
+opendss_expected=$("$PY" benchmarks/validate_opendss.py --count)
+bmopf_schema_expected=$("$PY" benchmarks/validate_bmopf_schema.py --count)
+expected=$((${#MCASES[@]} * 7 + ${#RAWCASES[@]} + ${#EGCASES[@]} + opendss_expected + bmopf_schema_expected + 1))
 got=$(wc -l <"$PIO_RESULTS_TSV")
 short=0
 [ "$got" -lt "$expected" ] && short=1

--- a/benchmarks/validate_bmopf_schema.py
+++ b/benchmarks/validate_bmopf_schema.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Validate emitted BMOPF JSON against the task force schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from jsonschema import validators
+
+import powerio.dist as dist
+
+
+SCHEMA = Path("tests/data/dist/bmopf/draft_bmopf_schema.json")
+BMOPF_CASES = [
+    path
+    for path in sorted(Path("tests/data/dist/bmopf").glob("*.json"))
+    if path.name != SCHEMA.name
+] + sorted(Path("powerio-dist/examples/bmopf").glob("*.json"))
+DSS_CASES = sorted(Path("tests/data/dist/micro").glob("*.dss")) + [
+    Path("tests/data/dist/opendss/ieee13/IEEE13Nodeckt.dss"),
+    Path("tests/data/dist/opendss/ieee34/ieee34Mod1.dss"),
+    Path("tests/data/dist/opendss/ieee123/IEEE123Master.dss"),
+]
+PMD_CASES = sorted(Path("tests/data/dist/pmd").glob("*.json"))
+CASES = BMOPF_CASES + DSS_CASES + PMD_CASES
+
+
+def append_result(case: Path, mark: str) -> None:
+    out = os.environ.get("PIO_RESULTS_TSV")
+    if out:
+        with open(out, "a", encoding="utf-8") as fh:
+            fh.write(f"{case.as_posix()}\tbmopf_schema\t{mark}\n")
+
+
+def schema_validator(schema_path: Path):
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator_cls = validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+def error_path(error) -> str:
+    path = "".join(f"[{part!r}]" for part in error.absolute_path)
+    return path or "$"
+
+
+def validate_case(validator, case: Path) -> list[str]:
+    net = dist.parse_file(case)
+    out = net.to_canonical_format("bmopf-json")
+    if not out.text.strip():
+        return ["writer returned an empty document"]
+
+    doc = json.loads(out.text)
+    errors = sorted(
+        validator.iter_errors(doc),
+        key=lambda err: (tuple(err.absolute_path), err.message),
+    )
+    return [f"{error_path(err)}: {err.message}" for err in errors]
+
+
+def check_paths(paths: Iterable[Path]) -> list[str]:
+    missing = [path.as_posix() for path in paths if not path.is_file()]
+    if not SCHEMA.is_file():
+        missing.append(SCHEMA.as_posix())
+    return missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", action="store_true", help="print the number of validated cases")
+    args = parser.parse_args()
+
+    if args.count:
+        print(len(CASES))
+        return 0
+
+    missing = check_paths(CASES)
+    if missing:
+        for path in missing:
+            print(f"missing fixture: {path}", file=sys.stderr)
+        return 2
+
+    validator = schema_validator(SCHEMA)
+    failures: list[str] = []
+    for case in CASES:
+        try:
+            case_failures = validate_case(validator, case)
+        except Exception as err:  # noqa: BLE001
+            case_failures = [str(err)]
+
+        mark = "ok" if not case_failures else "FAIL"
+        append_result(case, mark)
+        print(f"{case}: {mark}")
+        for failure in case_failures[:10]:
+            print(f"  {failure}")
+        if case_failures:
+            failures.append(f"{case}: {len(case_failures)} validation error(s)")
+
+    if failures:
+        print("\nBMOPF schema validation failed:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/validate_opendss.py
+++ b/benchmarks/validate_opendss.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import math
 import os
 import sys
@@ -87,6 +88,14 @@ def validate_case(case: Path) -> list[str]:
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--count", action="store_true", help="print the number of validated cases")
+    args = parser.parse_args()
+
+    if args.count:
+        print(len(FIXTURES))
+        return 0
+
     failures: list[str] = []
     for case in FIXTURES:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ bench = [
     "gridx-egret>=0.6; python_version >= '3.11'",
     "pypsa>=1.0; python_version >= '3.11'",
     "opendssdirect.py>=0.9,<0.10; python_version >= '3.11'",
+    "jsonschema>=4.18; python_version >= '3.11'",
 ]
 # The published wheel includes the native gridfm writer. This extra installs
 # Python packages for reading and inspecting the Parquet output.


### PR DESCRIPTION
## Summary

- Adds a Python BMOPF schema validation oracle to the validation matrix.
- Converts the distribution fixture corpus to canonical `bmopf-json` through the built wheel, then validates each emitted document with Python `jsonschema`.
- Wires the oracle into `benchmarks/run_validation.sh` and the validation workflow dependency set.

Fixes #192.

## Acceptance Criteria

- The gate validates emitted BMOPF documents, not raw vendored inputs.
- The validator is external to the Rust reader and writer.
- DSS, PMD JSON, and BMOPF JSON fixtures are covered.
- Failures print the case, JSON path, and validator message.

## Out of Scope

- Posting schema issues to BMOPF task force repositories. Any discovered schema gaps go in `private/loops/v061-spec-gaps.md`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio-dist`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `actionlint .github/workflows/validation.yml`
- `cargo build --release -p powerio-capi`
- `PYTHONPATH=<unpacked current wheel> .venv/bin/python benchmarks/validate_bmopf_schema.py`
- `PYTHONPATH=<unpacked current wheel> PYTHON=.venv/bin/python bash benchmarks/run_validation.sh`

Merge order: 5 of 14. Base: dist/ibr-dss-mapping.