### PR TITLE
Add package study block diagnostics

### DIFF
--- a/docs/src/format-fidelity.md
+++ b/docs/src/format-fidelity.md
@@ -105,6 +105,10 @@ Write side losses are reported in `Conversion::warnings`; the pandapower and
 PyPSA readers itemize what they ignore in `Parsed::warnings` (`read_warnings`
 in Python), naming the table and counting the affected rows.
 `convert_file`/`convert_str` fold the read warnings into `Conversion::warnings`.
+Package builders lift balanced reader warnings into structured diagnostics with
+code `READ.TRANSMISSION.PARSE_WARNING`. GridFM package reads use
+`READ.GRIDFM.FIDELITY_WARNING`; distribution packages already carry
+`READ.DIST.PARSE_WARNING`.
 
 - **PSS/E** reads revisions 33, 34, and 35. 3-winding transformers are kept as
   typed records and star-lowered into \\(Y_{\mathrm{bus}}\\)/connectivity by the indexed view;

--- a/docs/src/study-block.md
+++ b/docs/src/study-block.md
@@ -1,7 +1,8 @@
 # The study block
 
-> **Status: design.** Nothing in this chapter ships in 0.5.x. The tracking
-> issues are linked at the end.
+> **Status: Rust package surface.** The `.pio.json` block, validation, uid
+> stamping, and materialization APIs ship in the Rust package crate. CLI,
+> Python, Julia, and C binding surfaces are tracked by #185.
 
 Interactive tools hold a base case plus an ordered log of edits, and replay the
 log to reconstruct the current operating point. tellegen's `Study` works this
@@ -114,12 +115,10 @@ display concern.
 
 ## API surface
 
-- `NetworkPackage::study()`, `with_study`, `clear_study`,
-  `materialize_study_commit(k)`;
-- `powerio study materialize --commit k --to <format>` in the CLI;
-- C ABI: `pio_package_study_json` and `pio_package_materialize_study_commit`,
-  additive symbols beside the operating point calls, no ABI bump.
+- `NetworkPackage::study()`, `with_study`, `set_study`, `clear_study`,
+  `materialize_study_commit(k)`, `materialize_balanced_study_commit(k)`;
+- `ensure_payload_uids(&mut Network)` for deterministic payload row identity.
 
 Tracking issues: [#181](https://github.com/eigenergy/powerio/issues/181)
 (block, materialization, uid contract),
-[#185](https://github.com/eigenergy/powerio/issues/185) (bindings).
+[#185](https://github.com/eigenergy/powerio/issues/185) (bindings and CLI).

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1338,7 +1338,11 @@ pub unsafe extern "C" fn pio_package_from_balanced_network(
             "panic while packaging balanced network",
             || {
                 let net = network_ref(net).ok_or_else(|| "network handle is NULL".to_string())?;
-                let mut package = powerio_pkg::NetworkPackage::from_balanced(net.net.clone());
+                let mut package = powerio_pkg::NetworkPackage::from_balanced_with_read_warnings(
+                    net.net.clone(),
+                    powerio_pkg::READ_TRANSMISSION_PARSE_WARNING,
+                    net.warnings.clone(),
+                );
                 if include_solver_metadata != 0 {
                     package
                         .attach_normalized_solver_table_metadata()

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -17,10 +17,7 @@ use powerio_matrix::opf_pipeline::{DcOpfOptions, write_dcopf_bundle};
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
 use powerio_matrix::synth::{SynthSpec, Topology};
 use powerio_matrix::{MissingGenCostPolicy, WriteOptions};
-use powerio_pkg::{
-    DiagnosticSeverity, DiagnosticStage, NetworkPackage, Origin, SourceDescriptor,
-    StructuredDiagnostic, ValidationSummary,
-};
+use powerio_pkg::{NetworkPackage, Origin, READ_GRIDFM_FIDELITY_WARNING, SourceDescriptor};
 use serde_json::json;
 mod tui;
 
@@ -984,8 +981,11 @@ fn build_package(
     if from == Some(FormatArg::Gridfm) || (from.is_none() && looks_like_gridfm_dir(input)) {
         let read = powerio_matrix::read_gridfm_dataset(input, scenario)
             .with_context(|| format!("reading gridfm dataset {}", input.display()))?;
-        let mut pkg = NetworkPackage::from_balanced(read.network);
-        add_read_warning_diagnostics(&mut pkg, "READ.GRIDFM.FIDELITY_WARNING", &read.warnings);
+        let mut pkg = NetworkPackage::from_balanced_with_read_warnings(
+            read.network,
+            READ_GRIDFM_FIDELITY_WARNING,
+            read.warnings,
+        );
         set_package_source(&mut pkg, input, PackageSourceKind::Folder, "gridfm", false);
         pkg.run_sane_validation();
         return Ok(pkg);
@@ -1018,12 +1018,7 @@ fn build_package(
         .with_context(|| format!("reading {}", input.display()))?;
     let format = parsed.network.source_format.name();
     let retained_source = parsed.network.source.is_some();
-    let mut pkg = NetworkPackage::from_balanced(parsed.network);
-    add_read_warning_diagnostics(
-        &mut pkg,
-        "READ.TRANSMISSION.PARSE_WARNING",
-        &parsed.warnings,
-    );
+    let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
     set_package_source(
         &mut pkg,
         input,
@@ -1033,18 +1028,6 @@ fn build_package(
     );
     pkg.run_sane_validation();
     Ok(pkg)
-}
-
-fn add_read_warning_diagnostics(pkg: &mut NetworkPackage, code: &str, warnings: &[String]) {
-    pkg.diagnostics.extend(warnings.iter().map(|w| {
-        StructuredDiagnostic::new(
-            code,
-            DiagnosticSeverity::Warning,
-            DiagnosticStage::Read,
-            w.clone(),
-        )
-    }));
-    pkg.validation = ValidationSummary::from_diagnostics(&pkg.diagnostics);
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -46,6 +46,7 @@ pub mod model;
 pub mod operating;
 pub mod package;
 pub mod provenance;
+pub mod study;
 pub mod summary;
 pub mod validation;
 
@@ -63,9 +64,11 @@ pub use package::{
     NormalizedSolverTableSourceRows, PIO_PACKAGE_SCHEMA_URL, PIO_PACKAGE_SCHEMA_VERSION,
     PIO_PAYLOAD_BALANCED_SCHEMA_URL, PIO_PAYLOAD_BALANCED_SCHEMA_VERSION,
     PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL, PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION,
+    READ_GRIDFM_FIDELITY_WARNING, READ_TRANSMISSION_PARSE_WARNING, ensure_payload_uids,
 };
 pub use provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
 };
+pub use study::{StudyBlock, StudyCommit, StudyEdit};
 pub use summary::{ObjectSummary, ObjectTopology, ObjectUnits};
 pub use validation::{ValidationCounts, ValidationPass, ValidationStatus, ValidationSummary};

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -463,7 +463,7 @@ fn per_period_metadata(obj: &Map<String, Value>, index: usize) -> BTreeMap<Strin
     metadata
 }
 
-fn json_error(message: impl Into<String>) -> serde_json::Error {
+pub(crate) fn json_error(message: impl Into<String>) -> serde_json::Error {
     <serde_json::Error as serde::de::Error>::custom(message.into())
 }
 
@@ -551,7 +551,7 @@ pub(crate) fn check_series_identities(
     findings
 }
 
-fn payload_key(model: &ModelPayload) -> &'static str {
+pub(crate) fn payload_key(model: &ModelPayload) -> &'static str {
     match model {
         ModelPayload::Balanced { .. } => "balanced_network",
         ModelPayload::Multiconductor { .. } => "multiconductor_network",
@@ -559,7 +559,7 @@ fn payload_key(model: &ModelPayload) -> &'static str {
 }
 
 /// The uid -> row index for one payload table.
-struct IdentityIndex {
+pub(crate) struct IdentityIndex {
     by_uid: HashMap<String, usize>,
     /// Uids on more than one row; resolving through one is ambiguous.
     duplicates: BTreeSet<String>,
@@ -591,7 +591,7 @@ fn table_identity_index(table: &[Value]) -> IdentityIndex {
 /// Resolve one update to its payload row, first rejecting any update that would
 /// rewrite `uid`. Identity is immutable: letting a field write change it would
 /// invalidate the per table indexes mid application.
-fn resolve_update(
+pub(crate) fn resolve_update(
     payload: &Map<String, Value>,
     indexes: &mut HashMap<String, IdentityIndex>,
     update: &ElementUpdate,
@@ -609,7 +609,7 @@ fn resolve_update(
 /// uid bearing table is authoritative and a present wire `row` must agree with
 /// it; an unknown or duplicated uid in such a table is an error; a table without
 /// uids falls back to the wire row.
-fn resolve_update_row(
+pub(crate) fn resolve_update_row(
     payload: &Map<String, Value>,
     indexes: &mut HashMap<String, IdentityIndex>,
     element: &ElementRef,
@@ -666,7 +666,7 @@ fn resolve_update_row(
     Ok(resolved)
 }
 
-fn apply_update_fields(
+pub(crate) fn apply_update_fields(
     payload: &mut serde_json::Map<String, Value>,
     table_name: &str,
     row: usize,
@@ -688,7 +688,7 @@ fn apply_update_fields(
     Ok(())
 }
 
-fn validate_update_fields_survived(
+pub(crate) fn validate_update_fields_survived(
     model: &ModelPayload,
     updates: &[ElementUpdate],
     resolved_rows: &[usize],

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -24,6 +24,7 @@ use crate::operating::{
 use crate::provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
 };
+use crate::study::{StudyBlock, apply_study_to_model, check_study_identities};
 use crate::summary::{ObjectSummary, ObjectTopology, ObjectUnits};
 use crate::validation::{ValidationPass, ValidationStatus, ValidationSummary};
 
@@ -57,6 +58,9 @@ pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL: &str =
 /// The multiconductor payload schema version (semver); the same policy as
 /// [`PIO_PAYLOAD_BALANCED_SCHEMA_VERSION`].
 pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.0.0";
+
+pub const READ_TRANSMISSION_PARSE_WARNING: &str = "READ.TRANSMISSION.PARSE_WARNING";
+pub const READ_GRIDFM_FIDELITY_WARNING: &str = "READ.GRIDFM.FIDELITY_WARNING";
 
 fn default_schema_url() -> String {
     PIO_PACKAGE_SCHEMA_URL.to_owned()
@@ -223,6 +227,9 @@ pub struct NetworkPackage {
     /// constructors and setters omit empty series for static single state cases.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operating_points: Option<OperatingPointSeries>,
+    /// Cumulative interactive edits over the package payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub study: Option<StudyBlock>,
     pub origin: Origin,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<SourceDescriptor>,
@@ -246,7 +253,7 @@ impl NetworkPackage {
     /// GOC3 sources also lift their time series into `operating_points`.
     pub fn from_balanced(net: BalancedNetwork) -> Self {
         let mut net = net;
-        ensure_balanced_payload_uids(&mut net);
+        ensure_payload_uids(&mut net);
         let origin = balanced_origin(&net);
         let summary = balanced_summary(&net);
         let sources = balanced_sources(&net);
@@ -290,6 +297,7 @@ impl NetworkPackage {
             payload_schema_version: Some(payload_schema_version.to_owned()),
             model: ModelPayload::balanced(net),
             operating_points,
+            study: None,
             origin,
             sources,
             source_maps,
@@ -299,6 +307,56 @@ impl NetworkPackage {
             lowering_history: Vec::new(),
             derived: DerivedMetadata::default(),
         }
+    }
+
+    /// Wrap the result of a balanced case reader and lift its warnings into
+    /// package diagnostics.
+    pub fn from_parsed_balanced(parsed: powerio::Parsed) -> Self {
+        Self::from_balanced_with_read_warnings(
+            parsed.network,
+            READ_TRANSMISSION_PARSE_WARNING,
+            parsed.warnings,
+        )
+    }
+
+    /// Wrap a balanced network and lift reader warnings into structured
+    /// diagnostics under `code`.
+    pub fn from_balanced_with_read_warnings<I, S>(
+        net: BalancedNetwork,
+        code: &str,
+        warnings: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut package = Self::from_balanced(net);
+        package.record_read_warnings(code, warnings);
+        package
+    }
+
+    /// Append reader warnings to package diagnostics.
+    pub fn record_read_warnings<I, S>(&mut self, code: &str, warnings: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let diagnostics: Vec<StructuredDiagnostic> = warnings
+            .into_iter()
+            .map(|w| {
+                StructuredDiagnostic::new(
+                    code,
+                    DiagnosticSeverity::Warning,
+                    DiagnosticStage::Read,
+                    w.into(),
+                )
+            })
+            .collect();
+        if diagnostics.is_empty() {
+            return;
+        }
+        self.diagnostics.extend(diagnostics);
+        self.validation = ValidationSummary::from_diagnostics(&self.diagnostics);
     }
 
     /// Wrap a multiconductor network. Parse `warnings` are lifted into structured
@@ -339,6 +397,7 @@ impl NetworkPackage {
             payload_schema_version: Some(payload_schema_version.to_owned()),
             model: ModelPayload::multiconductor(net),
             operating_points: None,
+            study: None,
             origin,
             sources,
             source_maps,
@@ -394,6 +453,29 @@ impl NetworkPackage {
         self.operating_points = None;
     }
 
+    /// Cumulative study edits over the static payload, when present.
+    #[must_use]
+    pub fn study(&self) -> Option<&StudyBlock> {
+        self.study.as_ref()
+    }
+
+    /// Attach a study block to this package. Empty blocks are omitted.
+    #[must_use]
+    pub fn with_study(mut self, study: StudyBlock) -> Self {
+        self.set_study(study);
+        self
+    }
+
+    /// Attach or replace the study block in place. Empty blocks are omitted.
+    pub fn set_study(&mut self, study: StudyBlock) {
+        self.study = (!study.is_empty()).then_some(study);
+    }
+
+    /// Remove the study block from this package.
+    pub fn clear_study(&mut self) {
+        self.study = None;
+    }
+
     /// Materialize one operating point into a static package.
     ///
     /// The returned package has the same metadata and model kind, with its
@@ -434,6 +516,7 @@ impl NetworkPackage {
             payload_schema_version: self.payload_schema_version.clone(),
             model: updated_model,
             operating_points: None,
+            study: None,
             origin: Origin::Derived {
                 parent_package_id: self.package_id.clone(),
                 pass: "materialize-operating-point".to_owned(),
@@ -509,6 +592,98 @@ impl NetworkPackage {
             .materialize_operating_point(index)?
             .model
             .as_multiconductor()
+            .cloned())
+    }
+
+    /// Materialize a study commit into a static package.
+    ///
+    /// The returned package folds commits `0..=commit_index`, clears
+    /// `operating_points` and `study`, and records the replay pass in
+    /// `lowering_history`.
+    pub fn materialize_study_commit(&self, commit_index: usize) -> serde_json::Result<Self> {
+        let study = self.study.as_ref().ok_or_else(|| {
+            <serde_json::Error as serde::de::Error>::custom("package has no study block")
+        })?;
+        let base = if let Some(index) = study.base_operating_point {
+            self.materialize_operating_point(index)?
+        } else {
+            self.clone()
+        };
+        let (updated_model, updated_paths) =
+            apply_study_to_model(&base.model, study, commit_index)?;
+        let had_normalized_solver_tables = base.derived.normalized_solver_tables.is_some();
+        let options = materialize_study_commit_options(study, commit_index);
+
+        let mut package = Self {
+            schema: base.schema.clone(),
+            schema_version: base.schema_version.clone(),
+            producer: base.producer.clone(),
+            package_id: None,
+            created_at: base.created_at.clone(),
+            model_kind: base.model_kind,
+            payload_schema: base.payload_schema.clone(),
+            payload_schema_version: base.payload_schema_version.clone(),
+            model: updated_model,
+            operating_points: None,
+            study: None,
+            origin: Origin::Derived {
+                parent_package_id: self.package_id.clone(),
+                pass: "materialize-study-commit".to_owned(),
+                options: options.clone(),
+            },
+            sources: base.sources.clone(),
+            source_maps: base
+                .source_maps
+                .iter()
+                .filter(|entry| !updated_paths.contains(entry.element_path.as_str()))
+                .cloned()
+                .collect(),
+            diagnostics: base
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| {
+                    diagnostic
+                        .element_path
+                        .as_deref()
+                        .is_none_or(|path| !updated_paths.contains(path))
+                })
+                .cloned()
+                .collect(),
+            validation: base.validation.clone(),
+            summary: base.summary.clone(),
+            lowering_history: base.lowering_history.clone(),
+            derived: DerivedMetadata::default(),
+        };
+        let mut record =
+            LoweringRecord::new("materialize-study-commit", base.model_kind, base.model_kind);
+        record.options = options;
+        record
+            .assumptions
+            .push(format!("applied study commits 0..={commit_index}"));
+        package.run_sane_validation();
+        record.validation_status = package.validation.status;
+        package.push_lowering(record);
+        if had_normalized_solver_tables {
+            package
+                .attach_normalized_solver_table_metadata()
+                .map_err(|err| {
+                    <serde_json::Error as serde::de::Error>::custom(format!(
+                        "failed to recompute normalized solver table metadata: {err}"
+                    ))
+                })?;
+        }
+        Ok(package)
+    }
+
+    /// Materialize a study commit and return the balanced payload.
+    pub fn materialize_balanced_study_commit(
+        &self,
+        commit_index: usize,
+    ) -> serde_json::Result<Option<BalancedNetwork>> {
+        Ok(self
+            .materialize_study_commit(commit_index)?
+            .model
+            .as_balanced()
             .cloned())
     }
 
@@ -701,6 +876,11 @@ impl NetworkPackage {
             diagnostics.extend(identity_diagnostics);
             passes.push(identity_pass);
         }
+        if let Some(study) = &self.study {
+            let (study_diagnostics, study_pass) = validate_study(&self.model, study);
+            diagnostics.extend(study_diagnostics);
+            passes.push(study_pass);
+        }
 
         attach_source_refs(&mut diagnostics, &self.source_maps);
         self.diagnostics.extend(diagnostics);
@@ -712,6 +892,18 @@ impl NetworkPackage {
 fn materialize_operating_point_options(index: usize) -> serde_json::Map<String, serde_json::Value> {
     let mut options = serde_json::Map::new();
     options.insert("index".to_owned(), serde_json::json!(index));
+    options
+}
+
+fn materialize_study_commit_options(
+    study: &StudyBlock,
+    commit_index: usize,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut options = serde_json::Map::new();
+    options.insert("commit_index".to_owned(), serde_json::json!(commit_index));
+    if let Some(index) = study.base_operating_point {
+        options.insert("base_operating_point".to_owned(), serde_json::json!(index));
+    }
     options
 }
 
@@ -777,7 +969,7 @@ fn supported_payload_schema_major(kind: ModelKind) -> u64 {
 /// updates can resolve against any powerio built package. Synthesized values
 /// record the row an element had at package build; they stay put if rows
 /// reorder later, which is the point.
-fn ensure_balanced_payload_uids(net: &mut BalancedNetwork) {
+pub fn ensure_payload_uids(net: &mut BalancedNetwork) {
     macro_rules! fill {
         ($table:ident) => {
             for (row, element) in net.$table.iter_mut().enumerate() {
@@ -798,7 +990,7 @@ fn ensure_balanced_payload_uids(net: &mut BalancedNetwork) {
     fill!(transformers_3w);
 }
 
-const SANE_VALIDATION_CODES: [&str; 7] = [
+const SANE_VALIDATION_CODES: [&str; 9] = [
     "VALIDATE.BALANCED.STRUCTURE",
     "VALIDATE.BALANCED.VALUE_DOMAIN",
     "VALIDATE.MULTI.STRUCTURE",
@@ -806,6 +998,8 @@ const SANE_VALIDATION_CODES: [&str; 7] = [
     "VALIDATE.MULTI.UNTYPED_OBJECT",
     "VALIDATE.MULTI.NO_VOLTAGE_SOURCE",
     "VALIDATE.PACKAGE.OPERATING_IDENTITY",
+    "VALIDATE.PACKAGE.STUDY_MODEL_KIND",
+    "VALIDATE.PACKAGE.STUDY_IDENTITY",
 ];
 
 /// Check every operating point update against the payload's identity index:
@@ -835,6 +1029,45 @@ fn validate_operating_identity(
     (
         diagnostics,
         ValidationPass::new("package.operating_identity", status),
+    )
+}
+
+fn validate_study(
+    model: &ModelPayload,
+    study: &StudyBlock,
+) -> (Vec<StructuredDiagnostic>, ValidationPass) {
+    if !matches!(model, ModelPayload::Balanced { .. }) {
+        let diagnostics = vec![
+            StructuredDiagnostic::new(
+                "VALIDATE.PACKAGE.STUDY_MODEL_KIND",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Validate,
+                "study blocks are only defined for balanced packages",
+            )
+            .with_element_path("/study"),
+        ];
+        return (
+            diagnostics,
+            ValidationPass::new("package.study", ValidationStatus::Error),
+        );
+    }
+
+    let diagnostics: Vec<StructuredDiagnostic> = check_study_identities(model, study)
+        .into_iter()
+        .map(|(commit_pos, edit_pos, message)| {
+            StructuredDiagnostic::new(
+                "VALIDATE.PACKAGE.STUDY_IDENTITY",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Validate,
+                message,
+            )
+            .with_element_path(format!("/study/commits/{commit_pos}/edits/{edit_pos}"))
+        })
+        .collect();
+    let status = validation_status(&diagnostics);
+    (
+        diagnostics,
+        ValidationPass::new("package.study_identity", status),
     )
 }
 

--- a/powerio-pkg/src/study.rs
+++ b/powerio-pkg/src/study.rs
@@ -1,0 +1,481 @@
+//! Cumulative study edits for `.pio.json` packages.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize, de::Error as _};
+use serde_json::{Map, Value, json};
+
+use crate::model::ModelPayload;
+use crate::operating::{
+    ElementRef, ElementUpdate, IdentityIndex, apply_update_fields, json_error, payload_key,
+    resolve_update, resolve_update_row, validate_update_fields_survived,
+};
+
+/// Additive study block stored on a package envelope.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StudyBlock {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_operating_point: Option<usize>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commits: Vec<StudyCommit>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub app: BTreeMap<String, Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+impl StudyBlock {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.label.is_none()
+            && self.author.is_none()
+            && self.created_at.is_none()
+            && self.base_operating_point.is_none()
+            && self.commits.is_empty()
+            && self.app.is_empty()
+            && self.metadata.is_empty()
+    }
+}
+
+/// One cumulative commit in a study block.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StudyCommit {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edits: Vec<StudyEdit>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, Value>,
+}
+
+/// One study edit. Unknown edit kinds are preserved and rejected only when a
+/// caller tries to materialize them.
+#[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
+pub enum StudyEdit {
+    DemandDelta {
+        bus: ElementRef,
+        p_mw: f64,
+        q_mvar: Option<f64>,
+    },
+    RatingDelta {
+        branch: ElementRef,
+        delta_mw: f64,
+    },
+    SetFields {
+        update: ElementUpdate,
+    },
+    Unknown {
+        kind: String,
+        value: Value,
+    },
+}
+
+impl StudyEdit {
+    #[must_use]
+    pub fn kind(&self) -> &str {
+        match self {
+            Self::DemandDelta { .. } => "demand_delta",
+            Self::RatingDelta { .. } => "rating_delta",
+            Self::SetFields { .. } => "set_fields",
+            Self::Unknown { kind, .. } => kind,
+        }
+    }
+}
+
+impl Serialize for StudyEdit {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::DemandDelta { bus, p_mw, q_mvar } => {
+                #[derive(Serialize)]
+                struct Wire<'a> {
+                    kind: &'static str,
+                    bus: &'a ElementRef,
+                    p_mw: f64,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    q_mvar: Option<f64>,
+                }
+                Wire {
+                    kind: "demand_delta",
+                    bus,
+                    p_mw: *p_mw,
+                    q_mvar: *q_mvar,
+                }
+                .serialize(serializer)
+            }
+            Self::RatingDelta { branch, delta_mw } => {
+                #[derive(Serialize)]
+                struct Wire<'a> {
+                    kind: &'static str,
+                    branch: &'a ElementRef,
+                    delta_mw: f64,
+                }
+                Wire {
+                    kind: "rating_delta",
+                    branch,
+                    delta_mw: *delta_mw,
+                }
+                .serialize(serializer)
+            }
+            Self::SetFields { update } => {
+                #[derive(Serialize)]
+                struct Wire<'a> {
+                    kind: &'static str,
+                    update: &'a ElementUpdate,
+                }
+                Wire {
+                    kind: "set_fields",
+                    update,
+                }
+                .serialize(serializer)
+            }
+            Self::Unknown { value, .. } => value.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StudyEdit {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(deserializer)?;
+        let object = value
+            .as_object()
+            .ok_or_else(|| serde::de::Error::custom("study edit must be an object"))?;
+        let kind = object
+            .get("kind")
+            .and_then(Value::as_str)
+            .ok_or_else(|| serde::de::Error::custom("study edit needs string `kind`"))?;
+        match kind {
+            "demand_delta" => {
+                #[derive(Deserialize)]
+                struct Wire {
+                    bus: ElementRef,
+                    p_mw: f64,
+                    #[serde(default)]
+                    q_mvar: Option<f64>,
+                }
+                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                Ok(Self::DemandDelta {
+                    bus: wire.bus,
+                    p_mw: wire.p_mw,
+                    q_mvar: wire.q_mvar,
+                })
+            }
+            "rating_delta" => {
+                #[derive(Deserialize)]
+                struct Wire {
+                    branch: ElementRef,
+                    delta_mw: f64,
+                }
+                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                Ok(Self::RatingDelta {
+                    branch: wire.branch,
+                    delta_mw: wire.delta_mw,
+                })
+            }
+            "set_fields" => {
+                #[derive(Deserialize)]
+                struct Wire {
+                    update: ElementUpdate,
+                }
+                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                Ok(Self::SetFields {
+                    update: wire.update,
+                })
+            }
+            other => Ok(Self::Unknown {
+                kind: other.to_owned(),
+                value,
+            }),
+        }
+    }
+}
+
+/// Apply commits `0..=commit_index` to a balanced model and return the updated
+/// model plus JSON Pointer paths touched by the edits.
+pub(crate) fn apply_study_to_model(
+    model: &ModelPayload,
+    study: &StudyBlock,
+    commit_index: usize,
+) -> serde_json::Result<(ModelPayload, BTreeSet<String>)> {
+    if !matches!(model, ModelPayload::Balanced { .. }) {
+        return Err(json_error(
+            "STUDY.WRONG_MODEL_KIND: study materialization requires a balanced package",
+        ));
+    }
+    if study.commits.get(commit_index).is_none() {
+        return Err(json_error(format!(
+            "package has no study commit {commit_index}"
+        )));
+    }
+
+    let mut value = serde_json::to_value(model)?;
+    let payload_key = payload_key(model);
+    let payload = value
+        .as_object_mut()
+        .and_then(|root| root.get_mut(payload_key))
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| json_error(format!("model payload missing `{payload_key}` object")))?;
+
+    let mut indexes = HashMap::new();
+    let mut updated_paths = BTreeSet::new();
+    let mut set_field_updates = Vec::new();
+    let mut set_field_rows = Vec::new();
+    let mut context = StudyApplyContext {
+        payload,
+        payload_key,
+        indexes: &mut indexes,
+        updated_paths: &mut updated_paths,
+        set_field_updates: &mut set_field_updates,
+        set_field_rows: &mut set_field_rows,
+    };
+    for (commit_pos, commit) in study.commits.iter().take(commit_index + 1).enumerate() {
+        for (edit_pos, edit) in commit.edits.iter().enumerate() {
+            context.apply_edit(edit, commit_pos, edit_pos)?;
+        }
+    }
+
+    let updated = serde_json::from_value(value)?;
+    validate_update_fields_survived(&updated, &set_field_updates, &set_field_rows)?;
+    Ok((updated, updated_paths))
+}
+
+/// Dry run identity resolution for every known study edit.
+pub(crate) fn check_study_identities(
+    model: &ModelPayload,
+    study: &StudyBlock,
+) -> Vec<(usize, usize, String)> {
+    let payload_key = payload_key(model);
+    let payload = match serde_json::to_value(model) {
+        Ok(Value::Object(mut root)) => match root.remove(payload_key) {
+            Some(Value::Object(payload)) => payload,
+            _ => {
+                return vec![(
+                    0,
+                    0,
+                    format!("model payload missing `{payload_key}` object"),
+                )];
+            }
+        },
+        _ => return vec![(0, 0, "model payload did not serialize to object".to_owned())],
+    };
+
+    let mut indexes = HashMap::new();
+    let mut findings = Vec::new();
+    for (commit_pos, commit) in study.commits.iter().enumerate() {
+        for (edit_pos, edit) in commit.edits.iter().enumerate() {
+            let result = match edit {
+                StudyEdit::DemandDelta { bus, .. } => {
+                    resolve_update_row(&payload, &mut indexes, bus).map(|_| ())
+                }
+                StudyEdit::RatingDelta { branch, .. } => {
+                    resolve_update_row(&payload, &mut indexes, branch).map(|_| ())
+                }
+                StudyEdit::SetFields { update } => {
+                    resolve_update(&payload, &mut indexes, update).map(|_| ())
+                }
+                StudyEdit::Unknown { .. } => Ok(()),
+            };
+            if let Err(message) = result {
+                findings.push((commit_pos, edit_pos, message));
+            }
+        }
+    }
+    findings
+}
+
+struct StudyApplyContext<'a> {
+    payload: &'a mut Map<String, Value>,
+    payload_key: &'a str,
+    indexes: &'a mut HashMap<String, IdentityIndex>,
+    updated_paths: &'a mut BTreeSet<String>,
+    set_field_updates: &'a mut Vec<ElementUpdate>,
+    set_field_rows: &'a mut Vec<usize>,
+}
+
+impl StudyApplyContext<'_> {
+    fn apply_edit(
+        &mut self,
+        edit: &StudyEdit,
+        commit_pos: usize,
+        edit_pos: usize,
+    ) -> serde_json::Result<()> {
+        match edit {
+            StudyEdit::DemandDelta { bus, p_mw, q_mvar } => {
+                let bus_row =
+                    resolve_update_row(self.payload, self.indexes, bus).map_err(json_error)?;
+                let touched = apply_demand_delta(self.payload, bus_row, *p_mw, *q_mvar)?;
+                for path in touched {
+                    self.updated_paths
+                        .insert(format!("/model/{}/{path}", self.payload_key));
+                }
+                self.indexes.remove("loads");
+            }
+            StudyEdit::RatingDelta { branch, delta_mw } => {
+                let branch_row =
+                    resolve_update_row(self.payload, self.indexes, branch).map_err(json_error)?;
+                let branch = row_object_mut(self.payload, "branches", branch_row)?;
+                let old = number_field(branch, "rate_a", "branch", branch_row)?;
+                branch.insert("rate_a".to_owned(), json!(old + delta_mw));
+                self.updated_paths.insert(format!(
+                    "/model/{}/branches/{branch_row}/rate_a",
+                    self.payload_key
+                ));
+            }
+            StudyEdit::SetFields { update } => {
+                let row = resolve_update(self.payload, self.indexes, update).map_err(json_error)?;
+                apply_update_fields(self.payload, &update.element.table, row, &update.fields)?;
+                for field in update.fields.keys() {
+                    self.updated_paths.insert(format!(
+                        "/model/{}/{}/{row}/{field}",
+                        self.payload_key, update.element.table
+                    ));
+                }
+                self.set_field_updates.push(update.clone());
+                self.set_field_rows.push(row);
+            }
+            StudyEdit::Unknown { kind, .. } => {
+                return Err(json_error(format!(
+                    "STUDY.UNKNOWN_EDIT_KIND: study commit {commit_pos} edit {edit_pos} has unsupported kind `{kind}`"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn apply_demand_delta(
+    payload: &mut Map<String, Value>,
+    bus_row: usize,
+    p_delta: f64,
+    q_delta: Option<f64>,
+) -> serde_json::Result<Vec<String>> {
+    let (bus_id, bus_uid) = {
+        let bus = row_object(payload, "buses", bus_row)?;
+        let bus_id = bus
+            .get("id")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| json_error(format!("bus row {bus_row} has no numeric `id`")))?;
+        let bus_uid = bus
+            .get("uid")
+            .and_then(Value::as_str)
+            .map_or_else(|| format!("buses:{bus_row}"), str::to_owned);
+        (bus_id, bus_uid)
+    };
+
+    let loads = payload
+        .get_mut("loads")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| json_error("balanced payload has no `loads` array"))?;
+    let mut rows = Vec::new();
+    let mut total_p = 0.0;
+    let mut total_q = 0.0;
+    for (row, load) in loads.iter().enumerate() {
+        let Some(load) = load.as_object() else {
+            continue;
+        };
+        if load.get("bus").and_then(Value::as_u64) != Some(bus_id) {
+            continue;
+        }
+        if !load
+            .get("in_service")
+            .and_then(Value::as_bool)
+            .unwrap_or(true)
+        {
+            continue;
+        }
+        let p = load.get("p").and_then(Value::as_f64).unwrap_or(0.0);
+        let q = load.get("q").and_then(Value::as_f64).unwrap_or(0.0);
+        rows.push((row, p, q));
+        total_p += p;
+        total_q += q;
+    }
+
+    if rows.is_empty() || total_p == 0.0 {
+        let q = q_delta.unwrap_or(0.0);
+        loads.push(json!({
+            "bus": bus_id,
+            "p": p_delta,
+            "q": q,
+            "voltage_model": null,
+            "in_service": true,
+            "uid": format!("study:load:{bus_uid}"),
+            "extras": {
+                "study": {
+                    "synthetic": true,
+                    "source": "demand_delta"
+                }
+            }
+        }));
+        let row = loads.len() - 1;
+        return Ok(vec![
+            format!("loads/{row}/p"),
+            format!("loads/{row}/q"),
+            format!("loads/{row}/uid"),
+            format!("loads/{row}/extras"),
+        ]);
+    }
+
+    let q_delta = q_delta.unwrap_or_else(|| p_delta * total_q / total_p);
+    let mut touched = Vec::new();
+    for (row, p, q) in rows {
+        let p_share = p / total_p;
+        let q_share = if total_q == 0.0 { p_share } else { q / total_q };
+        let load = loads
+            .get_mut(row)
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| json_error(format!("load row {row} disappeared")))?;
+        load.insert("p".to_owned(), json!(p + p_delta * p_share));
+        load.insert("q".to_owned(), json!(q + q_delta * q_share));
+        touched.push(format!("loads/{row}/p"));
+        touched.push(format!("loads/{row}/q"));
+    }
+    Ok(touched)
+}
+
+fn row_object<'a>(
+    payload: &'a Map<String, Value>,
+    table_name: &str,
+    row: usize,
+) -> serde_json::Result<&'a Map<String, Value>> {
+    payload
+        .get(table_name)
+        .and_then(Value::as_array)
+        .and_then(|table| table.get(row))
+        .and_then(Value::as_object)
+        .ok_or_else(|| json_error(format!("table `{table_name}` has no object row {row}")))
+}
+
+fn row_object_mut<'a>(
+    payload: &'a mut Map<String, Value>,
+    table_name: &str,
+    row: usize,
+) -> serde_json::Result<&'a mut Map<String, Value>> {
+    payload
+        .get_mut(table_name)
+        .and_then(Value::as_array_mut)
+        .and_then(|table| table.get_mut(row))
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| json_error(format!("table `{table_name}` has no object row {row}")))
+}
+
+fn number_field(
+    object: &Map<String, Value>,
+    field: &str,
+    label: &str,
+    row: usize,
+) -> serde_json::Result<f64> {
+    object
+        .get(field)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| json_error(format!("{label} row {row} has no numeric `{field}` field")))
+}

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -8,8 +8,9 @@ use powerio_pkg::{
     NetworkPackage, OperatingPoint, OperatingPointSeries, Origin, PIO_PACKAGE_SCHEMA_URL,
     PIO_PACKAGE_SCHEMA_VERSION, PIO_PAYLOAD_BALANCED_SCHEMA_URL,
     PIO_PAYLOAD_BALANCED_SCHEMA_VERSION, PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL,
-    SequenceTransformConvention, SourceDescriptor, SourceMapEntry, SourceRef, StructuredDiagnostic,
-    TimeAxis, ValidationStatus, check_multiconductor_to_balanced_lowering,
+    READ_TRANSMISSION_PARSE_WARNING, SequenceTransformConvention, SourceDescriptor, SourceMapEntry,
+    SourceRef, StructuredDiagnostic, StudyBlock, StudyCommit, StudyEdit, TimeAxis,
+    ValidationStatus, check_multiconductor_to_balanced_lowering, ensure_payload_uids,
     lower_multiconductor_to_balanced,
 };
 
@@ -143,6 +144,18 @@ fn sample_operating_points() -> OperatingPointSeries {
         "source".to_owned(),
         serde_json::json!("unit-test"),
     )]))
+}
+
+fn study_commit(edits: Vec<StudyEdit>) -> StudyCommit {
+    let mut commit = StudyCommit::default();
+    commit.edits = edits;
+    commit
+}
+
+fn study_block(commits: Vec<StudyCommit>) -> StudyBlock {
+    let mut study = StudyBlock::default();
+    study.commits = commits;
+    study
 }
 
 fn strings(values: &[&str]) -> Vec<String> {
@@ -1963,4 +1976,263 @@ fn goc3_updates_resolve_by_identity_not_row_order() {
         .materialize_operating_point(0)
         .expect_err("unknown uid must fail");
     assert!(err.to_string().contains("unknown identity"), "{err}");
+}
+
+#[test]
+fn package_balanced_reader_warnings_become_diagnostics() {
+    let parsed = powerio::parse_str(MATPOWER_SRC, "matpower").expect("parse matpower");
+    let mut pkg = NetworkPackage::from_balanced_with_read_warnings(
+        parsed.network,
+        READ_TRANSMISSION_PARSE_WARNING,
+        vec!["ignored source table".to_owned()],
+    );
+
+    assert!(pkg.diagnostics.iter().any(|d| {
+        d.code.as_str() == READ_TRANSMISSION_PARSE_WARNING
+            && d.severity == DiagnosticSeverity::Warning
+            && d.stage == DiagnosticStage::Read
+            && d.message == "ignored source table"
+    }));
+
+    pkg.run_sane_validation();
+    assert!(
+        pkg.diagnostics
+            .iter()
+            .any(|d| d.code.as_str() == READ_TRANSMISSION_PARSE_WARNING),
+        "reader warning diagnostic was dropped by validation"
+    );
+}
+
+#[test]
+fn ensure_payload_uids_is_public_and_deterministic() {
+    let mut net = powerio::parse_str(MATPOWER_WITH_GEN_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+    net.buses[0].uid = Some("source-bus".to_owned());
+    net.loads[0].uid = Some("source-load".to_owned());
+
+    ensure_payload_uids(&mut net);
+    let first = serde_json::to_value(&net).expect("serialize network with uids");
+    ensure_payload_uids(&mut net);
+    let second = serde_json::to_value(&net).expect("serialize network with uids again");
+
+    assert_eq!(first, second);
+    assert_eq!(net.buses[0].uid.as_deref(), Some("source-bus"));
+    assert_eq!(net.buses[1].uid.as_deref(), Some("buses:1"));
+    assert_eq!(net.loads[0].uid.as_deref(), Some("source-load"));
+    assert_eq!(net.generators[0].uid.as_deref(), Some("generators:0"));
+}
+
+#[test]
+fn study_commit_materialization_folds_commits_and_set_fields() {
+    let study = study_block(vec![
+        study_commit(vec![
+            StudyEdit::DemandDelta {
+                bus: ElementRef::by_source_uid("buses", "buses:1"),
+                p_mw: 5.0,
+                q_mvar: None,
+            },
+            StudyEdit::RatingDelta {
+                branch: ElementRef::by_source_uid("branches", "branch_1"),
+                delta_mw: -10.0,
+            },
+        ]),
+        study_commit(vec![
+            StudyEdit::DemandDelta {
+                bus: ElementRef::by_source_uid("buses", "buses:1"),
+                p_mw: 5.0,
+                q_mvar: Some(1.0),
+            },
+            StudyEdit::SetFields {
+                update: ElementUpdate::new(
+                    ElementRef::by_source_uid("generators", "gen_1"),
+                    fields(&[("pg", serde_json::json!(55.0))]),
+                ),
+            },
+        ]),
+    ]);
+    let pkg = balanced_package_with_gen()
+        .with_package_id("parent")
+        .with_study(study);
+
+    let materialized = pkg.materialize_study_commit(1).expect("materialize study");
+    assert!(materialized.study.is_none());
+    assert!(materialized.operating_points.is_none());
+    assert!(matches!(materialized.origin, Origin::Derived { .. }));
+    assert!(
+        materialized
+            .lowering_history
+            .iter()
+            .any(|record| record.pass == "materialize-study-commit")
+    );
+
+    let net = materialized.as_balanced().expect("balanced output");
+    assert_close(net.loads[0].p, 20.0);
+    assert_close(net.loads[0].q, 8.5);
+    assert_close(net.branches[0].rate_a, 90.0);
+    assert_close(net.generators[0].pg, 55.0);
+}
+
+#[test]
+fn study_demand_delta_distributes_over_existing_loads() {
+    let mut net = powerio::parse_str(MATPOWER_WITH_GEN_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+    net.loads[0].uid = Some("load_1".to_owned());
+    let mut extra_load = powerio::Load::new(powerio::BusId(2), 30.0, 15.0);
+    extra_load.uid = Some("load_2".to_owned());
+    net.loads.push(extra_load);
+
+    let study = study_block(vec![study_commit(vec![StudyEdit::DemandDelta {
+        bus: ElementRef::by_source_uid("buses", "buses:1"),
+        p_mw: 8.0,
+        q_mvar: None,
+    }])]);
+    let materialized = NetworkPackage::from_balanced(net)
+        .with_study(study)
+        .materialize_study_commit(0)
+        .expect("materialize proportional demand delta");
+    let net = materialized.as_balanced().expect("balanced output");
+
+    assert_close(net.loads[0].p, 12.0);
+    assert_close(net.loads[0].q, 6.0);
+    assert_close(net.loads[1].p, 36.0);
+    assert_close(net.loads[1].q, 18.0);
+}
+
+#[test]
+fn study_demand_delta_appends_synthetic_load_for_empty_bus() {
+    let mut net = powerio::parse_str(MATPOWER_SRC, "matpower")
+        .expect("parse matpower")
+        .network;
+    net.loads.clear();
+    let study = study_block(vec![study_commit(vec![StudyEdit::DemandDelta {
+        bus: ElementRef::by_source_uid("buses", "buses:1"),
+        p_mw: 12.0,
+        q_mvar: Some(3.0),
+    }])]);
+
+    let materialized = NetworkPackage::from_balanced(net)
+        .with_study(study)
+        .materialize_study_commit(0)
+        .expect("materialize synthetic load");
+    let net = materialized.as_balanced().expect("balanced output");
+
+    assert_eq!(net.loads.len(), 1);
+    assert_eq!(net.loads[0].bus, powerio::BusId(2));
+    assert_close(net.loads[0].p, 12.0);
+    assert_close(net.loads[0].q, 3.0);
+    assert_eq!(net.loads[0].uid.as_deref(), Some("study:load:buses:1"));
+    assert_eq!(
+        net.loads[0]
+            .extras
+            .get("study")
+            .and_then(|v| v.get("synthetic"))
+            .and_then(serde_json::Value::as_bool),
+        Some(true)
+    );
+}
+
+#[test]
+fn study_uses_base_operating_point_before_commits() {
+    let mut study = study_block(vec![study_commit(vec![StudyEdit::DemandDelta {
+        bus: ElementRef::by_source_uid("buses", "buses:1"),
+        p_mw: 2.0,
+        q_mvar: Some(1.0),
+    }])]);
+    study.base_operating_point = Some(1);
+
+    let materialized = balanced_package_with_gen()
+        .with_operating_points(sample_operating_points())
+        .with_study(study)
+        .materialize_study_commit(0)
+        .expect("materialize study from operating point");
+    let net = materialized.as_balanced().expect("balanced output");
+
+    assert_close(net.loads[0].p, 24.0);
+    assert_close(net.loads[0].q, 10.0);
+    assert!(materialized.operating_points.is_none());
+    assert!(materialized.study.is_none());
+    assert_eq!(
+        materialized
+            .lowering_history
+            .iter()
+            .map(|record| record.pass.as_str())
+            .collect::<Vec<_>>(),
+        vec!["materialize-operating-point", "materialize-study-commit"]
+    );
+}
+
+#[test]
+fn study_unknown_edit_kind_roundtrips_and_refuses_materialization() {
+    let mut value = serde_json::to_value(balanced_package()).expect("serialize package");
+    value["study"] = serde_json::json!({
+        "commits": [
+            {
+                "edits": [
+                    {
+                        "kind": "solver_knob",
+                        "value": {"name": "shed", "enabled": false},
+                        "extra": [1, 2, 3]
+                    }
+                ]
+            }
+        ]
+    });
+
+    let pkg: NetworkPackage = serde_json::from_value(value.clone()).expect("parse package");
+    let round_trip = serde_json::to_value(&pkg).expect("serialize package again");
+    assert_eq!(round_trip["study"], value["study"]);
+
+    let err = pkg
+        .materialize_study_commit(0)
+        .expect_err("unknown study edit kind must fail");
+    assert!(err.to_string().contains("STUDY.UNKNOWN_EDIT_KIND"), "{err}");
+    assert!(err.to_string().contains("solver_knob"), "{err}");
+}
+
+#[test]
+fn study_set_fields_rejects_fields_not_in_typed_model() {
+    let study = study_block(vec![study_commit(vec![StudyEdit::SetFields {
+        update: ElementUpdate::new(
+            ElementRef::by_source_uid("loads", "load_1"),
+            fields(&[("ghost_field", serde_json::json!(1.0))]),
+        ),
+    }])]);
+
+    let err = balanced_package_with_gen()
+        .with_study(study)
+        .materialize_study_commit(0)
+        .expect_err("unknown field should not survive typed materialization");
+    assert!(err.to_string().contains("field `ghost_field`"), "{err}");
+}
+
+#[test]
+fn study_validation_reports_bad_identity() {
+    let study = study_block(vec![study_commit(vec![StudyEdit::DemandDelta {
+        bus: ElementRef::by_source_uid("buses", "ghost"),
+        p_mw: 1.0,
+        q_mvar: None,
+    }])]);
+    let mut pkg = balanced_package().with_study(study);
+    pkg.run_sane_validation();
+
+    assert!(pkg.diagnostics.iter().any(|d| {
+        d.code.as_str() == "VALIDATE.PACKAGE.STUDY_IDENTITY"
+            && d.element_path.as_deref() == Some("/study/commits/0/edits/0")
+    }));
+    assert_eq!(pkg.validation.status, ValidationStatus::Error);
+}
+
+#[test]
+fn study_validation_rejects_multiconductor_payload() {
+    let study = study_block(vec![study_commit(Vec::new())]);
+    let mut pkg = multiconductor_package().with_study(study);
+    pkg.run_sane_validation();
+
+    assert!(pkg.diagnostics.iter().any(|d| {
+        d.code.as_str() == "VALIDATE.PACKAGE.STUDY_MODEL_KIND"
+            && d.element_path.as_deref() == Some("/study")
+    }));
+    assert_eq!(pkg.validation.status, ValidationStatus::Error);
 }

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -35,8 +35,7 @@ use powerio_matrix::{
     DisplayData, IndexCore, IndexedNetwork, MissingGenCostPolicy, Network, PwdDisplay, WriteOptions,
 };
 use powerio_pkg::{
-    DiagnosticSeverity, DiagnosticStage, NetworkPackage, Origin, SourceDescriptor,
-    StructuredDiagnostic, ValidationSummary,
+    DiagnosticSeverity, NetworkPackage, Origin, READ_TRANSMISSION_PARSE_WARNING, SourceDescriptor,
 };
 
 #[cfg(feature = "gridfm")]
@@ -283,18 +282,6 @@ fn package_to_dist_py(pkg: &NetworkPackage) -> PyResult<PyDistNetwork> {
     Ok(PyDistNetwork { net })
 }
 
-fn add_package_read_warning_diagnostics(pkg: &mut NetworkPackage, code: &str, warnings: &[String]) {
-    pkg.diagnostics.extend(warnings.iter().map(|w| {
-        StructuredDiagnostic::new(
-            code,
-            DiagnosticSeverity::Warning,
-            DiagnosticStage::Read,
-            w.clone(),
-        )
-    }));
-    pkg.validation = ValidationSummary::from_diagnostics(&pkg.diagnostics);
-}
-
 #[derive(Clone, Copy)]
 enum PackageSourceKind {
     File,
@@ -428,11 +415,10 @@ fn build_package_from_path(
         {
             let read = gridfm_read_dataset(input.to_string_lossy().as_ref(), scenario)
                 .map_err(to_pyerr)?;
-            let mut pkg = NetworkPackage::from_balanced(read.network);
-            add_package_read_warning_diagnostics(
-                &mut pkg,
-                "READ.GRIDFM.FIDELITY_WARNING",
-                &read.warnings,
+            let mut pkg = NetworkPackage::from_balanced_with_read_warnings(
+                read.network,
+                powerio_pkg::READ_GRIDFM_FIDELITY_WARNING,
+                read.warnings,
             );
             set_package_source(&mut pkg, input, PackageSourceKind::Folder, "gridfm", false);
             pkg.run_sane_validation();
@@ -472,12 +458,7 @@ fn build_package_from_path(
     let parsed = powerio_matrix::parse_file(input, from_).map_err(to_pyerr)?;
     let format = parsed.network.source_format.name();
     let retained_source = parsed.network.source.is_some();
-    let mut pkg = NetworkPackage::from_balanced(parsed.network);
-    add_package_read_warning_diagnostics(
-        &mut pkg,
-        "READ.TRANSMISSION.PARSE_WARNING",
-        &parsed.warnings,
-    );
+    let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
     set_package_source(
         &mut pkg,
         input,
@@ -526,12 +507,7 @@ fn build_package_from_str(text: &str, from_: Option<&str>) -> PyResult<NetworkPa
 
     let parsed = powerio_matrix::parse_str(text, source_format.as_deref().unwrap_or("matpower"))
         .map_err(to_pyerr)?;
-    let mut pkg = NetworkPackage::from_balanced(parsed.network);
-    add_package_read_warning_diagnostics(
-        &mut pkg,
-        "READ.TRANSMISSION.PARSE_WARNING",
-        &parsed.warnings,
-    );
+    let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
     pkg.run_sane_validation();
     Ok(pkg)
 }
@@ -1426,7 +1402,11 @@ impl PyPackage {
         network: PyRef<'_, PyNetwork>,
         include_solver_metadata: bool,
     ) -> PyResult<Self> {
-        let mut pkg = NetworkPackage::from_balanced(network.inner.clone());
+        let mut pkg = NetworkPackage::from_balanced_with_read_warnings(
+            network.inner.clone(),
+            READ_TRANSMISSION_PARSE_WARNING,
+            network.warnings.clone(),
+        );
         if include_solver_metadata {
             pkg.attach_normalized_solver_table_metadata()
                 .map_err(to_pyerr)?;


### PR DESCRIPTION
## Summary

- Adds the `.pio.json` study block model, validation, and Rust materialization APIs.
- Preserves unknown study edit kinds verbatim on read and rejects them by name when materializing.
- Promotes deterministic payload uid stamping to `ensure_payload_uids`.
- Records balanced reader warnings as package diagnostics, matching the existing distribution package behavior.

Fixes #181.
Fixes #193.

## Acceptance Criteria

- `NetworkPackage` carries an optional `study` envelope field without a schema version bump.
- `materialize_study_commit(k)` folds commits `0..=k`, clears dynamic state, appends a lowering record, and supports studies over a base operating point.
- `demand_delta` resolves buses by identity first, distributes across in service loads, and creates `study:load:{bus_uid}` when no active load exists.
- `rating_delta` and `set_fields` use the same identity semantics as operating point updates.
- Package validation dry runs study identities and rejects study blocks on multiconductor payloads with structured diagnostics.
- Balanced parse and GridFM reader warnings survive package construction as structured read diagnostics.

## Out of Scope

- CLI, C, Python, and Julia study materialization bindings; those remain tracked by #185.

## Validation

- `cargo fmt --all --check`
- `cargo test -p powerio-pkg`
- `cargo test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p powerio-py`
- `cargo test -p powerio-capi --features pkg`

Merge order: 7 of 14. Base: main.