### PR TITLE
Sparse PTDF and drop tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ powerio package tests/data/case14.m -o case14.pio.json
 powerio package goc3_case.json --from goc3-json -o goc3_case.pio.json
 powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
-powerio sensitivities tests/data/case30.m -o out
+powerio sensitivities tests/data/case30.m -o out --solver auto --drop-tolerance 1e-10
 powerio gridfm tests/data/case14.m -o out
 powerio
 ```
@@ -187,7 +187,8 @@ The `powerio-matrix` Rust crate derives an `IndexedNetwork` with dense bus indic
 - Nodal admittance matrix
 - LACPF block matrix
 - Signed incidence, weighted Laplacian, and flow map matrices
-- PTDF and LODF sensitivity matrices
+- PTDF and LODF sensitivity matrices, with dense and iterative solver paths
+- Streamed CLI PTDF/LODF writes for iterative sensitivity exports
 - Adjacency matrix and `petgraph` graph output
 - Matrix Market bundles for OPF solvers
 - KKT operators for OPF solvers (experimental)

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -18,16 +18,24 @@ The DC OPF bundle has its own schema in
 | signed incidence \\(A\\) | \\(n \times m\\) | `build_incidence` | column \\(e\\) has \\(+1\\) at from-bus, \\(-1\\) at to-bus |
 | weighted Laplacian \\(L\\) | \\(n \times n\\) | `build_weighted_laplacian` | \\(L = A \operatorname{diag}(w) A^\mathsf{T}\\), `ground_at` removes a row/col |
 | flow map \\(B A^\mathsf{T}\\) | \\(m \times n\\) | `build_flow_map` | \\(f = B A^\mathsf{T}\theta\\) |
-| PTDF | \\(m \times n\\) | `build_ptdf` | dense; factors the Laplacian grounded at the reference buses |
-| LODF | \\(m \times m\\) | `build_lodf` | dense DC line-outage factors |
+| PTDF | \\(m \times n\\) | `build_ptdf` | dense oracle builder; `build_ptdf_lodf_with_options` can use iterative solves |
+| LODF | \\(m \times m\\) | `build_lodf` | dense oracle builder; option based builds can prune small output entries |
 | adjacency | \\(n \times n\\) | `build_adjacency` | sparse graph adjacency |
 | petgraph graph | n/a | `IndexedNetwork::to_petgraph` | `UnGraph<bus_idx, branch_idx>` |
 
-Computing PTDF and LODF matrices requires a linear solve. Both factor the
-Laplacian with one row and column removed for each reference bus, using the dense
-Cholesky in
-`matrix::sensitivity`. Every connected component must contain at least one
-reference bus. PTDF is dense \\(m \times n\\). The DC OPF
+Computing PTDF and LODF matrices requires a linear solve. The stable
+`build_ptdf`, `build_lodf`, and `build_ptdf_lodf` builders keep the dense
+grounded inverse path and remain the small case oracle. The option based
+`build_ptdf_lodf_with_options` path accepts `SensitivityOptions`: `Dense` forces
+the dense oracle path, `Iterative` uses preconditioned conjugate gradient on one
+grounded right hand side at a time, and `Auto` selects dense up to a reduced
+dimension of 512 and iterative above it. The iterative path avoids forming the
+\\((n-r) \times (n-r)\\) dense inverse; the PTDF/LODF outputs themselves can still
+be large. The iterative path requires positive finite branch susceptances, which
+make the grounded Laplacian positive definite after reference coverage is
+checked; the dense path remains the fallback for nonsingular indefinite cases.
+Every connected component must contain at least one reference bus.
+The DC OPF
 instance bundle (\\(A\\), \\(b\\), \\(L\\), costs, bounds, thermal limits, \\(C_g\\)) is documented in
 [the DC OPF bundle guide](https://eigenergy.github.io/powerio/guide/dcopf-bundle.html).
 
@@ -90,8 +98,17 @@ are returned as warnings.
 
 Matrices write as Matrix Market files or stay in memory. A symmetric matrix is
 stored as its lower triangle with the `symmetric` header and 1-based indices
-(`io::mtx::write_mtx`). The `sensitivities` and `dcopf` CLI subcommands bundle
-the relevant family with a JSON manifest.
+(`io::mtx::write_mtx`). The `sensitivities` command writes
+`<case>_ptdf.mtx`, `<case>_lodf.mtx`, and `<case>_sensitivity_meta.json`. Use
+`--solver dense|iterative|auto` to choose the PTDF/LODF solve path and
+`--drop-tolerance <value>` to omit entries with absolute value at or below the
+tolerance. When the CLI uses the iterative path, it writes retained Matrix
+Market coordinates through temp files and does not hold the full sparse output
+in memory. The Rust `build_ptdf_lodf_with_options` API still returns `CsMat`
+values and is intended for outputs that fit in memory. The metadata records the
+requested solver, the actual solver path, matrix dimensions, nonzero counts,
+tolerance, and dropped entry counts. The `dcopf` CLI subcommand bundles its
+matrix family with a JSON manifest.
 
 The standard case solver property fixture lives at
 `powerio-matrix/tests/fixtures/solver_matrix_stats.json`. It records B',

--- a/powerio-cli/README.md
+++ b/powerio-cli/README.md
@@ -16,9 +16,13 @@ powerio package tests/data/case14.m -o case14.pio.json
 powerio package goc3_case.json --from goc3-json -o goc3_case.pio.json
 powerio verify tests/data/case30.m --kind bdoubleprime
 powerio dcopf tests/data/case30.m -o out
-powerio sensitivities tests/data/case30.m -o out
+powerio sensitivities tests/data/case30.m -o out --solver auto --drop-tolerance 1e-10
 powerio
 ```
+
+`powerio sensitivities --solver iterative` writes Matrix Market coordinates
+through temp files, so the command does not keep the full sparse PTDF/LODF
+output in memory.
 
 The workspace README has install notes and library examples:
 <https://github.com/eigenergy/powerio>.

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -16,7 +16,7 @@ use powerio_matrix::matrix::{BuildOptions, DcConvention, Scheme, Units, sddm_che
 use powerio_matrix::opf_pipeline::{DcOpfOptions, write_dcopf_bundle};
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
 use powerio_matrix::synth::{SynthSpec, Topology};
-use powerio_matrix::{MissingGenCostPolicy, WriteOptions};
+use powerio_matrix::{MissingGenCostPolicy, SensitivityOptions, SensitivitySolver, WriteOptions};
 use powerio_pkg::{NetworkPackage, Origin, READ_GRIDFM_FIDELITY_WARNING, SourceDescriptor};
 use serde_json::json;
 mod tui;
@@ -119,6 +119,12 @@ enum Command {
         /// DC susceptance convention.
         #[arg(long, value_enum, default_value = "paper-pure")]
         convention: DcConvArg,
+        /// Sensitivity solve path.
+        #[arg(long, value_enum, default_value = "auto")]
+        solver: SensitivitySolverArg,
+        /// Omit written PTDF/LODF entries with absolute value at or below this.
+        #[arg(long, default_value_t = 1e-12)]
+        drop_tolerance: f64,
     },
     /// Print the canonical network summary JSON.
     Summary {
@@ -457,6 +463,23 @@ impl From<DcConvArg> for DcConvention {
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
+enum SensitivitySolverArg {
+    Auto,
+    Dense,
+    Iterative,
+}
+
+impl From<SensitivitySolverArg> for SensitivitySolver {
+    fn from(value: SensitivitySolverArg) -> Self {
+        match value {
+            SensitivitySolverArg::Auto => Self::Auto,
+            SensitivitySolverArg::Dense => Self::Dense,
+            SensitivitySolverArg::Iterative => Self::Iterative,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
 enum UnitsArg {
     PerUnit,
     Native,
@@ -553,7 +576,9 @@ fn main() -> anyhow::Result<()> {
             input,
             output,
             convention,
-        } => run_sensitivities(&input, &output, convention.into()),
+            solver,
+            drop_tolerance,
+        } => run_sensitivities(&input, &output, convention, solver, drop_tolerance),
         Command::Summary {
             input,
             from,
@@ -724,21 +749,48 @@ fn run_gen(
     Ok(())
 }
 
-fn run_sensitivities(input: &Path, output: &Path, convention: DcConvention) -> anyhow::Result<()> {
+fn run_sensitivities(
+    input: &Path,
+    output: &Path,
+    convention: DcConvArg,
+    solver: SensitivitySolverArg,
+    drop_tolerance: f64,
+) -> anyhow::Result<()> {
     let mpc = powerio_matrix::parse_matpower_file(input)
         .with_context(|| format!("parse {}", input.display()))?;
     std::fs::create_dir_all(output)?;
     let view = powerio_matrix::IndexedNetwork::new(&mpc);
-    let (ptdf, lodf) = powerio_matrix::build_ptdf_lodf(&view, convention)
-        .with_context(|| format!("DC sensitivities for {}", input.display()))?;
+    let options = SensitivityOptions {
+        convention: convention.into(),
+        solver: solver.into(),
+        drop_tolerance,
+        ..Default::default()
+    };
     let ptdf_path = output.join(format!("{}_ptdf.mtx", view.name()));
     let lodf_path = output.join(format!("{}_lodf.mtx", view.name()));
-    powerio_matrix::io::mtx::write_mtx(&ptdf, &ptdf_path)?;
-    powerio_matrix::io::mtx::write_mtx(&lodf, &lodf_path)?;
+    let meta_path = output.join(format!("{}_sensitivity_meta.json", view.name()));
+    let metadata = powerio_matrix::io::write_sensitivity_mtx_with_options(
+        &view, &options, &ptdf_path, &lodf_path,
+    )
+    .with_context(|| format!("DC sensitivities for {}", input.display()))?;
+    let meta = json!({
+        "case": view.name(),
+        "convention": options.convention,
+        "files": {
+            "ptdf": ptdf_path.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+            "lodf": lodf_path.file_name().and_then(|s| s.to_str()).unwrap_or("")
+        },
+        "sensitivity": &metadata
+    });
+    serde_json::to_writer_pretty(std::fs::File::create(&meta_path)?, &meta)?;
     tracing::info!(
         case = %view.name(),
         ptdf = %ptdf_path.display(),
         lodf = %lodf_path.display(),
+        metadata = %meta_path.display(),
+        solver = metadata.solver_path.as_str(),
+        ptdf_dropped = metadata.ptdf.dropped_entries,
+        lodf_dropped = metadata.lodf.dropped_entries,
         "wrote DC sensitivities"
     );
     Ok(())

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -182,6 +182,51 @@ fn batch_writes_requested_matrices_rhs_and_metadata() {
 }
 
 #[test]
+fn sensitivities_write_solver_metadata() {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let out_dir = std::env::temp_dir().join(format!("powerio-cli-sensitivities-{stamp}"));
+
+    let case = repo_file("tests/data/case9.m");
+    let out = run(&[
+        "sensitivities",
+        case.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+        "--solver",
+        "iterative",
+        "--drop-tolerance",
+        "1e-10",
+    ]);
+    assert_success(&out);
+
+    for name in [
+        "case9_ptdf.mtx",
+        "case9_lodf.mtx",
+        "case9_sensitivity_meta.json",
+    ] {
+        assert!(out_dir.join(name).is_file(), "missing {name}");
+    }
+
+    let meta: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(out_dir.join("case9_sensitivity_meta.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(meta["case"], "case9");
+    assert_eq!(meta["sensitivity"]["requested_solver"], "iterative");
+    assert_eq!(meta["sensitivity"]["solver_path"], "iterative_cg");
+    assert_eq!(meta["sensitivity"]["drop_tolerance"], 1e-10);
+    assert_eq!(meta["sensitivity"]["ptdf"]["rows"], 9);
+    assert_eq!(meta["sensitivity"]["ptdf"]["cols"], 9);
+    assert_eq!(meta["sensitivity"]["lodf"]["rows"], 9);
+    assert_eq!(meta["sensitivity"]["lodf"]["cols"], 9);
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}
+
+#[test]
 fn pypsa_directory_target_requires_output_directory() {
     let case = repo_file("tests/data/case9.m");
     let out = run(&["convert", case.to_str().unwrap(), "--to", "pypsa-csv"]);

--- a/powerio-matrix/src/io/mod.rs
+++ b/powerio-matrix/src/io/mod.rs
@@ -5,6 +5,7 @@
 pub mod gridfm;
 pub mod meta;
 pub mod mtx;
+pub mod sensitivity;
 
 #[cfg(feature = "gridfm")]
 pub use gridfm::{
@@ -14,6 +15,7 @@ pub use gridfm::{
 };
 pub use meta::{CaseMetadata, MatrixMetadata, write_meta_json};
 pub use mtx::{read_mtx, read_vector_mtx, write_mtx, write_vector_mtx};
+pub use sensitivity::write_sensitivity_mtx_with_options;
 
 /// Read one scenario of a dataset directory in the named `from` format: the
 /// directory sibling of [`powerio::parse_file`], and the one place dataset

--- a/powerio-matrix/src/io/sensitivity.rs
+++ b/powerio-matrix/src/io/sensitivity.rs
@@ -1,0 +1,116 @@
+//! Streamed Matrix Market output for DC sensitivity matrices.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::Result;
+use crate::indexed::IndexedNetwork;
+use crate::matrix::sensitivity::for_each_ptdf_lodf_entry;
+use crate::matrix::{SensitivityMetadata, SensitivityOptions};
+
+/// Write PTDF and LODF Matrix Market files from the option based sensitivity
+/// path and return the metadata for the same entries. The iterative solver path
+/// streams retained coordinates through temp files, so it does not keep the
+/// full sparse output in memory.
+pub fn write_sensitivity_mtx_with_options(
+    case: &IndexedNetwork,
+    options: &SensitivityOptions,
+    ptdf_path: impl AsRef<Path>,
+    lodf_path: impl AsRef<Path>,
+) -> Result<SensitivityMetadata> {
+    let mut ptdf = CoordinateMtxWriter::new(ptdf_path.as_ref())?;
+    let mut lodf = CoordinateMtxWriter::new(lodf_path.as_ref())?;
+
+    let metadata = match for_each_ptdf_lodf_entry(
+        case,
+        options,
+        |row, col, value| ptdf.write_entry(row, col, value),
+        |row, col, value| lodf.write_entry(row, col, value),
+    ) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            ptdf.cleanup();
+            lodf.cleanup();
+            return Err(err);
+        }
+    };
+
+    ptdf.finish(metadata.ptdf.rows, metadata.ptdf.cols)?;
+    lodf.finish(metadata.lodf.rows, metadata.lodf.cols)?;
+    Ok(metadata)
+}
+
+struct CoordinateMtxWriter {
+    target_path: PathBuf,
+    body_path: PathBuf,
+    final_tmp_path: PathBuf,
+    body: Option<BufWriter<File>>,
+    nnz: usize,
+}
+
+impl CoordinateMtxWriter {
+    fn new(target_path: &Path) -> Result<Self> {
+        let body_path = temp_path(target_path, "body");
+        let final_tmp_path = temp_path(target_path, "final");
+        let body = BufWriter::new(File::create(&body_path)?);
+        Ok(Self {
+            target_path: target_path.to_path_buf(),
+            body_path,
+            final_tmp_path,
+            body: Some(body),
+            nnz: 0,
+        })
+    }
+
+    fn write_entry(&mut self, row: usize, col: usize, value: f64) -> Result<()> {
+        if value == 0.0 {
+            return Ok(());
+        }
+        let body = self
+            .body
+            .as_mut()
+            .expect("coordinate writer body is open before finish");
+        writeln!(body, "{} {} {:.16e}", row + 1, col + 1, value)?;
+        self.nnz += 1;
+        Ok(())
+    }
+
+    fn finish(mut self, rows: usize, cols: usize) -> Result<()> {
+        if let Some(mut body) = self.body.take() {
+            body.flush()?;
+        }
+
+        let mut out = BufWriter::new(File::create(&self.final_tmp_path)?);
+        writeln!(out, "%%MatrixMarket matrix coordinate real general")?;
+        writeln!(out, "% written by powerio")?;
+        writeln!(out, "{rows} {cols} {}", self.nnz)?;
+        let mut body = BufReader::new(File::open(&self.body_path)?);
+        std::io::copy(&mut body, &mut out)?;
+        out.flush()?;
+
+        std::fs::rename(&self.final_tmp_path, &self.target_path)?;
+        let _ = std::fs::remove_file(&self.body_path);
+        Ok(())
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(mut body) = self.body.take() {
+            let _ = body.flush();
+        }
+        let _ = std::fs::remove_file(&self.body_path);
+        let _ = std::fs::remove_file(&self.final_tmp_path);
+    }
+}
+
+fn temp_path(target_path: &Path, suffix: &str) -> PathBuf {
+    let pid = std::process::id();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos());
+    let name = target_path
+        .file_name()
+        .map_or_else(|| "matrix".into(), |name| name.to_string_lossy());
+    target_path.with_file_name(format!(".{name}.{pid}.{nanos}.{suffix}.tmp"))
+}

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -57,11 +57,12 @@ pub mod synth;
 
 pub use matrix::{
     BuildOptions, BusCosts, DcConvention, GenCosts, GroundedIndexMap, IncidenceParts, MatrixStats,
-    OpfInstance, Scheme, Units, ZeroImpedanceRule, ZeroImpedanceSkips, build_adjacency,
-    build_bdoubleprime, build_bprime, build_flow_map, build_incidence, build_lacpf, build_lodf,
-    build_opf_instance, build_ptdf, build_ptdf_lodf, build_weighted_laplacian, build_ybus,
-    ground_at, ground_at_each, reference_indicator, sddm_check, skipped_zero_impedance,
-    susceptance_diag, unit_vector,
+    OpfInstance, Scheme, SensitivityMatrices, SensitivityMatrixMetadata, SensitivityMetadata,
+    SensitivityOptions, SensitivitySolver, SensitivitySolverPath, Units, ZeroImpedanceRule,
+    ZeroImpedanceSkips, build_adjacency, build_bdoubleprime, build_bprime, build_flow_map,
+    build_incidence, build_lacpf, build_lodf, build_opf_instance, build_ptdf, build_ptdf_lodf,
+    build_ptdf_lodf_with_options, build_weighted_laplacian, build_ybus, ground_at, ground_at_each,
+    reference_indicator, sddm_check, skipped_zero_impedance, susceptance_diag, unit_vector,
 };
 pub use opf_pipeline::{DcOpfOptions, DcOpfOutputs, write_dcopf_bundle};
 pub use pipeline::{

--- a/powerio-matrix/src/matrix/mod.rs
+++ b/powerio-matrix/src/matrix/mod.rs
@@ -37,7 +37,11 @@ pub use laplacian::{
     unit_vector,
 };
 pub use opf::{BusCosts, GenCosts, OpfInstance, Units, build_opf_instance};
-pub use sensitivity::{build_lodf, build_ptdf, build_ptdf_lodf};
+pub use sensitivity::{
+    SensitivityMatrices, SensitivityMatrixMetadata, SensitivityMetadata, SensitivityOptions,
+    SensitivitySolver, SensitivitySolverPath, build_lodf, build_ptdf, build_ptdf_lodf,
+    build_ptdf_lodf_with_options,
+};
 pub use ybus::{YbusParts, build_ybus};
 // Crate-internal: the gridfm columnar export reuses the per-branch admittance and
 // flow kernels so its branch table and Y_bus agree with `build_ybus` by construction.

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -3,13 +3,13 @@
 //! PTDF maps nodal injections to branch flows (`f = PTDF · p`); LODF maps a
 //! branch outage to the flow it redistributes onto the others. Both come from
 //! the reference grounded DC Laplacian `ABA = ground_with(L, refs)`: one
-//! row/column removed per reference bus. Positive branch weights use a dense
-//! Cholesky factorization; nonsingular indefinite cases fall back to dense
-//! Gaussian elimination. Disconnected networks with one reference per island are
-//! supported. Several references in one island are fixed angle buses; this is
-//! not a participation factor based distributed slack model. PTDF is dense
-//! `m × n`; a future sparse path would compute selected columns or use sparse
-//! factors rather than make PTDF itself sparse.
+//! row/column removed per reference bus. The default public builders keep the
+//! dense Cholesky path, with dense Gaussian elimination as the nonsingular
+//! indefinite fallback. Option based builders can choose an iterative path that
+//! solves one grounded right hand side at a time and writes directly into sparse
+//! output. Disconnected networks with one reference per island are supported.
+//! Several references in one island are fixed angle buses; this is not a
+//! participation factor based distributed slack model.
 
 // Dense linear algebra: indexed triangular-solve loops and the `.iter()`
 // sparse traversal read clearer than the iterator rewrites clippy suggests.
@@ -26,6 +26,149 @@ use crate::{Error, Result};
 
 /// Entries below this magnitude are dropped from the emitted sparse matrices.
 const PRUNE: f64 = 1e-12;
+const DEFAULT_CG_TOLERANCE: f64 = 1e-10;
+const DEFAULT_CG_MAX_ITERATIONS: usize = 20_000;
+const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 512;
+const LODF_ISLAND_TOLERANCE: f64 = 1e-9;
+
+/// Solver selection for option based DC sensitivity builds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SensitivitySolver {
+    /// Dense below [`SensitivityOptions::auto_dense_threshold`], iterative above it.
+    #[default]
+    Auto,
+    /// Dense grounded inverse. This is the historical builder path.
+    Dense,
+    /// Preconditioned conjugate gradient, one right hand side at a time.
+    Iterative,
+}
+
+/// Solver path actually used for a sensitivity build.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SensitivitySolverPath {
+    DenseCholesky,
+    DenseInverse,
+    IterativeCg,
+}
+
+impl SensitivitySolverPath {
+    #[inline]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DenseCholesky => "dense_cholesky",
+            Self::DenseInverse => "dense_inverse",
+            Self::IterativeCg => "iterative_cg",
+        }
+    }
+}
+
+/// Options for PTDF/LODF builders that expose solver choice and output pruning.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct SensitivityOptions {
+    /// DC branch susceptance convention.
+    pub convention: DcConvention,
+    /// Solver selection policy.
+    pub solver: SensitivitySolver,
+    /// Entries with absolute value at or below this value are omitted from the
+    /// returned sparse matrices. LODF diagonal entries are structural and kept.
+    pub drop_tolerance: f64,
+    /// Relative residual tolerance for the iterative solver.
+    pub cg_tolerance: f64,
+    /// Maximum conjugate gradient iterations per right hand side.
+    pub cg_max_iterations: usize,
+    /// Reduced dimension above which [`SensitivitySolver::Auto`] selects the
+    /// iterative path.
+    pub auto_dense_threshold: usize,
+}
+
+impl Default for SensitivityOptions {
+    fn default() -> Self {
+        Self {
+            convention: DcConvention::PaperPure,
+            solver: SensitivitySolver::Auto,
+            drop_tolerance: PRUNE,
+            cg_tolerance: DEFAULT_CG_TOLERANCE,
+            cg_max_iterations: DEFAULT_CG_MAX_ITERATIONS,
+            auto_dense_threshold: DEFAULT_AUTO_DENSE_THRESHOLD,
+        }
+    }
+}
+
+impl SensitivityOptions {
+    fn validate(&self) -> Result<()> {
+        if !self.drop_tolerance.is_finite() || self.drop_tolerance < 0.0 {
+            return Err(Error::InvalidSensitivityOptions {
+                reason: format!(
+                    "drop_tolerance must be finite and nonnegative, got {}",
+                    self.drop_tolerance
+                ),
+            });
+        }
+        if !self.cg_tolerance.is_finite() || self.cg_tolerance <= 0.0 {
+            return Err(Error::InvalidSensitivityOptions {
+                reason: format!(
+                    "cg_tolerance must be finite and positive, got {}",
+                    self.cg_tolerance
+                ),
+            });
+        }
+        if self.cg_max_iterations == 0 {
+            return Err(Error::InvalidSensitivityOptions {
+                reason: "cg_max_iterations must be positive".into(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Return the concrete solver selected for a reduced grounded dimension.
+    pub fn selected_solver_for_reduced_dimension(
+        &self,
+        reduced_dimension: usize,
+    ) -> SensitivitySolver {
+        match self.solver {
+            SensitivitySolver::Auto if reduced_dimension > self.auto_dense_threshold => {
+                SensitivitySolver::Iterative
+            }
+            SensitivitySolver::Auto => SensitivitySolver::Dense,
+            other => other,
+        }
+    }
+}
+
+/// PTDF/LODF matrices plus metadata for serialized outputs.
+#[derive(Debug, Clone)]
+pub struct SensitivityMatrices {
+    pub ptdf: CsMat<f64>,
+    pub lodf: CsMat<f64>,
+    pub metadata: SensitivityMetadata,
+}
+
+/// Metadata describing a sensitivity build.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SensitivityMetadata {
+    pub requested_solver: SensitivitySolver,
+    pub solver_path: SensitivitySolverPath,
+    pub drop_tolerance: f64,
+    pub cg_tolerance: Option<f64>,
+    pub cg_max_iterations: Option<usize>,
+    pub auto_dense_threshold: usize,
+    pub reduced_dimension: usize,
+    pub ptdf: SensitivityMatrixMetadata,
+    pub lodf: SensitivityMatrixMetadata,
+}
+
+/// Shape and pruning metadata for one sensitivity matrix.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SensitivityMatrixMetadata {
+    pub rows: usize,
+    pub cols: usize,
+    pub nnz: usize,
+    pub dropped_entries: usize,
+}
 
 /// PTDF (`m × n`): branch flows from nodal injections, `f = PTDF · p`. Every
 /// reference-bus column is zero. The Laplacian is grounded at the whole
@@ -69,9 +212,151 @@ pub fn build_ptdf_lodf(
     Ok((ptdf, lodf))
 }
 
+/// PTDF and LODF with solver selection, drop tolerance, and output metadata.
+pub fn build_ptdf_lodf_with_options(
+    case: &IndexedNetwork,
+    options: &SensitivityOptions,
+) -> Result<SensitivityMatrices> {
+    options.validate()?;
+    case.check_reference_coverage()?;
+    let refs = case.reference_bus_indices();
+    let inc = build_incidence(case, options.convention, &BuildOptions::default())?;
+    let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
+
+    let (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped) = match options
+        .selected_solver_for_reduced_dimension(reduced_dimension)
+    {
+        SensitivitySolver::Dense => {
+            let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
+            let (ptdf, ptdf_dropped) = dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
+            let (lodf, lodf_dropped) =
+                lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
+            (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped)
+        }
+        SensitivitySolver::Iterative => {
+            ensure_iterative_solver_eligible(&inc)?;
+            let (ptdf, ptdf_dropped, lodf, lodf_dropped) =
+                iterative_ptdf_lodf(&inc, &refs, options)?;
+            (
+                ptdf,
+                lodf,
+                SensitivitySolverPath::IterativeCg,
+                ptdf_dropped,
+                lodf_dropped,
+            )
+        }
+        SensitivitySolver::Auto => unreachable!("selected_solver resolves Auto"),
+    };
+
+    let metadata = sensitivity_metadata(
+        options,
+        solver_path,
+        reduced_dimension,
+        matrix_metadata(&ptdf, ptdf_dropped),
+        matrix_metadata(&lodf, lodf_dropped),
+    );
+
+    Ok(SensitivityMatrices {
+        ptdf,
+        lodf,
+        metadata,
+    })
+}
+
+pub(crate) fn for_each_ptdf_lodf_entry(
+    case: &IndexedNetwork,
+    options: &SensitivityOptions,
+    mut ptdf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
+    mut lodf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
+) -> Result<SensitivityMetadata> {
+    options.validate()?;
+    case.check_reference_coverage()?;
+    let refs = case.reference_bus_indices();
+    let inc = build_incidence(case, options.convention, &BuildOptions::default())?;
+    let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
+
+    let (solver_path, ptdf, lodf) = match options
+        .selected_solver_for_reduced_dimension(reduced_dimension)
+    {
+        SensitivitySolver::Dense => {
+            let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
+            let (ptdf, ptdf_dropped) = dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
+            let (lodf, lodf_dropped) =
+                lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
+            let ptdf_meta = matrix_metadata(&ptdf, ptdf_dropped);
+            let lodf_meta = matrix_metadata(&lodf, lodf_dropped);
+            for (&v, (row, col)) in &ptdf {
+                ptdf_entry(row, col, v)?;
+            }
+            for (&v, (row, col)) in &lodf {
+                lodf_entry(row, col, v)?;
+            }
+            (solver_path, ptdf_meta, lodf_meta)
+        }
+        SensitivitySolver::Iterative => {
+            ensure_iterative_solver_eligible(&inc)?;
+            let (ptdf, lodf) =
+                iterative_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
+            (SensitivitySolverPath::IterativeCg, ptdf, lodf)
+        }
+        SensitivitySolver::Auto => {
+            unreachable!("selected_solver_for_reduced_dimension resolves Auto")
+        }
+    };
+
+    Ok(sensitivity_metadata(
+        options,
+        solver_path,
+        reduced_dimension,
+        ptdf,
+        lodf,
+    ))
+}
+
+fn sensitivity_metadata(
+    options: &SensitivityOptions,
+    solver_path: SensitivitySolverPath,
+    reduced_dimension: usize,
+    ptdf: SensitivityMatrixMetadata,
+    lodf: SensitivityMatrixMetadata,
+) -> SensitivityMetadata {
+    SensitivityMetadata {
+        requested_solver: options.solver,
+        solver_path,
+        drop_tolerance: options.drop_tolerance,
+        cg_tolerance: matches!(solver_path, SensitivitySolverPath::IterativeCg)
+            .then_some(options.cg_tolerance),
+        cg_max_iterations: matches!(solver_path, SensitivitySolverPath::IterativeCg)
+            .then_some(options.cg_max_iterations),
+        auto_dense_threshold: options.auto_dense_threshold,
+        reduced_dimension,
+        ptdf,
+        lodf,
+    }
+}
+
+fn matrix_metadata(matrix: &CsMat<f64>, dropped_entries: usize) -> SensitivityMatrixMetadata {
+    SensitivityMatrixMetadata {
+        rows: matrix.rows(),
+        cols: matrix.cols(),
+        nnz: matrix.nnz(),
+        dropped_entries,
+    }
+}
+
 /// LODF from a dense PTDF and the signed incidence (the shared tail of
 /// [`build_lodf`] and [`build_ptdf_lodf`]).
 fn lodf_from_dense(ptdf: &[f64], a: &CsMat<f64>, m: usize, n: usize) -> CsMat<f64> {
+    lodf_from_dense_with_drop(ptdf, a, m, n, PRUNE).0
+}
+
+fn lodf_from_dense_with_drop(
+    ptdf: &[f64],
+    a: &CsMat<f64>,
+    m: usize,
+    n: usize,
+    drop_tolerance: f64,
+) -> (CsMat<f64>, usize) {
     // Branch endpoints (dense bus indices), recovered from the incidence.
     let (from, to) = endpoints(a, m);
 
@@ -80,9 +365,10 @@ fn lodf_from_dense(ptdf: &[f64], a: &CsMat<f64>, m: usize, n: usize) -> CsMat<f6
     let delta = |l: usize, k: usize| ptdf[l * n + from[k]] - ptdf[l * n + to[k]];
 
     let mut lodf = CooBuilder::new(m); // m × m
+    let mut dropped = 0usize;
     for k in 0..m {
         let denom = 1.0 - delta(k, k);
-        let islands = denom.abs() < 1e-9;
+        let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
         for l in 0..m {
             let v = if l == k {
                 -1.0
@@ -91,17 +377,27 @@ fn lodf_from_dense(ptdf: &[f64], a: &CsMat<f64>, m: usize, n: usize) -> CsMat<f6
             } else {
                 delta(l, k) / denom
             };
-            if v.abs() > PRUNE {
+            if l == k || v.abs() > drop_tolerance {
                 lodf.add(l, k, v);
+            } else if v != 0.0 {
+                dropped += 1;
             }
         }
     }
-    lodf.finish_csr()
+    (lodf.finish_csr(), dropped)
 }
 
 /// Dense PTDF (`m × n`, row-major) plus its shape. `refs` is the reference set;
 /// the Laplacian is grounded at every entry (one row/column each).
 fn ptdf_dense(inc: &IncidenceParts, refs: &[usize]) -> Result<(Vec<f64>, usize, usize)> {
+    let (ptdf, m, n, _) = ptdf_dense_with_path(inc, refs)?;
+    Ok((ptdf, m, n))
+}
+
+fn ptdf_dense_with_path(
+    inc: &IncidenceParts,
+    refs: &[usize],
+) -> Result<(Vec<f64>, usize, usize, SensitivitySolverPath)> {
     let n = inc.n();
     let m = inc.m();
     let g = Grounding::new(refs);
@@ -110,9 +406,13 @@ fn ptdf_dense(inc: &IncidenceParts, refs: &[usize]) -> Result<(Vec<f64>, usize, 
     // Reduced inverse of the grounded Laplacian: Rinv = (ABA_refs)^{-1}.
     let lr = ground_with(&build_weighted_laplacian(&inc.a, &inc.b), &g);
     let dense_lr = densify(&lr, nr);
-    let rinv = DenseCholesky::factor(&dense_lr, nr).map_or_else(
-        || dense_inverse(&dense_lr, nr).ok_or(Error::SingularNetwork),
-        |chol| Ok(chol.inverse()),
+    let (rinv, solver_path) = DenseCholesky::factor(&dense_lr, nr).map_or_else(
+        || {
+            dense_inverse(&dense_lr, nr)
+                .map(|rinv| (rinv, SensitivitySolverPath::DenseInverse))
+                .ok_or(Error::SingularNetwork)
+        },
+        |chol| Ok((chol.inverse(), SensitivitySolverPath::DenseCholesky)),
     )?; // nr × nr, row-major
 
     // Minv (n × n) is Rinv padded with a zero row/col at every grounded bus, so
@@ -129,7 +429,146 @@ fn ptdf_dense(inc: &IncidenceParts, refs: &[usize]) -> Result<(Vec<f64>, usize, 
             }
         }
     }
-    Ok((ptdf, m, n))
+    Ok((ptdf, m, n, solver_path))
+}
+
+fn iterative_ptdf_lodf(
+    inc: &IncidenceParts,
+    refs: &[usize],
+    options: &SensitivityOptions,
+) -> Result<(CsMat<f64>, usize, CsMat<f64>, usize)> {
+    ensure_iterative_solver_eligible(inc)?;
+    let mut ptdf = CooBuilder::new_rect(inc.m(), inc.n());
+    let mut lodf = CooBuilder::new(inc.m());
+    let (ptdf_meta, lodf_meta) = iterative_ptdf_lodf_entries(
+        inc,
+        refs,
+        options,
+        |row, col, value| {
+            ptdf.add(row, col, value);
+            Ok(())
+        },
+        |row, col, value| {
+            lodf.add(row, col, value);
+            Ok(())
+        },
+    )?;
+    Ok((
+        ptdf.finish_csr(),
+        ptdf_meta.dropped_entries,
+        lodf.finish_csr(),
+        lodf_meta.dropped_entries,
+    ))
+}
+
+fn iterative_ptdf_lodf_entries(
+    inc: &IncidenceParts,
+    refs: &[usize],
+    options: &SensitivityOptions,
+    mut ptdf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
+    mut lodf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
+) -> Result<(SensitivityMatrixMetadata, SensitivityMatrixMetadata)> {
+    let n = inc.n();
+    let m = inc.m();
+    let g = Grounding::new(refs);
+    let nr = n - g.len();
+    let lr = ground_with(&build_weighted_laplacian(&inc.a, &inc.b), &g);
+    let solver = CgSolver::new(&lr, options.cg_tolerance, options.cg_max_iterations)?;
+    let (from, to) = endpoints(&inc.a, m);
+
+    let mut rhs = vec![0.0; nr];
+    let mut ptdf_nnz = 0usize;
+    let mut ptdf_dropped = 0usize;
+    for bus in 0..n {
+        let Some(rb) = g.reduced(bus) else {
+            continue;
+        };
+        rhs.fill(0.0);
+        rhs[rb] = 1.0;
+        let theta = solver.solve(&rhs)?;
+        for branch in 0..m {
+            let v = branch_flow(branch, &from, &to, &inc.b, &g, &theta);
+            if v.abs() > options.drop_tolerance {
+                ptdf_entry(branch, bus, v)?;
+                ptdf_nnz += 1;
+            } else if v != 0.0 {
+                ptdf_dropped += 1;
+            }
+        }
+    }
+
+    let mut lodf_nnz = 0usize;
+    let mut lodf_dropped = 0usize;
+    for outage in 0..m {
+        rhs.fill(0.0);
+        if let Some(rf) = g.reduced(from[outage]) {
+            rhs[rf] += 1.0;
+        }
+        if let Some(rt) = g.reduced(to[outage]) {
+            rhs[rt] -= 1.0;
+        }
+        let theta = solver.solve(&rhs)?;
+        let outage_delta = branch_flow(outage, &from, &to, &inc.b, &g, &theta);
+        let denom = 1.0 - outage_delta;
+        let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
+        for branch in 0..m {
+            let v = if branch == outage {
+                -1.0
+            } else if islands {
+                0.0
+            } else {
+                branch_flow(branch, &from, &to, &inc.b, &g, &theta) / denom
+            };
+            if branch == outage || v.abs() > options.drop_tolerance {
+                lodf_entry(branch, outage, v)?;
+                lodf_nnz += 1;
+            } else if v != 0.0 {
+                lodf_dropped += 1;
+            }
+        }
+    }
+
+    Ok((
+        SensitivityMatrixMetadata {
+            rows: m,
+            cols: n,
+            nnz: ptdf_nnz,
+            dropped_entries: ptdf_dropped,
+        },
+        SensitivityMatrixMetadata {
+            rows: m,
+            cols: m,
+            nnz: lodf_nnz,
+            dropped_entries: lodf_dropped,
+        },
+    ))
+}
+
+fn ensure_iterative_solver_eligible(inc: &IncidenceParts) -> Result<()> {
+    for (branch, &b) in inc.b.iter().enumerate() {
+        if !b.is_finite() || b <= 0.0 {
+            return Err(Error::InvalidSensitivityOptions {
+                reason: format!(
+                    "iterative sensitivity solver requires positive finite branch susceptances; \
+                     branch {branch} has {b}; use solver=dense for nonsingular indefinite cases"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn branch_flow(
+    branch: usize,
+    from: &[usize],
+    to: &[usize],
+    b: &[f64],
+    g: &Grounding,
+    theta: &[f64],
+) -> f64 {
+    let theta_from = g.reduced(from[branch]).map_or(0.0, |i| theta[i]);
+    let theta_to = g.reduced(to[branch]).map_or(0.0, |i| theta[i]);
+    b[branch] * (theta_from - theta_to)
 }
 
 /// Branch endpoints from the signed incidence: `+1` row is from, `−1` is to.
@@ -155,16 +594,28 @@ fn densify(a: &CsMat<f64>, n: usize) -> Vec<f64> {
 }
 
 fn dense_to_csr(dense: &[f64], rows: usize, cols: usize) -> CsMat<f64> {
+    dense_to_csr_with_drop(dense, rows, cols, PRUNE).0
+}
+
+fn dense_to_csr_with_drop(
+    dense: &[f64],
+    rows: usize,
+    cols: usize,
+    drop_tolerance: f64,
+) -> (CsMat<f64>, usize) {
     let mut coo = CooBuilder::with_capacity_rect(rows, cols, dense.len() / 2);
+    let mut dropped = 0usize;
     for i in 0..rows {
         for j in 0..cols {
             let v = dense[i * cols + j];
-            if v.abs() > PRUNE {
+            if v.abs() > drop_tolerance {
                 coo.add(i, j, v);
+            } else if v != 0.0 {
+                dropped += 1;
             }
         }
     }
-    coo.finish_csr()
+    (coo.finish_csr(), dropped)
 }
 
 fn dense_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {
@@ -218,6 +669,125 @@ fn swap_dense_rows(a: &mut [f64], n: usize, r1: usize, r2: usize) {
     for c in 0..n {
         a.swap(r1 * n + c, r2 * n + c);
     }
+}
+
+struct CgSolver<'a> {
+    a: &'a CsMat<f64>,
+    diag: Vec<f64>,
+    tolerance: f64,
+    max_iterations: usize,
+}
+
+impl<'a> CgSolver<'a> {
+    fn new(a: &'a CsMat<f64>, tolerance: f64, max_iterations: usize) -> Result<Self> {
+        let n = a.rows();
+        if a.cols() != n {
+            return Err(Error::ShapeMismatch {
+                what: "grounded Laplacian columns",
+                expected: n,
+                got: a.cols(),
+            });
+        }
+        let mut diag = vec![0.0; n];
+        for (i, slot) in diag.iter_mut().enumerate() {
+            *slot = a.get(i, i).copied().unwrap_or(0.0);
+            if !slot.is_finite() || *slot <= 0.0 {
+                return Err(Error::SingularNetwork);
+            }
+        }
+        Ok(Self {
+            a,
+            diag,
+            tolerance,
+            max_iterations,
+        })
+    }
+
+    fn solve(&self, rhs: &[f64]) -> Result<Vec<f64>> {
+        let n = self.a.rows();
+        if rhs.len() != n {
+            return Err(Error::DimensionMismatch {
+                n,
+                b_len: rhs.len(),
+            });
+        }
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+
+        let rhs_norm = norm2(rhs);
+        if rhs_norm == 0.0 {
+            return Ok(vec![0.0; n]);
+        }
+        let target = self.tolerance * rhs_norm;
+        let mut solution = vec![0.0; n];
+        let mut residual_vec = rhs.to_vec();
+        let mut preconditioned = self.precondition(&residual_vec);
+        let mut direction = preconditioned.clone();
+        let mut residual_dot = dot(&residual_vec, &preconditioned);
+        if !residual_dot.is_finite() || residual_dot <= 0.0 {
+            return Err(Error::SingularNetwork);
+        }
+        let mut matvec_out = vec![0.0; n];
+
+        for iter in 1..=self.max_iterations {
+            matvec(self.a, &direction, &mut matvec_out);
+            let denom = dot(&direction, &matvec_out);
+            if !denom.is_finite() || denom <= 0.0 {
+                return Err(Error::SingularNetwork);
+            }
+            let alpha = residual_dot / denom;
+            for i in 0..n {
+                solution[i] += alpha * direction[i];
+                residual_vec[i] -= alpha * matvec_out[i];
+            }
+            let residual = norm2(&residual_vec);
+            if residual <= target {
+                return Ok(solution);
+            }
+            preconditioned = self.precondition(&residual_vec);
+            let next_residual_dot = dot(&residual_vec, &preconditioned);
+            if !next_residual_dot.is_finite() || next_residual_dot <= 0.0 {
+                return Err(Error::SingularNetwork);
+            }
+            let beta = next_residual_dot / residual_dot;
+            for i in 0..n {
+                direction[i] = preconditioned[i] + beta * direction[i];
+            }
+            residual_dot = next_residual_dot;
+
+            if iter == self.max_iterations {
+                return Err(Error::SensitivitySolveDidNotConverge {
+                    iterations: iter,
+                    relative_residual: residual / rhs_norm,
+                });
+            }
+        }
+        unreachable!("positive max_iterations loop returns")
+    }
+
+    fn precondition(&self, r: &[f64]) -> Vec<f64> {
+        r.iter().zip(&self.diag).map(|(&ri, &di)| ri / di).collect()
+    }
+}
+
+fn matvec(a: &CsMat<f64>, x: &[f64], out: &mut [f64]) {
+    out.fill(0.0);
+    for (i, row) in a.outer_iterator().enumerate() {
+        let mut sum = 0.0;
+        for (j, &v) in row.iter() {
+            sum += v * x[j];
+        }
+        out[i] = sum;
+    }
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(&x, &y)| x * y).sum()
+}
+
+fn norm2(a: &[f64]) -> f64 {
+    dot(a, a).sqrt()
 }
 
 /// Dense lower-triangular Cholesky `A = L Lᵀ` for a small SPD matrix.

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -2,11 +2,16 @@
 //! bundle. Run against vendored MATPOWER cases.
 
 use powerio_matrix::IndexedNetwork;
+use powerio_matrix::io::{read_mtx, write_sensitivity_mtx_with_options};
 use powerio_matrix::{
     Branch, BuildOptions, Bus, BusId, BusType, DcConvention, Error, GenCost, Generator,
     MissingGenCostPolicy, Network, Scheme, Units, build_adjacency, build_bprime, build_flow_map,
     build_incidence, build_lodf, build_opf_instance, build_ptdf, build_weighted_laplacian,
     build_ybus, ground_at, parse_matpower_file,
+};
+use powerio_matrix::{
+    SensitivityOptions, SensitivitySolver, SensitivitySolverPath, build_ptdf_lodf,
+    build_ptdf_lodf_with_options,
 };
 use sprs::CsMat;
 
@@ -44,6 +49,24 @@ fn dense(m: &CsMat<f64>) -> Vec<Vec<f64>> {
         d[i][j] = v;
     }
     d
+}
+
+fn assert_matrix_close(left: &CsMat<f64>, right: &CsMat<f64>, tol: f64, label: &str) {
+    assert_eq!(left.rows(), right.rows(), "{label}: row count");
+    assert_eq!(left.cols(), right.cols(), "{label}: col count");
+    let dl = dense(left);
+    let dr = dense(right);
+    for i in 0..left.rows() {
+        for j in 0..left.cols() {
+            let err = (dl[i][j] - dr[i][j]).abs();
+            assert!(
+                err <= tol,
+                "{label}[{i},{j}] differs by {err}: {} vs {}",
+                dl[i][j],
+                dr[i][j]
+            );
+        }
+    }
 }
 
 fn operator<'a>(meta: &'a serde_json::Value, name: &str) -> &'a serde_json::Value {
@@ -451,6 +474,196 @@ fn lodf_diagonal_is_minus_one() {
             }
         }
     }
+}
+
+#[test]
+fn iterative_sensitivities_match_dense_oracle() {
+    for path in [
+        "../tests/data/case9.m",
+        "../tests/data/case14.m",
+        "../tests/data/case30.m",
+    ] {
+        let case = load(path);
+        let view = IndexedNetwork::new(&case);
+        let (dense_ptdf, dense_lodf) = build_ptdf_lodf(&view, DcConvention::PaperPure).unwrap();
+        let iterative = build_ptdf_lodf_with_options(
+            &view,
+            &SensitivityOptions {
+                solver: SensitivitySolver::Iterative,
+                drop_tolerance: 1e-12,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            iterative.metadata.solver_path,
+            SensitivitySolverPath::IterativeCg,
+            "{path}: solver path"
+        );
+        assert_matrix_close(&iterative.ptdf, &dense_ptdf, 1e-7, path);
+        assert_matrix_close(&iterative.lodf, &dense_lodf, 1e-7, path);
+    }
+}
+
+#[test]
+fn sensitivity_drop_tolerance_records_dropped_entries() {
+    let case = load("../tests/data/case30.m");
+    let view = IndexedNetwork::new(&case);
+    let full = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Dense,
+            drop_tolerance: 0.0,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let pruned = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Dense,
+            drop_tolerance: 0.2,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(pruned.metadata.ptdf.dropped_entries > 0);
+    assert!(pruned.metadata.lodf.dropped_entries > 0);
+    assert!(pruned.ptdf.nnz() < full.ptdf.nnz());
+    assert!(pruned.lodf.nnz() < full.lodf.nnz());
+    assert_eq!(pruned.metadata.ptdf.rows, pruned.ptdf.rows());
+    assert_eq!(pruned.metadata.ptdf.cols, pruned.ptdf.cols());
+    assert_eq!(pruned.metadata.lodf.rows, pruned.lodf.rows());
+    assert_eq!(pruned.metadata.lodf.cols, pruned.lodf.cols());
+}
+
+#[test]
+fn streamed_iterative_sensitivities_match_in_memory() {
+    let case = load("../tests/data/case30.m");
+    let view = IndexedNetwork::new(&case);
+    let options = SensitivityOptions {
+        solver: SensitivitySolver::Iterative,
+        drop_tolerance: 1e-9,
+        ..Default::default()
+    };
+    let expected = build_ptdf_lodf_with_options(&view, &options).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let ptdf_path = temp.path().join("ptdf.mtx");
+    let lodf_path = temp.path().join("lodf.mtx");
+
+    let meta = write_sensitivity_mtx_with_options(&view, &options, &ptdf_path, &lodf_path).unwrap();
+    let ptdf = read_mtx(&ptdf_path).unwrap();
+    let lodf = read_mtx(&lodf_path).unwrap();
+
+    assert_eq!(meta.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(meta.ptdf.nnz, ptdf.nnz());
+    assert_eq!(meta.lodf.nnz, lodf.nnz());
+    assert_matrix_close(&ptdf, &expected.ptdf, 0.0, "streamed PTDF");
+    assert_matrix_close(&lodf, &expected.lodf, 0.0, "streamed LODF");
+}
+
+#[test]
+fn auto_sensitivity_solver_switches_to_iterative_above_threshold() {
+    let case = load("../tests/data/case118.m");
+    let view = IndexedNetwork::new(&case);
+    let out = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Auto,
+            auto_dense_threshold: 16,
+            drop_tolerance: 1e-9,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(out.metadata.requested_solver, SensitivitySolver::Auto);
+    assert_eq!(out.metadata.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(out.metadata.ptdf.rows, out.ptdf.rows());
+    assert_eq!(out.metadata.ptdf.cols, out.ptdf.cols());
+    assert_eq!(out.metadata.lodf.rows, out.lodf.rows());
+    assert_eq!(out.metadata.lodf.cols, out.lodf.cols());
+    assert!(out.metadata.reduced_dimension > 16);
+}
+
+#[test]
+fn default_auto_writes_iterative_outputs_above_dense_threshold() {
+    let n = 600;
+    let mut buses = Vec::with_capacity(n);
+    buses.push(bus(1, BusType::Ref));
+    for id in 2..=n {
+        buses.push(bus(id, BusType::Pq));
+    }
+    let branches = (2..=n).map(|id| branch(1, id, 0.1)).collect::<Vec<_>>();
+    let branch_count = branches.len();
+    let case = net("star600", buses, branches);
+    let view = IndexedNetwork::new(&case);
+    let reduced_dimension = view.n() - view.reference_bus_indices().len();
+    assert!(reduced_dimension > 512);
+
+    let temp = tempfile::tempdir().unwrap();
+    let ptdf_path = temp.path().join("ptdf.mtx");
+    let lodf_path = temp.path().join("lodf.mtx");
+    let meta = write_sensitivity_mtx_with_options(
+        &view,
+        &SensitivityOptions::default(),
+        &ptdf_path,
+        &lodf_path,
+    )
+    .unwrap();
+    let ptdf = read_mtx(&ptdf_path).unwrap();
+    let lodf = read_mtx(&lodf_path).unwrap();
+
+    assert_eq!(meta.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(meta.reduced_dimension, reduced_dimension);
+    assert_eq!(ptdf.rows(), branch_count);
+    assert_eq!(ptdf.cols(), n);
+    assert_eq!(lodf.rows(), branch_count);
+    assert_eq!(lodf.cols(), branch_count);
+    assert_eq!(meta.ptdf.nnz, ptdf.nnz());
+    assert_eq!(meta.lodf.nnz, lodf.nnz());
+    assert!(meta.ptdf.nnz <= branch_count);
+    assert_eq!(meta.lodf.nnz, branch_count);
+}
+
+#[test]
+fn auto_iterative_rejects_non_positive_susceptance() {
+    let case = net(
+        "negative_x",
+        vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+        vec![branch(1, 2, -0.1)],
+    );
+    let view = IndexedNetwork::new(&case);
+    let err = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Auto,
+            auto_dense_threshold: 0,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+
+    match err {
+        Error::InvalidSensitivityOptions { reason } => {
+            assert!(reason.contains("positive finite branch susceptances"));
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+
+    let dense = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Dense,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        dense.metadata.solver_path,
+        SensitivitySolverPath::DenseInverse
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -87,6 +87,17 @@ pub enum Error {
     )]
     SingularNetwork,
 
+    #[error("invalid DC sensitivity option: {reason}")]
+    InvalidSensitivityOptions { reason: String },
+
+    #[error(
+        "DC sensitivity iterative solve did not converge after {iterations} iterations (relative residual {relative_residual:.3e})"
+    )]
+    SensitivitySolveDidNotConverge {
+        iterations: usize,
+        relative_residual: f64,
+    },
+
     #[error(
         "{components} connected component(s) have no reference (slack) bus to ground; DC sensitivities need at least one reference per island"
     )]
@@ -215,6 +226,8 @@ impl Error {
             | Error::InvalidNormalizeOption { .. }
             | Error::ShapeMismatch { .. }
             | Error::SingularNetwork
+            | Error::InvalidSensitivityOptions { .. }
+            | Error::SensitivitySolveDidNotConverge { .. }
             | Error::UngroundedComponent { .. }
             | Error::EmptyScenarioBatch
             | Error::ScenarioIdOverflow { .. }


### PR DESCRIPTION
Fixes #8.

## Scope

This PR adds an option driven DC sensitivity path in `powerio-matrix` for PTDF
and LODF builds. The existing dense builder remains the default small case
oracle. Larger cases can use an iterative grounded Laplacian solve that computes
one right hand side at a time, so the builder does not materialize the dense
inverse of the grounded Laplacian.

The CLI `sensitivities` command gains a drop tolerance option and writes a JSON
metadata file beside the Matrix Market outputs. Iterative CLI exports stream
retained coordinates through temp files, so the command does not keep the full
sparse PTDF/LODF output in memory. The metadata records the selected solver
path, matrix dimensions, tolerance, nonzero counts, and dropped entry counts.

## Acceptance Criteria

- Small fixtures match the dense PTDF/LODF path within the requested tolerance.
- Large cases avoid dense factor memory growth from forming the full grounded
  inverse or accumulating the full sparse output in memory.
- Output metadata records tolerance, solver path, dimensions, and dropped entry
  counts.
- Docs state when the iterative path is selected and how tolerance affects the
  written matrices. They also state that the CG path requires positive finite
  branch susceptances; nonsingular indefinite cases should use the dense solver.

## Out Of Scope

This PR does not add a third party sparse LDLT dependency or a partial column
selector API. It keeps the public dense builders stable and adds option based
entry points for callers that need solver selection and metadata.

Merge order: 10 of 14. Base: `main`.