### PR TITLE
Serve generated JSON Schemas

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -160,9 +160,9 @@ jobs:
         HTML
     # The schema URLs stamped into .pio.json files (`schema`, `payload_schema`)
     # are identifiers first, but the site serves them so they also resolve.
-    # Each redirects to its section of the format chapter. Relative targets
-    # keep the redirects working under both powerio.dev and
-    # eigenergy.github.io/powerio.
+    # Each path exposes the machine-readable schema and redirects browsers to
+    # its section of the format chapter. Relative targets keep the redirects
+    # working under both powerio.dev and eigenergy.github.io/powerio.
     - name: Schema identifier pages
       run: |
         redirect_schema_page() {
@@ -172,6 +172,8 @@ jobs:
           grep -q "id=\"$anchor\"" target/doc/guide/pio-json-schema.html
           target="../../../guide/pio-json-schema.html#$anchor"
           mkdir -p "target/doc/schema/$1"
+          test -f "docs/schema/$1/schema.json"
+          cp "docs/schema/$1/schema.json" "target/doc/schema/$1/schema.json"
           cat > "target/doc/schema/$1/index.html" <<HTML
         <!doctype html>
         <meta charset="utf-8">

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,6 +72,10 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --verbose
+    - name: Check generated JSON schemas
+      run: |
+        cargo run -p powerio-pkg --example generate_schemas --features schema -- docs/schema
+        git diff --exit-code -- docs/schema
     # Deny the workspace pedantic lints on the non-extension crates. The PyO3
     # ext crates are linted in the Python workflow with their feature enabled.
     - name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2004,7 @@ dependencies = [
  "lexical-core",
  "num-complex",
  "petgraph",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2039,6 +2046,7 @@ name = "powerio-dist"
 version = "0.6.0"
 dependencies = [
  "jsonschema",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2074,6 +2082,7 @@ dependencies = [
  "num-complex",
  "powerio",
  "powerio-dist",
+ "schemars",
  "serde",
  "serde_json",
 ]
@@ -2475,6 +2484,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2550,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ arrow = { version = "59", default-features = false }
 num-complex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+schemars = { version = "1", features = ["derive"] }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/docs/schema/pio-package/0.1/schema.json
+++ b/docs/schema/pio-package/0.1/schema.json
@@ -1,0 +1,4473 @@
+{
+  "$defs": {
+    "ActivePowerReference": {
+      "enum": [
+        "P_AVAILABLE",
+        "P_MAX",
+        "S_MAX"
+      ],
+      "type": "string"
+    },
+    "ActivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "W"
+      ],
+      "type": "string"
+    },
+    "Area": {
+      "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "net_interchange": {
+          "description": "Scheduled net interchange (MW); positive is export out of the area.",
+          "format": "double",
+          "type": "number"
+        },
+        "number": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "slack_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The area swing (slack) bus, or `None` when unset."
+        },
+        "tolerance": {
+          "description": "Interchange tolerance bandwidth (MW).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "number",
+        "net_interchange",
+        "tolerance"
+      ],
+      "type": "object"
+    },
+    "Branch": {
+      "properties": {
+        "angmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "angmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "b": {
+          "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+          "format": "double",
+          "type": "number"
+        },
+        "charging": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCharging"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TransformerControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+        },
+        "current_ratings": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCurrentRatings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Current ratings, when the source distinguishes them from MVA ratings."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "r": {
+          "description": "Series resistance (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "rating_sets": {
+          "default": [],
+          "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+          "items": {
+            "$ref": "#/$defs/BranchRatingSet"
+          },
+          "type": "array"
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "solution": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchSolution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solved branch flow values, when present in a case snapshot."
+        },
+        "tap": {
+          "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "description": "Series reactance (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "r",
+        "x",
+        "b",
+        "rate_a",
+        "rate_b",
+        "rate_c",
+        "tap",
+        "shift",
+        "in_service",
+        "angmin",
+        "angmax",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BranchCharging": {
+      "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+      "properties": {
+        "b_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "b_to": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_to": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "g_fr",
+        "b_fr",
+        "g_to",
+        "b_to"
+      ],
+      "type": "object"
+    },
+    "BranchCurrentRatings": {
+      "description": "Current limits for a branch, in source units.",
+      "properties": {
+        "c_rating_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_c": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "c_rating_a",
+        "c_rating_b",
+        "c_rating_c"
+      ],
+      "type": "object"
+    },
+    "BranchRatingSet": {
+      "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rate_mva": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "rate_mva"
+      ],
+      "type": "object"
+    },
+    "BranchSolution": {
+      "description": "Solved branch terminal flows in MW/MVAr.",
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf",
+        "qf",
+        "pt",
+        "qt"
+      ],
+      "type": "object"
+    },
+    "Bus": {
+      "properties": {
+        "area": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "base_kv": {
+          "format": "double",
+          "type": "number"
+        },
+        "evhi": {
+          "default": null,
+          "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "evlo": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "id": {
+          "$ref": "#/$defs/BusId",
+          "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+        },
+        "kind": {
+          "$ref": "#/$defs/BusType"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "va": {
+          "description": "Voltage angle (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "vm": {
+          "description": "Voltage magnitude (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "vmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "vmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "zone": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "vm",
+        "va",
+        "base_kv",
+        "vmax",
+        "vmin",
+        "area",
+        "zone",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BusId": {
+      "description": "A bus identifier as it appears in the source file: the external, stable id\n(1-based in MATPOWER, and possibly sparse; pegase has gaps in its ids).\nDistinct from the dense `[0, n)` analysis index, which only\n[`IndexedNetwork`](crate::IndexedNetwork) produces, via\n[`bus_index`](crate::IndexedNetwork::bus_index). The two are both integers\nand trivially confused; making the id its own type stops one being used where\nthe other is meant (using a 1-based id to index a matrix is off-by-one on a\ncontiguous case and pure garbage on a sparse one).\n\n`#[serde(transparent)]` so the JSON transport carries a bare integer, not a\nwrapper object; the wire format is unchanged.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "BusType": {
+      "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+      "enum": [
+        "PQ",
+        "PV",
+        "REF",
+        "ISOLATED"
+      ],
+      "type": "string"
+    },
+    "Confidence": {
+      "description": "How confident the source map entry is.",
+      "enum": [
+        "exact",
+        "high",
+        "medium",
+        "low"
+      ],
+      "type": "string"
+    },
+    "Configuration": {
+      "enum": [
+        "wye",
+        "delta",
+        "single_phase"
+      ],
+      "type": "string"
+    },
+    "ControlVoltageReference": {
+      "enum": [
+        "PN_PER_PHASE",
+        "PP_PER_PHASE",
+        "PP_AVERAGED",
+        "PG_AVERAGED",
+        "PN_AVERAGED",
+        "PG_PER_PHASE"
+      ],
+      "type": "string"
+    },
+    "DerivedMetadata": {
+      "description": "Optional derived metadata: matrix statistics, solver table metadata, and\ncache keys.\nEmpty by default; the scaffold never populates it.",
+      "properties": {
+        "cache_keys": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "matrix_stats": true,
+        "normalized_solver_tables": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NormalizedSolverTableMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "DiagnosticCode": {
+      "description": "A stable, dotted diagnostic code, e.g. `EMIT.PSSE.DROP_ANGLE_LIMITS`.\n\nThe leading segment is the namespace and names the stage family:\n`PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`, `EMIT`, `BINDING`,\n`PARTNER`, `PERF`. The conventional shape is `NAMESPACE.SOURCE_OR_TARGET.SPECIFIC`.",
+      "type": "string"
+    },
+    "DiagnosticSeverity": {
+      "description": "Severity, ordered worst-last so [`Ord`] gives the dominant severity of a set.",
+      "oneOf": [
+        {
+          "const": "debug",
+          "description": "Useful in development; normally hidden.",
+          "type": "string"
+        },
+        {
+          "const": "info",
+          "description": "A provenance or normalization event worth recording.",
+          "type": "string"
+        },
+        {
+          "const": "warning",
+          "description": "Usable, but semantics were defaulted, approximated, lost, or the target\nis incomplete.",
+          "type": "string"
+        },
+        {
+          "const": "error",
+          "description": "The package exists but the model is not valid for the intended use\nwithout repair.",
+          "type": "string"
+        },
+        {
+          "const": "fatal",
+          "description": "The package could not be produced.",
+          "type": "string"
+        }
+      ]
+    },
+    "DiagnosticStage": {
+      "description": "The compiler stage that emitted a diagnostic.",
+      "enum": [
+        "parse",
+        "read",
+        "canonicalize",
+        "validate",
+        "lower",
+        "emit",
+        "bind",
+        "partner"
+      ],
+      "type": "string"
+    },
+    "DistBus": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "grounded": {
+          "description": "Terminals tied to ground with zero impedance.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "terminals": {
+          "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "v_min": {
+          "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral, phase to phase, and symmetrical component families (the\nfour BMOPF bound families).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vpn_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpn_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpp_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpp_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vsym_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vsym_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "terminals",
+        "grounded",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistControlProfile": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "power_factor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PowerFactorControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_var": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltVarControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_watt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltWattControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistGenerator": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "cost": {
+          "description": "$/kWh; no OpenDSS equivalent, so it is None until a format supplies it.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_nom": {
+          "description": "Setpoint, watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_nom": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistIbr": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "control_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "description": "Per conductor current limits, amperes.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_avail": {
+          "description": "Available active power, watts.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prime_mover": {
+          "$ref": "#/$defs/IbrPrimeMover"
+        },
+        "q_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "s_max": {
+          "description": "Per phase apparent power nameplate ratings, volt amperes.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "topology": {
+          "$ref": "#/$defs/IbrTopology"
+        },
+        "voltage_aggregation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IbrVoltageAggregation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "topology",
+        "prime_mover",
+        "s_max",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLine": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "length": {
+          "description": "Meters.",
+          "format": "double",
+          "type": "number"
+        },
+        "linecode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "linecode",
+        "length",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLineCode": {
+      "properties": {
+        "b_from": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "b_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g_from": {
+          "description": "Shunt admittance halves at each end, S per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "g_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "i_max": {
+          "description": "Ampacity per conductor.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "n_conductors": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "r_series": {
+          "description": "Series impedance, ohm per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "s_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "x_series": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "n_conductors",
+        "r_series",
+        "x_series",
+        "g_from",
+        "b_from",
+        "g_to",
+        "b_to",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoad": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_nom": {
+          "description": "Watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_nom": {
+          "description": "Vars per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "voltage_model": {
+          "$ref": "#/$defs/DistLoadVoltageModel"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "voltage_model",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoadVoltageModel": {
+      "oneOf": [
+        {
+          "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+          "properties": {
+            "model": {
+              "const": "constant_power",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant current load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_current",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant impedance load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_impedance",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+          "properties": {
+            "alpha_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "zip",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "alpha_z",
+            "alpha_i",
+            "alpha_p",
+            "beta_z",
+            "beta_i",
+            "beta_p"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+          "properties": {
+            "gamma_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "gamma_q": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "DistNetwork": {
+      "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+      "properties": {
+        "base_frequency": {
+          "description": "Hz.",
+          "format": "double",
+          "type": "number"
+        },
+        "buses": {
+          "items": {
+            "$ref": "#/$defs/DistBus"
+          },
+          "type": "array"
+        },
+        "commands": {
+          "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "control_profiles": {
+          "items": {
+            "$ref": "#/$defs/DistControlProfile"
+          },
+          "type": "array"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "generators": {
+          "items": {
+            "$ref": "#/$defs/DistGenerator"
+          },
+          "type": "array"
+        },
+        "ibrs": {
+          "items": {
+            "$ref": "#/$defs/DistIbr"
+          },
+          "type": "array"
+        },
+        "linecodes": {
+          "items": {
+            "$ref": "#/$defs/DistLineCode"
+          },
+          "type": "array"
+        },
+        "lines": {
+          "items": {
+            "$ref": "#/$defs/DistLine"
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "$ref": "#/$defs/DistLoad"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "shunts": {
+          "items": {
+            "$ref": "#/$defs/DistShunt"
+          },
+          "type": "array"
+        },
+        "source_format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DistSourceFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+          "items": {
+            "$ref": "#/$defs/VoltageSource"
+          },
+          "type": "array"
+        },
+        "switches": {
+          "items": {
+            "$ref": "#/$defs/DistSwitch"
+          },
+          "type": "array"
+        },
+        "transformers": {
+          "items": {
+            "$ref": "#/$defs/DistTransformer"
+          },
+          "type": "array"
+        },
+        "untyped": {
+          "items": {
+            "$ref": "#/$defs/UntypedObject"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "base_frequency",
+        "buses",
+        "linecodes",
+        "lines",
+        "switches",
+        "transformers",
+        "loads",
+        "generators",
+        "shunts",
+        "sources",
+        "untyped",
+        "commands",
+        "options",
+        "warnings",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistShunt": {
+      "properties": {
+        "b": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Total siemens in conductor order.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "g",
+        "b",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistSourceFormat": {
+      "description": "Where the network came from; fixes the echo tier target.",
+      "enum": [
+        "dss",
+        "bmopf-json",
+        "pmd-json"
+      ],
+      "type": "string"
+    },
+    "DistSwitch": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "open",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistTransformer": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phases": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "windings": {
+          "items": {
+            "$ref": "#/$defs/Winding2"
+          },
+          "type": "array"
+        },
+        "xsc_pct": {
+          "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "windings",
+        "xsc_pct",
+        "phases",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "ElementRef": {
+      "anyOf": [
+        {
+          "properties": {
+            "row": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row"
+          ]
+        },
+        {
+          "properties": {
+            "source_uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source_uid"
+          ]
+        }
+      ],
+      "description": "A row in one table of the static payload.\n\n`source_uid` is the row's payload identity: when the referenced table\ncarries `uid` values, a present `source_uid` resolves the target row and a\npresent `row` must agree with it. In a table without uids (packages written\nbefore payload identity existed), `source_uid` is advisory and `row`\naddresses the update alone. On the wire, `row` may be omitted when\n`source_uid` is given.",
+      "properties": {
+        "row": {
+          "description": "Zero based row index in `table`, when the producer addressed one.\n`None` on refs built by [`ElementRef::by_source_uid`], which address by\nidentity alone.",
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "source_uid": {
+          "description": "The row's payload identity (its `uid` field), when the producer knows it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
+          "description": "Payload table name, such as `loads`, `generators`, `branches`, or `hvdc`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "table"
+      ],
+      "type": "object"
+    },
+    "ElementUpdate": {
+      "description": "Field values to apply to one static payload row.",
+      "properties": {
+        "element": {
+          "$ref": "#/$defs/ElementRef",
+          "description": "Table row to update."
+        },
+        "fields": {
+          "additionalProperties": true,
+          "description": "JSON field values to overwrite on that row.",
+          "type": "object"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format for this update.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "element"
+      ],
+      "type": "object"
+    },
+    "GenCost": {
+      "description": "A generator cost curve (`mpc.gencost` row).",
+      "properties": {
+        "coeffs": {
+          "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "1 = piecewise linear, 2 = polynomial.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ncost": {
+          "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "shutdown": {
+          "format": "double",
+          "type": "number"
+        },
+        "startup": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "model",
+        "startup",
+        "shutdown",
+        "ncost",
+        "coeffs"
+      ],
+      "type": "object"
+    },
+    "Generator": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "caps": {
+          "additionalProperties": {
+            "format": "double",
+            "type": "number"
+          },
+          "default": {},
+          "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+          "type": "object"
+        },
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mbase": {
+          "format": "double",
+          "type": "number"
+        },
+        "pg": {
+          "description": "Real power set point (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qg": {
+          "description": "Reactive power set point (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "regulated_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vg": {
+          "description": "Voltage set point (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "pg",
+        "qg",
+        "pmax",
+        "pmin",
+        "qmax",
+        "qmin",
+        "vg",
+        "mbase",
+        "in_service"
+      ],
+      "type": "object"
+    },
+    "Hvdc": {
+      "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+      "properties": {
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "loss0": {
+          "format": "double",
+          "type": "number"
+        },
+        "loss1": {
+          "format": "double",
+          "type": "number"
+        },
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qminf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmint": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vf": {
+          "format": "double",
+          "type": "number"
+        },
+        "vt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "in_service",
+        "pf",
+        "pt",
+        "qf",
+        "qt",
+        "vf",
+        "vt",
+        "pmin",
+        "pmax",
+        "qminf",
+        "qmaxf",
+        "qmint",
+        "qmaxt",
+        "loss0",
+        "loss1",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "IbrPrimeMover": {
+      "enum": [
+        "PV",
+        "BATTERY",
+        "GENERIC",
+        "STATCOM",
+        "DSTATCOM"
+      ],
+      "type": "string"
+    },
+    "IbrTopology": {
+      "enum": [
+        "SINGLE_PHASE",
+        "THREE_LEG",
+        "FOUR_LEG"
+      ],
+      "type": "string"
+    },
+    "IbrVoltageAggregation": {
+      "enum": [
+        "PER_PHASE",
+        "AVERAGE"
+      ],
+      "type": "string"
+    },
+    "Impedance": {
+      "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+      "properties": {
+        "base_mva": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "r",
+        "x",
+        "base_mva"
+      ],
+      "type": "object"
+    },
+    "Load": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p": {
+          "description": "Active demand (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "q": {
+          "description": "Reactive demand (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "voltage_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LoadVoltageModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Voltage dependence, when the source states one. `None` is constant power."
+        }
+      },
+      "required": [
+        "bus",
+        "p",
+        "q",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "LoadVoltageModel": {
+      "description": "Voltage dependence for a transmission load.",
+      "oneOf": [
+        {
+          "description": "Explicit constant power marker.",
+          "properties": {
+            "kind": {
+              "const": "constant_power",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+          "properties": {
+            "kind": {
+              "const": "zip",
+              "type": "string"
+            },
+            "load_type": {
+              "default": null,
+              "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "p_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "scaling": {
+              "default": null,
+              "description": "Source scaling factor, when a format has one.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p_constant_power",
+            "q_constant_power",
+            "p_constant_current",
+            "q_constant_current",
+            "p_constant_impedance",
+            "q_constant_impedance"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+          "properties": {
+            "gamma_p": {
+              "format": "double",
+              "type": "number"
+            },
+            "gamma_q": {
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "p": {
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p",
+            "q",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "LoweringRecord": {
+      "description": "One lowering/normalization/emission pass and what it changed.",
+      "properties": {
+        "approximations": {
+          "description": "Approximations the pass introduced (e.g. \"Kron reduction of neutral\").",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "assumptions": {
+          "description": "Modeling assumptions the pass relied on (e.g. \"balanced four-wire feeder\").",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/StructuredDiagnostic"
+          },
+          "type": "array"
+        },
+        "dropped_fields": {
+          "description": "Fields/constraints dropped because the output family cannot carry them.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "input_kind": {
+          "$ref": "#/$defs/ModelKind"
+        },
+        "options": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "output_kind": {
+          "$ref": "#/$defs/ModelKind"
+        },
+        "pass": {
+          "description": "A stable pass name, e.g. `normalize-balanced` or `multiconductor-to-balanced`.",
+          "type": "string"
+        },
+        "validation_status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "pass",
+        "input_kind",
+        "output_kind",
+        "validation_status"
+      ],
+      "type": "object"
+    },
+    "MappingKind": {
+      "description": "How a canonical field relates to its source value.",
+      "oneOf": [
+        {
+          "const": "exact",
+          "description": "Copied verbatim from the source.",
+          "type": "string"
+        },
+        {
+          "const": "defaulted",
+          "description": "Materialized from a format default rather than the source text.",
+          "type": "string"
+        },
+        {
+          "const": "inferred",
+          "description": "Inferred from other source data.",
+          "type": "string"
+        },
+        {
+          "const": "converted_units",
+          "description": "Converted into canonical units (e.g. ohms to per unit).",
+          "type": "string"
+        },
+        {
+          "const": "lowered",
+          "description": "Produced by a lowering pass (e.g. positive-sequence equivalent).",
+          "type": "string"
+        },
+        {
+          "const": "aggregated",
+          "description": "One canonical field aggregated from several source records.",
+          "type": "string"
+        },
+        {
+          "const": "split",
+          "description": "One source record split into several canonical fields/elements.",
+          "type": "string"
+        },
+        {
+          "const": "synthetic",
+          "description": "Synthesized with no direct source (e.g. a generated bus id).",
+          "type": "string"
+        },
+        {
+          "const": "retained_extra",
+          "description": "Extra data from the source preserved verbatim.",
+          "type": "string"
+        }
+      ]
+    },
+    "ModelKind": {
+      "description": "Which concrete static-grid IR family the payload is.",
+      "oneOf": [
+        {
+          "const": "balanced",
+          "description": "Scalar positive-sequence transmission model ([`powerio::BalancedNetwork`]).",
+          "type": "string"
+        },
+        {
+          "const": "multiconductor",
+          "description": "Wire-coordinate distribution model ([`powerio_dist::MulticonductorNetwork`]).",
+          "type": "string"
+        }
+      ]
+    },
+    "ModelPayload": {
+      "description": "The one IR payload a package carries, tagged by `kind` in JSON so the payload\nis self-describing in addition to the top-level `model_kind`.\n\nThe payload is the serde snapshot of the PowerIO Rust IR\n([`powerio::Network`] / [`powerio_dist::DistNetwork`]), declared by the\npackage's `payload_schema` / `payload_schema_version` fields and versioned\nindependently of the envelope: additive IR growth bumps the payload minor\nwith no envelope version change. See `docs/src/pio-json-schema.md`.",
+      "oneOf": [
+        {
+          "properties": {
+            "balanced_network": {
+              "$ref": "#/$defs/Network"
+            },
+            "kind": {
+              "const": "balanced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "balanced_network"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "multiconductor",
+              "type": "string"
+            },
+            "multiconductor_network": {
+              "$ref": "#/$defs/DistNetwork"
+            }
+          },
+          "required": [
+            "kind",
+            "multiconductor_network"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Network": {
+      "description": "A format-neutral power network.",
+      "properties": {
+        "areas": {
+          "default": [],
+          "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+          "items": {
+            "$ref": "#/$defs/Area"
+          },
+          "type": "array"
+        },
+        "base_frequency": {
+          "default": 60.0,
+          "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+          "format": "double",
+          "type": "number"
+        },
+        "base_mva": {
+          "format": "double",
+          "type": "number"
+        },
+        "branches": {
+          "items": {
+            "$ref": "#/$defs/Branch"
+          },
+          "type": "array"
+        },
+        "buses": {
+          "items": {
+            "$ref": "#/$defs/Bus"
+          },
+          "type": "array"
+        },
+        "generators": {
+          "items": {
+            "$ref": "#/$defs/Generator"
+          },
+          "type": "array"
+        },
+        "hvdc": {
+          "items": {
+            "$ref": "#/$defs/Hvdc"
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "$ref": "#/$defs/Load"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "shunts": {
+          "items": {
+            "$ref": "#/$defs/Shunt"
+          },
+          "type": "array"
+        },
+        "solver": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SolverParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+        },
+        "source_format": {
+          "$ref": "#/$defs/SourceFormat"
+        },
+        "storage": {
+          "items": {
+            "$ref": "#/$defs/Storage"
+          },
+          "type": "array"
+        },
+        "switches": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Switch"
+          },
+          "type": "array"
+        },
+        "transformers_3w": {
+          "default": [],
+          "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+          "items": {
+            "$ref": "#/$defs/Transformer3W"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "base_mva",
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "generators",
+        "storage",
+        "hvdc",
+        "source_format"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableMetadata": {
+      "description": "Compact package metadata for `Network::to_normalized_solver_tables`.",
+      "properties": {
+        "branch_from_arc_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "branch_to_arc_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "bus_ids": {
+          "items": {
+            "$ref": "#/$defs/BusId"
+          },
+          "type": "array"
+        },
+        "component_labels": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "pass": {
+          "type": "string"
+        },
+        "reference_bus_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "row_counts": {
+          "$ref": "#/$defs/NormalizedSolverTableRowCounts"
+        },
+        "source_rows": {
+          "$ref": "#/$defs/NormalizedSolverTableSourceRows"
+        },
+        "units": {
+          "$ref": "#/$defs/SolverTableUnits"
+        }
+      },
+      "required": [
+        "pass",
+        "units",
+        "row_counts",
+        "bus_ids",
+        "reference_bus_indices",
+        "component_labels",
+        "branch_from_arc_indices",
+        "branch_to_arc_indices",
+        "source_rows"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableRowCounts": {
+      "description": "Row counts for every normalized solver table.",
+      "properties": {
+        "arcs": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "branches": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "buses": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generators": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "hvdc": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "loads": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "shunts": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "storage": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "switches": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "switches",
+        "arcs",
+        "generators",
+        "storage",
+        "hvdc"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableSourceRows": {
+      "description": "Source row provenance vectors for normalized solver tables.",
+      "properties": {
+        "branches": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "buses": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "generators": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "hvdc": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "shunts": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "storage": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "switches": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "switches",
+        "generators",
+        "storage",
+        "hvdc"
+      ],
+      "type": "object"
+    },
+    "ObjectSummary": {
+      "description": "Element counts, topology, and unit conventions, for a quick read of a package\nwithout deserializing the whole payload.",
+      "properties": {
+        "elements": {
+          "additionalProperties": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "description": "Element type name -> count, e.g. `{\"buses\": 118, \"branches\": 186}`.",
+          "type": "object"
+        },
+        "topology": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObjectTopology"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "units": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObjectUnits"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ObjectTopology": {
+      "properties": {
+        "connected_components": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "reference_buses": {
+          "description": "Reference bus ids as strings (balanced ids are integers, multiconductor\nids are strings; strings cover both).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ObjectUnits": {
+      "properties": {
+        "angle": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_mva": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "power": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "OperatingPoint": {
+      "description": "One replayable operating state over the package's static payload.",
+      "properties": {
+        "index": {
+          "description": "Zero based period index. Labels and durations live on the shared\n[`TimeAxis`], indexed by this.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format for this point.",
+          "type": "object"
+        },
+        "updates": {
+          "description": "Field updates to apply to the static payload.",
+          "items": {
+            "$ref": "#/$defs/ElementUpdate"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "index"
+      ],
+      "type": "object"
+    },
+    "OperatingPointSeries": {
+      "description": "A format neutral series of operating points over a package's static payload.",
+      "properties": {
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format, such as `source_format`.",
+          "type": "object"
+        },
+        "points": {
+          "description": "Ordered operating states. Each state is addressed by its `index`.",
+          "items": {
+            "$ref": "#/$defs/OperatingPoint"
+          },
+          "type": "array"
+        },
+        "time_axis": {
+          "$ref": "#/$defs/TimeAxis",
+          "description": "Shared period count, durations, and labels."
+        }
+      },
+      "required": [
+        "time_axis"
+      ],
+      "type": "object"
+    },
+    "Origin": {
+      "description": "Where the package came from. Internally tagged on `kind` in JSON, so a reader\ndistinguishes an in-memory model, a single text file (with or without\nretained source), a folder dataset, a partially decoded binary, a derived\nproduct of a lowering pass, or a composite of several sources.\n\nThe `hash` field is named consistently across all `Origin` variants.",
+      "oneOf": [
+        {
+          "description": "Built in process, no source artifact.",
+          "properties": {
+            "kind": {
+              "const": "in_memory",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "format": {
+              "type": "string"
+            },
+            "hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "file",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "retained_source": {
+              "default": false,
+              "description": "Whether the original source text was retained for a byte-exact\nsame-format echo. The retained text itself is not embedded in the\npackage; this only records that it exists at the frontend.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "file_hashes": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "format": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "folder",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "decoded_sections": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "format": {
+              "type": "string"
+            },
+            "hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "binary_file",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A model produced by a lowering/normalization pass from another package.",
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "options": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "parent_package_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pass": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "pass"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Several sources combined, e.g. a static case plus a profile set.",
+          "properties": {
+            "kind": {
+              "const": "composite",
+              "type": "string"
+            },
+            "sources": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "sources"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PowerFactorControl": {
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf"
+      ],
+      "type": "object"
+    },
+    "Producer": {
+      "description": "The tool and build that produced the package.",
+      "properties": {
+        "features": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "git_commit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "version"
+      ],
+      "type": "object"
+    },
+    "ReactivePowerReference": {
+      "enum": [
+        "VAR_MAX",
+        "VAR_AVAILABLE"
+      ],
+      "type": "string"
+    },
+    "ReactivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "VAR"
+      ],
+      "type": "string"
+    },
+    "Shunt": {
+      "properties": {
+        "b": {
+          "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+          "format": "double",
+          "type": "number"
+        },
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SwitchedShuntControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Shunt conductance (MW at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "g",
+        "b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "ShuntBlock": {
+      "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+      "properties": {
+        "b": {
+          "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "steps": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "steps",
+        "b"
+      ],
+      "type": "object"
+    },
+    "SolverParams": {
+      "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+      "properties": {
+        "adjust_area_interchange": {
+          "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_dc_taps": {
+          "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_phase_shift": {
+          "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_switched_shunt": {
+          "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_taps": {
+          "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "max_iterations": {
+          "description": "Newton iteration cap (`NEWTON ITMXN`).",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "newton_tolerance": {
+          "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "zero_impedance_threshold": {
+          "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SolverTableUnits": {
+      "description": "Units carried by [`NormalizedSolverTables`].",
+      "properties": {
+        "admittance": {
+          "type": "string"
+        },
+        "angle": {
+          "type": "string"
+        },
+        "dense_index_base": {
+          "type": "string"
+        },
+        "impedance": {
+          "type": "string"
+        },
+        "power": {
+          "type": "string"
+        },
+        "voltage": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "power",
+        "voltage",
+        "angle",
+        "impedance",
+        "admittance",
+        "dense_index_base"
+      ],
+      "type": "object"
+    },
+    "SourceDescriptor": {
+      "description": "A declared source artifact, referenced from source maps and diagnostics by\nits `id`. (`sources[]` in the package.)",
+      "properties": {
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "kind"
+      ],
+      "type": "object"
+    },
+    "SourceFormat": {
+      "description": "Which format a [`Network`] was read from. Drives the same format byte exact\necho on write.",
+      "oneOf": [
+        {
+          "enum": [
+            "Matpower",
+            "PowerModelsJson",
+            "EgretJson",
+            "Psse",
+            "PowerWorld",
+            "PandapowerJson"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "Pslf",
+          "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+          "type": "string"
+        },
+        {
+          "const": "PowerWorldBinary",
+          "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+          "type": "string"
+        },
+        {
+          "const": "InMemory",
+          "description": "Built in memory, for example from synth or an edited case; no source text.",
+          "type": "string"
+        },
+        {
+          "const": "Normalized",
+          "description": "A normalized derived form ([`Network::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+          "type": "string"
+        },
+        {
+          "const": "Gridfm",
+          "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+          "type": "string"
+        },
+        {
+          "const": "PypsaCsv",
+          "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+          "type": "string"
+        },
+        {
+          "const": "Goc3Json",
+          "description": "Read from an ARPA-E GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+          "type": "string"
+        },
+        {
+          "const": "SurgeJson",
+          "description": "Read from a Surge native JSON document.",
+          "type": "string"
+        }
+      ]
+    },
+    "SourceMapEntry": {
+      "description": "One `element_path -> source` mapping.",
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/Confidence"
+        },
+        "element_path": {
+          "description": "JSON pointer (or best-effort locator) into the package payload.",
+          "type": "string"
+        },
+        "mapping_kind": {
+          "$ref": "#/$defs/MappingKind"
+        },
+        "source_ref": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      },
+      "required": [
+        "element_path",
+        "source_ref",
+        "mapping_kind",
+        "confidence"
+      ],
+      "type": "object"
+    },
+    "SourceRef": {
+      "description": "A pointer into one source artifact: where a canonical field came from.",
+      "properties": {
+        "byte_offset": {
+          "description": "Byte offset, for binary sources.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "column": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "field": {
+          "description": "Canonical field / property name, e.g. `vm`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "raw_token": {
+          "description": "Raw token / value, when safe to embed.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "record": {
+          "description": "Record / section / object type, e.g. `bus`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id"
+      ],
+      "type": "object"
+    },
+    "Storage": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "charge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "charge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "discharge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "discharge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "ps": {
+          "format": "double",
+          "type": "number"
+        },
+        "q_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qs": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "thermal_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "ps",
+        "qs",
+        "energy",
+        "energy_rating",
+        "charge_rating",
+        "discharge_rating",
+        "charge_efficiency",
+        "discharge_efficiency",
+        "thermal_rating",
+        "qmin",
+        "qmax",
+        "r",
+        "x",
+        "p_loss",
+        "q_loss",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "StructuredDiagnostic": {
+      "description": "One structured finding.",
+      "properties": {
+        "code": {
+          "$ref": "#/$defs/DiagnosticCode"
+        },
+        "details": {
+          "additionalProperties": true,
+          "description": "Code-specific structured payload, e.g. `{\"dropped_fields\": [\"angmin\"]}`.",
+          "type": "object"
+        },
+        "element_path": {
+          "description": "JSON pointer (or best-effort locator) of the element the finding is about.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "safe_to_ignore": {
+          "description": "Workflows for which this finding is safe to ignore, e.g.\n`[\"power_flow\", \"opf\"]`. Empty means \"no such assurance\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "$ref": "#/$defs/DiagnosticSeverity"
+        },
+        "source_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stage": {
+          "$ref": "#/$defs/DiagnosticStage"
+        },
+        "suggested_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "severity",
+        "stage",
+        "message"
+      ],
+      "type": "object"
+    },
+    "StudyBlock": {
+      "description": "Additive study block stored on a package envelope.",
+      "properties": {
+        "app": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "author": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_operating_point": {
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "commits": {
+          "items": {
+            "$ref": "#/$defs/StudyCommit"
+          },
+          "type": "array"
+        },
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "StudyCommit": {
+      "description": "One cumulative commit in a study block.",
+      "properties": {
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edits": {
+          "items": {
+            "$ref": "#/$defs/StudyEdit"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "StudyEdit": {
+      "oneOf": [
+        {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/ElementRef"
+            },
+            "kind": {
+              "const": "demand_delta"
+            },
+            "p_mw": {
+              "type": "number"
+            },
+            "q_mvar": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "bus",
+            "p_mw"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "branch": {
+              "$ref": "#/$defs/ElementRef"
+            },
+            "delta_mw": {
+              "type": "number"
+            },
+            "kind": {
+              "const": "rating_delta"
+            }
+          },
+          "required": [
+            "kind",
+            "branch",
+            "delta_mw"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "set_fields"
+            },
+            "update": {
+              "$ref": "#/$defs/ElementUpdate"
+            }
+          },
+          "required": [
+            "kind",
+            "update"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "properties": {
+            "kind": {
+              "not": {
+                "enum": [
+                  "demand_delta",
+                  "rating_delta",
+                  "set_fields"
+                ]
+              },
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "Switch": {
+      "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+      "properties": {
+        "closed": {
+          "type": "boolean"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "pf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "pt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "thermal_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "closed",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntControl": {
+      "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+      "properties": {
+        "blocks": {
+          "items": {
+            "$ref": "#/$defs/ShuntBlock"
+          },
+          "type": "array"
+        },
+        "control_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The regulated bus; `None` means the shunt regulates its own bus."
+        },
+        "mode": {
+          "$ref": "#/$defs/SwitchedShuntMode"
+        },
+        "rmpct": {
+          "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+          "format": "double",
+          "type": "number"
+        },
+        "vhigh": {
+          "description": "Regulated voltage band (per unit).",
+          "format": "double",
+          "type": "number"
+        },
+        "vlow": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "vhigh",
+        "vlow",
+        "rmpct",
+        "blocks"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntMode": {
+      "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+      "oneOf": [
+        {
+          "const": "locked",
+          "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+          "type": "string"
+        },
+        {
+          "const": "continuous",
+          "description": "Continuous adjustment within the block range (`MODSW` 1).",
+          "type": "string"
+        },
+        {
+          "const": "discrete",
+          "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+          "type": "string"
+        }
+      ]
+    },
+    "TimeAxis": {
+      "description": "The time axis shared by every operating point in the series.",
+      "properties": {
+        "duration_hours": {
+          "description": "Optional duration per period, in hours.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "labels": {
+          "description": "Optional display labels for the periods.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "periods": {
+          "description": "Number of periods available in the series.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "periods"
+      ],
+      "type": "object"
+    },
+    "Transformer3W": {
+      "description": "A three-winding transformer: three terminal buses joined at a common star\npoint, with the series impedance given pairwise (winding 1-2, 2-3, 3-1).\n\nKept as a typed record (not three [`Branch`]es) so the star-point voltage and\nthe per-winding control data survive a same-format round trip. Both the PSS/E\n3-winding record and the PSLF tertiary-winding record map onto it.\n[`star_expansion`](Transformer3W::star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mag_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "mag_g": {
+          "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+          "format": "double",
+          "type": "number"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "star_va": {
+          "format": "double",
+          "type": "number"
+        },
+        "star_vm": {
+          "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windings": {
+          "description": "The three windings, in order (primary, secondary, tertiary).",
+          "items": {
+            "$ref": "#/$defs/Winding"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "z": {
+          "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+          "items": {
+            "$ref": "#/$defs/Impedance"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        }
+      },
+      "required": [
+        "windings",
+        "z",
+        "star_vm",
+        "star_va",
+        "mag_g",
+        "mag_b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "TransformerControl": {
+      "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+      "properties": {
+        "band_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "band_min": {
+          "format": "double",
+          "type": "number"
+        },
+        "controlled_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/TransformerControlMode"
+        },
+        "mva_base": {
+          "format": "double",
+          "type": "number"
+        },
+        "ntp": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tap_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "tap_min": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "tap_min",
+        "tap_max",
+        "band_min",
+        "band_max",
+        "ntp",
+        "mva_base"
+      ],
+      "type": "object"
+    },
+    "TransformerControlMode": {
+      "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+      "oneOf": [
+        {
+          "const": "fixed",
+          "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+          "type": "string"
+        },
+        {
+          "const": "voltage",
+          "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+          "type": "string"
+        },
+        {
+          "const": "reactive_flow",
+          "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+          "type": "string"
+        },
+        {
+          "const": "active_flow",
+          "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+          "type": "string"
+        }
+      ]
+    },
+    "UntypedObject": {
+      "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+      "properties": {
+        "class": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "props": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "class",
+        "name",
+        "props"
+      ],
+      "type": "object"
+    },
+    "ValidationCounts": {
+      "description": "Counts per severity. All five are always present; zero where unused.",
+      "properties": {
+        "debug": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "error": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "fatal": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "info": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "warning": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "ValidationPass": {
+      "description": "The status of one named validation pass.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "name",
+        "status"
+      ],
+      "type": "object"
+    },
+    "ValidationStatus": {
+      "description": "Overall validation status, ordered worst-last.",
+      "enum": [
+        "ok",
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ],
+      "type": "string"
+    },
+    "ValidationSummary": {
+      "description": "A cheap-to-inspect summary of validation: an overall status, per-severity\ncounts, and the named passes that ran.",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/ValidationCounts"
+        },
+        "passes": {
+          "items": {
+            "$ref": "#/$defs/ValidationPass"
+          },
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts"
+      ],
+      "type": "object"
+    },
+    "VoltVarControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_min_for_q": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_min_for_q_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "q_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "q_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "q_limits"
+      ],
+      "type": "object"
+    },
+    "VoltWattControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "p_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "p_limits"
+      ],
+      "type": "object"
+    },
+    "VoltageSource": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_angle": {
+          "description": "Radians per terminal.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "v_magnitude": {
+          "description": "Volts per terminal (0.0 on grounded terminals).",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "v_magnitude",
+        "v_angle",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "Winding": {
+      "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "nominal_kv": {
+          "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "tap": {
+          "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "tap",
+        "shift",
+        "nominal_kv",
+        "rate_a",
+        "rate_b",
+        "rate_c"
+      ],
+      "type": "object"
+    },
+    "Winding2": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "conn": {
+          "$ref": "#/$defs/WindingConn"
+        },
+        "r_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "r_pct": {
+          "description": "Winding resistance, percent of the winding base.",
+          "format": "double",
+          "type": "number"
+        },
+        "s_rating": {
+          "description": "Volt amperes.",
+          "format": "double",
+          "type": "number"
+        },
+        "tap": {
+          "format": "double",
+          "type": "number"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_ref": {
+          "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+          "format": "double",
+          "type": "number"
+        },
+        "x_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "terminal_map",
+        "conn",
+        "v_ref",
+        "s_rating",
+        "r_pct",
+        "tap"
+      ],
+      "type": "object"
+    },
+    "WindingConn": {
+      "enum": [
+        "wye",
+        "delta"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://powerio.dev/schema/pio-package/0.1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The compiler package: a versioned envelope around one IR payload plus the\nprovenance, diagnostics, validation, and lowering history that make the\nartifact trustworthy. Serializes to `.pio.json`.\n\n`model_kind` is stored explicitly and is authoritative; the payload is also\nself-describing (tagged by `kind`). [`NetworkPackage::kind_is_consistent`]\nasserts the two agree. Unknown future top-level fields are tolerated on read\n(ignored) so a newer producer's package still deserializes here.",
+  "properties": {
+    "created_at": {
+      "description": "RFC 3339 build timestamp. Left `None` by default for deterministic,\nround-trip-stable output; set explicitly when a timestamp is wanted.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "derived": {
+      "$ref": "#/$defs/DerivedMetadata"
+    },
+    "diagnostics": {
+      "items": {
+        "$ref": "#/$defs/StructuredDiagnostic"
+      },
+      "type": "array"
+    },
+    "lowering_history": {
+      "items": {
+        "$ref": "#/$defs/LoweringRecord"
+      },
+      "type": "array"
+    },
+    "model": {
+      "$ref": "#/$defs/ModelPayload"
+    },
+    "model_kind": {
+      "$ref": "#/$defs/ModelKind",
+      "description": "Explicit model kind. Authoritative; never inferred from field presence."
+    },
+    "operating_points": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OperatingPointSeries"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Replayable operating states over the static payload. The package\nconstructors and setters omit empty series for static single state cases."
+    },
+    "origin": {
+      "$ref": "#/$defs/Origin"
+    },
+    "package_id": {
+      "description": "Stable content id, e.g. `\"sha256:...\"`. The scaffold leaves it `None`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload_schema": {
+      "description": "The declared schema URL for the payload family named by `model_kind`.\n`None` on packages written before the payload contract was declared.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload_schema_version": {
+      "description": "The declared payload schema version (semver), independent of the\nenvelope `schema_version`: the envelope versions the package\nbookkeeping, this versions the network tables. A reader rejects a\ndifferent major before computing on payload fields; `None` (legacy\npackages) is accepted.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "producer": {
+      "$ref": "#/$defs/Producer"
+    },
+    "schema": {
+      "default": "https://powerio.dev/schema/pio-package/0.1",
+      "description": "The schema URL identifying this package format.",
+      "type": "string"
+    },
+    "schema_version": {
+      "default": "0.1.1",
+      "description": "The package schema version (semver).",
+      "type": "string"
+    },
+    "source_maps": {
+      "items": {
+        "$ref": "#/$defs/SourceMapEntry"
+      },
+      "type": "array"
+    },
+    "sources": {
+      "items": {
+        "$ref": "#/$defs/SourceDescriptor"
+      },
+      "type": "array"
+    },
+    "study": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StudyBlock"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Cumulative interactive edits over the package payload."
+    },
+    "summary": {
+      "$ref": "#/$defs/ObjectSummary",
+      "default": {}
+    },
+    "validation": {
+      "$ref": "#/$defs/ValidationSummary"
+    }
+  },
+  "required": [
+    "producer",
+    "model_kind",
+    "model",
+    "origin",
+    "validation"
+  ],
+  "title": "NetworkPackage",
+  "type": "object"
+}

--- a/docs/schema/pio-payload-balanced/1/schema.json
+++ b/docs/schema/pio-payload-balanced/1/schema.json
@@ -1,0 +1,1601 @@
+{
+  "$defs": {
+    "Area": {
+      "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "net_interchange": {
+          "description": "Scheduled net interchange (MW); positive is export out of the area.",
+          "format": "double",
+          "type": "number"
+        },
+        "number": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "slack_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The area swing (slack) bus, or `None` when unset."
+        },
+        "tolerance": {
+          "description": "Interchange tolerance bandwidth (MW).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "number",
+        "net_interchange",
+        "tolerance"
+      ],
+      "type": "object"
+    },
+    "Branch": {
+      "properties": {
+        "angmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "angmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "b": {
+          "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+          "format": "double",
+          "type": "number"
+        },
+        "charging": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCharging"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TransformerControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+        },
+        "current_ratings": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCurrentRatings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Current ratings, when the source distinguishes them from MVA ratings."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "r": {
+          "description": "Series resistance (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "rating_sets": {
+          "default": [],
+          "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+          "items": {
+            "$ref": "#/$defs/BranchRatingSet"
+          },
+          "type": "array"
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "solution": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchSolution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solved branch flow values, when present in a case snapshot."
+        },
+        "tap": {
+          "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "description": "Series reactance (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "r",
+        "x",
+        "b",
+        "rate_a",
+        "rate_b",
+        "rate_c",
+        "tap",
+        "shift",
+        "in_service",
+        "angmin",
+        "angmax",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BranchCharging": {
+      "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+      "properties": {
+        "b_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "b_to": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_to": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "g_fr",
+        "b_fr",
+        "g_to",
+        "b_to"
+      ],
+      "type": "object"
+    },
+    "BranchCurrentRatings": {
+      "description": "Current limits for a branch, in source units.",
+      "properties": {
+        "c_rating_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_c": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "c_rating_a",
+        "c_rating_b",
+        "c_rating_c"
+      ],
+      "type": "object"
+    },
+    "BranchRatingSet": {
+      "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rate_mva": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "rate_mva"
+      ],
+      "type": "object"
+    },
+    "BranchSolution": {
+      "description": "Solved branch terminal flows in MW/MVAr.",
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf",
+        "qf",
+        "pt",
+        "qt"
+      ],
+      "type": "object"
+    },
+    "Bus": {
+      "properties": {
+        "area": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "base_kv": {
+          "format": "double",
+          "type": "number"
+        },
+        "evhi": {
+          "default": null,
+          "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "evlo": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "id": {
+          "$ref": "#/$defs/BusId",
+          "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+        },
+        "kind": {
+          "$ref": "#/$defs/BusType"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "va": {
+          "description": "Voltage angle (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "vm": {
+          "description": "Voltage magnitude (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "vmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "vmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "zone": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "vm",
+        "va",
+        "base_kv",
+        "vmax",
+        "vmin",
+        "area",
+        "zone",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BusId": {
+      "description": "A bus identifier as it appears in the source file: the external, stable id\n(1-based in MATPOWER, and possibly sparse; pegase has gaps in its ids).\nDistinct from the dense `[0, n)` analysis index, which only\n[`IndexedNetwork`](crate::IndexedNetwork) produces, via\n[`bus_index`](crate::IndexedNetwork::bus_index). The two are both integers\nand trivially confused; making the id its own type stops one being used where\nthe other is meant (using a 1-based id to index a matrix is off-by-one on a\ncontiguous case and pure garbage on a sparse one).\n\n`#[serde(transparent)]` so the JSON transport carries a bare integer, not a\nwrapper object; the wire format is unchanged.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "BusType": {
+      "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+      "enum": [
+        "PQ",
+        "PV",
+        "REF",
+        "ISOLATED"
+      ],
+      "type": "string"
+    },
+    "GenCost": {
+      "description": "A generator cost curve (`mpc.gencost` row).",
+      "properties": {
+        "coeffs": {
+          "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "1 = piecewise linear, 2 = polynomial.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ncost": {
+          "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "shutdown": {
+          "format": "double",
+          "type": "number"
+        },
+        "startup": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "model",
+        "startup",
+        "shutdown",
+        "ncost",
+        "coeffs"
+      ],
+      "type": "object"
+    },
+    "Generator": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "caps": {
+          "additionalProperties": {
+            "format": "double",
+            "type": "number"
+          },
+          "default": {},
+          "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+          "type": "object"
+        },
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mbase": {
+          "format": "double",
+          "type": "number"
+        },
+        "pg": {
+          "description": "Real power set point (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qg": {
+          "description": "Reactive power set point (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "regulated_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vg": {
+          "description": "Voltage set point (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "pg",
+        "qg",
+        "pmax",
+        "pmin",
+        "qmax",
+        "qmin",
+        "vg",
+        "mbase",
+        "in_service"
+      ],
+      "type": "object"
+    },
+    "Hvdc": {
+      "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+      "properties": {
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "loss0": {
+          "format": "double",
+          "type": "number"
+        },
+        "loss1": {
+          "format": "double",
+          "type": "number"
+        },
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qminf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmint": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vf": {
+          "format": "double",
+          "type": "number"
+        },
+        "vt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "in_service",
+        "pf",
+        "pt",
+        "qf",
+        "qt",
+        "vf",
+        "vt",
+        "pmin",
+        "pmax",
+        "qminf",
+        "qmaxf",
+        "qmint",
+        "qmaxt",
+        "loss0",
+        "loss1",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "Impedance": {
+      "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+      "properties": {
+        "base_mva": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "r",
+        "x",
+        "base_mva"
+      ],
+      "type": "object"
+    },
+    "Load": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p": {
+          "description": "Active demand (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "q": {
+          "description": "Reactive demand (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "voltage_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LoadVoltageModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Voltage dependence, when the source states one. `None` is constant power."
+        }
+      },
+      "required": [
+        "bus",
+        "p",
+        "q",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "LoadVoltageModel": {
+      "description": "Voltage dependence for a transmission load.",
+      "oneOf": [
+        {
+          "description": "Explicit constant power marker.",
+          "properties": {
+            "kind": {
+              "const": "constant_power",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+          "properties": {
+            "kind": {
+              "const": "zip",
+              "type": "string"
+            },
+            "load_type": {
+              "default": null,
+              "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "p_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "scaling": {
+              "default": null,
+              "description": "Source scaling factor, when a format has one.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p_constant_power",
+            "q_constant_power",
+            "p_constant_current",
+            "q_constant_current",
+            "p_constant_impedance",
+            "q_constant_impedance"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+          "properties": {
+            "gamma_p": {
+              "format": "double",
+              "type": "number"
+            },
+            "gamma_q": {
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "p": {
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p",
+            "q",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Shunt": {
+      "properties": {
+        "b": {
+          "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+          "format": "double",
+          "type": "number"
+        },
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SwitchedShuntControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Shunt conductance (MW at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "g",
+        "b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "ShuntBlock": {
+      "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+      "properties": {
+        "b": {
+          "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "steps": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "steps",
+        "b"
+      ],
+      "type": "object"
+    },
+    "SolverParams": {
+      "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+      "properties": {
+        "adjust_area_interchange": {
+          "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_dc_taps": {
+          "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_phase_shift": {
+          "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_switched_shunt": {
+          "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_taps": {
+          "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "max_iterations": {
+          "description": "Newton iteration cap (`NEWTON ITMXN`).",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "newton_tolerance": {
+          "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "zero_impedance_threshold": {
+          "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SourceFormat": {
+      "description": "Which format a [`Network`] was read from. Drives the same format byte exact\necho on write.",
+      "oneOf": [
+        {
+          "enum": [
+            "Matpower",
+            "PowerModelsJson",
+            "EgretJson",
+            "Psse",
+            "PowerWorld",
+            "PandapowerJson"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "Pslf",
+          "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+          "type": "string"
+        },
+        {
+          "const": "PowerWorldBinary",
+          "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+          "type": "string"
+        },
+        {
+          "const": "InMemory",
+          "description": "Built in memory, for example from synth or an edited case; no source text.",
+          "type": "string"
+        },
+        {
+          "const": "Normalized",
+          "description": "A normalized derived form ([`Network::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+          "type": "string"
+        },
+        {
+          "const": "Gridfm",
+          "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+          "type": "string"
+        },
+        {
+          "const": "PypsaCsv",
+          "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+          "type": "string"
+        },
+        {
+          "const": "Goc3Json",
+          "description": "Read from an ARPA-E GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+          "type": "string"
+        },
+        {
+          "const": "SurgeJson",
+          "description": "Read from a Surge native JSON document.",
+          "type": "string"
+        }
+      ]
+    },
+    "Storage": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "charge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "charge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "discharge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "discharge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "ps": {
+          "format": "double",
+          "type": "number"
+        },
+        "q_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qs": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "thermal_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "ps",
+        "qs",
+        "energy",
+        "energy_rating",
+        "charge_rating",
+        "discharge_rating",
+        "charge_efficiency",
+        "discharge_efficiency",
+        "thermal_rating",
+        "qmin",
+        "qmax",
+        "r",
+        "x",
+        "p_loss",
+        "q_loss",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "Switch": {
+      "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+      "properties": {
+        "closed": {
+          "type": "boolean"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "pf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "pt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "thermal_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "closed",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntControl": {
+      "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+      "properties": {
+        "blocks": {
+          "items": {
+            "$ref": "#/$defs/ShuntBlock"
+          },
+          "type": "array"
+        },
+        "control_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The regulated bus; `None` means the shunt regulates its own bus."
+        },
+        "mode": {
+          "$ref": "#/$defs/SwitchedShuntMode"
+        },
+        "rmpct": {
+          "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+          "format": "double",
+          "type": "number"
+        },
+        "vhigh": {
+          "description": "Regulated voltage band (per unit).",
+          "format": "double",
+          "type": "number"
+        },
+        "vlow": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "vhigh",
+        "vlow",
+        "rmpct",
+        "blocks"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntMode": {
+      "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+      "oneOf": [
+        {
+          "const": "locked",
+          "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+          "type": "string"
+        },
+        {
+          "const": "continuous",
+          "description": "Continuous adjustment within the block range (`MODSW` 1).",
+          "type": "string"
+        },
+        {
+          "const": "discrete",
+          "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+          "type": "string"
+        }
+      ]
+    },
+    "Transformer3W": {
+      "description": "A three-winding transformer: three terminal buses joined at a common star\npoint, with the series impedance given pairwise (winding 1-2, 2-3, 3-1).\n\nKept as a typed record (not three [`Branch`]es) so the star-point voltage and\nthe per-winding control data survive a same-format round trip. Both the PSS/E\n3-winding record and the PSLF tertiary-winding record map onto it.\n[`star_expansion`](Transformer3W::star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mag_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "mag_g": {
+          "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+          "format": "double",
+          "type": "number"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "star_va": {
+          "format": "double",
+          "type": "number"
+        },
+        "star_vm": {
+          "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windings": {
+          "description": "The three windings, in order (primary, secondary, tertiary).",
+          "items": {
+            "$ref": "#/$defs/Winding"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "z": {
+          "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+          "items": {
+            "$ref": "#/$defs/Impedance"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        }
+      },
+      "required": [
+        "windings",
+        "z",
+        "star_vm",
+        "star_va",
+        "mag_g",
+        "mag_b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "TransformerControl": {
+      "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+      "properties": {
+        "band_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "band_min": {
+          "format": "double",
+          "type": "number"
+        },
+        "controlled_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/TransformerControlMode"
+        },
+        "mva_base": {
+          "format": "double",
+          "type": "number"
+        },
+        "ntp": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tap_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "tap_min": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "tap_min",
+        "tap_max",
+        "band_min",
+        "band_max",
+        "ntp",
+        "mva_base"
+      ],
+      "type": "object"
+    },
+    "TransformerControlMode": {
+      "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+      "oneOf": [
+        {
+          "const": "fixed",
+          "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+          "type": "string"
+        },
+        {
+          "const": "voltage",
+          "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+          "type": "string"
+        },
+        {
+          "const": "reactive_flow",
+          "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+          "type": "string"
+        },
+        {
+          "const": "active_flow",
+          "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+          "type": "string"
+        }
+      ]
+    },
+    "Winding": {
+      "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "nominal_kv": {
+          "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "tap": {
+          "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "tap",
+        "shift",
+        "nominal_kv",
+        "rate_a",
+        "rate_b",
+        "rate_c"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://powerio.dev/schema/pio-payload-balanced/1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A format-neutral power network.",
+  "properties": {
+    "areas": {
+      "default": [],
+      "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+      "items": {
+        "$ref": "#/$defs/Area"
+      },
+      "type": "array"
+    },
+    "base_frequency": {
+      "default": 60.0,
+      "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+      "format": "double",
+      "type": "number"
+    },
+    "base_mva": {
+      "format": "double",
+      "type": "number"
+    },
+    "branches": {
+      "items": {
+        "$ref": "#/$defs/Branch"
+      },
+      "type": "array"
+    },
+    "buses": {
+      "items": {
+        "$ref": "#/$defs/Bus"
+      },
+      "type": "array"
+    },
+    "generators": {
+      "items": {
+        "$ref": "#/$defs/Generator"
+      },
+      "type": "array"
+    },
+    "hvdc": {
+      "items": {
+        "$ref": "#/$defs/Hvdc"
+      },
+      "type": "array"
+    },
+    "loads": {
+      "items": {
+        "$ref": "#/$defs/Load"
+      },
+      "type": "array"
+    },
+    "name": {
+      "type": "string"
+    },
+    "shunts": {
+      "items": {
+        "$ref": "#/$defs/Shunt"
+      },
+      "type": "array"
+    },
+    "solver": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SolverParams"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+    },
+    "source_format": {
+      "$ref": "#/$defs/SourceFormat"
+    },
+    "storage": {
+      "items": {
+        "$ref": "#/$defs/Storage"
+      },
+      "type": "array"
+    },
+    "switches": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/Switch"
+      },
+      "type": "array"
+    },
+    "transformers_3w": {
+      "default": [],
+      "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+      "items": {
+        "$ref": "#/$defs/Transformer3W"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "name",
+    "base_mva",
+    "buses",
+    "loads",
+    "shunts",
+    "branches",
+    "generators",
+    "storage",
+    "hvdc",
+    "source_format"
+  ],
+  "title": "Network",
+  "type": "object"
+}

--- a/docs/schema/pio-payload-multiconductor/1/schema.json
+++ b/docs/schema/pio-payload-multiconductor/1/schema.json
@@ -1,0 +1,1419 @@
+{
+  "$defs": {
+    "ActivePowerReference": {
+      "enum": [
+        "P_AVAILABLE",
+        "P_MAX",
+        "S_MAX"
+      ],
+      "type": "string"
+    },
+    "ActivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "W"
+      ],
+      "type": "string"
+    },
+    "Configuration": {
+      "enum": [
+        "wye",
+        "delta",
+        "single_phase"
+      ],
+      "type": "string"
+    },
+    "ControlVoltageReference": {
+      "enum": [
+        "PN_PER_PHASE",
+        "PP_PER_PHASE",
+        "PP_AVERAGED",
+        "PG_AVERAGED",
+        "PN_AVERAGED",
+        "PG_PER_PHASE"
+      ],
+      "type": "string"
+    },
+    "DistBus": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "grounded": {
+          "description": "Terminals tied to ground with zero impedance.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "terminals": {
+          "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "v_min": {
+          "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral, phase to phase, and symmetrical component families (the\nfour BMOPF bound families).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vpn_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpn_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpp_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpp_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vsym_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vsym_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "terminals",
+        "grounded",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistControlProfile": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "power_factor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PowerFactorControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_var": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltVarControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_watt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltWattControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistGenerator": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "cost": {
+          "description": "$/kWh; no OpenDSS equivalent, so it is None until a format supplies it.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_nom": {
+          "description": "Setpoint, watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_nom": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistIbr": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "control_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "description": "Per conductor current limits, amperes.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_avail": {
+          "description": "Available active power, watts.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prime_mover": {
+          "$ref": "#/$defs/IbrPrimeMover"
+        },
+        "q_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "s_max": {
+          "description": "Per phase apparent power nameplate ratings, volt amperes.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "topology": {
+          "$ref": "#/$defs/IbrTopology"
+        },
+        "voltage_aggregation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IbrVoltageAggregation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "topology",
+        "prime_mover",
+        "s_max",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLine": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "length": {
+          "description": "Meters.",
+          "format": "double",
+          "type": "number"
+        },
+        "linecode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "linecode",
+        "length",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLineCode": {
+      "properties": {
+        "b_from": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "b_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g_from": {
+          "description": "Shunt admittance halves at each end, S per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "g_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "i_max": {
+          "description": "Ampacity per conductor.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "n_conductors": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "r_series": {
+          "description": "Series impedance, ohm per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "s_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "x_series": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "n_conductors",
+        "r_series",
+        "x_series",
+        "g_from",
+        "b_from",
+        "g_to",
+        "b_to",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoad": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_nom": {
+          "description": "Watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_nom": {
+          "description": "Vars per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "voltage_model": {
+          "$ref": "#/$defs/DistLoadVoltageModel"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "voltage_model",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoadVoltageModel": {
+      "oneOf": [
+        {
+          "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+          "properties": {
+            "model": {
+              "const": "constant_power",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant current load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_current",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant impedance load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_impedance",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+          "properties": {
+            "alpha_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "zip",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "alpha_z",
+            "alpha_i",
+            "alpha_p",
+            "beta_z",
+            "beta_i",
+            "beta_p"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+          "properties": {
+            "gamma_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "gamma_q": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "DistShunt": {
+      "properties": {
+        "b": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Total siemens in conductor order.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "g",
+        "b",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistSourceFormat": {
+      "description": "Where the network came from; fixes the echo tier target.",
+      "enum": [
+        "dss",
+        "bmopf-json",
+        "pmd-json"
+      ],
+      "type": "string"
+    },
+    "DistSwitch": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "open",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistTransformer": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phases": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "windings": {
+          "items": {
+            "$ref": "#/$defs/Winding"
+          },
+          "type": "array"
+        },
+        "xsc_pct": {
+          "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "windings",
+        "xsc_pct",
+        "phases",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "IbrPrimeMover": {
+      "enum": [
+        "PV",
+        "BATTERY",
+        "GENERIC",
+        "STATCOM",
+        "DSTATCOM"
+      ],
+      "type": "string"
+    },
+    "IbrTopology": {
+      "enum": [
+        "SINGLE_PHASE",
+        "THREE_LEG",
+        "FOUR_LEG"
+      ],
+      "type": "string"
+    },
+    "IbrVoltageAggregation": {
+      "enum": [
+        "PER_PHASE",
+        "AVERAGE"
+      ],
+      "type": "string"
+    },
+    "PowerFactorControl": {
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf"
+      ],
+      "type": "object"
+    },
+    "ReactivePowerReference": {
+      "enum": [
+        "VAR_MAX",
+        "VAR_AVAILABLE"
+      ],
+      "type": "string"
+    },
+    "ReactivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "VAR"
+      ],
+      "type": "string"
+    },
+    "UntypedObject": {
+      "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+      "properties": {
+        "class": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "props": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "class",
+        "name",
+        "props"
+      ],
+      "type": "object"
+    },
+    "VoltVarControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_min_for_q": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_min_for_q_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "q_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "q_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "q_limits"
+      ],
+      "type": "object"
+    },
+    "VoltWattControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "p_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "p_limits"
+      ],
+      "type": "object"
+    },
+    "VoltageSource": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_angle": {
+          "description": "Radians per terminal.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "v_magnitude": {
+          "description": "Volts per terminal (0.0 on grounded terminals).",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "v_magnitude",
+        "v_angle",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "Winding": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "conn": {
+          "$ref": "#/$defs/WindingConn"
+        },
+        "r_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "r_pct": {
+          "description": "Winding resistance, percent of the winding base.",
+          "format": "double",
+          "type": "number"
+        },
+        "s_rating": {
+          "description": "Volt amperes.",
+          "format": "double",
+          "type": "number"
+        },
+        "tap": {
+          "format": "double",
+          "type": "number"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_ref": {
+          "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+          "format": "double",
+          "type": "number"
+        },
+        "x_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "terminal_map",
+        "conn",
+        "v_ref",
+        "s_rating",
+        "r_pct",
+        "tap"
+      ],
+      "type": "object"
+    },
+    "WindingConn": {
+      "enum": [
+        "wye",
+        "delta"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://powerio.dev/schema/pio-payload-multiconductor/1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+  "properties": {
+    "base_frequency": {
+      "description": "Hz.",
+      "format": "double",
+      "type": "number"
+    },
+    "buses": {
+      "items": {
+        "$ref": "#/$defs/DistBus"
+      },
+      "type": "array"
+    },
+    "commands": {
+      "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+      "items": {
+        "maxItems": 2,
+        "minItems": 2,
+        "prefixItems": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "type": "array"
+      },
+      "type": "array"
+    },
+    "control_profiles": {
+      "items": {
+        "$ref": "#/$defs/DistControlProfile"
+      },
+      "type": "array"
+    },
+    "extras": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "generators": {
+      "items": {
+        "$ref": "#/$defs/DistGenerator"
+      },
+      "type": "array"
+    },
+    "ibrs": {
+      "items": {
+        "$ref": "#/$defs/DistIbr"
+      },
+      "type": "array"
+    },
+    "linecodes": {
+      "items": {
+        "$ref": "#/$defs/DistLineCode"
+      },
+      "type": "array"
+    },
+    "lines": {
+      "items": {
+        "$ref": "#/$defs/DistLine"
+      },
+      "type": "array"
+    },
+    "loads": {
+      "items": {
+        "$ref": "#/$defs/DistLoad"
+      },
+      "type": "array"
+    },
+    "name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "options": {
+      "items": {
+        "maxItems": 2,
+        "minItems": 2,
+        "prefixItems": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "type": "array"
+      },
+      "type": "array"
+    },
+    "shunts": {
+      "items": {
+        "$ref": "#/$defs/DistShunt"
+      },
+      "type": "array"
+    },
+    "source_format": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DistSourceFormat"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "sources": {
+      "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+      "items": {
+        "$ref": "#/$defs/VoltageSource"
+      },
+      "type": "array"
+    },
+    "switches": {
+      "items": {
+        "$ref": "#/$defs/DistSwitch"
+      },
+      "type": "array"
+    },
+    "transformers": {
+      "items": {
+        "$ref": "#/$defs/DistTransformer"
+      },
+      "type": "array"
+    },
+    "untyped": {
+      "items": {
+        "$ref": "#/$defs/UntypedObject"
+      },
+      "type": "array"
+    },
+    "warnings": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "base_frequency",
+    "buses",
+    "linecodes",
+    "lines",
+    "switches",
+    "transformers",
+    "loads",
+    "generators",
+    "shunts",
+    "sources",
+    "untyped",
+    "commands",
+    "options",
+    "warnings",
+    "extras"
+  ],
+  "title": "DistNetwork",
+  "type": "object"
+}

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -67,15 +67,17 @@ The two versions are independent because they change at different rates and
 break different consumers: the payload grows whenever the IR grows (a minor
 `payload_schema_version` bump), while the envelope bookkeeping barely moves.
 
-The schema URLs are identifiers, not fetch locations (the JSON Schema `$id`
-convention). The site serves them anyway; each redirects to its section of
-this chapter.
+The schema URLs are JSON Schema `$id` identifiers. The docs site also serves a
+generated schema at each identifier path under `schema.json`, so consumers can
+fetch a machine readable view of the serde contract.
 
 ## The envelope: `pio-package/0.1` {#pio-package}
 
 The `schema` field on every package names the envelope contract:
 `https://powerio.dev/schema/pio-package/0.1`. `schema_version` is semver; the
 current value is `0.1.1`.
+The generated schema is served at
+`https://powerio.dev/schema/pio-package/0.1/schema.json`.
 
 - Optional additive envelope fields (a reader that ignores them loses nothing
   it relied on before) land without a version change; `operating_points` landed
@@ -138,10 +140,11 @@ semver) before computing on payload fields. Both fields are absent on packages
 written before envelope 0.1.1; such payloads predate the declared contract and
 are accepted.
 
-There is no separate schema document for the payloads. Each payload is what
-its Rust model serializes, and the model's rustdoc is the field reference. The
-balanced payload's wire form is additionally held to a committed golden file
-by `powerio/tests/snapshot_schema.rs`.
+Each payload is what its Rust model serializes. The generated JSON Schema is
+derived from those serde models and checked in CI against the committed
+`docs/schema/**/schema.json` files. The model's rustdoc is the field reference,
+and the balanced payload's wire form is additionally held to a committed
+golden file by `powerio/tests/snapshot_schema.rs`.
 
 ### The balanced payload: `pio-payload-balanced/1` {#pio-payload-balanced}
 
@@ -155,6 +158,8 @@ conventions: MW and MVAr power, per unit voltage magnitudes and impedances on
 the system base, degree angles. Every element carries an `extras` map for
 source format fields the model does not name. The field reference is the
 [`powerio::Network` rustdoc](../powerio/network/struct.Network.html).
+The generated schema is served at
+`https://powerio.dev/schema/pio-payload-balanced/1/schema.json`.
 
 ### The multiconductor payload: `pio-payload-multiconductor/1` {#pio-payload-multiconductor}
 
@@ -164,6 +169,8 @@ when `model_kind` is `multiconductor`: the wire-coordinate distribution model,
 in SI units with radian angles. [Compiler IR](compiler-ir.md) describes the
 model family. The field reference is the
 [`powerio_dist::DistNetwork` rustdoc](../powerio_dist/model/struct.DistNetwork.html).
+The generated schema is served at
+`https://powerio.dev/schema/pio-payload-multiconductor/1/schema.json`.
 For a standalone distribution exchange file, write BMOPF instead of extracting
 this payload ([relation to interchange formats](#interchange)).
 

--- a/powerio-dist/Cargo.toml
+++ b/powerio-dist/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["science", "parsing"]
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+schema = ["dep:schemars"]
+
 [dependencies]
 thiserror = "2"
 serde.workspace = true
@@ -22,6 +25,7 @@ serde.workspace = true
 # representation its own serializer prints; the round trip contracts need
 # parse(print(x)) == x exactly.
 serde_json = { workspace = true, features = ["float_roundtrip"] }
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Draft 2020-12 validation against the vendored BMOPF schema in tests.

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -25,6 +25,7 @@ pub type Mat = Vec<Vec<f64>>;
 
 /// Where the network came from; fixes the echo tier target.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum DistSourceFormat {
@@ -46,6 +47,7 @@ impl DistSourceFormat {
 }
 
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistBus {
     pub id: String,
@@ -88,6 +90,7 @@ impl DistBus {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistLineCode {
     pub name: String,
@@ -127,6 +130,7 @@ impl DistLineCode {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistLine {
     pub name: String,
@@ -165,6 +169,7 @@ impl DistLine {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistSwitch {
     pub name: String,
@@ -201,6 +206,7 @@ impl DistSwitch {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Configuration {
@@ -210,6 +216,7 @@ pub enum Configuration {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistLoad {
     pub name: String,
@@ -248,6 +255,7 @@ impl DistLoad {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "model", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum DistLoadVoltageModel {
@@ -299,6 +307,7 @@ impl DistLoadVoltageModel {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistGenerator {
     pub name: String,
@@ -345,6 +354,7 @@ impl DistGenerator {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum IbrTopology {
@@ -354,6 +364,7 @@ pub enum IbrTopology {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum IbrPrimeMover {
@@ -365,6 +376,7 @@ pub enum IbrPrimeMover {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum IbrVoltageAggregation {
@@ -373,6 +385,7 @@ pub enum IbrVoltageAggregation {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistIbr {
     pub name: String,
@@ -426,6 +439,7 @@ impl DistIbr {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ControlVoltageReference {
@@ -438,6 +452,7 @@ pub enum ControlVoltageReference {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ReactivePowerUnit {
@@ -446,6 +461,7 @@ pub enum ReactivePowerUnit {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ActivePowerUnit {
@@ -454,6 +470,7 @@ pub enum ActivePowerUnit {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ReactivePowerReference {
@@ -462,6 +479,7 @@ pub enum ReactivePowerReference {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[non_exhaustive]
 pub enum ActivePowerReference {
@@ -471,12 +489,14 @@ pub enum ActivePowerReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct PowerFactorControl {
     pub pf: f64,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct VoltVarControl {
     pub voltage_reference: Option<ControlVoltageReference>,
@@ -489,6 +509,7 @@ pub struct VoltVarControl {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct VoltWattControl {
     pub voltage_reference: Option<ControlVoltageReference>,
@@ -499,6 +520,7 @@ pub struct VoltWattControl {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistControlProfile {
     pub name: String,
@@ -522,6 +544,7 @@ impl DistControlProfile {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistShunt {
     pub name: String,
@@ -554,6 +577,7 @@ impl DistShunt {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum WindingConn {
@@ -562,6 +586,7 @@ pub enum WindingConn {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Winding {
     pub bus: String,
@@ -604,6 +629,7 @@ impl Winding {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistTransformer {
     pub name: String,
@@ -634,6 +660,7 @@ impl DistTransformer {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct VoltageSource {
     pub name: String,
@@ -669,6 +696,7 @@ impl VoltageSource {
 /// An object the reader recognized but does not type: preserved by class,
 /// name, and raw property text so conversions can warn precisely.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct UntypedObject {
     pub class: String,
@@ -697,6 +725,7 @@ impl UntypedObject {
 /// `defaulted` records, per element (`"class.name"` key), the fields the
 /// reader materialized from format defaults rather than the source text.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct DistNetwork {
     pub name: Option<String>,

--- a/powerio-pkg/Cargo.toml
+++ b/powerio-pkg/Cargo.toml
@@ -15,12 +15,16 @@ categories = ["science", "data-structures"]
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+schema = ["dep:schemars", "powerio/schema", "powerio-dist/schema"]
+
 [dependencies]
 num-complex = { workspace = true }
 powerio = { workspace = true }
 powerio-dist = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/powerio-pkg/examples/generate_schemas.rs
+++ b/powerio-pkg/examples/generate_schemas.rs
@@ -1,0 +1,64 @@
+#[cfg(feature = "schema")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate::main()
+}
+
+#[cfg(not(feature = "schema"))]
+fn main() {
+    eprintln!("enable the `schema` feature to generate JSON Schemas");
+    std::process::exit(1);
+}
+
+#[cfg(feature = "schema")]
+mod generate {
+    use std::{
+        env, fs,
+        path::{Path, PathBuf},
+    };
+
+    use schemars::{JsonSchema, schema_for};
+    use serde_json::json;
+
+    pub(super) fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let out = env::args_os()
+            .nth(1)
+            .map_or_else(|| PathBuf::from("docs/schema"), PathBuf::from);
+
+        write_schema::<powerio_pkg::NetworkPackage>(
+            &out,
+            "pio-package/0.1",
+            powerio_pkg::PIO_PACKAGE_SCHEMA_URL,
+        )?;
+        write_schema::<powerio::BalancedNetwork>(
+            &out,
+            "pio-payload-balanced/1",
+            powerio_pkg::PIO_PAYLOAD_BALANCED_SCHEMA_URL,
+        )?;
+        write_schema::<powerio_dist::MulticonductorNetwork>(
+            &out,
+            "pio-payload-multiconductor/1",
+            powerio_pkg::PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL,
+        )?;
+
+        Ok(())
+    }
+
+    fn write_schema<T: JsonSchema>(
+        out: &Path,
+        rel: &str,
+        id: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut schema = serde_json::to_value(schema_for!(T))?;
+        let root = schema
+            .as_object_mut()
+            .ok_or("schemars returned a non-object schema root")?;
+        root.insert("$id".to_owned(), json!(id));
+
+        let path = out.join(rel).join("schema.json");
+        fs::create_dir_all(path.parent().ok_or("schema path has no parent")?)?;
+        let mut text = serde_json::to_string_pretty(&schema)?;
+        text.push('\n');
+        fs::write(path, text)?;
+        Ok(())
+    }
+}

--- a/powerio-pkg/src/diagnostics.rs
+++ b/powerio-pkg/src/diagnostics.rs
@@ -17,6 +17,7 @@ use crate::provenance::SourceRef;
 /// `PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`, `EMIT`, `BINDING`,
 /// `PARTNER`, `PERF`. The conventional shape is `NAMESPACE.SOURCE_OR_TARGET.SPECIFIC`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct DiagnosticCode(pub String);
 
@@ -56,6 +57,7 @@ impl From<String> for DiagnosticCode {
 
 /// Severity, ordered worst-last so [`Ord`] gives the dominant severity of a set.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticSeverity {
     /// Useful in development; normally hidden.
@@ -74,6 +76,7 @@ pub enum DiagnosticSeverity {
 
 /// The compiler stage that emitted a diagnostic.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum DiagnosticStage {
@@ -89,6 +92,7 @@ pub enum DiagnosticStage {
 
 /// One structured finding.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct StructuredDiagnostic {
     pub code: DiagnosticCode,
     pub severity: DiagnosticSeverity,

--- a/powerio-pkg/src/lowering.rs
+++ b/powerio-pkg/src/lowering.rs
@@ -25,6 +25,7 @@ use crate::validation::ValidationStatus;
 
 /// One lowering/normalization/emission pass and what it changed.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct LoweringRecord {
     /// A stable pass name, e.g. `normalize-balanced` or `multiconductor-to-balanced`.
     pub pass: String,
@@ -64,6 +65,7 @@ impl LoweringRecord {
 
 /// Sequence transform used by the multiconductor to balanced lowering.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SequenceTransformConvention {
     FortescuePowerInvariant,
@@ -87,6 +89,7 @@ fn default_lowering_base_mva() -> f64 {
 
 /// Options for the multiconductor to balanced lowering preflight and pass.
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MulticonductorToBalancedOptions {
     pub convention: SequenceTransformConvention,
     /// Three phase system power base used for the balanced per-unit projection.
@@ -105,6 +108,7 @@ impl Default for MulticonductorToBalancedOptions {
 
 /// Readiness report for the multiconductor to balanced lowering pass.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MulticonductorToBalancedReadiness {
     pub convention: SequenceTransformConvention,
     pub base_mva: f64,
@@ -126,6 +130,7 @@ impl MulticonductorToBalancedReadiness {
 
 /// A successful raw multiconductor to balanced lowering result.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MulticonductorToBalancedLowering {
     pub network: BalancedNetwork,
     pub record: LoweringRecord,
@@ -133,6 +138,7 @@ pub struct MulticonductorToBalancedLowering {
 
 /// Structured failure from the raw multiconductor to balanced lowering pass.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MulticonductorToBalancedError {
     pub options: MulticonductorToBalancedOptions,
     pub status: ValidationStatus,

--- a/powerio-pkg/src/model.rs
+++ b/powerio-pkg/src/model.rs
@@ -13,6 +13,7 @@ use powerio_dist::MulticonductorNetwork;
 
 /// Which concrete static-grid IR family the payload is.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ModelKind {
@@ -31,6 +32,7 @@ pub enum ModelKind {
 /// independently of the envelope: additive IR growth bumps the payload minor
 /// with no envelope version change. See `docs/src/pio-json-schema.md`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ModelPayload {
     Balanced {

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -16,6 +16,7 @@ use crate::model::ModelPayload;
 
 /// A format neutral series of operating points over a package's static payload.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct OperatingPointSeries {
     /// Shared period count, durations, and labels.
@@ -73,6 +74,7 @@ impl OperatingPointSeries {
 
 /// The time axis shared by every operating point in the series.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct TimeAxis {
     /// Number of periods available in the series.
@@ -115,6 +117,7 @@ impl TimeAxis {
 
 /// One replayable operating state over the package's static payload.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct OperatingPoint {
     /// Zero based period index. Labels and durations live on the shared
@@ -148,6 +151,8 @@ impl OperatingPoint {
 /// addresses the update alone. On the wire, `row` may be omitted when
 /// `source_uid` is given.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(transform = element_ref_schema))]
 #[non_exhaustive]
 pub struct ElementRef {
     /// Payload table name, such as `loads`, `generators`, `branches`, or `hvdc`.
@@ -189,9 +194,35 @@ impl ElementRef {
     }
 }
 
+#[cfg(feature = "schema")]
+fn element_ref_schema(schema: &mut schemars::Schema) {
+    schema.ensure_object().insert(
+        "anyOf".to_owned(),
+        json!([
+            {
+                "required": ["row"],
+                "properties": {
+                    "row": {
+                        "format": "uint",
+                        "minimum": 0,
+                        "type": "integer"
+                    }
+                }
+            },
+            {
+                "required": ["source_uid"],
+                "properties": {
+                    "source_uid": { "type": "string" }
+                }
+            }
+        ]),
+    );
+}
+
 impl<'de> Deserialize<'de> for ElementRef {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
+        #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
         struct Wire {
             table: String,
             #[serde(default)]
@@ -215,6 +246,7 @@ impl<'de> Deserialize<'de> for ElementRef {
 
 /// Field values to apply to one static payload row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct ElementUpdate {
     /// Table row to update.

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -88,6 +88,7 @@ fn payload_schema_for(kind: ModelKind) -> (&'static str, &'static str) {
 /// cache keys.
 /// Empty by default; the scaffold never populates it.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct DerivedMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub matrix_stats: Option<serde_json::Value>,
@@ -107,6 +108,7 @@ impl DerivedMetadata {
 
 /// Compact package metadata for `Network::to_normalized_solver_tables`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NormalizedSolverTableMetadata {
     pub pass: String,
@@ -122,6 +124,7 @@ pub struct NormalizedSolverTableMetadata {
 
 /// Row counts for every normalized solver table.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NormalizedSolverTableRowCounts {
     pub buses: usize,
@@ -137,6 +140,7 @@ pub struct NormalizedSolverTableRowCounts {
 
 /// Source row provenance vectors for normalized solver tables.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NormalizedSolverTableSourceRows {
     pub buses: Vec<Option<usize>>,
@@ -193,6 +197,7 @@ impl From<&NormalizedSolverTables> for NormalizedSolverTableMetadata {
 /// asserts the two agree. Unknown future top-level fields are tolerated on read
 /// (ignored) so a newer producer's package still deserializes here.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NetworkPackage {
     /// The schema URL identifying this package format.

--- a/powerio-pkg/src/provenance.rs
+++ b/powerio-pkg/src/provenance.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// The tool and build that produced the package.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct Producer {
     pub tool: String,
     pub version: String,
@@ -38,6 +39,7 @@ impl Producer {
 ///
 /// The `hash` field is named consistently across all `Origin` variants.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Origin {
@@ -83,6 +85,7 @@ pub enum Origin {
 /// A declared source artifact, referenced from source maps and diagnostics by
 /// its `id`. (`sources[]` in the package.)
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SourceDescriptor {
     pub id: String,
     pub kind: String,
@@ -96,6 +99,7 @@ pub struct SourceDescriptor {
 
 /// A pointer into one source artifact: where a canonical field came from.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SourceRef {
     pub source_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -154,6 +158,7 @@ impl SourceRef {
 
 /// How a canonical field relates to its source value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum MappingKind {
@@ -179,6 +184,7 @@ pub enum MappingKind {
 
 /// How confident the source map entry is.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum Confidence {
     Exact,
@@ -189,6 +195,7 @@ pub enum Confidence {
 
 /// One `element_path -> source` mapping.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct SourceMapEntry {
     /// JSON pointer (or best-effort locator) into the package payload.
     pub element_path: String,

--- a/powerio-pkg/src/study.rs
+++ b/powerio-pkg/src/study.rs
@@ -13,6 +13,7 @@ use crate::operating::{
 
 /// Additive study block stored on a package envelope.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct StudyBlock {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -46,6 +47,7 @@ impl StudyBlock {
 
 /// One cumulative commit in a study block.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct StudyCommit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -90,6 +92,64 @@ impl StudyEdit {
             Self::SetFields { .. } => "set_fields",
             Self::Unknown { kind, .. } => kind,
         }
+    }
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for StudyEdit {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "StudyEdit".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let element_ref = generator.subschema_for::<ElementRef>().to_value();
+        let element_update = generator.subschema_for::<ElementUpdate>().to_value();
+        let schema = json!({
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["kind", "bus", "p_mw"],
+                    "properties": {
+                        "kind": { "const": "demand_delta" },
+                        "bus": element_ref,
+                        "p_mw": { "type": "number" },
+                        "q_mvar": { "type": "number" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": ["kind", "branch", "delta_mw"],
+                    "properties": {
+                        "kind": { "const": "rating_delta" },
+                        "branch": element_ref,
+                        "delta_mw": { "type": "number" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": ["kind", "update"],
+                    "properties": {
+                        "kind": { "const": "set_fields" },
+                        "update": element_update
+                    }
+                },
+                {
+                    "type": "object",
+                    "required": ["kind"],
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "not": {
+                                "enum": ["demand_delta", "rating_delta", "set_fields"]
+                            }
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            ]
+        });
+        schemars::Schema::try_from(schema).expect("study edit schema is an object")
     }
 }
 

--- a/powerio-pkg/src/summary.rs
+++ b/powerio-pkg/src/summary.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 /// Element counts, topology, and unit conventions, for a quick read of a package
 /// without deserializing the whole payload.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ObjectSummary {
     /// Element type name -> count, e.g. `{"buses": 118, "branches": 186}`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -18,6 +19,7 @@ pub struct ObjectSummary {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ObjectTopology {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connected_components: Option<u64>,
@@ -28,6 +30,7 @@ pub struct ObjectTopology {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ObjectUnits {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub power: Option<String>,

--- a/powerio-pkg/src/validation.rs
+++ b/powerio-pkg/src/validation.rs
@@ -6,6 +6,7 @@ use crate::diagnostics::{DiagnosticSeverity, StructuredDiagnostic};
 
 /// Overall validation status, ordered worst-last.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum ValidationStatus {
     Ok,
@@ -29,6 +30,7 @@ impl ValidationStatus {
 
 /// Counts per severity. All five are always present; zero where unused.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ValidationCounts {
     #[serde(default)]
     pub fatal: u32,
@@ -56,6 +58,7 @@ impl ValidationCounts {
 
 /// The status of one named validation pass.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ValidationPass {
     pub name: String,
     pub status: ValidationStatus,
@@ -73,6 +76,7 @@ impl ValidationPass {
 /// A cheap-to-inspect summary of validation: an overall status, per-severity
 /// counts, and the named passes that ran.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ValidationSummary {
     pub status: ValidationStatus,
     pub counts: ValidationCounts,

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -1917,6 +1917,25 @@ fn element_ref_wire_requires_row_or_identity() {
 }
 
 #[test]
+#[cfg(feature = "schema")]
+fn element_ref_schema_requires_non_null_row_or_identity() {
+    let schema = serde_json::to_value(schemars::schema_for!(ElementRef)).unwrap();
+    let any_of = schema
+        .get("anyOf")
+        .and_then(serde_json::Value::as_array)
+        .expect("ElementRef schema has anyOf");
+
+    assert!(any_of.iter().any(|entry| {
+        entry.get("required") == Some(&serde_json::json!(["row"]))
+            && entry.pointer("/properties/row/type") == Some(&serde_json::json!("integer"))
+    }));
+    assert!(any_of.iter().any(|entry| {
+        entry.get("required") == Some(&serde_json::json!(["source_uid"]))
+            && entry.pointer("/properties/source_uid/type") == Some(&serde_json::json!("string"))
+    }));
+}
+
+#[test]
 fn goc3_updates_resolve_by_identity_not_row_order() {
     // The uid-less producer fixture from the row assignment test: `prod` is
     // payload row 1 and row 0 is a synthesized identity. Identity alone finds

--- a/powerio/Cargo.toml
+++ b/powerio/Cargo.toml
@@ -18,6 +18,9 @@ categories = ["science", "parsing"]
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+schema = ["dep:schemars"]
+
 [dependencies]
 thiserror = "2"
 num-complex.workspace = true
@@ -28,6 +31,7 @@ petgraph = "0.8"
 serde.workspace = true
 # Format converters (PowerModels / egret JSON) serialize the typed model.
 serde_json.workspace = true
+schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -55,6 +55,7 @@ fn default_base_frequency() -> f64 {
 /// `#[serde(transparent)]` so the JSON transport carries a bare integer, not a
 /// wrapper object; the wire format is unchanged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(transparent)]
 pub struct BusId(pub usize);
 
@@ -73,6 +74,7 @@ impl std::fmt::Display for BusId {
 
 /// Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "UPPERCASE")]
 #[repr(u8)]
 #[non_exhaustive]
@@ -109,6 +111,7 @@ impl BusType {
 
 /// A generator cost curve (`mpc.gencost` row).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct GenCost {
     /// 1 = piecewise linear, 2 = polynomial.
@@ -188,6 +191,7 @@ impl GenCost {
 /// Which format a [`Network`] was read from. Drives the same format byte exact
 /// echo on write.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub enum SourceFormat {
     Matpower,
@@ -258,6 +262,7 @@ impl SourceFormat {
 
 /// A format-neutral power network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Network {
     pub name: String,
@@ -318,6 +323,7 @@ pub struct Network {
 pub type BalancedNetwork = Network;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Bus {
     /// Stable bus id (1-based in MATPOWER; preserved verbatim).
@@ -374,6 +380,7 @@ impl Bus {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Load {
     pub bus: BusId,
@@ -408,6 +415,7 @@ impl Load {
 
 /// Voltage dependence for a transmission load.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(tag = "kind", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum LoadVoltageModel {
@@ -473,6 +481,7 @@ impl LoadVoltageModel {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Shunt {
     pub bus: BusId,
@@ -510,6 +519,7 @@ impl Shunt {
 
 /// How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SwitchedShuntMode {
@@ -523,6 +533,7 @@ pub enum SwitchedShuntMode {
 
 /// One block of a switched shunt: `steps` equal increments of susceptance `b`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct ShuntBlock {
     pub steps: u32,
@@ -542,6 +553,7 @@ impl ShuntBlock {
 /// adjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial
 /// value within the blocks' total range.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SwitchedShuntControl {
     pub mode: SwitchedShuntMode,
@@ -570,6 +582,7 @@ impl SwitchedShuntControl {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Branch {
     pub from: BusId,
@@ -620,6 +633,7 @@ pub struct Branch {
 
 /// Extra branch MVA rating set beyond the canonical A/B/C columns.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct BranchRatingSet {
     pub name: String,
@@ -639,6 +653,7 @@ impl BranchRatingSet {
 /// Per terminal branch shunt admittance in p.u. This is the canonical
 /// physical branch shunt model when present.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct BranchCharging {
     pub g_fr: f64,
@@ -688,6 +703,7 @@ impl BranchCharging {
 
 /// Current limits for a branch, in source units.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct BranchCurrentRatings {
     pub c_rating_a: f64,
@@ -708,6 +724,7 @@ impl BranchCurrentRatings {
 
 /// Solved branch terminal flows in MW/MVAr.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct BranchSolution {
     pub pf: f64,
@@ -797,6 +814,7 @@ impl Branch {
 /// A transmission switch. Closed switches are preserved as data; matrix builders
 /// do not lower them into zero impedance branches.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Switch {
     pub from: BusId,
@@ -842,6 +860,7 @@ impl Switch {
 /// What a regulating transformer's tap (or phase shift) automatically controls.
 /// Maps to the PSS/E control code `COD` and the PSLF transformer `type`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum TransformerControlMode {
@@ -865,6 +884,7 @@ pub enum TransformerControlMode {
 /// `controlled_bus` is the regulated bus (`None` = the transformer's own
 /// terminal). `mva_base` is the winding MVA base the impedance is referred to.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct TransformerControl {
     pub mode: TransformerControlMode,
@@ -904,6 +924,7 @@ impl TransformerControl {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Generator {
     pub bus: BusId,
@@ -929,6 +950,7 @@ pub struct Generator {
     /// schema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a
     /// snapshot that omits it deserializes to the empty set.
     #[serde(default = "default_caps", with = "caps_serde")]
+    #[cfg_attr(feature = "schema", schemars(with = "BTreeMap<String, f64>"))]
     pub caps: GenCaps,
     /// The remote bus whose voltage this generator regulates, when that is not its
     /// own terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.
@@ -1022,6 +1044,7 @@ mod caps_serde {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Storage {
     pub bus: BusId,
@@ -1085,6 +1108,7 @@ impl Storage {
 /// opposite sign). The flip is a format-boundary translation, so a derived view
 /// like `to_normalized` keeps the MATPOWER convention and only scales to per unit.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Hvdc {
     pub from: BusId,
@@ -1147,6 +1171,7 @@ impl Hvdc {
 /// the area slack) that the bus number alone can't. Maps to the PSS/E area record
 /// (`I, ISW, PDES, PTOL, ARNAME`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Area {
     pub number: usize,
@@ -1181,6 +1206,7 @@ impl Area {
 /// (`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/
 /// `DCTAPS`/`SWSHNT`).
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverParams {
     /// Newton power flow mismatch tolerance (`NEWTON TOLN`).
@@ -1226,6 +1252,7 @@ impl SolverParams {
 /// (winding voltage base, turns-ratio units) as the transformer control work
 /// lands without reshaping the [`Transformer3W::z`] array.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Impedance {
     pub r: f64,
@@ -1243,6 +1270,7 @@ impl Impedance {
 /// One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase
 /// shift, nominal voltage, and thermal ratings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Winding {
     pub bus: BusId,
@@ -1283,6 +1311,7 @@ impl Winding {
 /// [`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,
 /// so a 3-winding transformer contributes to `Y_bus` and connectivity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct Transformer3W {
     /// The three windings, in order (primary, secondary, tertiary).

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -25,6 +25,7 @@ pub const NORMALIZED_SOLVER_TABLES_PASS: &str = "balanced-to-normalized-solver-t
 /// buses and branches. Source ids are preserved as metadata; every reference used
 /// for computation is dense and zero based.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NormalizedSolverTables {
     pub pass: String,
@@ -46,6 +47,7 @@ pub struct NormalizedSolverTables {
 
 /// Units carried by [`NormalizedSolverTables`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverTableUnits {
     pub power: String,
@@ -71,6 +73,7 @@ impl Default for SolverTableUnits {
 
 /// Identity and provenance vectors that apply across the tables.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverTableIndex {
     /// Source bus id for each dense bus row. Synthetic 3-winding star buses also
@@ -91,6 +94,7 @@ pub struct SolverTableIndex {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverBusRow {
     pub index: usize,
@@ -113,6 +117,7 @@ pub struct SolverBusRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverLoadRow {
     pub index: usize,
@@ -124,6 +129,7 @@ pub struct SolverLoadRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverShuntRow {
     pub index: usize,
@@ -134,6 +140,7 @@ pub struct SolverShuntRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverBranchRow {
     pub index: usize,
@@ -159,6 +166,7 @@ pub struct SolverBranchRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverSwitchRow {
     pub index: usize,
@@ -175,6 +183,7 @@ pub struct SolverSwitchRow {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum SolverArcTerminal {
     From,
@@ -182,6 +191,7 @@ pub enum SolverArcTerminal {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverArcRow {
     pub index: usize,
@@ -197,6 +207,7 @@ pub struct SolverArcRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverGeneratorRow {
     pub index: usize,
@@ -216,6 +227,7 @@ pub struct SolverGeneratorRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverStorageRow {
     pub index: usize,
@@ -240,6 +252,7 @@ pub struct SolverStorageRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverHvdcRow {
     pub index: usize,
@@ -264,6 +277,7 @@ pub struct SolverHvdcRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct SolverCostRow {
     pub model: u8,


### PR DESCRIPTION
# Serve generated JSON Schemas

Fixes #178.

## Scope

This PR generates JSON Schema documents from the serde models for
`powerio::Network`, `powerio_dist::DistNetwork`, and
`powerio_pkg::NetworkPackage`. The schema files are copied into the Pages
artifact as `schema.json` under the existing identifier URL paths:

- `schema/pio-package/0.1/schema.json`
- `schema/pio-payload-balanced/1/schema.json`
- `schema/pio-payload-multiconductor/1/schema.json`

The docs workflow keeps the existing redirect pages and serves the machine
readable schema beside them. A CI check fails when the committed generated files
drift from the Rust serde models.

## Acceptance Criteria

- The three schema identifier URLs have a `schema.json` file in the built Pages
  artifact.
- The generated schemas use the identifier URLs as `$id`.
- Hand written serde surfaces that need schema help are represented accurately,
  including `BusId` and package element references.
- CI checks the generated files against the Rust models.
- The serde model remains the source of truth.

## Out Of Scope

This PR does not change the `.pio.json` schema version or the package wire
format. After PR4 and PR7 landed, this branch was rebased and the generated
files were refreshed so the IBR/control and study fields appear in the served
documents.

Merge order: 11 of 14. Base: `main`.
