### PR TITLE
Expose study and dist graph bindings

### DIFF
--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -1,8 +1,9 @@
 # Geographic and display data
 
-> **Status: partial.** The distribution graph projection from #182 ships in
-> 0.6.1 as `DistNetwork::graph()`. The coordinate model and GeoLayer
-> interchange remain design work.
+> **Status: partial.** The distribution graph projection from #182 ships as
+> Rust `DistNetwork::graph()`, Python `dist_net.graph()`, and C
+> `pio_dist_graph_json`. The coordinate model and GeoLayer interchange remain
+> design work.
 
 Power system case files disagree about where equipment sits on a map, and most
 say nothing at all. PowerWorld aux exports carry substation latitude and

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -37,6 +37,8 @@ Verb taxonomy:
 | `.pio.json` document JSON | `NetworkPackage::to_json()` | `Package` class / package transport | `to_package` / `write_package` | `pio_package_*` |
 | `.pio.json` operating points | `pkg.operating_points()` | `pkg.operating_points()` | planned | `pio_package_operating_points_json` |
 | Materialize operating point | `pkg.materialize_operating_point(i)` | `pkg.materialize_operating_point(i)` | planned | `pio_package_materialize_operating_point` |
+| `.pio.json` study block | `pkg.study()` | `pkg.study()` | planned | `pio_package_study_json` |
+| Materialize study commit | `pkg.materialize_study_commit(i)` | `pkg.materialize_study_commit(i)` | planned | `pio_package_materialize_study_commit` |
 | Normalized copy | `net.to_normalized()` | `net.to_normalized()` | `to_normalized(net)` | `pio_normalize` |
 | Dense tables | typed table API | `to_dense` | `to_dense` | `pio_*` extractors |
 | PyPSA CSV folder | `read_pypsa_csv_folder` / `write_pypsa_csv_folder` | `read_pypsa_csv_folder` / `net.write_pypsa_csv_folder` | `parse_file(dir; from="pypsa-csv")` / `write_pypsa_csv_folder` | `pio_parse_file` / `pio_write_dir` + `"pypsa-csv"` |
@@ -121,3 +123,4 @@ the distribution C conversion helpers.
 | Text conversion | `powerio_dist::convert_str(text, to, format)` | `dist.convert_str(text, to, format)` | `convert_str(DistNetwork, text, to, format)` | `pio_dist_convert_str(text, from, to, ...)` |
 | Parsed conversion | `net.to_format(to)` | `case.to_format(to)` | `to_format(net, to)` | `pio_dist_to_format` |
 | Parse warnings | `net.warnings` | `case.warnings` | `warnings(net)` | `pio_dist_warnings` |
+| Graph projection | `net.graph()` | `case.graph()` | planned | `pio_dist_graph_json` |

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -51,6 +51,7 @@ normalized = net.to_normalized()
 dense = net.to_dense()       # needs powerio[matrix]
 bprime = net.bprime()        # needs powerio[matrix]
 graph = net.to_networkx()    # needs powerio[graph]
+dist_graph = pio.dist.parse_file("feeder.dss").graph()
 ```
 
 ## Model names
@@ -61,7 +62,8 @@ The old `powerio.Case` compatibility alias was removed in v0.4.
 
 For distribution models, use `powerio.dist.MulticonductorNetwork` or the
 existing `powerio.dist.DistNetwork` handle name. The old
-`powerio.dist.DistCase` alias was removed in v0.4.
+`powerio.dist.DistCase` alias was removed in v0.4. `dist_net.graph()` returns
+the collapsed bus and terminal graph as Python data.
 
 `parse_file(path, from_=None)` reads network case files (inferred from the
 extension, or forced with `from_`); `parse_str(text, format)` reads in-memory
@@ -154,6 +156,9 @@ static `Package` with one point applied; updates resolve by the model rows'
 `ValueError`. GOC3 documents populate this series from the source time series
 while the static model JSON holds the first interval. Network table dicts
 (`net.buses`, `net.loads`, ...) expose each row's `uid`.
+`pkg.study()` returns a Python dict for the package study block, or `None`;
+`pkg.materialize_study_commit(i)` folds cumulative commits through `i` into a
+new static package and clears both replay blocks.
 `pkg.validate()`, `pkg.validation()`, and `pkg.diagnostics()` expose the
 document validation profile, and multiconductor documents lower through
 `pkg.multiconductor_to_balanced_preflight()` and

--- a/docs/src/study-block.md
+++ b/docs/src/study-block.md
@@ -1,8 +1,10 @@
 # The study block
 
-> **Status: Rust package surface.** The `.pio.json` block, validation, uid
-> stamping, and materialization APIs ship in the Rust package crate. CLI,
-> Python, Julia, and C binding surfaces are tracked by #185.
+> **Status: Rust plus C and Python read and materialization surface.** The
+> `.pio.json` block, validation, uid stamping, and materialization APIs ship in
+> the Rust package crate. C and Python expose study readback and commit
+> materialization. CLI, authoring helpers, Julia, and geo related bindings
+> remain tracked by #185.
 
 Interactive tools hold a base case plus an ordered log of edits, and replay the
 log to reconstruct the current operating point. tellegen's `Study` works this
@@ -119,8 +121,12 @@ display concern.
 
 - `NetworkPackage::study()`, `with_study`, `set_study`, `clear_study`,
   `materialize_study_commit(k)`, `materialize_balanced_study_commit(k)`;
+- Python: `pkg.study()` and `pkg.materialize_study_commit(k)`;
+- C ABI: `pio_package_study_json` and
+  `pio_package_materialize_study_commit`;
 - `ensure_payload_uids(&mut Network)` for deterministic payload row identity.
 
 Tracking issues: [#181](https://github.com/eigenergy/powerio/issues/181)
 (block, materialization, uid contract),
-[#185](https://github.com/eigenergy/powerio/issues/185) (bindings and CLI).
+[#185](https://github.com/eigenergy/powerio/issues/185) (remaining bindings and
+CLI).

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -788,6 +788,14 @@ char *pio_package_operating_points_json(const PioPackage *pkg, char *errbuf, siz
 
 #if defined(PIO_PKG)
 /**
+ * Return the package study block as JSON, or `null` when absent. The returned
+ * string is owned by the library; free it with [`pio_string_free`].
+ */
+char *pio_package_study_json(const PioPackage *pkg, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
  * Materialize one operating point into a new static package.
  *
  * The returned handle owns a package with the selected updates applied and no
@@ -797,6 +805,19 @@ PioPackage *pio_package_materialize_operating_point(const PioPackage *pkg,
                                                     int64_t index,
                                                     char *errbuf,
                                                     size_t errlen);
+#endif
+
+#if defined(PIO_PKG)
+/**
+ * Materialize one study commit into a new static package.
+ *
+ * The returned handle owns a package with commits `0..=index` applied and no
+ * operating point series or study block. Free it with [`pio_package_free`].
+ */
+PioPackage *pio_package_materialize_study_commit(const PioPackage *pkg,
+                                                 int64_t index,
+                                                 char *errbuf,
+                                                 size_t errlen);
 #endif
 
 #if defined(PIO_PKG)
@@ -881,6 +902,15 @@ size_t pio_dist_warnings(const PioDistNetwork *net, char *warnbuf, size_t warnle
  * Returns an owned C string (free with [`pio_string_free`]), `NULL` on error.
  */
 char *pio_dist_to_json(const PioDistNetwork *net, char *errbuf, size_t errlen);
+#endif
+
+#if defined(PIO_DIST)
+/**
+ * Serialize the collapsed bus and terminal graph projection for `net` as JSON.
+ * The returned string is owned by the library; free it with
+ * [`pio_string_free`].
+ */
+char *pio_dist_graph_json(const PioDistNetwork *net, char *errbuf, size_t errlen);
 #endif
 
 #if defined(PIO_DIST)

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1614,6 +1614,26 @@ pub unsafe extern "C" fn pio_package_operating_points_json(
     }
 }
 
+/// Return the package study block as JSON, or `null` when absent. The returned
+/// string is owned by the library; free it with [`pio_string_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_study_json(
+    pkg: *const PioPackage,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        finish_package_json(
+            pkg,
+            errbuf,
+            errlen,
+            "panic while reading package study block",
+            |p| serde_json::to_string(&p.package.study).map_err(|e| e.to_string()),
+        )
+    }
+}
+
 /// Materialize one operating point into a new static package.
 ///
 /// The returned handle owns a package with the selected updates applied and no
@@ -1639,6 +1659,37 @@ pub unsafe extern "C" fn pio_package_materialize_operating_point(
                     .map_err(|_| "operating point index must be non-negative".to_string())?;
                 pkg.package
                     .materialize_operating_point(index)
+                    .map_err(|e| e.to_string())
+            },
+        )
+    }
+}
+
+/// Materialize one study commit into a new static package.
+///
+/// The returned handle owns a package with commits `0..=index` applied and no
+/// operating point series or study block. Free it with [`pio_package_free`].
+#[cfg(feature = "pkg")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_package_materialize_study_commit(
+    pkg: *const PioPackage,
+    index: i64,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut PioPackage {
+    unsafe {
+        finish_package(
+            errbuf,
+            errlen,
+            "panic while materializing package study commit",
+            || {
+                let pkg = pkg
+                    .as_ref()
+                    .ok_or_else(|| "package handle is NULL".to_string())?;
+                let index = usize::try_from(index)
+                    .map_err(|_| "study commit index must be non-negative".to_string())?;
+                pkg.package
+                    .materialize_study_commit(index)
                     .map_err(|e| e.to_string())
             },
         )
@@ -1863,6 +1914,26 @@ pub unsafe extern "C" fn pio_dist_to_json(
                 .as_ref()
                 .ok_or_else(|| "distribution network handle is NULL".to_string())?;
             serde_json::to_string(&net.net).map_err(|e| e.to_string())
+        })
+    }
+}
+
+/// Serialize the collapsed bus and terminal graph projection for `net` as JSON.
+/// The returned string is owned by the library; free it with
+/// [`pio_string_free`].
+#[cfg(feature = "dist")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pio_dist_graph_json(
+    net: *const PioDistNetwork,
+    errbuf: *mut c_char,
+    errlen: usize,
+) -> *mut c_char {
+    unsafe {
+        finish_string(errbuf, errlen, "panic while serializing graph JSON", || {
+            let net = net
+                .as_ref()
+                .ok_or_else(|| "distribution network handle is NULL".to_string())?;
+            serde_json::to_string(&net.net.graph()).map_err(|e| e.to_string())
         })
     }
 }
@@ -2359,7 +2430,9 @@ mod tests {
             "char *pio_package_validation_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_diagnostics_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "char *pio_package_operating_points_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
+            "char *pio_package_study_json(const PioPackage *pkg, char *errbuf, size_t errlen);",
             "PioPackage *pio_package_materialize_operating_point(const PioPackage *pkg, int64_t index, char *errbuf, size_t errlen);",
+            "PioPackage *pio_package_materialize_study_commit(const PioPackage *pkg, int64_t index, char *errbuf, size_t errlen);",
             "char *pio_package_multiconductor_to_balanced_preflight_json(const PioPackage *pkg, double base_mva, char *errbuf, size_t errlen);",
             "PioPackage *pio_package_lower_multiconductor_to_balanced(const PioPackage *pkg, double base_mva, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_parse_file(const char *path, const char *from, char *errbuf, size_t errlen);",
@@ -2367,6 +2440,7 @@ mod tests {
             "void pio_dist_network_free(PioDistNetwork *net);",
             "size_t pio_dist_warnings(const PioDistNetwork *net, char *warnbuf, size_t warnlen);",
             "char *pio_dist_to_json(const PioDistNetwork *net, char *errbuf, size_t errlen);",
+            "char *pio_dist_graph_json(const PioDistNetwork *net, char *errbuf, size_t errlen);",
             "PioDistNetwork *pio_dist_from_json(const char *text, char *errbuf, size_t errlen);",
             "char *pio_dist_to_format(const PioDistNetwork *net, const char *to, char *warnbuf, size_t warnlen, char *errbuf, size_t errlen);",
             "char *pio_dist_convert_file(const char *path, const char *from, const char *to, char *warnbuf, size_t warnlen, char *errbuf, size_t errlen);",
@@ -3188,6 +3262,79 @@ mpc.branch = [
 
     #[cfg(feature = "pkg")]
     #[test]
+    fn package_study_json_and_materialize_commit() {
+        use powerio_pkg::{ElementRef, NetworkPackage, StudyBlock, StudyCommit, StudyEdit};
+
+        let case = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data")
+            .join("case9.m");
+        let net = powerio::parse_str(&std::fs::read_to_string(case).unwrap(), "matpower")
+            .unwrap()
+            .network;
+        let mut commit = StudyCommit::default();
+        commit.label = Some("load step".to_owned());
+        commit.edits.push(StudyEdit::DemandDelta {
+            bus: ElementRef::by_source_uid("buses", "buses:0"),
+            p_mw: 7.0,
+            q_mvar: Some(3.0),
+        });
+        let mut study = StudyBlock::default();
+        study.label = Some("binding study".to_owned());
+        study.commits.push(commit);
+        let package = NetworkPackage::from_balanced(net).with_study(study);
+        let json = CString::new(package.to_json().unwrap()).unwrap();
+
+        let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+        unsafe {
+            let pkg = pio_package_parse_str(json.as_ptr(), err.as_mut_ptr(), err.len());
+            assert!(
+                !pkg.is_null(),
+                "package parse_str failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+
+            let study = package_report_json(pio_package_study_json, pkg);
+            assert_eq!(study["label"], serde_json::json!("binding study"));
+            assert_eq!(
+                study["commits"][0]["edits"][0]["kind"],
+                serde_json::json!("demand_delta")
+            );
+
+            let materialized =
+                pio_package_materialize_study_commit(pkg, 0, err.as_mut_ptr(), err.len());
+            assert!(
+                !materialized.is_null(),
+                "study materialization failed: {}",
+                CStr::from_ptr(err.as_ptr()).to_str().unwrap()
+            );
+            let materialized_json = package_json(materialized);
+            assert!(materialized_json.get("study").is_none());
+            assert!(materialized_json.get("operating_points").is_none());
+            let loads = materialized_json["model"]["balanced_network"]["loads"]
+                .as_array()
+                .unwrap();
+            assert!(loads.iter().any(|load| {
+                load["uid"] == serde_json::json!("study:load:buses:0")
+                    && load["p"] == serde_json::json!(7.0)
+                    && load["q"] == serde_json::json!(3.0)
+            }));
+
+            let negative =
+                pio_package_materialize_study_commit(pkg, -1, err.as_mut_ptr(), err.len());
+            assert!(negative.is_null());
+            let message = CStr::from_ptr(err.as_ptr()).to_str().unwrap();
+            assert!(
+                message.contains("study commit index must be non-negative"),
+                "unexpected error: {message}"
+            );
+
+            pio_package_free(materialized);
+            pio_package_free(pkg);
+        }
+    }
+
+    #[cfg(feature = "pkg")]
+    #[test]
     fn package_parse_free_to_json_and_reports() {
         let net = case9();
         let mut err = [0 as c_char; PIO_ERRBUF_MIN];
@@ -3678,6 +3825,49 @@ mpc.branch = [
             unsafe { pio_string_free(s) };
 
             unsafe { pio_dist_network_free(net) };
+        }
+
+        #[test]
+        fn graph_json_reports_bus_edge_projection() {
+            let path = fourwire_cstr();
+            let mut err = [0 as c_char; PIO_ERRBUF_MIN];
+            let net = unsafe {
+                pio_dist_parse_file(path.as_ptr(), std::ptr::null(), err.as_mut_ptr(), err.len())
+            };
+            assert!(
+                !net.is_null(),
+                "{}",
+                unsafe { CStr::from_ptr(err.as_ptr()) }.to_str().unwrap()
+            );
+
+            let graph = unsafe { pio_dist_graph_json(net, err.as_mut_ptr(), err.len()) };
+            assert!(
+                !graph.is_null(),
+                "graph json failed: {}",
+                unsafe { CStr::from_ptr(err.as_ptr()) }.to_str().unwrap()
+            );
+            let graph_json: serde_json::Value =
+                serde_json::from_str(unsafe { CStr::from_ptr(graph) }.to_str().unwrap()).unwrap();
+            let buses = graph_json["buses"].as_array().unwrap();
+            assert_eq!(buses.len(), 2);
+            assert!(buses.iter().any(|bus| {
+                bus["id"] == serde_json::json!("sourcebus")
+                    && bus["has_source"] == serde_json::json!(true)
+            }));
+            let edges = graph_json["edges"].as_array().unwrap();
+            assert!(edges.iter().any(|edge| {
+                edge["kind"] == serde_json::json!("line")
+                    && edge["id"] == serde_json::json!("l1")
+                    && edge["from"] == serde_json::json!("sourcebus")
+                    && edge["to"] == serde_json::json!("loadbus")
+                    && edge["n_phases"] == serde_json::json!(4)
+                    && edge["conductors"].as_array().unwrap().len() == 4
+            }));
+
+            unsafe {
+                pio_string_free(graph);
+                pio_dist_network_free(net);
+            }
         }
 
         #[test]

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -1341,6 +1341,12 @@ impl PyDistNetwork {
         Ok((conv.text, conv.warnings))
     }
 
+    /// The collapsed bus and terminal graph projection as JSON.
+    fn graph_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.net.graph())
+            .map_err(|e| PowerIOError::new_err(format!("serializing graph JSON: {e}")))
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "DistNetwork(n_buses={}, n_lines={}, n_transformers={}, n_loads={})",
@@ -1485,10 +1491,23 @@ impl PyPackage {
         serde_json::to_string(&self.pkg.operating_points).map_err(package_pyerr)
     }
 
+    /// The study block as JSON, or `null` when absent.
+    fn study_json(&self) -> PyResult<String> {
+        serde_json::to_string(&self.pkg.study).map_err(package_pyerr)
+    }
+
     /// Materialize one operating point into a new static package handle.
     fn materialize_operating_point(&self, index: usize) -> PyResult<Self> {
         self.pkg
             .materialize_operating_point(index)
+            .map_err(package_pyerr)
+            .map(|pkg| Self { pkg })
+    }
+
+    /// Materialize one study commit into a new static package handle.
+    fn materialize_study_commit(&self, index: usize) -> PyResult<Self> {
+        self.pkg
+            .materialize_study_commit(index)
             .map_err(package_pyerr)
             .map(|pkg| Self { pkg })
     }

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -775,9 +775,17 @@ class Package:
         """
         return _json.loads(self._inner.operating_points_json())
 
+    def study(self) -> Any:
+        """The study block as Python data, or ``None``."""
+        return _json.loads(self._inner.study_json())
+
     def materialize_operating_point(self, index: int) -> "Package":
         """Materialize one operating point into a new static package."""
         return Package(self._inner.materialize_operating_point(index))
+
+    def materialize_study_commit(self, index: int) -> "Package":
+        """Materialize one study commit into a new static package."""
+        return Package(self._inner.materialize_study_commit(index))
 
     def validate(self) -> None:
         """Run the package semantic validation profile in place."""

--- a/python/powerio/dist.py
+++ b/python/powerio/dist.py
@@ -17,6 +17,7 @@ the :class:`~powerio.Conversion` warnings instead of dropping it silently.
 
 from __future__ import annotations
 
+import json as _json
 from typing import Any, Optional
 
 from . import Conversion, _powerio
@@ -96,6 +97,10 @@ class DistNetwork:
         """Serialize to ``to`` from the typed model, bypassing source echo."""
         text, warnings = self._inner.to_canonical_format(to)
         return Conversion(text, warnings)
+
+    def graph(self) -> Any:
+        """Collapsed bus and terminal graph as Python data."""
+        return _json.loads(self._inner.graph_json())
 
     def __repr__(self) -> str:
         return self._inner.__repr__()

--- a/python/tests/test_dist.py
+++ b/python/tests/test_dist.py
@@ -44,6 +44,19 @@ def test_cross_format_writes():
     assert "bus" in json.loads(bmopf.text)
 
 
+def test_graph_projection():
+    graph = dist.parse_file(FOURWIRE).graph()
+    assert {bus["id"] for bus in graph["buses"]} == {"sourcebus", "loadbus"}
+    source = next(bus for bus in graph["buses"] if bus["id"] == "sourcebus")
+    assert source["has_source"] is True
+    edge = next(edge for edge in graph["edges"] if edge["id"] == "l1")
+    assert edge["kind"] == "line"
+    assert edge["from"] == "sourcebus"
+    assert edge["to"] == "loadbus"
+    assert edge["n_phases"] == 4
+    assert len(edge["conductors"]) == 4
+
+
 def test_json_sniffing_round_trip(tmp_path):
     case = dist.parse_file(FOURWIRE)
     for fmt in ("pmd-json", "bmopf-json"):

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -56,6 +56,42 @@ def test_package_operating_points_and_materialize():
     assert sum(dense.demand.pd) == pytest.approx(30.0)
 
 
+def test_package_study_and_materialize_commit():
+    import json
+
+    pkg = pio.Package.from_file(DATA / "case9.m")
+    doc = json.loads(pkg.to_json())
+    doc["study"] = {
+        "label": "binding study",
+        "commits": [
+            {
+                "label": "load step",
+                "edits": [
+                    {
+                        "kind": "demand_delta",
+                        "bus": {"table": "buses", "source_uid": "buses:0"},
+                        "p_mw": 7.0,
+                        "q_mvar": 3.0,
+                    }
+                ],
+            }
+        ],
+    }
+    pkg = pio.Package.from_json(json.dumps(doc))
+
+    assert pkg.study()["label"] == "binding study"
+    static_pkg = pkg.materialize_study_commit(0)
+    assert static_pkg.study() is None
+    assert static_pkg.operating_points() is None
+    loads = static_pkg.as_balanced().loads
+    assert any(
+        load["uid"] == "study:load:buses:0"
+        and load["p"] == pytest.approx(7.0)
+        and load["q"] == pytest.approx(3.0)
+        for load in loads
+    )
+
+
 def test_package_without_operating_points():
     pkg = pio.Package.from_file(DATA / "case9.m")
     assert pkg.operating_points() is None


### PR DESCRIPTION
Merge order: 2 of 7 in the v0.6.2/v0.6.3 geo interop series. Base: `main`.

Part of #185.

## Scope

This exposes the already shipped study block and distribution graph model through the binding layers:

- adds C ABI functions `pio_dist_graph_json`, `pio_package_study_json`, and `pio_package_materialize_study_commit`
- regenerates `powerio-capi/include/powerio.h` and extends the pinned ABI manifest test
- adds Python wrappers `dist_net.graph()`, `pkg.study()`, and `pkg.materialize_study_commit(k)`
- documents the new C and Python accessors without marking #185 complete

## Validation

- `cargo test -p powerio-capi package_study_json_and_materialize_commit -- --nocapture`
- `cargo test -p powerio-capi graph_json_reports_bus_edge_projection -- --nocapture`
- `scripts/capi-header-parity.sh`
- `cargo fmt --all --check`
- `.venv/bin/maturin develop --release`
- `.venv/bin/python -m pytest python/tests -q`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`

## Review

- Local review found and fixed the Python graph JSON error mapper and docs wording.
- Fresh reviewer agent found no material issues.

## Out of Scope

- geo binding symbols from the remaining half of #185
- typed geographic fields (#180)
- balanced format coordinate IO (#183)
- GeoLayer document support (#184)
- PowerIO.jl changes