### PR TITLE
Preserve fixed OpenDSS transformer taps in BMOPF export

### DIFF
--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -607,7 +607,7 @@ const DISTRIBUTION_FORMATS: [DistributionFormat; 3] = [
     },
 ];
 
-const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 188, 120], [1, 0, 0], [22, 117, 0]];
+const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 188, 120], [1, 0, 0], [22, 72, 0]];
 
 const DISTRIBUTION_CASES: [(&str, &str, DistributionFormat); 7] = [
     (

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -56,9 +56,17 @@ const IBR_EXTRA_FIELDS: &[&str] = &[
 
 const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 4] =
     ["g_no_load", "b_no_load", "%noloadloss", "%imag"];
-const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 10] = [
+const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
     "tap_min",
     "tap_max",
+    "mintap",
+    "maxtap",
+    "numtaps",
+    "pmd_tm_set",
+    "pmd_tm_lb",
+    "pmd_tm_ub",
+    "pmd_tm_fix",
+    "pmd_tm_step",
     "g_no_load",
     "b_no_load",
     "r_neutral_from",
@@ -794,6 +802,7 @@ impl Writer {
                 .insert(name, v);
         };
         for t in &net.transformers {
+            self.warn_nonuniform_per_phase_taps(t);
             match classify(t) {
                 Kind::SinglePhase => {
                     if t.windings.iter().any(|w| w.conn == WindingConn::Delta) {
@@ -928,7 +937,7 @@ impl Writer {
         o.insert("terminal_map_from".into(), json!(from.terminal_map));
         o.insert("terminal_map_to".into(), json!(to.terminal_map));
         self.transformer_neutral_fields(&mut o, t, from, to);
-        self.transformer_tap_fields(&mut o, t, from);
+        self.transformer_tap_fields(&mut o, t, from, to);
         if emit_no_load {
             self.transformer_no_load_fields(&mut o, t, from, s);
         }
@@ -971,6 +980,21 @@ impl Writer {
             / (v_new * v_new);
         let r_neutral = self.center_tap_neutral(t, "r_neutral", w2.r_neutral, w3.r_neutral);
         let x_neutral = self.center_tap_neutral(t, "x_neutral", w2.x_neutral, w3.x_neutral);
+        if (w2.tap - w3.tap).abs() > 1e-9 {
+            let mut details = Map::new();
+            details.insert("from_tap".into(), json!(from.tap));
+            details.insert("secondary_taps".into(), json!([w2.tap, w3.tap]));
+            details.insert("emitted_secondary_tap".into(), json!(w2.tap));
+            self.transformer_diagnostic(
+                t,
+                "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_TAP_COLLAPSED",
+                format!(
+                    "transformer {}: center tap secondary half winding taps ({}, {}) differ; emitted the first half tap",
+                    t.name, w2.tap, w3.tap
+                ),
+                details,
+            );
+        }
         let to = Winding {
             bus: w2.bus.clone(),
             terminal_map: {
@@ -982,7 +1006,7 @@ impl Writer {
             v_ref: v_new,
             s_rating: from.s_rating,
             r_pct: r_pct_new,
-            tap: 1.0,
+            tap: w2.tap,
             r_neutral,
             x_neutral,
         };
@@ -1063,7 +1087,7 @@ impl Writer {
         o.insert("terminal_map_from".into(), json!(from.terminal_map));
         o.insert("terminal_map_to".into(), json!(to.terminal_map));
         self.transformer_neutral_fields(&mut o, t, from, to);
-        self.transformer_tap_fields(&mut o, t, from);
+        self.transformer_tap_fields(&mut o, t, from, to);
         self.transformer_no_load_fields(&mut o, t, from, s);
         self.transformer_extras_dropped(t, &TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS);
         o.into()
@@ -1229,25 +1253,59 @@ impl Writer {
         o: &mut Map<String, Value>,
         t: &DistTransformer,
         from: &Winding,
+        to: &Winding,
     ) {
-        if (from.tap - 1.0).abs() > 1e-12 || t.extras.contains_key("tap") {
-            o.insert("tap".into(), self.num(from.tap, "transformer tap"));
+        if to.tap.abs() <= 1e-12 {
+            if (from.tap - 1.0).abs() > 1e-12 || (to.tap - 1.0).abs() > 1e-12 {
+                let mut details = Map::new();
+                details.insert("from_tap".into(), json!(from.tap));
+                details.insert("to_tap".into(), json!(to.tap));
+                self.transformer_diagnostic(
+                    t,
+                    "EMIT.BMOPF.TRANSFORMER_TAP_DROPPED",
+                    format!(
+                        "transformer {}: to-side tap {} cannot form a finite BMOPF ratio; dropped",
+                        t.name, to.tap
+                    ),
+                    details,
+                );
+            }
+        } else {
+            let tap = from.tap / to.tap;
+            if (tap - 1.0).abs() > 1e-12 || t.extras.contains_key("tap") {
+                o.insert("tap".into(), self.num(tap, "transformer tap"));
+            }
         }
         for key in ["tap_min", "tap_max"] {
             if let Some(v) = extras_number(&t.extras, key) {
                 o.insert(key.into(), self.num(v, &format!("transformer {key}")));
             }
         }
-        for w in t.windings.iter().skip(1) {
-            if (w.tap - 1.0).abs() > 1e-12 {
+    }
+
+    fn warn_nonuniform_per_phase_taps(&mut self, t: &DistTransformer) {
+        let Some(tm_set) = t.extras.get("pmd_tm_set").and_then(Value::as_array) else {
+            return;
+        };
+        for (idx, raw) in tm_set.iter().enumerate() {
+            let Some(taps) = tap_values(raw) else {
+                continue;
+            };
+            let Some(first) = taps.first().copied() else {
+                continue;
+            };
+            if taps.iter().any(|tap| (tap - first).abs() > 1e-9) {
                 let mut details = Map::new();
-                details.insert("tap".into(), json!(w.tap));
+                details.insert("winding".into(), json!(idx + 1));
+                details.insert("source_taps".into(), json!(taps));
+                details.insert("emitted_winding_tap".into(), json!(first));
                 self.transformer_diagnostic(
                     t,
-                    "EMIT.BMOPF.TRANSFORMER_TAP_DROPPED",
+                    "EMIT.BMOPF.TRANSFORMER_PER_PHASE_TAP_COLLAPSED",
                     format!(
-                        "transformer {}: non-from-side tap {} has no BMOPF field; dropped",
-                        t.name, w.tap
+                        "transformer {}: winding {} has non-uniform per phase taps; emitted the first phase tap",
+                        t.name,
+                        idx + 1
                     ),
                     details,
                 );
@@ -1636,6 +1694,22 @@ fn raw_bmopf_value(u: &crate::model::UntypedObject) -> Option<Value> {
 
 fn extras_number(extras: &crate::model::Extras, key: &str) -> Option<f64> {
     let v = extras.get(key)?;
+    v.as_f64()
+        .or_else(|| v.as_i64().map(|v| v as f64))
+        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        .filter(|v| v.is_finite())
+}
+
+fn tap_values(v: &Value) -> Option<Vec<f64>> {
+    if let Some(items) = v.as_array() {
+        let out: Vec<f64> = items.iter().filter_map(value_number).collect();
+        Some(out)
+    } else {
+        value_number(v).map(|tap| vec![tap])
+    }
+}
+
+fn value_number(v: &Value) -> Option<f64> {
     v.as_f64()
         .or_else(|| v.as_i64().map(|v| v as f64))
         .or_else(|| v.as_str().and_then(|s| s.parse().ok()))

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use powerio_dist::dss::{parse_dss_file, parse_dss_str};
 use powerio_dist::{
     Configuration, DiagnosticSeverity, DiagnosticStage, DistBus, DistLineCode, DistNetwork,
-    DistTransformer, Winding, WindingConn, parse_bmopf_file, parse_bmopf_str, write_bmopf_json,
-    write_dss,
+    DistTransformer, Winding, WindingConn, parse_bmopf_file, parse_bmopf_str, parse_pmd_str,
+    write_bmopf_json, write_dss,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -709,6 +709,157 @@ fn transformer_tap_fields_round_trip_through_bmopf() {
     assert_eq!(t["tap_max"], 1.1);
     assert_eq!(t["g_no_load"], serde_json::json!(0.000_001));
     assert_eq!(t["b_no_load"], serde_json::json!(0.0));
+}
+
+#[test]
+fn dss_fixed_to_side_tap_emits_bmopf_ratio_without_bounds() {
+    let v = schema_validator();
+    let net = parse_dss_str(
+        "New Circuit.tap basekv=7.2 pu=1.0 phases=1 bus1=src.1\n\
+         New Transformer.t1 phases=1 windings=2 buses=(src.1, load.1) \
+         conns=(wye, wye) kvs=(7.2, 0.24) kvas=(25, 25) taps=(1.0, 1.05) \
+         mintap=0.9 maxtap=1.1 numtaps=32 xhl=2.0 %Rs=(0.5, 0.5)\n",
+    );
+    assert!((net.transformers[0].windings[1].tap - 1.05).abs() < 1e-12);
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    assert!(
+        out.warnings.iter().all(|w| !w.contains("TAP_DROPPED")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("mintap") && !w.contains("maxtap") && !w.contains("numtaps")),
+        "{:?}",
+        out.warnings
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["single_phase"]["t1"];
+    assert!((t["tap"].as_f64().unwrap() - (1.0 / 1.05)).abs() < 1e-12);
+    assert!(t.get("tap_min").is_none(), "{t:?}");
+    assert!(t.get("tap_max").is_none(), "{t:?}");
+}
+
+#[test]
+fn dss_center_tap_uses_first_secondary_tap_and_warns_if_halves_differ() {
+    let net = parse_dss_str(
+        "New Circuit.ct basekv=7.2 pu=1.0 phases=1 bus1=sourcebus.1\n\
+         New Transformer.t1 phases=1 windings=3\n\
+         ~ wdg=1 bus=sourcebus.1 kv=7.2 kva=25 conn=wye tap=1.02 %R=0.6\n\
+         ~ wdg=2 bus=secondary.1.0 kv=0.12 kva=25 conn=wye tap=1.01 %R=1.2\n\
+         ~ wdg=3 bus=secondary.0.2 kv=0.12 kva=25 conn=wye tap=1.03 %R=1.2\n\
+         ~ xhl=2.04 xht=2.04 xlt=1.36\n",
+    );
+
+    let out = write_bmopf_json(&net);
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("EMIT.BMOPF.TRANSFORMER_CENTER_TAP_TAP_COLLAPSED")),
+        "{:?}",
+        out.warnings
+    );
+    let diag = diagnostic(
+        &out,
+        "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_TAP_COLLAPSED",
+        "transformer t1",
+    );
+    assert_eq!(
+        diag.details["secondary_taps"],
+        serde_json::json!([1.01, 1.03])
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["center_tap"]["t1"];
+    assert!((t["tap"].as_f64().unwrap() - (1.02 / 1.01)).abs() < 1e-12);
+}
+
+#[test]
+fn pmd_uniform_per_phase_taps_emit_ratio_without_warning() {
+    let net = parse_pmd_str(
+        r#"{
+          "data_model": "ENGINEERING",
+          "transformer": {"reg": {"bus": ["b1", "b2"],
+            "connections": [[1, 2, 3, 4], [1, 2, 3, 4]],
+            "configuration": ["WYE", "WYE"], "polarity": [1, 1],
+            "rw": [0.005, 0.005], "xsc": [0.01],
+            "sm_nom": [1666.0, 1666.0], "vm_nom": [2.4, 2.4],
+            "tm_set": [[1.0, 1.0, 1.0], [1.05, 1.05, 1.05]],
+            "tm_lb": [[0.9, 0.9, 0.9], [0.9, 0.9, 0.9]],
+            "tm_ub": [[1.1, 1.1, 1.1], [1.1, 1.1, 1.1]],
+            "tm_fix": [[true, true, true], [false, false, false]],
+            "tm_step": [[0.03125, 0.03125, 0.03125], [0.03125, 0.03125, 0.03125]],
+            "status": "ENABLED"}}
+        }"#,
+    )
+    .unwrap();
+
+    let out = write_bmopf_json(&net);
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("TRANSFORMER_PER_PHASE_TAP_COLLAPSED")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("TRANSFORMER_EXTRA_DROPPED") && !w.contains("pmd_tm_")),
+        "{:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["single_phase"]["reg_1"];
+    assert!((t["tap"].as_f64().unwrap() - (1.0 / 1.05)).abs() < 1e-12);
+    assert!(t.get("tap_min").is_none());
+    assert!(t.get("tap_max").is_none());
+}
+
+#[test]
+fn pmd_nonuniform_per_phase_taps_warn_with_stable_code() {
+    let net = parse_pmd_str(
+        r#"{
+          "data_model": "ENGINEERING",
+          "transformer": {"reg": {"bus": ["b1", "b2"],
+            "connections": [[1, 2, 3, 4], [1, 2, 3, 4]],
+            "configuration": ["WYE", "WYE"], "polarity": [1, 1],
+            "rw": [0.005, 0.005], "xsc": [0.01],
+            "sm_nom": [1666.0, 1666.0], "vm_nom": [2.4, 2.4],
+            "tm_set": [[1.0, 1.0, 1.0], [1.05, 1.04, 1.05]],
+            "status": "ENABLED"}}
+        }"#,
+    )
+    .unwrap();
+
+    let out = write_bmopf_json(&net);
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("EMIT.BMOPF.TRANSFORMER_PER_PHASE_TAP_COLLAPSED")),
+        "{:?}",
+        out.warnings
+    );
+    let diag = diagnostic(
+        &out,
+        "EMIT.BMOPF.TRANSFORMER_PER_PHASE_TAP_COLLAPSED",
+        "transformer reg",
+    );
+    assert_eq!(diag.severity, DiagnosticSeverity::Warning);
+    assert_eq!(diag.stage, DiagnosticStage::Emit);
+    assert_eq!(diag.details["winding"], serde_json::json!(2));
+    assert_eq!(
+        diag.details["source_taps"],
+        serde_json::json!([1.05, 1.04, 1.05])
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["single_phase"]["reg_1"];
+    assert!((t["tap"].as_f64().unwrap() - (1.0 / 1.05)).abs() < 1e-12);
 }
 
 #[test]


### PR DESCRIPTION
# Preserve fixed OpenDSS transformer taps in BMOPF export

Merge order: 2 of 7. Base: `main` after #220.

Fixes #214.

## Scope

- Emit BMOPF `tap` for supported OpenDSS transformer subtypes when source winding taps define a fixed off nominal ratio.
- Use the BMOPF single from-side multiplier `tap = tap_from / tap_to`.
- Keep `tap_min` and `tap_max` unset for OpenDSS default regulator limits.
- Report a structured warning only when source tap detail is finer than BMOPF can represent: non-uniform per phase taps, or unequal center tap secondary half winding taps.

## Acceptance

- DSS to BMOPF preserves a fixed two winding tap.
- `tap_min` and `tap_max` are absent for default OpenDSS regulator limits.
- Uniform per phase taps do not warn.
- Non-uniform per phase taps warn with a stable diagnostic code.
- Unequal center tap secondary half winding taps warn with a stable diagnostic code.
- BMOPF JSON for fixtures without fixed taps stays byte identical.

## Out of Scope

- No center tap leakage or convention repair; that remains A3.
- No delta_wye leakage referral change; that remains A4.
- No n_winding reconstruction or delta roll change; those remain A5.
- No capability flag change; that remains A7.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p powerio-dist --test bmopf tap -- --nocapture`
- `POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a2-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
- End to end:
  - `tests/data/dist/opendss/ieee13/IEEE13Nodeckt.dss` converts to byte identical BMOPF JSON on `main` and this branch.
  - A fixed tap DSS fixture emits `tap = 1 / 1.05` and omits `tap_min` / `tap_max`.
  - The PMD IEEE13 fixture emits no `pmd_tm_*` carrier fields into BMOPF JSON.

## Review

- Local review found that unequal center tap secondary half winding taps also need a stable warning; fixed with `EMIT.BMOPF.TRANSFORMER_CENTER_TAP_TAP_COLLAPSED`.
- Fresh reviewer found PMD `tm_lb`, `tm_ub`, `tm_fix`, and `tm_step` carriers still warning as dropped extras; fixed by treating them as internal carrier fields while keeping BMOPF tap bounds unset.
