### PR TITLE
Emit BMOPF center tap transformers in the BMOPF convention

### DIFF
--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -607,7 +607,7 @@ const DISTRIBUTION_FORMATS: [DistributionFormat; 3] = [
     },
 ];
 
-const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 188, 120], [1, 0, 0], [22, 72, 0]];
+const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 187, 120], [1, 0, 0], [22, 71, 0]];
 
 const DISTRIBUTION_CASES: [(&str, &str, DistributionFormat); 7] = [
     (

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -826,19 +826,24 @@ impl Reader<'_> {
                 0.0
             }
         };
-        let (r_from_pct, r_to_pct, xsc) = if three_phase {
+        let (r_from_pct, r_to_pct, xsc_pct) = if three_phase {
             let wye_v = if subtype == "wye_delta" { v_from } else { v_to };
             // The schema puts one series impedance on the wye side; the
             // model splits resistance evenly across the windings.
             let r = pct(o.get("r_series").map_or(0.0, f), wye_v);
             let x = pct(o.get("x_series").map_or(0.0, f), wye_v);
-            (r / 2.0, r / 2.0, x)
+            (r / 2.0, r / 2.0, vec![x])
         } else {
             let r_from = pct(o.get("r_series_from").map_or(0.0, f), v_from);
             let r_to = pct(o.get("r_series_to").map_or(0.0, f), v_to);
-            let x = pct(o.get("x_series_from").map_or(0.0, f), v_from)
-                + pct(o.get("x_series_to").map_or(0.0, f), v_to);
-            (r_from, r_to, x)
+            let x_from = pct(o.get("x_series_from").map_or(0.0, f), v_from);
+            let x_to = pct(o.get("x_series_to").map_or(0.0, f), v_to);
+            let xsc = if subtype == "center_tap" {
+                vec![x_from + x_to, x_from + x_to, 2.0 * x_to]
+            } else {
+                vec![x_from + x_to]
+            };
+            (r_from, r_to, xsc)
         };
 
         let conn = |delta: bool| {
@@ -872,7 +877,7 @@ impl Reader<'_> {
                 x_neutral: first_float(o.get("x_neutral_to")),
             },
         ];
-        expand_center_tap_windings(subtype, &mut windings);
+        expand_center_tap_windings(subtype, &mut windings, &self.net.buses);
         let mut extras = take_extras(
             o,
             &known,
@@ -896,7 +901,7 @@ impl Reader<'_> {
         DistTransformer {
             name: name.to_string(),
             windings,
-            xsc_pct: vec![xsc],
+            xsc_pct,
             phases,
             extras,
         }
@@ -998,21 +1003,35 @@ impl Reader<'_> {
     }
 }
 
-fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>) {
+fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>, buses: &[DistBus]) {
     if subtype != "center_tap" || windings[1].terminal_map.len() < 3 {
         return;
     }
     let to = windings.pop().expect("secondary winding exists");
-    let common = to.terminal_map.last().cloned().unwrap_or_default();
-    let hot_a = to.terminal_map[0].clone();
-    let hot_b = to.terminal_map[1].clone();
+    let neutral_idx = center_tap_neutral_index(&to, buses);
+    let canonical = neutral_idx == 1;
+    let common = to
+        .terminal_map
+        .get(neutral_idx)
+        .cloned()
+        .unwrap_or_default();
+    let hots: Vec<String> = to
+        .terminal_map
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, term)| (idx != neutral_idx).then_some(term.clone()))
+        .collect();
+    let hot_a = hots.first().cloned().unwrap_or_default();
+    let hot_b = hots.get(1).cloned().unwrap_or_default();
+    let v_ref = if canonical { to.v_ref } else { to.v_ref / 2.0 };
+    let r_pct = if canonical { to.r_pct } else { to.r_pct * 2.0 };
     let half = Winding {
         bus: to.bus.clone(),
         terminal_map: vec![hot_a, common.clone()],
         conn: WindingConn::Wye,
-        v_ref: to.v_ref / 2.0,
+        v_ref,
         s_rating: to.s_rating,
-        r_pct: to.r_pct * 2.0,
+        r_pct,
         tap: to.tap,
         r_neutral: to.r_neutral,
         x_neutral: to.x_neutral,
@@ -1021,15 +1040,31 @@ fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>) {
         bus: to.bus,
         terminal_map: vec![common, hot_b],
         conn: WindingConn::Wye,
-        v_ref: to.v_ref / 2.0,
+        v_ref,
         s_rating: to.s_rating,
-        r_pct: to.r_pct * 2.0,
+        r_pct,
         tap: to.tap,
         r_neutral: None,
         x_neutral: None,
     };
     windings.push(half);
     windings.push(other_half);
+}
+
+fn center_tap_neutral_index(to: &Winding, buses: &[DistBus]) -> usize {
+    if let Some(bus) = buses.iter().find(|bus| bus.id == to.bus)
+        && let Some((idx, _)) = to
+            .terminal_map
+            .iter()
+            .enumerate()
+            .find(|(_, term)| bus.grounded.iter().any(|ground| ground == *term))
+    {
+        return idx;
+    }
+    to.terminal_map
+        .iter()
+        .position(|term| term.eq_ignore_ascii_case("n") || term == "4")
+        .unwrap_or_else(|| to.terminal_map.len() - 1)
 }
 
 fn n_winding_internal_v_ref(conn: WindingConn, terminal_map: &[String], bmopf_v_nom: f64) -> f64 {

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -948,36 +948,9 @@ impl Writer {
     }
 
     fn center_tap(&mut self, t: &DistTransformer) -> Value {
-        // The split secondary collapses to one to side winding: voltage is
-        // the full 240 V across the outer terminals, the center tap is the
-        // shared terminal, listed last.
         let from = &t.windings[0];
         let (w2, w3) = (&t.windings[1], &t.windings[2]);
-        let common = w2
-            .terminal_map
-            .iter()
-            .find(|term| w3.terminal_map.contains(term))
-            .cloned()
-            .unwrap_or_default();
-        let mut hots: Vec<String> = Vec::new();
-        for term in w2.terminal_map.iter().chain(&w3.terminal_map) {
-            if *term != common && !hots.contains(term) {
-                hots.push(term.clone());
-            }
-        }
-        // Percent resistance does not transfer to the doubled voltage:
-        // each winding's impedance base is its own v^2/s (PMD eng2math
-        // builds zbase per winding from vnom^2/snom). Convert each half to
-        // ohms on its own base, sum the series path, and express the total
-        // on the base two_winding gives the combined winding,
-        // v_new^2/from.s_rating. Equal ratings make the s factors exactly
-        // 1, leaving the plain v^2 weighting. The leakage reactance needs
-        // no such move: two_winding applies xsc_pct at the from side,
-        // whose base the collapse does not touch.
-        let v_new = w2.v_ref + w3.v_ref;
-        let r_pct_new = (w2.r_pct * w2.v_ref * w2.v_ref * (from.s_rating / w2.s_rating)
-            + w3.r_pct * w3.v_ref * w3.v_ref * (from.s_rating / w3.s_rating))
-            / (v_new * v_new);
+        let common = center_tap_common_terminal(w2, w3);
         let r_neutral = self.center_tap_neutral(t, "r_neutral", w2.r_neutral, w3.r_neutral);
         let x_neutral = self.center_tap_neutral(t, "x_neutral", w2.x_neutral, w3.x_neutral);
         if (w2.tap - w3.tap).abs() > 1e-9 {
@@ -995,31 +968,7 @@ impl Writer {
                 details,
             );
         }
-        let to = Winding {
-            bus: w2.bus.clone(),
-            terminal_map: {
-                let mut m = hots;
-                m.push(common);
-                m
-            },
-            conn: WindingConn::Wye,
-            v_ref: v_new,
-            s_rating: from.s_rating,
-            r_pct: r_pct_new,
-            tap: w2.tap,
-            r_neutral,
-            x_neutral,
-        };
-        self.transformer_diagnostic(
-            t,
-            "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_COLLAPSED",
-            format!(
-                "transformer {}: center tap secondary collapsed to one winding; the \
-                 xht/xlt impedance split is not representable and was dropped",
-                t.name
-            ),
-            Map::new(),
-        );
+        let to = center_tap_to_winding(w2, w3, &common, from.s_rating, r_neutral, x_neutral);
         if w2.s_rating.to_bits() != from.s_rating.to_bits()
             || w3.s_rating.to_bits() != from.s_rating.to_bits()
         {
@@ -1031,14 +980,93 @@ impl Writer {
                 "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_RATING_COLLAPSED",
                 format!(
                     "transformer {}: center tap half winding s_ratings ({}, {}) differ \
-                     from the primary's {}; the collapsed winding keeps the primary \
-                     rating, the half ratings only survive in the resistance conversion",
+                     from the primary's {}; BMOPF carries one transformer rating, and \
+                     the first secondary half rating is used for the to-side impedance base",
                     t.name, w2.s_rating, w3.s_rating, from.s_rating
                 ),
                 details,
             );
         }
-        self.two_winding(t, from, &to, 1.0, true, true)
+        let s = from.s_rating;
+        let zb_from = winding_base(from);
+        let zb_to = winding_base(w2);
+        if t.xsc_pct.is_empty() {
+            self.transformer_diagnostic(
+                t,
+                "EMIT.BMOPF.TRANSFORMER_MISSING_XSC",
+                format!(
+                    "transformer {}: xsc_pct is empty; emitted x_series_from=0",
+                    t.name
+                ),
+                Map::new(),
+            );
+        }
+        let (x_from_pct, x_to_pct) = self.center_tap_leakage_percentages(t);
+
+        let mut o = Map::new();
+        o.insert("bus_from".into(), json!(from.bus));
+        o.insert("bus_to".into(), json!(to.bus));
+        o.insert("s_rating".into(), self.num(s, "transformer s_rating"));
+        o.insert(
+            "v_nom_from".into(),
+            self.num(from.v_ref, "transformer v_nom_from"),
+        );
+        o.insert(
+            "v_nom_to".into(),
+            self.num(to.v_ref, "transformer v_nom_to"),
+        );
+        o.insert(
+            "r_series_from".into(),
+            self.num(from.r_pct / 100.0 * zb_from, "transformer r_series_from"),
+        );
+        o.insert(
+            "r_series_to".into(),
+            self.num(w2.r_pct / 100.0 * zb_to, "transformer r_series_to"),
+        );
+        o.insert(
+            "x_series_from".into(),
+            self.num(x_from_pct / 100.0 * zb_from, "transformer x_series_from"),
+        );
+        o.insert(
+            "x_series_to".into(),
+            self.num(x_to_pct / 100.0 * zb_to, "transformer x_series_to"),
+        );
+        o.insert("terminal_map_from".into(), json!(from.terminal_map));
+        o.insert("terminal_map_to".into(), json!(to.terminal_map));
+        self.transformer_neutral_fields(&mut o, t, from, &to);
+        self.transformer_tap_fields(&mut o, t, from, &to);
+        self.transformer_no_load_fields(&mut o, t, from, s);
+        self.transformer_extras_dropped(t, &TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS);
+        o.into()
+    }
+
+    fn center_tap_leakage_percentages(&mut self, t: &DistTransformer) -> (f64, f64) {
+        let (x_from_pct, x_to_pct) = center_tap_star_percentages(&t.xsc_pct);
+        if x_from_pct.is_finite()
+            && x_to_pct.is_finite()
+            && x_from_pct >= -1e-12
+            && x_to_pct >= -1e-12
+        {
+            return (x_from_pct.max(0.0), x_to_pct.max(0.0));
+        }
+        let xhl = t.xsc_pct.first().copied().unwrap_or(0.0);
+        let emitted_from = if xhl.is_finite() { xhl.max(0.0) } else { 0.0 };
+        let mut details = Map::new();
+        details.insert("xsc_pct".into(), json!(&t.xsc_pct));
+        details.insert("star_percentages".into(), json!([x_from_pct, x_to_pct]));
+        details.insert("emitted_percentages".into(), json!([emitted_from, 0.0]));
+        self.transformer_diagnostic(
+            t,
+            "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_LEAKAGE_UNREPRESENTABLE",
+            format!(
+                "transformer {}: center tap leakage star arms ({x_from_pct}, {x_to_pct}) \
+                 are not representable as nonnegative BMOPF fields; emitted xhl on the \
+                 from side and zero on the to side",
+                t.name
+            ),
+            details,
+        );
+        (emitted_from, 0.0)
     }
 
     /// `wye_delta` / `delta_wye`: one series impedance in ohms on the wye
@@ -1723,6 +1751,59 @@ fn split_no_load_extras(t: &mut DistTransformer, phases: usize) {
             t.extras.insert(key.into(), json!(v / phases));
         }
     }
+}
+
+fn center_tap_common_terminal(w2: &Winding, w3: &Winding) -> String {
+    w2.terminal_map
+        .iter()
+        .find(|term| w3.terminal_map.contains(term))
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn center_tap_to_winding(
+    w2: &Winding,
+    w3: &Winding,
+    common: &str,
+    s_rating: f64,
+    r_neutral: Option<f64>,
+    x_neutral: Option<f64>,
+) -> Winding {
+    let terminal_map = center_tap_terminal_map(w2, w3, common);
+    Winding {
+        bus: w2.bus.clone(),
+        terminal_map,
+        conn: WindingConn::Wye,
+        v_ref: w2.v_ref,
+        s_rating,
+        r_pct: w2.r_pct,
+        tap: w2.tap,
+        r_neutral,
+        x_neutral,
+    }
+}
+
+fn center_tap_terminal_map(w2: &Winding, w3: &Winding, common: &str) -> Vec<String> {
+    let mut hots: Vec<String> = Vec::new();
+    for term in w2.terminal_map.iter().chain(&w3.terminal_map) {
+        if term != common && !hots.contains(term) {
+            hots.push(term.clone());
+        }
+    }
+    let first = hots.first().cloned().unwrap_or_default();
+    let second = hots.get(1).cloned().unwrap_or_default();
+    vec![first, common.to_string(), second]
+}
+
+fn center_tap_star_percentages(xsc_pct: &[f64]) -> (f64, f64) {
+    let xhl = xsc_pct.first().copied().unwrap_or(0.0);
+    let xht = xsc_pct.get(1).copied().unwrap_or(xhl);
+    let xlt = xsc_pct.get(2).copied().unwrap_or(0.0);
+    ((xhl + xht - xlt) / 2.0, (xhl + xlt - xht) / 2.0)
+}
+
+fn winding_base(w: &Winding) -> f64 {
+    w.v_ref * w.v_ref / w.s_rating
 }
 
 fn n_winding_phase_count(w: &Winding) -> usize {

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -1415,25 +1415,42 @@ fn shunt_size_mismatch_pads_the_smaller_matrix() {
 }
 
 #[test]
-fn center_tap_collapse_converts_resistance_through_ohms() {
-    // Each 120 V half carries %R=1.2 on 25 kVA: 0.012 * 120^2/25000 =
-    // 0.006912 ohm, so the series path across the outer terminals is
-    // 0.013824 ohm. Percent does not transfer to the 240 V base (zb
-    // scales 4x), so the collapse converts through ohms.
+fn center_tap_emits_bmopf_convention_and_star_leakage() {
+    // Each 120 V half carries %R=1.2 on 25 kVA:
+    // 0.012 * 120^2 / 25000 = 0.006912 ohm. BMOPF stores the per leg
+    // voltage and per leg to side series arm, not the full 240 V path.
     let net = parse_dss_file(fixture("micro/xfmr_center_tap.dss")).unwrap();
     let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("EMIT.BMOPF.TRANSFORMER_CENTER_TAP_COLLAPSED")),
+        "{:?}",
+        out.warnings
+    );
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     let t = &doc["transformer"]["center_tap"]["t1"];
-    assert_eq!(t["v_nom_to"], 240.0);
+    assert_eq!(t["terminal_map_to"], serde_json::json!(["1", "4", "2"]));
+    assert_eq!(t["v_nom_to"], 120.0);
     let r_to = t["r_series_to"].as_f64().unwrap();
-    assert!((r_to - 0.013_824).abs() < 1e-12, "r_series_to = {r_to}");
-    // The primary is untouched by the collapse: %R=0.6 on 7.2 kV/25 kVA.
+    assert!((r_to - 0.006_912).abs() < 1e-12, "r_series_to = {r_to}");
+    // The primary is untouched: %R=0.6 on 7.2 kV/25 kVA.
     let r_from = t["r_series_from"].as_f64().unwrap();
     assert!((r_from - 12.4416).abs() < 1e-9, "r_series_from = {r_from}");
+    // xhl=2.04, xht=2.04, xlt=1.36 gives symmetric star arms:
+    // x_from=(xhl+xht-xlt)/2=1.36%, x_to=(xhl+xlt-xht)/2=0.68%.
+    let x_from = t["x_series_from"].as_f64().unwrap();
+    assert!(
+        (x_from - 28.200_96).abs() < 1e-9,
+        "x_series_from = {x_from}"
+    );
+    let x_to = t["x_series_to"].as_f64().unwrap();
+    assert!((x_to - 0.003_916_8).abs() < 1e-12, "x_series_to = {x_to}");
 }
 
 #[test]
-fn bmopf_center_tap_rebuilds_dss_grounded_center() {
+fn bmopf_center_tap_canonical_order_rebuilds_dss_grounded_center() {
     let text = r#"{
         "bus": {
             "src": {"terminal_names": ["1", "2"], "perfectly_grounded_terminals": ["2"]},
@@ -1453,14 +1470,14 @@ fn bmopf_center_tap_rebuilds_dss_grounded_center() {
                     "bus_from": "src",
                     "bus_to": "lv",
                     "terminal_map_from": ["1", "2"],
-                    "terminal_map_to": ["1", "2", "3"],
+                    "terminal_map_to": ["1", "3", "2"],
                     "s_rating": 25000.0,
                     "v_nom_from": 7200.0,
-                    "v_nom_to": 240.0,
+                    "v_nom_to": 120.0,
                     "r_series_from": 12.4416,
-                    "r_series_to": 0.013824,
-                    "x_series_from": 42.2784,
-                    "x_series_to": 0.0
+                    "r_series_to": 0.006912,
+                    "x_series_from": 28.20096,
+                    "x_series_to": 0.0039168
                 }
             }
         }
@@ -1479,7 +1496,7 @@ fn bmopf_center_tap_rebuilds_dss_grounded_center() {
     );
     assert_eq!(
         doc["transformer"]["center_tap"]["ct"]["terminal_map_to"],
-        serde_json::json!(["1", "2", "4"])
+        serde_json::json!(["1", "4", "2"])
     );
 }
 
@@ -1538,10 +1555,9 @@ fn bmopf_center_tap_neutral_grounding_rebuilds_once() {
 }
 
 #[test]
-fn center_tap_collapse_uses_each_half_windings_own_s_rating() {
-    // Legal OpenDSS: the two 120 V halves carry different kva ratings, so
-    // each half's impedance base is its own v^2/s. The series path across
-    // the outer terminals is the sum of the per half ohms.
+fn center_tap_collapse_uses_first_secondary_half_rating() {
+    // BMOPF carries one to side series arm, so unequal half ratings collapse
+    // to the first secondary half rating with a warning.
     let net = parse_dss_str(
         "Clear\n\
          New Circuit.ct basekv=7.2 pu=1.0 phases=1 bus1=src.1\n\
@@ -1551,18 +1567,45 @@ fn center_tap_collapse_uses_each_half_windings_own_s_rating() {
     let out = write_bmopf_json(&net);
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     let t = &doc["transformer"]["center_tap"]["t1"];
-    assert_eq!(t["v_nom_to"], 240.0);
-    let expected = 0.02 * 120.0 * 120.0 / 50e3 + 0.04 * 120.0 * 120.0 / 25e3;
+    assert_eq!(t["v_nom_to"], 120.0);
+    let expected = 0.02 * 120.0 * 120.0 / 50e3;
     let r_to = t["r_series_to"].as_f64().unwrap();
     assert!((r_to - expected).abs() < 1e-12, "r_series_to = {r_to}");
-    // The collapsed winding keeps one s_rating; the half ratings drop loudly.
     assert!(
-        out.warnings
-            .iter()
-            .any(|w| w.contains("transformer t1") && w.contains("s_rating")),
+        out.warnings.iter().any(|w| w
+            .contains("EMIT.BMOPF.TRANSFORMER_CENTER_TAP_RATING_COLLAPSED")
+            && w.contains("first secondary half rating")),
         "{:?}",
         out.warnings
     );
+}
+
+#[test]
+fn center_tap_negative_star_arm_warns_and_falls_back_schema_valid() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.ct basekv=7.2 pu=1.0 phases=1 bus1=src.1\n\
+         New Transformer.t1 phases=1 windings=3 buses=(src.1.0, lv.1.0, lv.0.2) \
+         kvs=(7.2 0.12 0.12) kvas=(25 25 25) %Rs=(1 2 2) xhl=2 xht=10 xlt=2\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let diag = diagnostic(
+        &out,
+        "EMIT.BMOPF.TRANSFORMER_CENTER_TAP_LEAKAGE_UNREPRESENTABLE",
+        "transformer t1",
+    );
+    assert_eq!(diag.details["xsc_pct"], serde_json::json!([2.0, 10.0, 2.0]));
+    assert_eq!(
+        diag.details["emitted_percentages"],
+        serde_json::json!([2.0, 0.0])
+    );
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["center_tap"]["t1"];
+    let x_from = t["x_series_from"].as_f64().unwrap();
+    assert!((x_from - 41.472).abs() < 1e-12, "x_series_from = {x_from}");
+    assert_eq!(t["x_series_to"], serde_json::json!(0.0));
 }
 
 #[test]


### PR DESCRIPTION
# Emit BMOPF center tap transformers in the BMOPF convention

Merge order: 3 of 7. Base: `main` after #221.

Fixes #215.

## Scope

- Emit center tap BMOPF transformers with the secondary neutral in the middle of `terminal_map_to`.
- Emit `v_nom_to` on the per leg secondary basis.
- Emit the center tap leakage as the symmetric star arms from `xhl`, `xht`, and `xlt`.
- Keep BMOPF reads compatible with both canonical middle neutral input and legacy neutral last input.
- Drop the old lossy center tap warning on the normal supported path; keep warnings for genuinely collapsed details such as unequal secondary taps and unequal half ratings.
- Emit a stable diagnostic and schema valid fallback when source leakage cannot form nonnegative BMOPF star arms.

## Acceptance

- The DSS split phase center tap fixture emits `terminal_map_to = ["1", "4", "2"]`.
- The 120/240 V fixture emits `v_nom_to = 120`.
- The leakage fields match the BMOPF convention directly: `x_series_from = 28.20096`, `x_series_to = 0.0039168` for the micro fixture.
- A non center tap DSS fixture emits byte identical BMOPF JSON compared with `main`.
- The conversion matrix warning baseline drops only for the removed normal center tap lossy warning.

## Out of Scope

- No delta_wye leakage referral change; that remains A4.
- No `delta_roll` change; that remains A5.
- No voltage source merge; that remains A6.
- No capability flag change; that remains A7.
- No task force terminal label remap.

## Validation

- `cargo test -p powerio-dist --test bmopf center_tap -- --nocapture`
- `cargo test -p powerio-dist --test bmopf -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a3-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
- End to end:
  - `tests/data/dist/micro/xfmr_single_phase.dss` converts to byte identical BMOPF JSON on `main` and this branch.
  - `tests/data/dist/micro/xfmr_center_tap.dss` converts with middle neutral ordering, per leg `v_nom_to`, and nonzero from and to leakage star arms.

## Review

- Local review covered reader compatibility for canonical and legacy center tap ordering.
- Fresh reviewer found that invalid star arms could emit negative schema fields; fixed with `EMIT.BMOPF.TRANSFORMER_CENTER_TAP_LEAKAGE_UNREPRESENTABLE` and a schema valid fallback.
- Fresh reviewer found stale half rating warning text; fixed to state that the first secondary half rating is used for the to-side impedance base.
