### PR TITLE
Refer BMOPF delta_wye leakage to each winding base

### DIFF
--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -826,7 +826,21 @@ impl Reader<'_> {
                 0.0
             }
         };
-        let (r_from_pct, r_to_pct, xsc_pct) = if three_phase {
+        let has_split_three_phase_fields = [
+            "r_series_from",
+            "r_series_to",
+            "x_series_from",
+            "x_series_to",
+        ]
+        .iter()
+        .any(|k| o.contains_key(*k));
+        let (r_from_pct, r_to_pct, xsc_pct) = if three_phase && has_split_three_phase_fields {
+            let r_from = pct(o.get("r_series_from").map_or(0.0, f), v_from);
+            let r_to = pct(o.get("r_series_to").map_or(0.0, f), v_to);
+            let x_from = pct(o.get("x_series_from").map_or(0.0, f), v_from);
+            let x_to = pct(o.get("x_series_to").map_or(0.0, f), v_to);
+            (r_from, r_to, vec![x_from + x_to])
+        } else if three_phase {
             let wye_v = if subtype == "wye_delta" { v_from } else { v_to };
             // The schema puts one series impedance on the wye side; the
             // model splits resistance evenly across the windings.

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -1069,14 +1069,13 @@ impl Writer {
         (emitted_from, 0.0)
     }
 
-    /// `wye_delta` / `delta_wye`: one series impedance in ohms on the wye
-    /// side. `wye_idx` names which winding is the wye one.
+    /// `wye_delta` stays in the legacy lumped wye side form. `delta_wye`
+    /// uses split fields referred to each winding's own base.
     fn three_phase(&mut self, t: &DistTransformer, wye_idx: usize) -> Value {
         let from = &t.windings[0];
         let to = &t.windings[1];
-        let wye = &t.windings[wye_idx];
+        let is_delta_wye = wye_idx == 1;
         let s = from.s_rating;
-        let zb_wye = wye.v_ref * wye.v_ref / s;
         let mut o = Map::new();
         o.insert("bus_from".into(), json!(from.bus));
         o.insert("bus_to".into(), json!(to.bus));
@@ -1089,29 +1088,57 @@ impl Writer {
             "v_nom_to".into(),
             self.num(to.v_ref, "transformer v_nom_to"),
         );
-        o.insert(
-            "r_series".into(),
-            self.num(
-                (from.r_pct + to.r_pct) / 100.0 * zb_wye,
-                "transformer r_series",
-            ),
-        );
         if t.xsc_pct.is_empty() {
+            let emitted = if is_delta_wye {
+                "x_series_from=0 and x_series_to=0"
+            } else {
+                "x_series=0"
+            };
             self.transformer_diagnostic(
                 t,
                 "EMIT.BMOPF.TRANSFORMER_MISSING_XSC",
                 format!(
-                    "transformer {}: xsc_pct is empty; emitted x_series=0",
-                    t.name
+                    "transformer {}: xsc_pct is empty; emitted {emitted}",
+                    t.name,
                 ),
                 Map::new(),
             );
         }
         let xhl = t.xsc_pct.first().copied().unwrap_or(0.0);
-        o.insert(
-            "x_series".into(),
-            self.num(xhl / 100.0 * zb_wye, "transformer x_series"),
-        );
+        if is_delta_wye {
+            let zb_from = winding_base(from);
+            let zb_to = winding_base(to);
+            o.insert(
+                "r_series_from".into(),
+                self.num(from.r_pct / 100.0 * zb_from, "transformer r_series_from"),
+            );
+            o.insert(
+                "r_series_to".into(),
+                self.num(to.r_pct / 100.0 * zb_to, "transformer r_series_to"),
+            );
+            o.insert(
+                "x_series_from".into(),
+                self.num(xhl / 2.0 / 100.0 * zb_from, "transformer x_series_from"),
+            );
+            o.insert(
+                "x_series_to".into(),
+                self.num(xhl / 2.0 / 100.0 * zb_to, "transformer x_series_to"),
+            );
+        } else {
+            let wye = &t.windings[wye_idx];
+            let zb_wye = wye.v_ref * wye.v_ref / s;
+            o.insert(
+                "r_series".into(),
+                self.num(
+                    (from.r_pct + to.r_pct) / 100.0 * zb_wye,
+                    "transformer r_series",
+                ),
+            );
+            o.insert(
+                "x_series".into(),
+                self.num(xhl / 100.0 * zb_wye, "transformer x_series"),
+            );
+        }
         o.insert("terminal_map_from".into(), json!(from.terminal_map));
         o.insert("terminal_map_to".into(), json!(to.terminal_map));
         self.transformer_neutral_fields(&mut o, t, from, to);

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -319,6 +319,108 @@ fn single_phase_wye_delta_keeps_both_delta_terminals() {
 }
 
 #[test]
+fn delta_wye_leakage_uses_each_winding_base() {
+    let v = schema_validator();
+    let net = parse_dss_file(fixture("micro/xfmr_delta_wye.dss")).unwrap();
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["delta_wye"]["t1"];
+    assert!(t.get("r_series").is_none(), "{t:?}");
+    assert!(t.get("x_series").is_none(), "{t:?}");
+
+    let z_from = 12_470.0 * 12_470.0 / 300_000.0;
+    let z_to = 208.0 * 208.0 / 300_000.0;
+    let r_from = t["r_series_from"].as_f64().unwrap();
+    let r_to = t["r_series_to"].as_f64().unwrap();
+    let x_from = t["x_series_from"].as_f64().unwrap();
+    let x_to = t["x_series_to"].as_f64().unwrap();
+    assert!(
+        (r_from - 0.005 * z_from).abs() < 1e-12,
+        "r_series_from = {r_from}"
+    );
+    assert!((r_to - 0.005 * z_to).abs() < 1e-12, "r_series_to = {r_to}");
+    assert!(
+        (x_from - 0.0575 / 2.0 * z_from).abs() < 1e-12,
+        "x_series_from = {x_from}"
+    );
+    assert!(
+        (x_to - 0.0575 / 2.0 * z_to).abs() < 1e-12,
+        "x_series_to = {x_to}"
+    );
+
+    let round_trip = parse_bmopf_str(&out.text).unwrap();
+    let t = round_trip
+        .transformers
+        .iter()
+        .find(|t| t.name == "t1")
+        .unwrap();
+    assert_eq!(t.windings[0].conn, WindingConn::Delta);
+    assert_eq!(t.windings[1].conn, WindingConn::Wye);
+    assert!((t.windings[0].r_pct - 0.5).abs() < 1e-12);
+    assert!((t.windings[1].r_pct - 0.5).abs() < 1e-12);
+    assert_eq!(t.xsc_pct.len(), 1);
+    assert!((t.xsc_pct[0] - 5.75).abs() < 1e-12);
+}
+
+#[test]
+fn delta_wye_split_leakage_uses_each_winding_rating() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.dw basekv=12.47 pu=1.0 phases=3 bus1=sourcebus\n\
+         New Transformer.t1 phases=3 windings=2 buses=(sourcebus, secondary) \
+         conns=(delta, wye) kvs=(12.47, 0.208) kvas=(500, 300) \
+         xhl=5.75 %Rs=(0.5, 0.7)\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["delta_wye"]["t1"];
+    let z_from = 12_470.0 * 12_470.0 / 500_000.0;
+    let z_to = 208.0 * 208.0 / 300_000.0;
+    let r_from = t["r_series_from"].as_f64().unwrap();
+    let r_to = t["r_series_to"].as_f64().unwrap();
+    let x_from = t["x_series_from"].as_f64().unwrap();
+    let x_to = t["x_series_to"].as_f64().unwrap();
+    assert!(
+        (r_from - 0.005 * z_from).abs() < 1e-12,
+        "r_series_from = {r_from}"
+    );
+    assert!((r_to - 0.007 * z_to).abs() < 1e-12, "r_series_to = {r_to}");
+    assert!(
+        (x_from - 0.0575 / 2.0 * z_from).abs() < 1e-12,
+        "x_series_from = {x_from}"
+    );
+    assert!(
+        (x_to - 0.0575 / 2.0 * z_to).abs() < 1e-12,
+        "x_series_to = {x_to}"
+    );
+}
+
+#[test]
+fn wye_delta_leakage_stays_on_legacy_wye_side_fields() {
+    let v = schema_validator();
+    let net = parse_dss_file(fixture("micro/xfmr_wye_delta.dss")).unwrap();
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["wye_delta"]["t1"];
+    assert!(t.get("r_series_from").is_none(), "{t:?}");
+    assert!(t.get("r_series_to").is_none(), "{t:?}");
+    assert!(t.get("x_series_from").is_none(), "{t:?}");
+    assert!(t.get("x_series_to").is_none(), "{t:?}");
+
+    let z_wye = 12_470.0 * 12_470.0 / 500_000.0;
+    let r = t["r_series"].as_f64().unwrap();
+    let x = t["x_series"].as_f64().unwrap();
+    assert!((r - 0.01 * z_wye).abs() < 1e-12, "r_series = {r}");
+    assert!((x - 0.0575 * z_wye).abs() < 1e-12, "x_series = {x}");
+}
+
+#[test]
 fn ieee13_conversion_warnings_name_every_loss() {
     let net = parse_dss_file(fixture("opendss/ieee13/IEEE13Nodeckt.dss")).unwrap();
     let out = write_bmopf_json(&net);


### PR DESCRIPTION
# Refer BMOPF delta_wye leakage to each winding base

Merge order: 4 of 7. Base: `main` after #222.

Fixes #216.

## Scope

- Emit BMOPF `delta_wye` transformers with split `r_series_from`,
  `x_series_from`, `r_series_to`, and `x_series_to` fields.
- Refer each side to its own winding base, matching the BMOPFTools recovery
  rule: winding resistance on that winding's base and half of `xhl` on each
  winding base.
- Keep `wye_delta` output on the existing legacy `r_series` and `x_series`
  fields.
- Teach the BMOPF reader to parse split three phase impedance fields while
  preserving legacy three phase input.

## Acceptance

- The DSS `delta_wye` fixture emits split impedance fields and no legacy
  `r_series` or `x_series`.
- The emitted values match the BMOPFTools oracle for both equal and unequal
  winding ratings.
- A `wye_delta` fixture remains byte identical to `main`.
- BMOPF split three phase records round trip through the distribution model.

## Out of Scope

- No center tap convention changes; that landed in A3.
- No `delta_roll` change; that remains A5.
- No voltage source merge; that remains A6.
- No capability flag change; that remains A7.
- No task force terminal label remap.

## Validation

- `cargo test -p powerio-dist --test bmopf delta_wye -- --nocapture`
- `cargo test -p powerio-dist --test bmopf -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a4-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
- End to end:
  - `tests/data/dist/micro/xfmr_delta_wye.dss` converts to BMOPF JSON with
    split `r/x_series_from` and `r/x_series_to` fields on the expected bases.
  - `tests/data/dist/micro/xfmr_wye_delta.dss` converts to byte identical BMOPF
    JSON on `main` and this branch.

## Review

- Local review covered the writer path, reader compatibility, and unaffected
  `wye_delta` output.
- Fresh reviewer found no material issues. A residual unequal rating risk was
  closed with a regression test for separate winding ratings.
