### PR TITLE
Emit explicit delta_roll for BMOPF n_winding transformers

### DIFF
--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -60,6 +60,8 @@ struct Reader<'a> {
     net: &'a mut DistNetwork,
 }
 
+const BMOPF_DELTA_ROLLS_EXTRA: &str = "bmopf_delta_rolls";
+
 fn f(v: &Value) -> f64 {
     v.as_f64().unwrap_or(f64::NAN)
 }
@@ -73,6 +75,11 @@ fn first_float(v: Option<&Value>) -> Option<f64> {
         Value::Array(a) => a.first().map(f),
         v => Some(f(v)),
     }
+}
+
+fn delta_roll_value(v: Option<&Value>) -> Option<i64> {
+    v.and_then(Value::as_i64)
+        .filter(|roll| matches!(*roll, -1 | 1))
 }
 
 /// Like [`first_float`], but the field is per-phase-terminal in the schema
@@ -925,6 +932,7 @@ impl Reader<'_> {
         let known = ["windings", "x_sc", "s_rating", "g_no_load", "b_no_load"];
         let s = o.get("s_rating").map_or(f64::NAN, f);
         let mut windings = Vec::new();
+        let mut delta_rolls = Map::new();
         if let Some(items) = o.get("windings").and_then(Value::as_array) {
             for (idx, item) in items.iter().enumerate() {
                 let Some(w) = item.as_object() else {
@@ -954,6 +962,9 @@ impl Reader<'_> {
                 } else {
                     WindingConn::Wye
                 };
+                if let Some(delta_roll) = delta_roll_value(w.get("delta_roll")) {
+                    delta_rolls.insert((idx + 1).to_string(), Value::from(delta_roll));
+                }
                 let r_pct = if let Some(base_z) =
                     n_winding_base_from_bmopf(conn, &terminal_map, bmopf_v_nom, s)
                 {
@@ -997,6 +1008,9 @@ impl Reader<'_> {
             &[],
         );
         extras.insert("bmopf_subtype".into(), "n_winding".into());
+        if !delta_rolls.is_empty() {
+            extras.insert(BMOPF_DELTA_ROLLS_EXTRA.into(), Value::Object(delta_rolls));
+        }
         for key in ["g_no_load", "b_no_load"] {
             if let Some(v) = o.get(key) {
                 extras.insert(key.into(), v.clone());

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -54,8 +54,15 @@ const IBR_EXTRA_FIELDS: &[&str] = &[
     "time_series",
 ];
 
-const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 4] =
-    ["g_no_load", "b_no_load", "%noloadloss", "%imag"];
+const BMOPF_DELTA_ROLLS_EXTRA: &str = "bmopf_delta_rolls";
+
+const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 5] = [
+    "g_no_load",
+    "b_no_load",
+    "%noloadloss",
+    "%imag",
+    BMOPF_DELTA_ROLLS_EXTRA,
+];
 const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
     "tap_min",
     "tap_max",
@@ -1174,7 +1181,8 @@ impl Writer {
         let windings: Vec<Value> = t
             .windings
             .iter()
-            .map(|w| {
+            .enumerate()
+            .map(|(idx, w)| {
                 let mut wj = Map::new();
                 wj.insert("bus".into(), json!(w.bus));
                 wj.insert("terminal_map".into(), json!(w.terminal_map));
@@ -1194,6 +1202,9 @@ impl Writer {
                     "r_winding".into(),
                     self.num(w.r_pct / 100.0 * zbase, "transformer winding r_winding"),
                 );
+                if let Some(delta_roll) = bmopf_delta_roll(t, idx, w) {
+                    wj.insert("delta_roll".into(), json!(delta_roll));
+                }
                 Value::Object(wj)
             })
             .collect();
@@ -1847,6 +1858,19 @@ fn n_winding_bmopf_v_nom(w: &Winding) -> f64 {
 
 fn n_winding_base(w: &Winding, s: f64) -> Option<f64> {
     n_winding_impedance_base(n_winding_phase_count(w), n_winding_bmopf_v_nom(w), s)
+}
+
+fn bmopf_delta_roll(t: &DistTransformer, idx: usize, w: &Winding) -> Option<i64> {
+    if w.conn != WindingConn::Delta {
+        return None;
+    }
+    t.extras
+        .get(BMOPF_DELTA_ROLLS_EXTRA)
+        .and_then(Value::as_object)
+        .and_then(|rolls| rolls.get(&(idx + 1).to_string()))
+        .and_then(Value::as_i64)
+        .filter(|roll| *roll == 1 || *roll == -1)
+        .or(Some(-1))
 }
 
 fn no_load_voltage_base(from: &Winding) -> f64 {

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -1007,10 +1007,84 @@ fn n_winding_transformer_round_trips_through_bmopf() {
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     let t = &doc["transformer"]["n_winding"]["t3"];
     assert_eq!(t["windings"].as_array().unwrap().len(), 3);
+    assert_eq!(t["windings"][0]["delta_roll"], serde_json::json!(-1));
+    assert!(t["windings"][1].get("delta_roll").is_none(), "{t:?}");
+    assert!(t["windings"][2].get("delta_roll").is_none(), "{t:?}");
     assert_eq!(t["windings"][1]["v_nom"], serde_json::json!(100.0));
     assert_eq!(t["x_sc"]["1_2"], serde_json::json!(0.04));
     assert_eq!(t["g_no_load"], serde_json::json!(0.001));
     assert_eq!(t["b_no_load"], serde_json::json!(-0.002));
+}
+
+#[test]
+fn n_winding_explicit_delta_roll_round_trips_through_bmopf() {
+    let v = schema_validator();
+    let net = parse_bmopf_str(
+        r#"{
+          "bus": {
+            "a": {"terminal_names": ["1", "2", "3"]},
+            "b": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]},
+            "c": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]}
+          },
+          "transformer": {
+            "n_winding": {
+              "t3": {
+                "s_rating": 10000.0,
+                "windings": [
+                  {"bus": "a", "terminal_map": ["1", "2", "3"], "v_nom": 100.0, "configuration": "DELTA", "r_winding": 0.01, "delta_roll": 1},
+                  {"bus": "b", "terminal_map": ["1", "2", "3", "n"], "v_nom": 100.0, "configuration": "WYE", "r_winding": 0.02},
+                  {"bus": "c", "terminal_map": ["1", "2", "3", "n"], "v_nom": 100.0, "configuration": "WYE", "r_winding": 0.03}
+                ],
+                "x_sc": {"1_2": 0.04, "1_3": 0.05, "2_3": 0.06}
+              }
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("bmopf_delta_rolls")),
+        "{:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["n_winding"]["t3"];
+    assert_eq!(t["windings"][0]["delta_roll"], serde_json::json!(1));
+
+    let again = parse_bmopf_str(&out.text).unwrap();
+    let out2 = write_bmopf_json(&again);
+    assert_eq!(out.text, out2.text);
+}
+
+#[test]
+fn opendss_n_winding_delta_emits_delta_roll() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.dyn basekv=12.47 pu=1.0 phases=3 bus1=sourcebus\n\
+         New Transformer.t1 phases=3 windings=3 buses=(sourcebus, mid, low) \
+         conns=(delta, wye, wye) kvs=(12.47, 4.16, 0.48) \
+         kvas=(1000, 1000, 1000) %Rs=(0.5, 0.5, 0.5) xhl=5 xht=6 xlt=4\n",
+    );
+    let t = &net.transformers[0];
+    assert_eq!(t.windings.len(), 3);
+    assert_eq!(t.windings[0].conn, WindingConn::Delta);
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let t = &doc["transformer"]["n_winding"]["t1"];
+    assert_eq!(
+        t["windings"][0]["configuration"],
+        serde_json::json!("DELTA")
+    );
+    assert_eq!(t["windings"][0]["delta_roll"], serde_json::json!(-1));
+    assert!(t["windings"][1].get("delta_roll").is_none(), "{t:?}");
+    assert!(t["windings"][2].get("delta_roll").is_none(), "{t:?}");
 }
 
 #[test]


### PR DESCRIPTION
Merge order: A5 of A7. Base: `main` after #223.

Fixes #217.

## Scope

- Emit `delta_roll` for delta windings in BMOPF `n_winding` output.
- Default OpenDSS sourced delta windings to `delta_roll = -1`.
- Preserve valid explicit `delta_roll` values read from BMOPF input.
- Keep WYE windings without `delta_roll`.

## Acceptance

- A three winding OpenDSS Dyn fixture emits `delta_roll = -1` on the delta winding and validates against the vendored BMOPF schema.
- A BMOPF `n_winding` transformer with explicit `delta_roll = 1` round trips unchanged.
- `tests/data/dist/micro/xfmr_wye_delta.dss` emits byte identical BMOPF JSON on `main` and this branch.

## Out Of Scope

- Add a public `DistTransformer` or `Winding` field for `delta_roll`.
- Change two winding transformer subtypes.
- Merge per phase voltage sources (#218).

## Tests

- `cargo test -p powerio-dist --test bmopf n_winding -- --nocapture`
- `cargo test -p powerio-dist --test bmopf -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `env POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a5-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
