### PR TITLE
Merge split OpenDSS voltage sources in BMOPF export

### DIFF
--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -7,6 +7,7 @@
 //! naming the element and field.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::f64::consts::{FRAC_PI_2, PI, TAU};
 
 use serde_json::{Map, Value, json};
 
@@ -15,8 +16,8 @@ use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnost
 use crate::model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference,
     DistControlProfile, DistGenerator, DistIbr, DistLoadVoltageModel, DistNetwork, DistTransformer,
-    Mat, ReactivePowerReference, ReactivePowerUnit, VoltVarControl, VoltWattControl, Winding,
-    WindingConn, n_winding_impedance_base, pair_keys,
+    Extras, Mat, ReactivePowerReference, ReactivePowerUnit, VoltVarControl, VoltWattControl,
+    VoltageSource, Winding, WindingConn, n_winding_impedance_base, pair_keys,
 };
 
 /// The `$schema` stamped into every document's `meta`: the current BMOPF
@@ -476,17 +477,18 @@ impl Writer {
             }
             doc.insert("shunt".into(), Value::Object(shunts));
         }
+        let emitted_sources = bmopf_voltage_sources(net);
         let mut sources = Map::new();
-        if net.sources.is_empty() {
+        if emitted_sources.is_empty() {
             self.warn("network has no voltage source; BMOPF requires exactly one");
         }
-        for (i, vs) in net.sources.iter().enumerate() {
+        for (i, vs) in emitted_sources.iter().enumerate() {
             if i > 0 {
                 self.warn(format!(
                     "voltage source {}: the BMOPF formulation expects exactly one source; \
                      this network has {}",
                     vs.name,
-                    net.sources.len()
+                    emitted_sources.len()
                 ));
             }
             let mut o = Map::new();
@@ -498,13 +500,16 @@ impl Writer {
                 "v_angle".into(),
                 self.nums(&vs.v_angle, "voltage_source v_angle"),
             );
-            o.insert("bus".into(), json!(vs.bus));
-            o.insert("terminal_map".into(), json!(vs.terminal_map));
+            o.insert("bus".into(), json!(&vs.bus));
+            o.insert("terminal_map".into(), json!(&vs.terminal_map));
             let mut extras = vs.extras.clone();
             if let Some(cost) = extras.remove("cost") {
                 o.insert("cost".into(), cost);
             }
             self.extras_dropped(&extras, &format!("voltage source {}", vs.name));
+            for (name, extras) in &vs.dropped_extras {
+                self.extras_dropped(extras, &format!("voltage source {name}"));
+            }
             sources.insert(vs.name.clone(), Value::Object(o));
         }
         doc.insert("voltage_source".into(), Value::Object(sources));
@@ -1681,6 +1686,252 @@ fn prune_string_array(
         ));
     }
     *values = kept;
+}
+
+#[derive(Clone)]
+struct SourceEmit {
+    name: String,
+    bus: String,
+    terminal_map: Vec<String>,
+    v_magnitude: Vec<f64>,
+    v_angle: Vec<f64>,
+    extras: Extras,
+    dropped_extras: Vec<(String, Extras)>,
+}
+
+impl From<&VoltageSource> for SourceEmit {
+    fn from(source: &VoltageSource) -> Self {
+        Self {
+            name: source.name.clone(),
+            bus: source.bus.clone(),
+            terminal_map: source.terminal_map.clone(),
+            v_magnitude: source.v_magnitude.clone(),
+            v_angle: source.v_angle.clone(),
+            extras: source.extras.clone(),
+            dropped_extras: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PhaseSource {
+    label: String,
+    magnitude: f64,
+    angle: f64,
+    neutral: Option<String>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PhaseArrangement {
+    Zero,
+    Quadrature,
+    Positive,
+    Negative,
+    AntiPhase,
+    Incoherent,
+}
+
+fn bmopf_voltage_sources(net: &DistNetwork) -> Vec<SourceEmit> {
+    let emitted: Vec<SourceEmit> = net.sources.iter().map(SourceEmit::from).collect();
+    let bus_ids: BTreeMap<String, String> = net
+        .buses
+        .iter()
+        .map(|bus| (bus.id.to_ascii_lowercase(), bus.id.clone()))
+        .collect();
+    let mut by_bus: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, source) in emitted.iter().enumerate() {
+        by_bus
+            .entry(source.bus.to_ascii_lowercase())
+            .or_default()
+            .push(i);
+    }
+
+    let mut replacements = BTreeMap::new();
+    let mut removed = BTreeSet::new();
+    for (bus_key, indices) in by_bus.iter().filter(|(_, indices)| indices.len() > 1) {
+        if let Some((keep, merged)) =
+            merge_voltage_source_group(&emitted, indices, bus_ids.get(bus_key))
+        {
+            replacements.insert(keep, merged);
+            removed.extend(indices.iter().copied().filter(|i| *i != keep));
+        }
+    }
+
+    emitted
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, source)| {
+            if removed.contains(&i) {
+                None
+            } else {
+                Some(replacements.remove(&i).unwrap_or(source))
+            }
+        })
+        .collect()
+}
+
+fn merge_voltage_source_group(
+    sources: &[SourceEmit],
+    indices: &[usize],
+    bus_id: Option<&String>,
+) -> Option<(usize, SourceEmit)> {
+    let mut sorted = indices.to_vec();
+    sorted.sort_by(|a, b| sources[*a].name.cmp(&sources[*b].name));
+
+    let mut phases = Vec::new();
+    let mut seen = BTreeSet::new();
+    for index in &sorted {
+        let source = &sources[*index];
+        if source_has_bounds_or_cost(&source.extras) {
+            return None;
+        }
+        let (rank, phase) = single_phase_source(source)?;
+        if !seen.insert(rank) {
+            return None;
+        }
+        phases.push((rank, phase));
+    }
+
+    if phases.len() < 2 {
+        return None;
+    }
+    phases.sort_by_key(|(rank, _)| *rank);
+
+    let neutral = phases.first()?.1.neutral.clone();
+    if phases.iter().any(|(_, phase)| phase.neutral != neutral) {
+        return None;
+    }
+
+    match phase_arrangement(phases.iter().map(|(_, phase)| phase.angle)) {
+        PhaseArrangement::Zero | PhaseArrangement::Positive | PhaseArrangement::Negative => {}
+        PhaseArrangement::Quadrature
+        | PhaseArrangement::AntiPhase
+        | PhaseArrangement::Incoherent => {
+            return None;
+        }
+    }
+
+    let keep = sorted
+        .iter()
+        .copied()
+        .find(|i| sources[*i].name == "source")
+        .unwrap_or(sorted[0]);
+    let mut merged = sources[keep].clone();
+    if let Some(bus_id) = bus_id {
+        merged.bus.clone_from(bus_id);
+    }
+    merged.terminal_map = phases
+        .iter()
+        .map(|(_, phase)| phase.label.clone())
+        .collect();
+    merged.v_magnitude = phases.iter().map(|(_, phase)| phase.magnitude).collect();
+    merged.v_angle = phases.iter().map(|(_, phase)| phase.angle).collect();
+    if let Some(neutral) = neutral {
+        merged.terminal_map.push(neutral);
+        merged.v_magnitude.push(0.0);
+        merged.v_angle.push(0.0);
+    }
+    merged.dropped_extras = sorted
+        .iter()
+        .copied()
+        .filter(|i| *i != keep)
+        .map(|i| (sources[i].name.clone(), sources[i].extras.clone()))
+        .collect();
+    Some((keep, merged))
+}
+
+fn source_has_bounds_or_cost(extras: &Extras) -> bool {
+    ["p_min", "p_max", "q_min", "q_max", "cost"]
+        .iter()
+        .any(|key| extras.contains_key(*key))
+}
+
+fn single_phase_source(source: &SourceEmit) -> Option<(usize, PhaseSource)> {
+    let mut phase = None;
+    let mut neutral = None;
+    for (i, label) in source.terminal_map.iter().enumerate() {
+        if let Some(rank) = phase_rank(label) {
+            if phase.replace((rank, label.clone(), i)).is_some() {
+                return None;
+            }
+        } else if neutral.replace(label.clone()).is_some() {
+            return None;
+        }
+    }
+    let (rank, label, index) = phase?;
+    Some((
+        rank,
+        PhaseSource {
+            label,
+            magnitude: *source.v_magnitude.get(index)?,
+            angle: *source.v_angle.get(index)?,
+            neutral,
+        },
+    ))
+}
+
+fn phase_rank(label: &str) -> Option<usize> {
+    match label {
+        "1" | "a" | "A" => Some(0),
+        "2" | "b" | "B" => Some(1),
+        "3" | "c" | "C" => Some(2),
+        _ => None,
+    }
+}
+
+fn phase_arrangement(angles: impl IntoIterator<Item = f64>) -> PhaseArrangement {
+    let angles: Vec<f64> = angles.into_iter().collect();
+    if angles.len() < 2 {
+        return PhaseArrangement::Incoherent;
+    }
+    if angles.len() == 2 {
+        return separation_of_diff(angles[0] - angles[1]);
+    }
+    let mut arrangement = None;
+    for i in 0..angles.len() {
+        let next = (i + 1) % angles.len();
+        let current = separation_of_diff(angles[i] - angles[next]);
+        if current == PhaseArrangement::Incoherent {
+            return PhaseArrangement::Incoherent;
+        }
+        if let Some(previous) = arrangement {
+            if previous != current {
+                return PhaseArrangement::Incoherent;
+            }
+        } else {
+            arrangement = Some(current);
+        }
+    }
+    arrangement.unwrap_or(PhaseArrangement::Incoherent)
+}
+
+fn separation_of_diff(diff: f64) -> PhaseArrangement {
+    let diff = wrap_pi(diff);
+    let adiff = diff.abs();
+    if adiff <= PI / 6.0 {
+        PhaseArrangement::Zero
+    } else if (adiff - FRAC_PI_2).abs() <= PI / 12.0 {
+        PhaseArrangement::Quadrature
+    } else if (adiff - TAU / 3.0).abs() <= PI / 6.0 {
+        if diff > 0.0 {
+            PhaseArrangement::Positive
+        } else {
+            PhaseArrangement::Negative
+        }
+    } else if (adiff - PI).abs() <= PI / 12.0 {
+        PhaseArrangement::AntiPhase
+    } else {
+        PhaseArrangement::Incoherent
+    }
+}
+
+fn wrap_pi(angle: f64) -> f64 {
+    let wrapped = (angle + PI).rem_euclid(TAU) - PI;
+    if (wrapped + PI).abs() < f64::EPSILON {
+        PI
+    } else {
+        wrapped
+    }
 }
 
 enum Kind {

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use powerio_dist::dss::{parse_dss_file, parse_dss_str};
 use powerio_dist::{
     Configuration, DiagnosticSeverity, DiagnosticStage, DistBus, DistLineCode, DistNetwork,
-    DistTransformer, Winding, WindingConn, parse_bmopf_file, parse_bmopf_str, parse_pmd_str,
-    write_bmopf_json, write_dss,
+    DistTransformer, Extras, VoltageSource, Winding, WindingConn, parse_bmopf_file,
+    parse_bmopf_str, parse_pmd_str, write_bmopf_json, write_dss,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -768,6 +768,201 @@ fn voltage_source_cost_round_trips_as_extra() {
         "{:?}",
         out.warnings
     );
+}
+
+fn single_phase_source(name: &str, phase: &str, angle: f64, extras: Extras) -> VoltageSource {
+    let mut source = VoltageSource::new(
+        name,
+        "sourcebus",
+        vec![phase.into(), "4".into()],
+        vec![7200.0, 0.0],
+        vec![angle, 0.0],
+    );
+    source.extras = extras;
+    source
+}
+
+fn split_source_network(sources: Vec<VoltageSource>) -> DistNetwork {
+    let mut bus = DistBus::new(
+        "sourcebus",
+        vec!["1".into(), "2".into(), "3".into(), "4".into()],
+    );
+    bus.grounded = vec!["4".into()];
+    let mut net = DistNetwork::default();
+    net.name = Some("split".into());
+    net.buses = vec![bus];
+    net.sources = sources;
+    net
+}
+
+#[test]
+fn opendss_split_voltage_sources_merge_in_bmopf() {
+    let third = 2.0 * std::f64::consts::FRAC_PI_3;
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.split phases=1 basekv=7.2 pu=1.0 angle=0 bus1=SourceBus.1\n\
+         New Vsource.phb phases=1 basekv=7.2 pu=1.0 angle=-120 bus1=sourcebus.2\n\
+         New Vsource.phc phases=1 basekv=7.2 pu=1.0 angle=120 bus1=SOURCEBUS.3\n",
+    );
+    assert_eq!(net.sources.len(), 3);
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("expects exactly one source")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("voltage source phb: `angle`")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("voltage source phc: `basekv`")),
+        "{:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    assert!(doc["bus"].get("SourceBus").is_some(), "{}", out.text);
+    let sources = doc["voltage_source"].as_object().unwrap();
+    assert_eq!(sources.len(), 1, "{sources:?}");
+    let source = &sources["source"];
+    assert_eq!(source["bus"], serde_json::json!("SourceBus"));
+    assert_eq!(
+        source["terminal_map"],
+        serde_json::json!(["1", "2", "3", "4"])
+    );
+    assert_eq!(
+        source["v_magnitude"],
+        serde_json::json!([7200.0, 7200.0, 7200.0, 0.0])
+    );
+    let angles = source["v_angle"].as_array().unwrap();
+    assert_eq!(angles.len(), 4);
+    for (actual, expected) in angles.iter().zip([0.0, -third, third, 0.0]) {
+        let actual = actual.as_f64().unwrap();
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "v_angle entry = {actual}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn two_phase_split_voltage_sources_merge_in_bmopf() {
+    let third = 2.0 * std::f64::consts::FRAC_PI_3;
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.split phases=1 basekv=7.2 pu=1.0 angle=0 bus1=sourcebus.1\n\
+         New Vsource.phb phases=1 basekv=7.2 pu=1.0 angle=-120 bus1=sourcebus.2\n",
+    );
+    assert_eq!(net.sources.len(), 2);
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    assert!(
+        out.warnings
+            .iter()
+            .all(|w| !w.contains("expects exactly one source")),
+        "{:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let sources = doc["voltage_source"].as_object().unwrap();
+    assert_eq!(sources.len(), 1, "{sources:?}");
+    let source = &sources["source"];
+    assert_eq!(source["terminal_map"], serde_json::json!(["1", "2", "4"]));
+    assert_eq!(
+        source["v_magnitude"],
+        serde_json::json!([7200.0, 7200.0, 0.0])
+    );
+    let angles = source["v_angle"].as_array().unwrap();
+    assert_eq!(angles.len(), 3);
+    for (actual, expected) in angles.iter().zip([0.0, -third, 0.0]) {
+        let actual = actual.as_f64().unwrap();
+        assert!(
+            (actual - expected).abs() < 1e-12,
+            "v_angle entry = {actual}, expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn split_voltage_source_merge_declines_ambiguous_banks() {
+    let third = 2.0 * std::f64::consts::FRAC_PI_3;
+    let cases = [
+        (
+            "quadrature",
+            vec![
+                single_phase_source("source", "1", 0.0, Extras::new()),
+                single_phase_source("phb", "2", std::f64::consts::FRAC_PI_2, Extras::new()),
+            ],
+        ),
+        (
+            "anti phase",
+            vec![
+                single_phase_source("source", "1", 0.0, Extras::new()),
+                single_phase_source("phb", "2", std::f64::consts::PI, Extras::new()),
+            ],
+        ),
+        (
+            "incoherent",
+            vec![
+                single_phase_source("source", "1", 0.0, Extras::new()),
+                single_phase_source("phb", "2", -third, Extras::new()),
+                single_phase_source("phc", "3", 0.25, Extras::new()),
+            ],
+        ),
+        (
+            "phase conflict",
+            vec![
+                single_phase_source("source", "1", 0.0, Extras::new()),
+                single_phase_source("other", "1", -third, Extras::new()),
+            ],
+        ),
+        ("bounded", {
+            let mut extras = Extras::new();
+            extras.insert("p_min".into(), serde_json::json!([-1.0]));
+            vec![
+                single_phase_source("source", "1", 0.0, extras),
+                single_phase_source("phb", "2", -third, Extras::new()),
+                single_phase_source("phc", "3", third, Extras::new()),
+            ]
+        }),
+        ("priced", {
+            let mut extras = Extras::new();
+            extras.insert("cost".into(), serde_json::json!([1.0]));
+            vec![
+                single_phase_source("source", "1", 0.0, extras),
+                single_phase_source("phb", "2", -third, Extras::new()),
+                single_phase_source("phc", "3", third, Extras::new()),
+            ]
+        }),
+    ];
+
+    for (case, sources) in cases {
+        let source_count = sources.len();
+        let out = write_bmopf_json(&split_source_network(sources));
+        if case != "priced" {
+            assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+        }
+        let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+        let emitted = doc["voltage_source"].as_object().unwrap();
+        assert_eq!(emitted.len(), source_count, "{case}: {emitted:?}");
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("expects exactly one source")),
+            "{case}: {:?}",
+            out.warnings
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Merge order: A6 of A7. Base: `main` after #224.

Fixes #218.

## Scope

- Merge per phase OpenDSS voltage sources on the same bus into one BMOPF `voltage_source`.
- Preserve physical phase order in `terminal_map`, `v_magnitude`, and `v_angle`.
- Match OpenDSS bus spelling case insensitively while emitting the typed bus id.
- Keep source extra drop warnings for removed phase sources.
- Keep ambiguous source banks split, including quadrature, anti phase, incoherent, bounded, priced, and phase conflict cases.
- Leave single source output unchanged.

## Acceptance

- A three single phase OpenDSS source fixture emits one BMOPF `voltage_source` and validates against the vendored BMOPF schema.
- The merged `terminal_map`, `v_magnitude`, and `v_angle` arrays are aligned.
- Mixed case source bus spellings and valid two phase 120 degree banks merge.
- Ambiguous source banks keep the existing multiple source warning instead of merging.
- `tests/data/dist/micro/xfmr_wye_delta.dss` emits byte identical BMOPF JSON on `main` and this branch.

## Out Of Scope

- Rename OpenDSS numeric source terminals to task force labels.
- Change source cost or source bound modeling.
- Add capability flags (#213).

## Tests

- `cargo test -p powerio-dist --test bmopf voltage_source -- --nocapture`
- `cargo test -p powerio-dist --test bmopf -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `env POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a6-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`