### PR TITLE
Expose distribution capability flags through C ABI

### DIFF
--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -303,6 +303,25 @@ int main(int argc, char **argv) {
         CHECK(pio_has_feature("dist") == 1, "pio_has_feature(dist) should be 1");
         CHECK(pio_dist_abi_version() == PIO_DIST_ABI_VERSION,
               "dist ABI version mismatch");
+        char *dist_caps = pio_dist_capabilities_json();
+        CHECK(dist_caps != NULL, "pio_dist_capabilities_json returned NULL");
+        CHECK(strstr(dist_caps, "\"dist\":true") != NULL,
+              "dist capabilities did not report dist=true");
+        CHECK(strstr(dist_caps, "\"schema_version\":\"1.0.0\"") != NULL,
+              "dist capabilities schema_version mismatch");
+        CHECK(strstr(dist_caps, "\"bmopf_fixed_taps\":true") != NULL,
+              "fixed tap capability missing");
+        CHECK(strstr(dist_caps, "\"bmopf_center_tap_leakage\":true") != NULL,
+              "center tap capability missing");
+        CHECK(strstr(dist_caps, "\"bmopf_delta_wye_leakage\":true") != NULL,
+              "delta wye leakage capability missing");
+        CHECK(strstr(dist_caps, "\"bmopf_delta_roll\":true") != NULL,
+              "delta roll capability missing");
+        CHECK(strstr(dist_caps, "\"bmopf_voltage_source_merge\":true") != NULL,
+              "voltage source merge capability missing");
+        CHECK(strstr(dist_caps, "\"bmopf_transformer_diagnostics\":true") != NULL,
+              "transformer diagnostics capability missing");
+        pio_string_free(dist_caps);
         printf("dist surface OK\n");
     }
 #endif

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -260,6 +260,18 @@ uint32_t pio_abi_version(void);
 uint32_t pio_dist_abi_version(void);
 #endif
 
+#if defined(PIO_DIST)
+/**
+ * Return distribution capability flags as owned JSON. Free the returned string
+ * with [`pio_string_free`]. Only linked when the `dist` feature is compiled in;
+ * runtime loaders can either check `pio_has_feature("dist")` or probe for this
+ * symbol directly. The JSON schema is versioned separately from
+ * [`PIO_DIST_ABI_VERSION`] so new additive flags do not force a C signature
+ * change.
+ */
+char *pio_dist_capabilities_json(void);
+#endif
+
 /**
  * Whether the matrix Arrow table surface is usable in this build. Returns 1
  * only when both `arrow` and `matrix` are compiled in, since the matrices ride

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -230,6 +230,29 @@ pub extern "C" fn pio_dist_abi_version() -> u32 {
     PIO_DIST_ABI_VERSION
 }
 
+#[cfg(feature = "dist")]
+const DIST_CAPABILITIES_JSON: &str = concat!(
+    r#"{"dist":true,"schema_version":"1.0.0","#,
+    r#""bmopf_fixed_taps":true,"#,
+    r#""bmopf_center_tap_leakage":true,"#,
+    r#""bmopf_delta_wye_leakage":true,"#,
+    r#""bmopf_delta_roll":true,"#,
+    r#""bmopf_voltage_source_merge":true,"#,
+    r#""bmopf_transformer_diagnostics":true}"#
+);
+
+/// Return distribution capability flags as owned JSON. Free the returned string
+/// with [`pio_string_free`]. Only linked when the `dist` feature is compiled in;
+/// runtime loaders can either check `pio_has_feature("dist")` or probe for this
+/// symbol directly. The JSON schema is versioned separately from
+/// [`PIO_DIST_ABI_VERSION`] so new additive flags do not force a C signature
+/// change.
+#[cfg(feature = "dist")]
+#[unsafe(no_mangle)]
+pub extern "C" fn pio_dist_capabilities_json() -> *mut c_char {
+    into_cstring(DIST_CAPABILITIES_JSON.to_owned()).unwrap_or(std::ptr::null_mut())
+}
+
 /// Whether the matrix Arrow table surface is usable in this build. Returns 1
 /// only when both `arrow` and `matrix` are compiled in, since the matrices ride
 /// `pio_to_arrow`. Infallible.
@@ -2384,6 +2407,7 @@ mod tests {
             "typedef struct PioPackage PioPackage;",
             "uint32_t pio_abi_version(void);",
             "uint32_t pio_dist_abi_version(void);",
+            "char *pio_dist_capabilities_json(void);",
             "int32_t pio_matrix_available(void);",
             "int32_t pio_has_feature(const char *feature);",
             "const char *pio_version(void);",
@@ -3792,6 +3816,29 @@ mpc.branch = [
             assert_eq!(PIO_DIST_ABI_VERSION, 1);
             let feature = CString::new("dist").unwrap();
             assert_eq!(unsafe { pio_has_feature(feature.as_ptr()) }, 1);
+        }
+
+        #[test]
+        fn dist_capabilities_json_reports_bmopf_fidelity_flags() {
+            let ptr = pio_dist_capabilities_json();
+            assert!(!ptr.is_null(), "dist capabilities JSON returned NULL");
+            let text = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();
+            unsafe { pio_string_free(ptr) };
+
+            let caps: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(
+                caps,
+                serde_json::json!({
+                    "dist": true,
+                    "schema_version": "1.0.0",
+                    "bmopf_fixed_taps": true,
+                    "bmopf_center_tap_leakage": true,
+                    "bmopf_delta_wye_leakage": true,
+                    "bmopf_delta_roll": true,
+                    "bmopf_voltage_source_merge": true,
+                    "bmopf_transformer_diagnostics": true,
+                })
+            );
         }
 
         #[test]


### PR DESCRIPTION
## Summary

- add `pio_dist_capabilities_json` behind the `dist` C ABI feature
- return the PowerIO.jl probe shape with `dist`, `schema_version`, and the six BMOPF fidelity flags
- regenerate `powerio.h`, pin the new prototype in the C ABI manifest test, and cover the probe in the C smoke test

Fixes #213.

## Validation

- `cargo test -p powerio-capi --features dist dist_capabilities_json_reports_bmopf_fidelity_flags -- --nocapture`
- `cargo test -p powerio-capi c_header -- --nocapture`
- `cargo test -p powerio-capi -- --nocapture`
- `cargo test -p powerio-capi --no-default-features -- --nocapture`
- `cargo build -p powerio-capi --release --features dist`
- `cc -DPIO_DIST -I powerio-capi/include powerio-capi/examples/smoke.c -L target/release -lpowerio_capi -o /private/tmp/pio_smoke_dist_a7`
- `env DYLD_LIBRARY_PATH=target/release /private/tmp/pio_smoke_dist_a7 tests/data/case9.m`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/capi-header-parity.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p powerio-capi --all-targets --no-default-features -- -D warnings`
- `cargo clippy -p powerio-capi --all-targets --features dist -- -D warnings`
- `cargo test --workspace`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
- `cargo test -p powerio-capi --features arrow,matrix,gridfm,dist,pkg -- --nocapture`
- `cargo clippy -p powerio-capi --all-targets --features arrow,matrix,gridfm,dist,pkg -- -D warnings`
- `env POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-a7-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
