### PR TITLE
Add typed geographic fields to network models

### DIFF
--- a/docs/schema/pio-package/0.1/schema.json
+++ b/docs/schema/pio-package/0.1/schema.json
@@ -335,6 +335,17 @@
         "kind": {
           "$ref": "#/$defs/BusType"
         },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
+        },
         "name": {
           "type": [
             "string",
@@ -402,6 +413,58 @@
       ],
       "type": "string"
     },
+    "Canvas": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Canvas2": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "Confidence": {
       "description": "How confident the source map entry is.",
       "enum": [
@@ -428,6 +491,26 @@
         "PG_AVERAGED",
         "PN_AVERAGED",
         "PG_PER_PHASE"
+      ],
+      "type": "string"
+    },
+    "CoordsKind": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
+      ],
+      "type": "string"
+    },
+    "CoordsKind2": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
       ],
       "type": "string"
     },
@@ -517,6 +600,17 @@
         },
         "id": {
           "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
         },
         "terminals": {
           "description": "Ordered terminal names; OpenDSS node numbers as strings.",
@@ -1302,6 +1396,16 @@
           },
           "type": "array"
         },
+        "geo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GeoMeta2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "ibrs": {
           "items": {
             "$ref": "#/$defs/DistIbr"
@@ -1778,6 +1882,192 @@
       ],
       "type": "object"
     },
+    "GeoMeta": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
+      "type": "object"
+    },
+    "GeoMeta2": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas2"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
+      "type": "object"
+    },
     "Hvdc": {
       "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
       "properties": {
@@ -2118,6 +2408,68 @@
         }
       ]
     },
+    "Location": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
+    },
+    "Location2": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
+    },
     "LoweringRecord": {
       "description": "One lowering/normalization/emission pass and what it changed.",
       "properties": {
@@ -2314,6 +2666,16 @@
             "$ref": "#/$defs/Generator"
           },
           "type": "array"
+        },
+        "geo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GeoMeta"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "hvdc": {
           "items": {

--- a/docs/schema/pio-payload-balanced/1/schema.json
+++ b/docs/schema/pio-payload-balanced/1/schema.json
@@ -320,6 +320,17 @@
         "kind": {
           "$ref": "#/$defs/BusType"
         },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
+        },
         "name": {
           "type": [
             "string",
@@ -384,6 +395,42 @@
         "PV",
         "REF",
         "ISOLATED"
+      ],
+      "type": "string"
+    },
+    "Canvas": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "CoordsKind": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
       ],
       "type": "string"
     },
@@ -523,6 +570,99 @@
         "mbase",
         "in_service"
       ],
+      "type": "object"
+    },
+    "GeoMeta": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
       "type": "object"
     },
     "Hvdc": {
@@ -839,6 +979,37 @@
           "type": "object"
         }
       ]
+    },
+    "Location": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
     },
     "Shunt": {
       "properties": {
@@ -1525,6 +1696,16 @@
         "$ref": "#/$defs/Generator"
       },
       "type": "array"
+    },
+    "geo": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GeoMeta"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "hvdc": {
       "items": {

--- a/docs/schema/pio-payload-multiconductor/1/schema.json
+++ b/docs/schema/pio-payload-multiconductor/1/schema.json
@@ -15,6 +15,32 @@
       ],
       "type": "string"
     },
+    "Canvas": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "Configuration": {
       "enum": [
         "wye",
@@ -34,6 +60,16 @@
       ],
       "type": "string"
     },
+    "CoordsKind": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
+      ],
+      "type": "string"
+    },
     "DistBus": {
       "properties": {
         "extras": {
@@ -49,6 +85,17 @@
         },
         "id": {
           "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
         },
         "terminals": {
           "description": "Ordered terminal names; OpenDSS node numbers as strings.",
@@ -936,6 +983,99 @@
       ],
       "type": "object"
     },
+    "GeoMeta": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
+      "type": "object"
+    },
     "IbrPrimeMover": {
       "enum": [
         "PV",
@@ -960,6 +1100,37 @@
         "AVERAGE"
       ],
       "type": "string"
+    },
+    "Location": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
     },
     "PowerFactorControl": {
       "properties": {
@@ -1302,6 +1473,16 @@
         "$ref": "#/$defs/DistGenerator"
       },
       "type": "array"
+    },
+    "geo": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GeoMeta"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "ibrs": {
       "items": {

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -2,8 +2,8 @@
 
 > **Status: partial.** The distribution graph projection from #182 ships as
 > Rust `DistNetwork::graph()`, Python `dist_net.graph()`, and C
-> `pio_dist_graph_json`. The coordinate model and GeoLayer interchange remain
-> design work.
+> `pio_dist_graph_json`. The typed coordinate model and DSS/BMOPF coordinate
+> paths ship as layer 1. GeoLayer interchange remains design work.
 
 Power system case files disagree about where equipment sits on a map, and most
 say nothing at all. PowerWorld aux exports carry substation latitude and
@@ -70,7 +70,8 @@ defined in `powerio::geo` and mirrored in `powerio_dist::geo`, the same
 arrangement `Extras` already uses. A parity test in `powerio-pkg` serializes
 both and asserts identical JSON, so the copies cannot drift.
 
-Before this is implemented, it is worth considering whether a `powerio-geo` or `powerio-format` crate make be necessary.
+If the mirrored types grow beyond small data carriers, a `powerio-geo` or
+`powerio-format` crate may become worth the dependency split.
 
 Because the fields are additive and skipped when absent, they ride the
 `.pio.json` model JSON as a minor bump.

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -133,7 +133,7 @@ later families can be added).
 ## The Model JSON
 
 `payload_schema` names the model JSON contract per model kind and
-`payload_schema_version` versions it, currently `1.0.0` for both kinds.
+`payload_schema_version` versions it, currently `1.1.0` for both kinds.
 Additive optional fields bump the minor; field moves or removals bump the
 major. A reader rejects a different major (or a version that does not parse as
 semver) before computing on model fields. Both fields are absent on documents
@@ -307,7 +307,7 @@ bindings, or MCP operations.
   "producer": { "tool": "powerio", "version": "0.6.1" },
   "model_kind": "multiconductor",
   "payload_schema": "https://powerio.dev/schema/pio-payload-multiconductor/1",
-  "payload_schema_version": "1.0.0",
+  "payload_schema_version": "1.1.0",
   "model": {
     "kind": "multiconductor",
     "multiconductor_network": {

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1312,7 +1312,7 @@ fn run_convert(
             to.name()
         );
     }
-    let (text, warnings) = if let Some(target) = to.transmission() {
+    let (text, sidecars, warnings) = if let Some(target) = to.transmission() {
         let options = gen_cost_options.write_options()?;
         // gridfm reads a Parquet dataset directory (the parquet-free
         // `parse_file` can't), so it routes through powerio-matrix's reader,
@@ -1329,7 +1329,7 @@ fn run_convert(
         };
         let conv = powerio_matrix::write_as_with_options(&net, target, &options)
             .with_context(|| format!("serializing to {target}"))?;
-        (conv.text, conv.warnings)
+        (conv.text, Vec::new(), conv.warnings)
     } else {
         let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
             .with_context(|| format!("reading {}", input.display()))?;
@@ -1340,7 +1340,7 @@ fn run_convert(
             .distribution()
             .expect("the family check routed a transmission target here");
         let conv = net.to_format(target);
-        (conv.text, conv.warnings)
+        (conv.text, conv.sidecars, conv.warnings)
     };
     for w in &warnings {
         eprintln!("fidelity: {w}");
@@ -1349,8 +1349,27 @@ fn run_convert(
         Some(p) if p.as_os_str() != "-" => {
             std::fs::write(p, &text).with_context(|| format!("writing {}", p.display()))?;
             eprintln!("wrote {}", p.display());
+            let base = p.parent().unwrap_or_else(|| std::path::Path::new("."));
+            for sidecar in &sidecars {
+                let path = base.join(&sidecar.path);
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating {}", parent.display()))?;
+                }
+                std::fs::write(&path, &sidecar.text)
+                    .with_context(|| format!("writing {}", path.display()))?;
+                eprintln!("wrote {}", path.display());
+            }
         }
-        _ => print!("{text}"),
+        _ => {
+            for sidecar in &sidecars {
+                eprintln!(
+                    "fidelity: sidecar `{}` was not written because output is stdout",
+                    sidecar.path
+                );
+            }
+            print!("{text}");
+        }
     }
     Ok(())
 }
@@ -1717,6 +1736,60 @@ mpc.branch = [
 
         let _ = std::fs::remove_dir_all(input);
         let _ = std::fs::remove_file(output);
+    }
+
+    #[test]
+    fn convert_writes_distribution_sidecars_next_to_output_file() {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("powerio-convert-sidecar-{stamp}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        let input = dir.join("geo.bmopf.json");
+        let output = dir.join("geo.dss");
+
+        let mut bus = powerio_dist::DistBus::new("sourcebus", vec!["1".to_owned(), "4".to_owned()]);
+        bus.grounded = vec!["4".to_owned()];
+        bus.location = Some(powerio_dist::Location {
+            x: -80.0,
+            y: 35.0,
+            kind: None,
+        });
+        let mut net = powerio_dist::DistNetwork::default();
+        net.geo = Some(powerio_dist::GeoMeta {
+            space: powerio_dist::CoordinateSpace::Geographic { crs: None },
+            kind: Some(powerio_dist::CoordsKind::Source),
+        });
+        net.buses = vec![bus];
+        net.sources.push(powerio_dist::VoltageSource::new(
+            "source",
+            "sourcebus",
+            vec!["1".to_owned(), "4".to_owned()],
+            vec![7200.0, 0.0],
+            vec![0.0, 0.0],
+        ));
+        let mut options = powerio_dist::BmopfWriteOptions::default();
+        options.sideload_coordinates = true;
+        let bmopf = powerio_dist::write_bmopf_json_with_options(&net, &options);
+        std::fs::write(&input, bmopf.text).unwrap();
+
+        run_convert(
+            &input,
+            FormatArg::Dss,
+            Some(&output),
+            Some(FormatArg::BmopfJson),
+            0,
+            GenCostCliOptions::preserve(),
+        )
+        .unwrap();
+
+        let dss = std::fs::read_to_string(&output).unwrap();
+        let coords = std::fs::read_to_string(dir.join("buscoords.csv")).unwrap();
+        assert!(dss.contains("Buscoords buscoords.csv"), "{dss}");
+        assert!(coords.contains("sourcebus,-80,35"), "{coords}");
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/powerio-dist/src/bmopf/mod.rs
+++ b/powerio-dist/src/bmopf/mod.rs
@@ -10,4 +10,4 @@ mod read;
 mod write;
 
 pub use read::{parse_bmopf_file, parse_bmopf_str};
-pub use write::write_bmopf_json;
+pub use write::{BmopfWriteOptions, write_bmopf_json, write_bmopf_json_with_options};

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -15,6 +15,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 
 use crate::error::{Error, Result};
+use crate::geo::{CoordinateSpace, CoordsKind, GeoMeta, Location};
 use crate::model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
     DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
@@ -400,6 +401,8 @@ impl Reader<'_> {
             let known = [
                 "terminal_names",
                 "perfectly_grounded_terminals",
+                "longitude",
+                "latitude",
                 "v_min",
                 "v_max",
                 "vpn_min",
@@ -409,6 +412,36 @@ impl Reader<'_> {
                 "vsym_min",
                 "vsym_max",
             ];
+            let lon = first_float(o.get("longitude")).filter(|v| v.is_finite());
+            let lat = first_float(o.get("latitude")).filter(|v| v.is_finite());
+            let has_lon = o.contains_key("longitude");
+            let has_lat = o.contains_key("latitude");
+            let location = match (lon, lat) {
+                (Some(x), Some(y)) => {
+                    self.net.geo = Some(GeoMeta {
+                        space: CoordinateSpace::Geographic { crs: None },
+                        kind: Some(CoordsKind::Source),
+                    });
+                    Some(Location { x, y, kind: None })
+                }
+                _ if has_lon || has_lat => {
+                    self.net.warnings.push(format!(
+                        "bus {id}: longitude/latitude sideload is incomplete or nonfinite; kept in extras"
+                    ));
+                    None
+                }
+                _ => None,
+            };
+            let mut extras =
+                take_extras(o, &known, &format!("bus {id}"), &mut self.net.warnings, &[]);
+            if location.is_none() {
+                if let Some(value) = o.get("longitude") {
+                    extras.insert("longitude".into(), value.clone());
+                }
+                if let Some(value) = o.get("latitude") {
+                    extras.insert("latitude".into(), value.clone());
+                }
+            }
             self.net.buses.push(DistBus {
                 id: id.clone(),
                 terminals: strings(o.get("terminal_names")),
@@ -429,7 +462,8 @@ impl Reader<'_> {
                 vpp_max: floats(o.get("vpp_max")),
                 vsym_min: floats(o.get("vsym_min")),
                 vsym_max: floats(o.get("vsym_max")),
-                extras: take_extras(o, &known, &format!("bus {id}"), &mut self.net.warnings, &[]),
+                location,
+                extras,
             });
         }
     }

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -13,6 +13,7 @@ use serde_json::{Map, Value, json};
 
 use crate::convert::Conversion;
 use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
+use crate::geo::CoordinateSpace;
 use crate::model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference,
     DistControlProfile, DistGenerator, DistIbr, DistLoadVoltageModel, DistNetwork, DistTransformer,
@@ -85,6 +86,17 @@ const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
     "%imag",
 ];
 
+/// Options for BMOPF JSON output.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct BmopfWriteOptions {
+    /// Emit the BMOPFTools coordinate sideload fields on buses.
+    ///
+    /// The default stays schema strict because the BMOPF schema rejects these
+    /// fields with `additionalProperties: false`.
+    pub sideload_coordinates: bool,
+}
+
 /// Writes the strict BMOPF document. Every field the schema cannot carry
 /// is reported in the warnings.
 ///
@@ -93,7 +105,18 @@ const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
 /// Never in practice: the document is maps, strings, and finite numbers,
 /// which always serialize.
 pub fn write_bmopf_json(net: &DistNetwork) -> Conversion {
+    write_bmopf_json_with_options(net, &BmopfWriteOptions::default())
+}
+
+/// Writes BMOPF JSON with explicit options.
+///
+/// # Panics
+///
+/// Never in practice: the document is maps, strings, and finite numbers,
+/// which always serialize.
+pub fn write_bmopf_json_with_options(net: &DistNetwork, options: &BmopfWriteOptions) -> Conversion {
     let mut w = Writer {
+        options: *options,
         warnings: Vec::new(),
         diagnostics: Vec::new(),
         grounded: net
@@ -105,12 +128,14 @@ pub fn write_bmopf_json(net: &DistNetwork) -> Conversion {
     let doc = w.document(net);
     Conversion {
         text: serde_json::to_string_pretty(&doc).expect("maps and finite numbers") + "\n",
+        sidecars: Vec::new(),
         warnings: w.warnings,
         diagnostics: w.diagnostics,
     }
 }
 
 struct Writer {
+    options: BmopfWriteOptions,
     warnings: Vec<String>,
     diagnostics: Vec<StructuredDiagnostic>,
     grounded: BTreeMap<String, Vec<String>>,
@@ -226,7 +251,8 @@ impl Writer {
                     o.insert(key.into(), self.nums(v, &format!("bus {key}")));
                 }
             }
-            // Coordinates and other extras have no bus fields in the schema.
+            self.bus_location(&mut o, b, net);
+            // Other extras have no bus fields in the schema.
             self.extras_dropped(&b.extras, &format!("bus {}", b.id));
             buses.insert(b.id.clone(), Value::Object(o));
         }
@@ -284,6 +310,79 @@ impl Writer {
         self.warn_unemitted_untyped(net);
         self.prune_unreferenced_buses(&mut doc);
         Value::Object(doc)
+    }
+
+    fn bus_location(
+        &mut self,
+        o: &mut Map<String, Value>,
+        b: &crate::model::DistBus,
+        net: &DistNetwork,
+    ) {
+        let Some(location) = b.location else {
+            return;
+        };
+        if !self.options.sideload_coordinates {
+            self.diagnostic(
+                "EMIT.BMOPF.BUS_LOCATION_DROPPED",
+                format!("bus {}", b.id),
+                format!(
+                    "bus {}: location has no place in the BMOPF schema; dropped from the output",
+                    b.id
+                ),
+                json!({
+                    "bus": b.id,
+                    "x": location.x,
+                    "y": location.y,
+                })
+                .as_object()
+                .expect("object literal")
+                .clone(),
+            );
+            return;
+        }
+        if !matches!(
+            net.geo.as_ref().map(|geo| &geo.space),
+            Some(CoordinateSpace::Geographic { .. })
+        ) {
+            self.diagnostic(
+                "EMIT.BMOPF.BUS_LOCATION_DROPPED",
+                format!("bus {}", b.id),
+                format!(
+                    "bus {}: non-geographic or undeclared location cannot be emitted as BMOPF longitude/latitude",
+                    b.id
+                ),
+                json!({
+                    "bus": b.id,
+                    "x": location.x,
+                    "y": location.y,
+                })
+                .as_object()
+                .expect("object literal")
+                .clone(),
+            );
+            return;
+        }
+        if !location.x.is_finite() || !location.y.is_finite() {
+            self.diagnostic(
+                "EMIT.BMOPF.BUS_LOCATION_DROPPED",
+                format!("bus {}", b.id),
+                format!(
+                    "bus {}: nonfinite location cannot be emitted as BMOPF longitude/latitude",
+                    b.id
+                ),
+                json!({
+                    "bus": b.id,
+                    "x": location.x,
+                    "y": location.y,
+                })
+                .as_object()
+                .expect("object literal")
+                .clone(),
+            );
+            return;
+        }
+        o.insert("longitude".into(), self.num(location.x, "bus longitude"));
+        o.insert("latitude".into(), self.num(location.y, "bus latitude"));
     }
 
     fn warn_unemitted_untyped(&mut self, net: &DistNetwork) {

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -2,6 +2,16 @@
 
 use crate::model::{DistNetwork, DistSourceFormat};
 
+/// Extra files a writer generated beside the primary text payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ConversionSidecar {
+    /// Relative file path the primary text refers to.
+    pub path: String,
+    /// File content.
+    pub text: String,
+}
+
 /// Text in the target format plus every fidelity loss the writer took.
 /// Nothing drops silently: a field the target cannot represent appears
 /// here as a warning naming the element and field.
@@ -9,6 +19,8 @@ use crate::model::{DistNetwork, DistSourceFormat};
 #[non_exhaustive]
 pub struct Conversion {
     pub text: String,
+    /// Extra files referenced by `text`, such as OpenDSS `Buscoords` CSV.
+    pub sidecars: Vec<ConversionSidecar>,
     pub warnings: Vec<String>,
     /// Structured diagnostics for warning paths with stable codes.
     ///
@@ -147,6 +159,7 @@ fn convert(net: &DistNetwork, target: DistTargetFormat) -> Conversion {
     warnings.extend(conv.warnings);
     Conversion {
         text: conv.text,
+        sidecars: conv.sidecars,
         warnings,
         diagnostics: conv.diagnostics,
     }
@@ -205,6 +218,7 @@ impl DistNetwork {
             if format.matches(source_format) {
                 return Conversion {
                     text: source.as_ref().clone(),
+                    sidecars: Vec::new(),
                     warnings: Vec::new(),
                     diagnostics: Vec::new(),
                 };

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -19,6 +19,7 @@ use super::defaults as dd;
 use super::lex::{BusSpec, Value, VarMap};
 use super::raw::{RawDss, RawObject, parse_raw_with};
 use crate::error::{Error, Result};
+use crate::geo::{CoordinateSpace, CoordsKind, GeoMeta, Location};
 use crate::model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
     DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
@@ -200,10 +201,27 @@ fn finish_buses(mut rd: Reader, raw: &RawDss) -> DistNetwork {
             neutral_names.insert(id.clone(), neutral.to_string());
         }
         if let Some((x, y)) = coords.get(&id) {
-            bus.extras.insert("x".into(), (*x).into());
-            bus.extras.insert("y".into(), (*y).into());
+            bus.location = Some(Location {
+                x: *x,
+                y: *y,
+                kind: None,
+            });
         }
         net.buses.push(bus);
+    }
+    if !coords.is_empty() {
+        net.geo = Some(GeoMeta {
+            space: CoordinateSpace::Unknown,
+            kind: Some(CoordsKind::Source),
+        });
+        if coords
+            .values()
+            .all(|(x, y)| (-180.0..=180.0).contains(x) && (-90.0..=90.0).contains(y))
+        {
+            net.warnings.push(
+                "OpenDSS buscoords fit longitude/latitude ranges; coordinate space remains unknown because Buscoords does not declare a CRS".to_owned(),
+            );
+        }
     }
 
     let rewrite = |bus: &str, map: &mut [String]| {

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -15,7 +15,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
-use crate::convert::Conversion;
+use crate::convert::{Conversion, ConversionSidecar};
 use crate::model::{
     ActivePowerReference, Configuration, ControlVoltageReference, DistBus, DistControlProfile,
     DistIbr, DistLoadVoltageModel, DistNetwork, Extras, IbrPrimeMover, IbrTopology,
@@ -33,12 +33,16 @@ pub struct DssWriteOptions {
     /// Default voltage validity band emitted on loads that do not already
     /// carry `vminpu` / `vmaxpu` extras.
     pub default_load_voltage_bounds: Option<DssLoadVoltageBounds>,
+    /// Relative companion file named by the emitted `Buscoords` command.
+    /// `None` drops typed bus locations with a warning.
+    pub buscoords_filename: Option<String>,
 }
 
 impl Default for DssWriteOptions {
     fn default() -> Self {
         Self {
             default_load_voltage_bounds: Some(DssLoadVoltageBounds::default()),
+            buscoords_filename: Some("buscoords.csv".to_owned()),
         }
     }
 }
@@ -69,6 +73,7 @@ pub fn write_dss(net: &DistNetwork) -> Conversion {
 pub fn write_dss_with_options(net: &DistNetwork, options: &DssWriteOptions) -> Conversion {
     let mut w = DssWriter {
         out: String::new(),
+        sidecars: Vec::new(),
         warnings: Vec::new(),
         options: options.clone(),
         grounded: net
@@ -86,6 +91,7 @@ pub fn write_dss_with_options(net: &DistNetwork, options: &DssWriteOptions) -> C
     w.network(net);
     Conversion {
         text: w.out,
+        sidecars: w.sidecars,
         warnings: w.warnings,
         diagnostics: Vec::new(),
     }
@@ -93,6 +99,7 @@ pub fn write_dss_with_options(net: &DistNetwork, options: &DssWriteOptions) -> C
 
 struct DssWriter {
     out: String,
+    sidecars: Vec<ConversionSidecar>,
     warnings: Vec<String>,
     options: DssWriteOptions,
     /// Bus id (lowercase) → perfectly grounded terminal names.
@@ -596,6 +603,7 @@ impl DssWriter {
         ));
         self.out.push('\n');
 
+        self.buscoords(net);
         self.sources(net);
         self.linecodes(net);
         self.lines(net);
@@ -684,7 +692,7 @@ impl DssWriter {
     fn bus_extras(&mut self, b: &DistBus) {
         for key in b.extras.keys() {
             if key == "x" || key == "y" {
-                continue; // coordinates have no command in canonical output yet
+                continue; // legacy coordinate extras are superseded by `location`
             }
             self.warnings.push(format!(
                 "bus {}: extra `{key}` is not regenerated in canonical dss output",
@@ -708,6 +716,56 @@ impl DssWriter {
                 ));
             }
         }
+    }
+
+    fn buscoords(&mut self, net: &DistNetwork) {
+        let rows: Vec<(&DistBus, crate::geo::Location)> = net
+            .buses
+            .iter()
+            .filter_map(|b| b.location.map(|location| (b, location)))
+            .collect();
+        if rows.is_empty() {
+            return;
+        }
+        let Some(path) = self.options.buscoords_filename.clone() else {
+            self.warn("typed bus locations have no OpenDSS buscoords filename; dropped");
+            return;
+        };
+        if path.is_empty() {
+            self.warn("typed bus locations have an empty OpenDSS buscoords filename; dropped");
+            return;
+        }
+        let (path_out, path_representable) = dss_value_out(&path);
+        if !path_representable {
+            self.warn(format!(
+                "buscoords filename `{path}` contains every dss quote closer and splits when scanned bare; emitted as written and a reparse will not see the same value"
+            ));
+        }
+
+        let mut text = String::new();
+        for (bus, location) in rows {
+            if !location.x.is_finite() || !location.y.is_finite() {
+                self.warn(format!(
+                    "bus {}: nonfinite location is not emitted to OpenDSS buscoords",
+                    bus.id
+                ));
+                continue;
+            }
+            let (bus_out, bus_representable) = dss_value_out(&bus.id);
+            if !bus_representable {
+                self.warn(format!(
+                    "bus {}: id contains every dss quote closer and splits in buscoords; coordinates dropped",
+                    bus.id
+                ));
+                continue;
+            }
+            let _ = writeln!(text, "{bus_out},{},{}", num(location.x), num(location.y));
+        }
+        if text.is_empty() {
+            return;
+        }
+        self.line_out(&format!("Buscoords {path_out}"));
+        self.sidecars.push(ConversionSidecar { path, text });
     }
 
     fn sources(&mut self, net: &DistNetwork) {
@@ -2076,6 +2134,7 @@ mod tests {
         };
         let options = DssWriteOptions {
             default_load_voltage_bounds: None,
+            ..DssWriteOptions::default()
         };
         let out = write_dss_with_options(&net, &options);
         let line = out.text.lines().find(|l| l.contains("Load.ld")).unwrap();

--- a/powerio-dist/src/geo.rs
+++ b/powerio-dist/src/geo.rs
@@ -1,0 +1,77 @@
+//! Typed coordinate metadata for the distribution model.
+
+use serde::{Deserialize, Serialize};
+
+/// A point attached to one model element.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Location {
+    /// X coordinate. In geographic space this is longitude.
+    pub x: f64,
+    /// Y coordinate. In geographic space this is latitude.
+    pub y: f64,
+    /// Per point provenance when it differs from the network default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CoordsKind>,
+}
+
+/// Coordinate provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CoordsKind {
+    Source,
+    Synthetic,
+    Manual,
+    Derived,
+}
+
+/// Network level coordinate metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GeoMeta {
+    /// Coordinate space shared by every location on the network.
+    #[serde(flatten)]
+    pub space: CoordinateSpace,
+    /// Default provenance for points without their own `kind`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CoordsKind>,
+}
+
+/// Coordinate space for locations in a network.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "space", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CoordinateSpace {
+    /// x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.
+    Geographic {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        crs: Option<String>,
+    },
+    /// Planar coordinates, with the CRS named when known.
+    Projected {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        crs: Option<String>,
+    },
+    /// Drawing coordinates with no earth referent.
+    Diagram {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        canvas: Option<Canvas>,
+    },
+    /// The source did not declare a coordinate space.
+    Unknown,
+}
+
+/// Diagram canvas metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Canvas {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub units: Option<String>,
+}

--- a/powerio-dist/src/graph.rs
+++ b/powerio-dist/src/graph.rs
@@ -348,6 +348,12 @@ fn bus_key(id: &str) -> String {
 }
 
 fn bus_xy(bus: &DistBus) -> Option<[f64; 2]> {
+    if let Some(location) = bus.location
+        && location.x.is_finite()
+        && location.y.is_finite()
+    {
+        return Some([location.x, location.y]);
+    }
     let x = number_extra(&bus.extras, &["x", "lon", "lng", "longitude"])?;
     let y = number_extra(&bus.extras, &["y", "lat", "latitude"])?;
     Some([x, y])

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -48,14 +48,18 @@ pub mod convert;
 pub mod diagnostics;
 pub mod dss;
 pub mod error;
+pub mod geo;
 pub mod graph;
 pub mod model;
 pub mod pmd;
 
-pub use bmopf::{parse_bmopf_file, parse_bmopf_str, write_bmopf_json};
+pub use bmopf::{
+    BmopfWriteOptions, parse_bmopf_file, parse_bmopf_str, write_bmopf_json,
+    write_bmopf_json_with_options,
+};
 pub use convert::{
-    Conversion, DistTargetFormat, convert_file, convert_str, dist_target_from_name, parse_file,
-    parse_str,
+    Conversion, ConversionSidecar, DistTargetFormat, convert_file, convert_str,
+    dist_target_from_name, parse_file, parse_str,
 };
 pub use diagnostics::{DiagnosticCode, DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
 pub use dss::{
@@ -63,6 +67,7 @@ pub use dss::{
     write_dss_with_options,
 };
 pub use error::{Error, Result};
+pub use geo::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};
 pub use graph::{
     DistGraph, DistGraphAttachment, DistGraphAttachmentKind, DistGraphBus, DistGraphEdge,
     DistGraphEdgeKind,

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+use crate::geo::{GeoMeta, Location};
+
 pub type Extras = BTreeMap<String, serde_json::Value>;
 
 /// A square matrix in conductor order, row major.
@@ -66,6 +68,9 @@ pub struct DistBus {
     pub vpp_max: Option<Vec<f64>>,
     pub vsym_min: Option<Vec<f64>>,
     pub vsym_max: Option<Vec<f64>>,
+    /// Optional bus coordinates in the network coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<Location>,
     pub extras: Extras,
 }
 
@@ -84,6 +89,7 @@ impl DistBus {
             vpp_max: None,
             vsym_min: None,
             vsym_max: None,
+            location: None,
             extras: Extras::new(),
         }
     }
@@ -731,6 +737,8 @@ pub struct DistNetwork {
     pub name: Option<String>,
     /// Hz.
     pub base_frequency: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geo: Option<GeoMeta>,
     pub buses: Vec<DistBus>,
     pub linecodes: Vec<DistLineCode>,
     pub lines: Vec<DistLine>,
@@ -781,6 +789,7 @@ impl Default for DistNetwork {
         DistNetwork {
             name: None,
             base_frequency: crate::dss::defaults::BASE_FREQUENCY,
+            geo: None,
             buses: Vec::new(),
             linecodes: Vec::new(),
             lines: Vec::new(),

--- a/powerio-dist/src/pmd/write.rs
+++ b/powerio-dist/src/pmd/write.rs
@@ -16,9 +16,10 @@ use std::collections::BTreeSet;
 use serde_json::{Map, Value, json};
 
 use crate::convert::Conversion;
+use crate::geo::CoordinateSpace;
 use crate::model::{
-    Configuration, DistLineCode, DistLoadVoltageModel, DistNetwork, DistTransformer, Extras, Mat,
-    VoltageSource, Winding, WindingConn,
+    Configuration, DistBus, DistLineCode, DistLoadVoltageModel, DistNetwork, DistTransformer,
+    Extras, Mat, VoltageSource, Winding, WindingConn,
 };
 
 /// Writes the ENGINEERING document.
@@ -34,6 +35,7 @@ pub fn write_pmd_json(net: &DistNetwork) -> Conversion {
     let doc = w.document(net);
     Conversion {
         text: serde_json::to_string_pretty(&doc).expect("maps and finite numbers") + "\n",
+        sidecars: Vec::new(),
         warnings: w.warnings,
         diagnostics: Vec::new(),
     }
@@ -123,6 +125,37 @@ impl Writer {
             .unwrap_or_else(|| json!("ENABLED"))
     }
 
+    fn bus_coordinates(&mut self, o: &mut Map<String, Value>, b: &DistBus, net: &DistNetwork) {
+        if let Some(location) = b.location {
+            if !matches!(
+                net.geo.as_ref().map(|geo| &geo.space),
+                Some(CoordinateSpace::Geographic { .. })
+            ) {
+                self.warnings.push(format!(
+                    "bus {}: non-geographic or undeclared location is not emitted to PMD lon/lat",
+                    b.id
+                ));
+                return;
+            }
+            if location.x.is_finite() && location.y.is_finite() {
+                o.insert("lon".into(), json!(location.x));
+                o.insert("lat".into(), json!(location.y));
+            } else {
+                self.warnings.push(format!(
+                    "bus {}: nonfinite location is not emitted to PMD JSON",
+                    b.id
+                ));
+            }
+            return;
+        }
+        if let Some(x) = Self::extras_f64(&b.extras, "x") {
+            o.insert("lon".into(), json!(x));
+        }
+        if let Some(y) = Self::extras_f64(&b.extras, "y") {
+            o.insert("lat".into(), json!(y));
+        }
+    }
+
     fn document(&mut self, net: &DistNetwork) -> Value {
         let mut doc = Map::new();
         doc.insert("data_model".into(), json!("ENGINEERING"));
@@ -184,12 +217,7 @@ impl Writer {
             }
             o.insert("grounded".into(), json!(grounded));
             o.insert("status".into(), Self::status(&b.extras));
-            if let Some(x) = Self::extras_f64(&b.extras, "x") {
-                o.insert("lon".into(), json!(x));
-            }
-            if let Some(y) = Self::extras_f64(&b.extras, "y") {
-                o.insert("lat".into(), json!(y));
-            }
+            self.bus_coordinates(&mut o, b, net);
             // Voltage bound families have no ENGINEERING fields in volts;
             // they drop loudly (PMD bounds are per unit).
             for (key, present) in [

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -6,9 +6,10 @@ use std::sync::Arc;
 
 use powerio_dist::dss::{parse_dss_file, parse_dss_str};
 use powerio_dist::{
-    Configuration, DiagnosticSeverity, DiagnosticStage, DistBus, DistLineCode, DistNetwork,
-    DistTransformer, Extras, VoltageSource, Winding, WindingConn, parse_bmopf_file,
-    parse_bmopf_str, parse_pmd_str, write_bmopf_json, write_dss,
+    BmopfWriteOptions, Configuration, CoordinateSpace, CoordsKind, DiagnosticSeverity,
+    DiagnosticStage, DistBus, DistLineCode, DistNetwork, DistTransformer, Extras, GeoMeta,
+    Location, VoltageSource, Winding, WindingConn, parse_bmopf_file, parse_bmopf_str,
+    parse_pmd_str, write_bmopf_json, write_bmopf_json_with_options, write_dss,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -31,6 +32,32 @@ fn errors(validator: &jsonschema::Validator, text: &str) -> Vec<String> {
         .iter_errors(&doc)
         .map(|e| format!("{}: {e}", e.instance_path()))
         .collect()
+}
+
+#[test]
+fn bmopf_sideloaded_coordinates_promote_to_locations() {
+    let net = parse_bmopf_str(
+        r#"{
+  "bus": {
+    "b1": {
+      "terminal_names": ["1", "2", "3", "4"],
+      "perfectly_grounded_terminals": ["4"],
+      "longitude": -80.0,
+      "latitude": 35.0
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    assert!(net.warnings.is_empty(), "{:?}", net.warnings);
+    let geo = net.geo.as_ref().expect("geo metadata");
+    assert_eq!(geo.space, CoordinateSpace::Geographic { crs: None });
+    assert_eq!(geo.kind, Some(CoordsKind::Source));
+    let bus = &net.buses[0];
+    assert_eq!(bus.location.unwrap().x.to_bits(), (-80.0f64).to_bits());
+    assert_eq!(bus.location.unwrap().y.to_bits(), 35.0f64.to_bits());
+    assert!(!bus.extras.contains_key("longitude"));
+    assert!(!bus.extras.contains_key("latitude"));
 }
 
 fn diagnostic<'a>(
@@ -793,6 +820,71 @@ fn split_source_network(sources: Vec<VoltageSource>) -> DistNetwork {
     net.buses = vec![bus];
     net.sources = sources;
     net
+}
+
+#[test]
+fn bmopf_coordinates_are_strict_by_default_and_opt_in_as_sideloads() {
+    let mut net =
+        split_source_network(vec![single_phase_source("source", "1", 0.0, Extras::new())]);
+    net.geo = Some(GeoMeta {
+        space: CoordinateSpace::Geographic { crs: None },
+        kind: Some(CoordsKind::Source),
+    });
+    net.buses[0].location = Some(Location {
+        x: -80.0,
+        y: 35.0,
+        kind: None,
+    });
+
+    let strict = write_bmopf_json(&net);
+    let strict_doc: serde_json::Value = serde_json::from_str(&strict.text).unwrap();
+    assert!(strict_doc["bus"]["sourcebus"].get("longitude").is_none());
+    assert!(
+        strict
+            .warnings
+            .iter()
+            .any(|w| w.contains("EMIT.BMOPF.BUS_LOCATION_DROPPED")),
+        "{:?}",
+        strict.warnings
+    );
+    assert_eq!(
+        diagnostic(&strict, "EMIT.BMOPF.BUS_LOCATION_DROPPED", "bus sourcebus").severity,
+        DiagnosticSeverity::Warning
+    );
+
+    let mut options = BmopfWriteOptions::default();
+    options.sideload_coordinates = true;
+    let sideloaded = write_bmopf_json_with_options(&net, &options);
+    let doc: serde_json::Value = serde_json::from_str(&sideloaded.text).unwrap();
+    assert_eq!(
+        doc["bus"]["sourcebus"]["longitude"],
+        serde_json::json!(-80.0)
+    );
+    assert_eq!(doc["bus"]["sourcebus"]["latitude"], serde_json::json!(35.0));
+    assert!(
+        sideloaded
+            .warnings
+            .iter()
+            .all(|w| !w.contains("BUS_LOCATION_DROPPED")),
+        "{:?}",
+        sideloaded.warnings
+    );
+
+    net.geo = Some(GeoMeta {
+        space: CoordinateSpace::Unknown,
+        kind: Some(CoordsKind::Source),
+    });
+    let unknown = write_bmopf_json_with_options(&net, &options);
+    let doc: serde_json::Value = serde_json::from_str(&unknown.text).unwrap();
+    assert!(doc["bus"]["sourcebus"].get("longitude").is_none());
+    assert!(
+        unknown
+            .warnings
+            .iter()
+            .any(|w| w.contains("EMIT.BMOPF.BUS_LOCATION_DROPPED")),
+        "{:?}",
+        unknown.warnings
+    );
 }
 
 #[test]

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 
 use powerio_dist::dss::{parse_dss_file, write_dss};
 use powerio_dist::{
-    Configuration, DistNetwork, IbrPrimeMover, IbrTopology, ReactivePowerReference,
-    ReactivePowerUnit, WindingConn,
+    Configuration, CoordinateSpace, CoordsKind, DistNetwork, IbrPrimeMover, IbrTopology,
+    ReactivePowerReference, ReactivePowerUnit, WindingConn,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -21,6 +21,13 @@ fn fixture(rel: &str) -> PathBuf {
 
 fn parse(rel: &str) -> DistNetwork {
     parse_dss_file(fixture(rel)).expect("fixture parses")
+}
+
+fn temp_case_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("powerio-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
 }
 
 /// Bus id (lowercased) → phase terminal names, excluding the materialized
@@ -39,6 +46,56 @@ fn phase_terminals(net: &DistNetwork) -> BTreeMap<String, Vec<String>> {
             )
         })
         .collect()
+}
+
+#[test]
+fn buscoords_promote_to_locations_and_write_a_sidecar() {
+    let dir = temp_case_dir("dss-geo");
+    std::fs::write(
+        dir.join("master.dss"),
+        "\
+New Circuit.geo basekv=12.47 pu=1 phases=3 bus1=a
+New Line.l1 bus1=a.1.2.3 bus2=b.1.2.3 phases=3 r1=0.1 x1=0.2 length=1 units=km
+New Load.ld bus1=b.1.2.3 phases=3 conn=wye kv=7.2 kw=10 kvar=1
+Buscoords coords.csv
+",
+    )
+    .unwrap();
+    std::fs::write(dir.join("coords.csv"), "a,-80,35\nb,-80.5,35.25\n").unwrap();
+
+    let net = parse_dss_file(dir.join("master.dss")).unwrap();
+    let geo = net.geo.as_ref().expect("geo metadata");
+    assert_eq!(geo.space, CoordinateSpace::Unknown);
+    assert_eq!(geo.kind, Some(CoordsKind::Source));
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("fit longitude/latitude ranges")),
+        "{:?}",
+        net.warnings
+    );
+    let a = net.buses.iter().find(|b| b.id == "a").unwrap();
+    assert_eq!(a.location.unwrap().x.to_bits(), (-80.0f64).to_bits());
+    assert_eq!(a.location.unwrap().y.to_bits(), 35.0f64.to_bits());
+    assert!(!a.extras.contains_key("x"));
+    assert!(!a.extras.contains_key("y"));
+
+    let out = write_dss(&net);
+    assert!(out.text.contains("Buscoords buscoords.csv"), "{}", out.text);
+    assert_eq!(out.sidecars.len(), 1);
+    assert_eq!(out.sidecars[0].path, "buscoords.csv");
+    assert!(out.sidecars[0].text.contains("a,-80,35"));
+    assert!(out.sidecars[0].text.contains("b,-80.5,35.25"));
+
+    let out_dir = temp_case_dir("dss-geo-out");
+    std::fs::write(out_dir.join("master.dss"), &out.text).unwrap();
+    for sidecar in &out.sidecars {
+        std::fs::write(out_dir.join(&sidecar.path), &sidecar.text).unwrap();
+    }
+    let reparsed = parse_dss_file(out_dir.join("master.dss")).unwrap();
+    let b = reparsed.buses.iter().find(|b| b.id == "b").unwrap();
+    assert_eq!(b.location.unwrap().x.to_bits(), (-80.5f64).to_bits());
+    assert_eq!(b.location.unwrap().y.to_bits(), 35.25f64.to_bits());
 }
 
 #[test]
@@ -97,9 +154,11 @@ fn ieee13_matches_the_engine_bus_map() {
     assert_eq!(sw.name, "671692");
     assert!(!sw.open);
 
-    // Bus coordinates landed as extras.
+    // Bus coordinates promote out of extras into the typed field.
     let b = net.bus("611").unwrap();
-    assert!(b.extras.contains_key("x"));
+    assert!(b.location.is_some());
+    assert!(!b.extras.contains_key("x"));
+    assert!(!b.extras.contains_key("y"));
 
     // Load 671 is 3 phase delta: 1155 kW total, 660 kvar.
     let l671 = net.loads.iter().find(|l| l.name == "671").unwrap();

--- a/powerio-dist/tests/matrix.rs
+++ b/powerio-dist/tests/matrix.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use powerio_dist::{
-    DistLoadVoltageModel, DistNetwork, DistTargetFormat, Result, parse_bmopf_str, parse_dss_file,
-    parse_pmd_str,
+    Conversion, ConversionSidecar, DistLoadVoltageModel, DistNetwork, DistTargetFormat, Result,
+    parse_bmopf_str, parse_dss_file, parse_pmd_str,
 };
 
 fn fixture(rel: &str) -> PathBuf {
@@ -35,22 +35,36 @@ impl Fmt {
         }
     }
 
-    fn parse(self, text: &str) -> Result<DistNetwork> {
+    fn parse_conversion(self, conv: &Conversion) -> Result<DistNetwork> {
+        self.parse_text_and_sidecars(&conv.text, &conv.sidecars)
+    }
+
+    fn parse_text_and_sidecars(
+        self,
+        text: &str,
+        sidecars: &[ConversionSidecar],
+    ) -> Result<DistNetwork> {
         match self {
             Fmt::Dss => {
                 // Unique path per call: the harness tests run in parallel
                 // threads and must not race on a shared temp file.
                 use std::sync::atomic::{AtomicU64, Ordering};
                 static COUNTER: AtomicU64 = AtomicU64::new(0);
-                let dir = std::env::temp_dir().join("powerio-dist-matrix");
+                let dir = std::env::temp_dir()
+                    .join("powerio-dist-matrix")
+                    .join(format!("{}", COUNTER.fetch_add(1, Ordering::Relaxed)));
                 std::fs::create_dir_all(&dir).unwrap();
-                let path = dir.join(format!(
-                    "roundtrip-{}.dss",
-                    COUNTER.fetch_add(1, Ordering::Relaxed)
-                ));
+                let path = dir.join("roundtrip.dss");
                 std::fs::write(&path, text).unwrap();
+                for sidecar in sidecars {
+                    let sidecar_path = dir.join(&sidecar.path);
+                    if let Some(parent) = sidecar_path.parent() {
+                        std::fs::create_dir_all(parent).unwrap();
+                    }
+                    std::fs::write(sidecar_path, &sidecar.text).unwrap();
+                }
                 let parsed = powerio_dist::dss::parse_dss_file(&path);
-                let _ = std::fs::remove_file(&path);
+                let _ = std::fs::remove_dir_all(&dir);
                 parsed
             }
             Fmt::Bmopf => parse_bmopf_str(text),
@@ -574,7 +588,7 @@ fn canonical_writers_are_idempotent() {
                 Fmt::Bmopf => powerio_dist::write_bmopf_json(&net),
                 Fmt::Pmd => powerio_dist::write_pmd_json(&net),
             };
-            let reparsed = match target.parse(&first.text) {
+            let reparsed = match target.parse_conversion(&first) {
                 Ok(n) => n,
                 Err(e) => panic!("{} → {}: reparse failed: {e}", case.label, target.name()),
             };
@@ -605,7 +619,7 @@ fn off_diagonal_round_trips() {
             let what = format!("{} → {} → back", case.label, target.name());
             let out = net.to_format(target.target());
             let back = target
-                .parse(&out.text)
+                .parse_conversion(&out)
                 .unwrap_or_else(|e| panic!("{what}: {e}"));
             let transformers = !(target == Fmt::Bmopf && case.bmopf_restates_transformers);
             let (expected, actual) = if target == Fmt::Bmopf {
@@ -657,7 +671,7 @@ fn write_conversion_matrix() {
                 continue;
             }
             let out = net.to_format(target.target());
-            match target.parse(&out.text) {
+            match target.parse_conversion(&out) {
                 Ok(_) => {
                     if out.warnings.is_empty() {
                         cells.push("ok".to_string());

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -7,7 +7,10 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use powerio_dist::dss::parse_dss_file;
-use powerio_dist::{DistNetwork, parse_pmd_file, parse_pmd_str, write_bmopf_json, write_pmd_json};
+use powerio_dist::{
+    CoordinateSpace, CoordsKind, DistBus, DistNetwork, GeoMeta, Location, parse_pmd_file,
+    parse_pmd_str, write_bmopf_json, write_pmd_json,
+};
 
 fn fixture(rel: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -186,12 +189,20 @@ fn dss_to_pmd_reproduces_the_reference_essentials() {
             .unwrap();
 
     assert_eq!(emitted["data_model"], reference["data_model"]);
-    // Bus terminals, grounding, and coordinates match the reference.
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("non-geographic or undeclared location")),
+        "{:?}",
+        out.warnings
+    );
+    // Bus terminals and grounding match the reference. DSS Buscoords are typed
+    // as unknown space, so they do not emit as PMD lon/lat.
     for (id, bus) in reference["bus"].as_object().unwrap() {
         let ours = &emitted["bus"][id];
         assert_eq!(ours["terminals"], bus["terminals"], "bus {id}");
         assert_eq!(ours["grounded"], bus["grounded"], "bus {id}");
-        assert_eq!(ours["lat"], bus["lat"], "bus {id}");
+        assert!(ours.get("lat").is_none(), "bus {id}");
         assert_eq!(ours["status"], bus["status"], "bus {id}");
     }
     // Loads match in power, model enum, and nominal voltage.
@@ -237,6 +248,40 @@ fn dss_to_pmd_reproduces_the_reference_essentials() {
         assert_eq!(ours["connections"], want["connections"], "{id}");
         assert_eq!(ours["tm_step"], want["tm_step"], "{id}");
     }
+}
+
+#[test]
+fn pmd_typed_locations_emit_only_when_geographic() {
+    let mut bus = DistBus::new("b1", vec!["1".to_owned()]);
+    bus.location = Some(Location {
+        x: -80.0,
+        y: 35.0,
+        kind: None,
+    });
+    let mut net = DistNetwork::default();
+    net.buses = vec![bus];
+
+    let unknown = write_pmd_json(&net);
+    let doc: serde_json::Value = serde_json::from_str(&unknown.text).unwrap();
+    assert!(doc["bus"]["b1"].get("lon").is_none());
+    assert!(doc["bus"]["b1"].get("lat").is_none());
+    assert!(
+        unknown
+            .warnings
+            .iter()
+            .any(|w| w.contains("non-geographic or undeclared location")),
+        "{:?}",
+        unknown.warnings
+    );
+
+    net.geo = Some(GeoMeta {
+        space: CoordinateSpace::Geographic { crs: None },
+        kind: Some(CoordsKind::Source),
+    });
+    let geographic = write_pmd_json(&net);
+    let doc: serde_json::Value = serde_json::from_str(&geographic.text).unwrap();
+    assert_eq!(doc["bus"]["b1"]["lon"], serde_json::json!(-80.0));
+    assert_eq!(doc["bus"]["b1"]["lat"], serde_json::json!(35.0));
 }
 
 fn rewrite(text: &str) -> serde_json::Value {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -48,7 +48,7 @@ pub const PIO_PAYLOAD_BALANCED_SCHEMA_URL: &str =
 /// the minor; field moves or removals bump the major. Versioned independently
 /// of the envelope: [`PIO_PACKAGE_SCHEMA_VERSION`] covers the package
 /// bookkeeping, this covers the network tables a consumer computes on.
-pub const PIO_PAYLOAD_BALANCED_SCHEMA_VERSION: &str = "1.0.0";
+pub const PIO_PAYLOAD_BALANCED_SCHEMA_VERSION: &str = "1.1.0";
 
 /// The declared schema URL for the multiconductor payload
 /// (`model.multiconductor_network`).
@@ -57,7 +57,7 @@ pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL: &str =
 
 /// The multiconductor payload schema version (semver); the same policy as
 /// [`PIO_PAYLOAD_BALANCED_SCHEMA_VERSION`].
-pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.0.0";
+pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.1.0";
 
 pub const READ_TRANSMISSION_PARSE_WARNING: &str = "READ.TRANSMISSION.PARSE_WARNING";
 pub const READ_GRIDFM_FIDELITY_WARNING: &str = "READ.GRIDFM.FIDELITY_WARNING";

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -8,9 +8,10 @@ use powerio_pkg::{
     NetworkPackage, OperatingPoint, OperatingPointSeries, Origin, PIO_PACKAGE_SCHEMA_URL,
     PIO_PACKAGE_SCHEMA_VERSION, PIO_PAYLOAD_BALANCED_SCHEMA_URL,
     PIO_PAYLOAD_BALANCED_SCHEMA_VERSION, PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL,
-    READ_TRANSMISSION_PARSE_WARNING, SequenceTransformConvention, SourceDescriptor, SourceMapEntry,
-    SourceRef, StructuredDiagnostic, StudyBlock, StudyCommit, StudyEdit, TimeAxis,
-    ValidationStatus, check_multiconductor_to_balanced_lowering, ensure_payload_uids,
+    PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION, READ_TRANSMISSION_PARSE_WARNING,
+    SequenceTransformConvention, SourceDescriptor, SourceMapEntry, SourceRef, StructuredDiagnostic,
+    StudyBlock, StudyCommit, StudyEdit, TimeAxis, ValidationStatus,
+    check_multiconductor_to_balanced_lowering, ensure_payload_uids,
     lower_multiconductor_to_balanced,
 };
 
@@ -1733,6 +1734,50 @@ fn package_declares_payload_schema_and_synthesizes_row_identity() {
         multi.payload_schema.as_deref(),
         Some(PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL)
     );
+    assert_eq!(
+        multi.payload_schema_version.as_deref(),
+        Some(PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION)
+    );
+}
+
+#[test]
+fn geo_types_share_the_same_json_shape() {
+    let balanced_location = powerio::Location {
+        x: -80.0,
+        y: 35.0,
+        kind: Some(powerio::CoordsKind::Manual),
+    };
+    let dist_location = powerio_dist::Location {
+        x: -80.0,
+        y: 35.0,
+        kind: Some(powerio_dist::CoordsKind::Manual),
+    };
+    assert_eq!(
+        serde_json::to_value(balanced_location).unwrap(),
+        serde_json::to_value(dist_location).unwrap()
+    );
+
+    let balanced_geo = powerio::GeoMeta {
+        space: powerio::CoordinateSpace::Geographic { crs: None },
+        kind: Some(powerio::CoordsKind::Source),
+    };
+    let dist_geo = powerio_dist::GeoMeta {
+        space: powerio_dist::CoordinateSpace::Geographic { crs: None },
+        kind: Some(powerio_dist::CoordsKind::Source),
+    };
+    let expected = serde_json::json!({"space": "geographic", "kind": "source"});
+    assert_eq!(serde_json::to_value(&balanced_geo).unwrap(), expected);
+    assert_eq!(
+        serde_json::to_value(balanced_geo).unwrap(),
+        serde_json::to_value(dist_geo).unwrap()
+    );
+
+    let empty_dist = powerio_dist::DistNetwork::default();
+    let v = serde_json::to_value(empty_dist).unwrap();
+    assert!(v.get("geo").is_none());
+    let bus = powerio_dist::DistBus::new("b1", vec!["1".to_owned()]);
+    let v = serde_json::to_value(bus).unwrap();
+    assert!(v.get("location").is_none());
 }
 
 #[test]

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -380,6 +380,7 @@ pub(crate) fn parse_egret_source(source: Arc<String>, name_hint: Option<&str>) -
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -535,6 +536,7 @@ fn read_bus(key: &str, v: &Value) -> Result<Bus> {
         zone: usize_or(v, "zone", 0)?,
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
         uid: None,
+        location: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/format/goc3.rs
+++ b/powerio/src/format/goc3.rs
@@ -151,6 +151,7 @@ pub(crate) fn parse_goc3_source(
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -217,6 +218,7 @@ fn read_buses(network: &Map<String, Value>) -> Result<(Vec<Bus>, Goc3BusMap)> {
             zone: 1,
             name: Some(uid.clone()),
             uid: Some(uid),
+            location: None,
             extras: extras(
                 obj,
                 &["uid", "base_nom_volt", "vm_ub", "vm_lb", "initial_status"],

--- a/powerio/src/format/matpower/mod.rs
+++ b/powerio/src/format/matpower/mod.rs
@@ -150,6 +150,7 @@ fn build_case<'a>(name: &str, get: impl Fn(&str) -> Option<&'a str>) -> Result<N
         name: name.to_string(),
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -160,6 +160,7 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
         zone: row[bus_col::ZONE] as usize,
         name: None,
         uid: None,
+        location: None,
         extras: Extras::new(),
     };
     let (pd, qd) = (row[bus_col::PD], row[bus_col::QD]);

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -121,6 +121,7 @@ pub(crate) fn parse_pandapower_source(
             zone: row.usize_or("zone", 1),
             name: row.string("name"),
             uid: None,
+            location: None,
             extras: Extras::default(),
         });
     }
@@ -634,6 +635,7 @@ pub(crate) fn parse_pandapower_source(
         name,
         base_mva,
         base_frequency: f_hz,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -2820,6 +2822,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::default(),
         }
     }
@@ -2829,6 +2832,7 @@ mod tests {
             name: "t".into(),
             base_mva: 100.0,
             base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+            geo: None,
             buses,
             loads: Vec::new(),
             shunts: Vec::new(),

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -481,6 +481,7 @@ pub(crate) fn parse_powermodels_json_source(
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses: sorted(root, "bus", "index")
             .iter()
             .map(|v| read_bus(v, ascale))
@@ -591,6 +592,7 @@ fn read_bus(v: &Value, ascale: f64) -> Result<Bus> {
         zone: uid(v, "zone"),
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
         uid: None,
+        location: None,
         extras: extras_excluding(
             v,
             &[

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -35,6 +35,7 @@ pub(super) const BRANCH_DEVICE_TYPE: &str = "BranchDeviceType";
 /// Owned-source entry used by the format hub: parse by borrowing `source`, then
 /// move the buffer into the retained source (no copy). `name_hint` (e.g. a file
 /// stem) names the network when the `.aux` carries no export marker.
+#[expect(clippy::too_many_lines)]
 pub(crate) fn parse_powerworld_source(
     source: Arc<String>,
     name_hint: Option<&str>,
@@ -143,6 +144,7 @@ pub(crate) fn parse_powerworld_source(
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -465,6 +467,7 @@ fn read_bus(r: &Row) -> Result<Bus> {
         zone: uid_alias(r, &["ZoneNum", "ZoneNumber"])?,
         name,
         uid: None,
+        location: None,
         extras,
     })
 }

--- a/powerio/src/format/powerworld/pwb.rs
+++ b/powerio/src/format/powerworld/pwb.rs
@@ -569,6 +569,7 @@ fn checked_network(
         name: name_hint.unwrap_or("case").to_string(),
         base_mva: MVA_BASE,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -1151,6 +1152,7 @@ fn read_bus_head(b: &[u8], at: usize) -> Probe<(BusHead, usize)> {
         zone,
         name: Some(String::from_utf8_lossy(name).into_owned()),
         uid: None,
+        location: None,
         extras: Extras::new(),
     };
     let shunt = bus_tail_shunt(b, c.pos, BusId(num));
@@ -1939,6 +1941,7 @@ mod tests {
             name: name.to_string(),
             base_mva: MVA_BASE,
             base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+            geo: None,
             buses: Vec::new(),
             loads: Vec::new(),
             shunts: Vec::new(),

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -115,6 +115,7 @@ pub(crate) fn parse_pslf_source(
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -476,6 +477,7 @@ fn read_bus(rec: &Record) -> Result<Bus> {
         zone: id_at(&rec.rhs, 5, 1, "bus zone", rec)?,
         name,
         uid: None,
+        location: None,
         extras: extras(rec, "bus data", 3, 21),
     })
 }
@@ -1812,6 +1814,7 @@ end
                     zone: 1,
                     name: None,
                     uid: None,
+                    location: None,
                     extras: Extras::new(),
                 },
                 Bus {
@@ -1828,6 +1831,7 @@ end
                     zone: 1,
                     name: None,
                     uid: None,
+                    location: None,
                     extras: Extras::new(),
                 },
             ],

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -1075,6 +1075,7 @@ pub(crate) fn parse_psse_source(
         name,
         base_mva,
         base_frequency,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -1600,6 +1601,7 @@ fn read_bus(f: &[String]) -> Result<Bus> {
         zone: id_at(f, 5, 0)?,
         name,
         uid: None,
+        location: None,
         extras: Extras::new(),
     })
 }
@@ -2317,6 +2319,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -106,6 +106,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
             zone: 1,
             name: bus_name,
             uid: None,
+            location: None,
             extras: Extras::default(),
         });
     }
@@ -399,6 +400,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
+        geo: None,
         buses,
         loads,
         shunts,
@@ -1132,6 +1134,7 @@ mod tests {
             zone: 1,
             name: name.map(str::to_string),
             uid: None,
+            location: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -518,6 +518,7 @@ pub(crate) fn parse_surge_source(
         name,
         base_mva: f_map_or(network, "base_mva", 100.0)?,
         base_frequency: f_map_or(network, "freq_hz", crate::network::DEFAULT_BASE_FREQUENCY)?,
+        geo: None,
         buses,
         loads: array_field(network, "loads", false)?
             .into_iter()
@@ -610,6 +611,7 @@ fn read_bus(value: &Value) -> Result<(Bus, Option<Shunt>)> {
             .filter(|name| !name.is_empty())
             .map(str::to_string),
         uid: None,
+        location: None,
         extras: Extras::new(),
     };
     Ok((bus, shunt))

--- a/powerio/src/geo.rs
+++ b/powerio/src/geo.rs
@@ -1,0 +1,77 @@
+//! Typed coordinate metadata for the balanced model.
+
+use serde::{Deserialize, Serialize};
+
+/// A point attached to one model element.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Location {
+    /// X coordinate. In geographic space this is longitude.
+    pub x: f64,
+    /// Y coordinate. In geographic space this is latitude.
+    pub y: f64,
+    /// Per point provenance when it differs from the network default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CoordsKind>,
+}
+
+/// Coordinate provenance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CoordsKind {
+    Source,
+    Synthetic,
+    Manual,
+    Derived,
+}
+
+/// Network level coordinate metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GeoMeta {
+    /// Coordinate space shared by every location on the network.
+    #[serde(flatten)]
+    pub space: CoordinateSpace,
+    /// Default provenance for points without their own `kind`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<CoordsKind>,
+}
+
+/// Coordinate space for locations in a network.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(tag = "space", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CoordinateSpace {
+    /// x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.
+    Geographic {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        crs: Option<String>,
+    },
+    /// Planar coordinates, with the CRS named when known.
+    Projected {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        crs: Option<String>,
+    },
+    /// Drawing coordinates with no earth referent.
+    Diagram {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        canvas: Option<Canvas>,
+    },
+    /// The source did not declare a coordinate space.
+    Unknown,
+}
+
+/// Diagram canvas metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Canvas {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub units: Option<String>,
+}

--- a/powerio/src/indexed.rs
+++ b/powerio/src/indexed.rs
@@ -421,6 +421,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod error;
 pub mod format;
 pub mod gen_cost;
+pub mod geo;
 pub mod indexed;
 pub mod network;
 mod normalize;
@@ -59,6 +60,7 @@ pub use format::{
     write_pypsa_csv_folder, write_surge_json,
 };
 pub use gen_cost::{GenCostPatch, GenCostPolicyReport, MissingGenCostPolicy, parse_gen_cost_csv};
+pub use geo::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};
 pub use indexed::{ConnectivityReport, IndexCore, IndexedNetwork};
 pub use network::{
     Area, BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet,

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::Error;
+use crate::geo::{GeoMeta, Location};
 
 /// Source-format fields the neutral model doesn't name, kept for round-trip and
 /// cross-format passthrough. Keys are the field names; values are JSON scalars.
@@ -275,6 +276,8 @@ pub struct Network {
     /// frequency field.
     #[serde(default = "default_base_frequency")]
     pub base_frequency: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geo: Option<GeoMeta>,
     pub buses: Vec<Bus>,
     pub loads: Vec<Load>,
     pub shunts: Vec<Shunt>,
@@ -354,6 +357,9 @@ pub struct Bus {
     /// field existed still deserializes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
+    /// Optional bus coordinates in the network coordinate space.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub location: Option<Location>,
     pub extras: Extras,
 }
 
@@ -374,6 +380,7 @@ impl Bus {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         }
     }
@@ -1390,6 +1397,7 @@ impl Transformer3W {
             zone: 0,
             name: self.name.clone(),
             uid: self.uid.clone(),
+            location: None,
             extras: Extras::new(),
         };
         let zs = self.star_impedances();
@@ -1477,6 +1485,7 @@ impl Network {
             name: name.into(),
             base_mva,
             base_frequency: DEFAULT_BASE_FREQUENCY,
+            geo: None,
             buses: Vec::new(),
             loads: Vec::new(),
             shunts: Vec::new(),
@@ -1563,7 +1572,7 @@ impl Network {
         }
         for (i, b) in self.buses.iter().enumerate() {
             #[rustfmt::skip]
-            let Bus { id: _, kind: _, vm, va, base_kv, vmax, vmin, evhi: _, evlo: _, area: _, zone: _, name: _, uid: _, extras: _ } = b;
+            let Bus { id: _, kind: _, vm, va, base_kv, vmax, vmin, evhi: _, evlo: _, area: _, zone: _, name: _, uid: _, location, extras: _ } = b;
             let fields = [
                 ("vm", *vm),
                 ("va", *va),
@@ -1572,6 +1581,10 @@ impl Network {
                 ("vmin", *vmin),
             ];
             out.extend(bad(fields).map(|f| format!("buses[{i}].{f}")));
+            if let Some(location) = location {
+                let fields = [("location.x", location.x), ("location.y", location.y)];
+                out.extend(bad(fields).map(|f| format!("buses[{i}].{f}")));
+            }
         }
         for (i, l) in self.loads.iter().enumerate() {
             let Load {
@@ -2182,6 +2195,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         }
     }
@@ -2388,6 +2402,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         };
         let branch = Branch {

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -583,6 +583,7 @@ impl Network {
             name: self.name.clone(),
             base_mva: base,
             base_frequency: self.base_frequency,
+            geo: self.geo.clone(),
             buses,
             loads,
             shunts,
@@ -703,6 +704,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         };
         let branch = Branch {
@@ -799,6 +801,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         };
         let mkgen = |bus: usize, pmax: f64| Generator {

--- a/powerio/src/operations.rs
+++ b/powerio/src/operations.rs
@@ -234,6 +234,7 @@ impl Network {
             name: format!("{} (subset)", self.name),
             base_mva: self.base_mva,
             base_frequency: self.base_frequency,
+            geo: self.geo.clone(),
             buses,
             loads,
             shunts,
@@ -569,6 +570,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -788,6 +788,7 @@ mod tests {
             zone: 1,
             name: None,
             uid: None,
+            location: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/tests/snapshot_schema.rs
+++ b/powerio/tests/snapshot_schema.rs
@@ -14,7 +14,10 @@
 
 use std::path::Path;
 
-use powerio::{Branch, Bus, BusId, BusType, GenCaps, Generator, Network, SourceFormat};
+use powerio::{
+    Branch, Bus, BusId, BusType, CoordinateSpace, CoordsKind, GenCaps, Generator, GeoMeta,
+    Location, Network, SourceFormat,
+};
 
 /// A v4-vintage snapshot, written by `powerio convert case30.m --to powerio-json`.
 /// Regenerate ONLY on a deliberate schema change, and then bump `PIO_ABI_VERSION`.
@@ -117,4 +120,41 @@ fn uid_survives_snapshot_roundtrip_and_stays_off_the_wire_when_absent() {
     let parsed = Network::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
     assert_eq!(parsed.generators[0].uid.as_deref(), Some("gen-a"));
     assert_eq!(parsed.buses[0].uid, None);
+}
+
+#[test]
+fn geo_fields_roundtrip_and_stay_off_the_wire_when_absent() {
+    let net = small_net();
+    let text = net.to_json().unwrap();
+    assert!(!text.contains(r#""geo""#));
+    assert!(!text.contains(r#""location""#));
+    let parsed = Network::from_json(&text).unwrap();
+    assert_eq!(parsed.to_json().unwrap(), text);
+
+    let v: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert!(v.get("geo").is_none());
+    assert!(v["buses"][0].get("location").is_none());
+
+    let mut with_geo = net;
+    with_geo.geo = Some(GeoMeta {
+        space: CoordinateSpace::Geographic { crs: None },
+        kind: Some(CoordsKind::Source),
+    });
+    with_geo.buses[0].location = Some(Location {
+        x: -80.0,
+        y: 35.0,
+        kind: None,
+    });
+
+    let v: serde_json::Value = serde_json::from_str(&with_geo.to_json().unwrap()).unwrap();
+    assert_eq!(
+        v["geo"],
+        serde_json::json!({"space": "geographic", "kind": "source"})
+    );
+    assert_eq!(v["buses"][0]["location"]["x"], serde_json::json!(-80.0));
+    assert_eq!(v["buses"][0]["location"]["y"], serde_json::json!(35.0));
+
+    let parsed = Network::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
+    assert_eq!(parsed.geo, with_geo.geo);
+    assert_eq!(parsed.buses[0].location, with_geo.buses[0].location);
 }

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -146,7 +146,7 @@ def test_package_declares_payload_schema_and_row_identity():
     doc = json.loads(pkg.to_json())
     assert doc["schema_version"] == "0.1.1"
     assert doc["payload_schema"].endswith("/pio-payload-balanced/1")
-    assert doc["payload_schema_version"] == "1.0.0"
+    assert doc["payload_schema_version"] == "1.1.0"
     # Every payload row carries an identity; case9 has no source uids, so they
     # are synthesized from the build position.
     assert doc["model"]["balanced_network"]["generators"][0]["uid"] == "generators:0"


### PR DESCRIPTION
## Summary

- add mirrored typed coordinate metadata to the balanced and distribution models
- promote OpenDSS Buscoords and BMOPF longitude/latitude sideloads into typed bus locations
- emit OpenDSS Buscoords sidecars and BMOPF coordinate sideloads only by explicit option
- bump balanced and multiconductor payload schemas to 1.1.0

Fixes #180.

## Acceptance

- `Network.geo` / `Bus.location` and `DistNetwork.geo` / `DistBus.location` are optional and skipped when absent.
- `powerio-pkg` checks that balanced and distribution geo types serialize to the same JSON shape.
- Coordinate free balanced JSON omits the new fields and writes back byte identical after parsing.
- OpenDSS Buscoords round trips through typed locations and a companion CSV sidecar.
- BMOPF output remains schema strict by default; `sideload_coordinates` opts into longitude/latitude fields.
- Writers do not relabel unknown coordinate spaces as longitude/latitude.

## Out Of Scope

- balanced format coordinate harvest and emission (#183)
- GeoLayer documents, routes, and display promotion (#184)
- C, Python, and Julia geo binding symbols (#185 follow up)

## Merge Order

Track B1. Base: `main`.

## Tests

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- `cargo test -p powerio-dist --features schema`
- `cargo test -p powerio-pkg --features schema`
- `env POWERIO_CONVERSION_MATRIX_DETAILS=/private/tmp/powerio-b1-conversion-details.md cargo test -p powerio-cli --test conversion_matrix_report conversion_matrix_report_matches_baseline -- --nocapture`
