### PR TITLE
Prepare v0.6.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.6.2
+
+- Normalization (#210): angle bound clamping now keeps every repaired branch
+  interval ordered. One sided intervals wholly outside the supported window are
+  widened to the configured pad instead of producing `angmin > angmax`; Rust,
+  C ABI, and Python normalize option coverage pin the behavior.
+- Binding coverage (#185): the already shipped study block and distribution
+  graph projection now have C ABI and Python accessors. The remaining geo
+  binding symbols stay in the v0.6.3 follow through.
+- BMOPF diagnostics (#219): distribution conversions now carry structured
+  diagnostics alongside warning strings, and transformer export losses expose
+  stable `EMIT.BMOPF.*` codes for downstream tests and capability checks.
+- BMOPF transformer fidelity (#214, #215, #216, #217): OpenDSS fixed
+  transformer taps, center tap convention fields, delta_wye leakage referral,
+  and n_winding `delta_roll` now export directly in BMOPF form with regression
+  coverage against schema valid output and unaffected fixture byte identity.
+- BMOPF source fidelity (#218): per phase OpenDSS voltage sources on the same
+  bus merge into one BMOPF `voltage_source` when their phase angles are
+  coherent; ambiguous, bounded, priced, or conflicting source banks stay split
+  with warnings.
+- Distribution capabilities (#213): the C ABI `dist` feature exposes
+  `pio_dist_capabilities_json`, reporting the six BMOPF fidelity flags that
+  PowerIO.jl and downstream tools can probe at runtime.
+- Geographic fields (#180): balanced and distribution models now share typed
+  `GeoMeta` / `Location` JSON shapes. `Network.geo`, `Bus.location`,
+  `DistNetwork.geo`, and `DistBus.location` are optional and omitted when
+  absent. OpenDSS Buscoords and BMOPF longitude/latitude sideloads promote into
+  typed bus locations; OpenDSS writes a Buscoords sidecar when locations are
+  present, while BMOPF longitude/latitude output remains opt in and only emits
+  declared geographic coordinates.
+- `.pio.json` model JSON: the balanced and multiconductor payload schema
+  versions move from `1.0.0` to `1.1.0` for the additive geographic fields.
+  The package metadata schema, C ABI version, and Python package surface stay
+  in the 0.6 compatibility band.
+
 ## 0.6.1
 
 - CI: added wasm32 coverage for the core Rust crates (#186), external BMOPF

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "arrow",
  "powerio",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "approx",
  "arrow",
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -31,10 +31,10 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.6.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.6.1" }
-powerio-dist = { path = "powerio-dist", version = "0.6.1" }
-powerio-pkg = { path = "powerio-pkg", version = "0.6.1" }
+powerio = { path = "powerio", version = "0.6.2" }
+powerio-matrix = { path = "powerio-matrix", version = "0.6.2" }
+powerio-dist = { path = "powerio-dist", version = "0.6.2" }
+powerio-pkg = { path = "powerio-pkg", version = "0.6.2" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -14,10 +14,11 @@ carry no geometry. Today PowerIO keeps what it happens to see in per element
 re-derive coordinates from those maps per source format, which is parsing work
 that belongs here.
 
-This chapter specifies a canonical coordinate model in two layers: typed
-optional fields on the network models, and a standalone geographic document for
-interchange. Both are optional everywhere. A case without coordinates
-serializes byte identically to today, and no writer invents geometry.
+This chapter specifies a canonical coordinate model in two layers. The shipped
+layer is typed optional fields on the network models. The planned layer is a
+standalone geographic document for interchange. Both are optional everywhere. A
+case without coordinates serializes byte identically to today, and no writer
+invents geometry.
 
 ## Layer 1: typed model fields
 
@@ -45,6 +46,12 @@ pub struct GeoMeta {
     pub space: CoordinateSpace,
     /// Default provenance for points without their own `kind`.
     pub kind: Option<CoordsKind>,
+}
+
+pub struct Canvas {
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub units: Option<String>,
 }
 
 pub enum CoordinateSpace {
@@ -76,11 +83,12 @@ If the mirrored types grow beyond small data carriers, a `powerio-geo` or
 Because the fields are additive and skipped when absent, they ride the
 `.pio.json` model JSON as a minor bump.
 
-## Layer 2: the geographic document
+## Planned layer 2: the geographic document
 
 Coordinates also arrive and leave as files of their own: a `Buscoords` CSV next
 to a DSS master, a GeoJSON export from a GIS tool, a layout computed by a
-renderer for a case that had no geometry. The container for these is
+renderer for a case that had no geometry. This layer is not implemented in
+v0.6.2. The planned container for these is
 `GeoLayer`, surfaced as a `DisplayData::Geo` variant beside the existing
 PowerWorld `.pwd` display path.
 
@@ -104,7 +112,7 @@ The canonical wire form is a GeoJSON FeatureCollection with one foreign member:
 When the space is geographic this is valid RFC 7946 GeoJSON, so GIS tools open
 it directly. The suggested extension is `.geo.json`.
 
-Reading is tolerant; writing is canonical. The reader accepts headerless
+The planned reader is tolerant; writing is canonical. It accepts headerless
 buscoords CSV (`bus,x,y`), CSV and JSON records with aliased field names
 (`bus_i`/`bus`/`id`, `lat`/`latitude`/`y`, `lon`/`lng`/`longitude`/`x`, branch
 endpoint pairs), and GeoJSON Point and LineString features. Writers emit only
@@ -120,19 +128,25 @@ model `uid`.
 
 ## Harvest and emit
 
-Readers promote coordinates out of `extras` into `location` and stamp the
-space. Promotion removes the raw keys: `location` is the single source of
-truth, and byte level round trips of an unmodified case already go through the
-retained source text, not through extras.
+The v0.6.2 implementation promotes the coordinate fields it owns into
+`location` and stamps the space. Promotion removes the raw keys:
+`location` is the single source of truth, and byte level round trips of an
+unmodified case already go through the retained source text, not through extras.
+
+| Format | Read | Space |
+| --- | --- | --- |
+| OpenDSS | `Buscoords` | unknown, with a range check diagnostic that suggests geographic when every point fits lon/lat bounds |
+| BMOPF JSON | out of schema `longitude`/`latitude` (the BMOPFTools sideload convention) | geographic |
+| PowerWorld aux, pandapower, PyPSA | planned for #183 | — |
+| MATPOWER, PSS/E, PowerModels, egret, GOC3, PSLF, Surge | nothing to read; `location` stays `None` | — |
+
+Planned balanced harvest rules:
 
 | Format | Read | Space |
 | --- | --- | --- |
 | PowerWorld aux | `Latitude:1`/`Longitude:1` bus fields (`SubNum` stays in extras; it is identity, not geometry) | geographic |
-| OpenDSS | `Buscoords` | unknown, with a range check diagnostic that suggests geographic when every point fits lon/lat bounds |
-| BMOPF JSON | out of schema `longitude`/`latitude` (the BMOPFTools sideload convention) | geographic |
 | pandapower | bus `geo` GeoJSON Point strings | geographic |
 | PyPSA | `buses.csv` x/y | geographic |
-| MATPOWER, PSS/E, PowerModels, egret, GOC3, PSLF, Surge | nothing to read; `location` stays `None` | — |
 
 Writers emit from `location`:
 
@@ -142,35 +156,45 @@ Writers emit from `location`:
   valid output. `BmopfWriteOptions::sideload_coordinates` opts in to emitting
   `longitude`/`latitude` per bus, matching the BMOPFTools convention. This
   default flips if the task force adopts coordinate fields upstream.
+
+Planned writer support:
+
 - **pandapower**: the bus `geo` column, replacing today's null.
 - **PowerWorld aux**: `Latitude:1`/`Longitude:1` bus columns.
 - **GeoJSON**: the canonical `GeoLayer` document.
 - Formats with no geometry concept warn that locations were dropped, the same
-  contract `base_frequency` uses. `powerio geo extract` writes the sidecar as
-  the escape hatch.
+  contract `base_frequency` uses. A future `powerio geo extract` writes the
+  sidecar as the escape hatch.
 
 ## PowerWorld `.pwd` promotion
 
 The `.pwd` reader already decodes substation symbols in diagram coordinates.
-Two additions connect it to the geo model: `geo_layer_from_pwd` produces a
+Planned additions connect it to the geo model: `geo_layer_from_pwd` produces a
 `GeoLayer` in diagram space with substation targets, and
 `apply_substation_points` joins those points onto buses through the `SubNum`
 extras key. The auto generated PowerWorld layouts equal a Mercator projection
-of geography, so `pwd_mercator_to_lonlat` ships as a documented, approximate
-inverse for consumers that want to place a diagram on a map.
+of geography, so a planned `pwd_mercator_to_lonlat` helper can document the
+approximate inverse for consumers that want to place a diagram on a map.
 
 ## API surface
 
-Rust (and therefore wasm consumers):
+Shipped Rust model surface:
 
-- `powerio::geo::{Location, CoordsKind, CoordinateSpace, GeoMeta, GeoLayer}`;
-- `parse_display_bytes(bytes, "geojson")` returning `DisplayData::Geo`;
+- `powerio::geo::{Location, CoordsKind, CoordinateSpace, GeoMeta, Canvas}`;
+- `powerio_dist::geo::{Location, CoordsKind, CoordinateSpace, GeoMeta, Canvas}`;
+- `Network.geo`, `Bus.location`, `DistNetwork.geo`, and `DistBus.location`.
+
+Planned Rust and CLI surface:
+
+- `GeoLayer` and `DisplayData::Geo`;
+- `parse_display_bytes(bytes, "geojson")`;
 - `Network::geo_layer()` and `Network::apply_geo_layer(&GeoLayer) -> GeoApplyReport`
   (matched and unmatched counts, notes); the multiconductor equivalents attach
   through `powerio-pkg`, which sees both model crates;
 - `powerio geo extract | apply | convert` in the CLI.
 
-C ABI: `pio_geo_parse`, `pio_geo_extract`, `pio_geo_apply`, and `pio_dist_geo_*`
+C ABI and Python direct geo helpers are planned. Candidate C symbols are
+`pio_geo_parse`, `pio_geo_extract`, `pio_geo_apply`, and `pio_dist_geo_*`
 counterparts, all string in and string out. No new object lifetimes and no ABI
 bump; format names stay strings.
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -304,7 +304,7 @@ bindings, or MCP operations.
 {
   "schema": "https://powerio.dev/schema/pio-package/0.1",
   "schema_version": "0.1.1",
-  "producer": { "tool": "powerio", "version": "0.6.1" },
+  "producer": { "tool": "powerio", "version": "0.6.2" },
   "model_kind": "multiconductor",
   "payload_schema": "https://powerio.dev/schema/pio-payload-multiconductor/1",
   "payload_schema_version": "1.1.0",


### PR DESCRIPTION
## Summary

- bump the workspace package version and intra workspace dependency pins to
  `0.6.2`
- add the `0.6.2` changelog entry for the completed release train
- update the package schema docs example producer version to `0.6.2`
- make the geo docs type sample pass `mdbook test`
- clarify the geo docs shipped versus planned surfaces for v0.6.2

## Acceptance criteria

- `Cargo.toml` and `Cargo.lock` report the PowerIO workspace packages at
  `0.6.2`
- the changelog covers the merged v0.6.2 work: angle clamp ordering, study and
  distribution graph bindings, BMOPF diagnostics and transformer fidelity,
  voltage source merging, distribution capability flags, typed geographic
  fields, and the additive payload schema `1.1.0` move
- package schema docs no longer show `0.6.1` as the current producer version
- the geo docs `Canvas` type appears in the typed coordinate sample that uses it
- the geo docs do not present planned GeoLayer, `powerio geo`, balanced
  coordinate writers, or direct geo C ABI/Python helpers as shipped in v0.6.2

## Draft release notes

### Added

- C ABI and Python accessors for the study block and distribution graph
  projection.
- Structured distribution conversion diagnostics, including stable
  `EMIT.BMOPF.*` diagnostic codes for BMOPF transformer export losses.
- C ABI distribution capability reporting through `pio_dist_capabilities_json`.
- Typed balanced and distribution geographic fields:
  `Network.geo`, `Bus.location`, `DistNetwork.geo`, and `DistBus.location`.

### Changed

- Branch angle bound clamping keeps repaired intervals ordered, including
  intervals wholly outside the supported window.
- OpenDSS fixed transformer taps, BMOPF center tap convention fields,
  delta_wye leakage referral, and explicit n_winding `delta_roll` export in
  BMOPF form.
- Coherent per phase OpenDSS voltage sources on the same bus merge into one
  BMOPF `voltage_source`; ambiguous or lossy source banks remain split with
  warnings.
- `.pio.json` balanced and multiconductor payload schema versions move from
  `1.0.0` to `1.1.0` for the additive geographic fields.

### Notes

- The package metadata schema, C ABI version, and Python package surface remain
  in the 0.6 compatibility band.
- The remaining geo binding follow through stays in the v0.6.3 track.

## Validation

- [x] `cargo check -p powerio -p powerio-dist -p powerio-pkg`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --target wasm32-unknown-unknown -p powerio -p powerio-dist -p powerio-pkg`
- [x] `cargo test -p powerio-dist --features schema`
- [x] `cargo test -p powerio-pkg --features schema`
- [x] `cargo test -p powerio-capi --no-default-features`
- [x] `cargo test -p powerio-capi --features arrow,matrix,gridfm,dist,pkg`
- [x] `cargo clippy -p powerio-capi --all-targets --no-default-features -- -D warnings`
- [x] `cargo clippy -p powerio-capi --all-targets --features arrow,matrix,gridfm,dist,pkg -- -D warnings`
- [x] `cargo build -p powerio-capi --release --features arrow,matrix,gridfm,dist,pkg`
- [x] `scripts/capi-header-parity.sh`
- [x] `scripts/capi-smoke.sh`
- [x] `mdbook build docs`
- [x] `mdbook test docs`

Review: fresh reviewer flagged that the geo chapter still presented planned
GeoLayer/API/balanced coordinate work as shipped. Fixed in docs and reran
`git diff --check`, `mdbook build docs`, and `mdbook test docs`.

## Out of scope

- tagging or publishing `v0.6.2`
- the v0.6.3 geo binding follow through
