### PR TITLE
DSS reader: take a line's conductor count from its linecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   build is matrix free; the `matrix` feature adds sparse projections, DC OPF
   bundle output, and experimental KKT operators.
 - Move DC OPF instance types and bundle output out of `powerio-matrix`.
+- DSS reader: `linecode=` now sets a line's conductor count the way the
+  engine's FetchLineCode does, the later of `phases=`/`linecode=` winning.
+  A 4-wire line without an explicit `phases=` keeps its neutral instead of
+  truncating the terminal map to 3 against a 4x4 linecode
+  (frederikgeth/BMOPFTools.jl#332).
 
 ## 0.6.3
 

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -79,6 +79,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
         buses: BTreeMap::new(),
         bus_order: Vec::new(),
         linecode_units: BTreeMap::new(),
+        linecode_nconds: BTreeMap::new(),
         xycurves: BTreeMap::new(),
         vars: &raw.vars,
     };
@@ -298,6 +299,10 @@ struct Reader<'a> {
     /// the linecode has no units. Lines need it: `ConvertLineUnits` couples
     /// the two sides' units.
     linecode_units: BTreeMap<String, Option<f64>>,
+    /// Linecode name (lowercase) → conductor count. Lines need it:
+    /// `linecode=` sets the line's phase count in the engine
+    /// (Line.cpp FetchLineCode), exactly like `phases=`.
+    linecode_nconds: BTreeMap<String, usize>,
     xycurves: BTreeMap<String, XyCurveRaw>,
     vars: &'a VarMap,
 }
@@ -543,6 +548,8 @@ impl Reader<'_> {
         let per_meter = units_m.unwrap_or(1.0);
         self.linecode_units
             .insert(obj.name.to_ascii_lowercase(), units_m);
+        self.linecode_nconds
+            .insert(obj.name.to_ascii_lowercase(), n);
 
         let freq = self
             .f64_prop(props.get("basefreq"))
@@ -756,9 +763,34 @@ impl Reader<'_> {
 
     fn line(&mut self, obj: &RawObject) {
         let props = Props::new(obj);
-        let phases = self
-            .usize_prop(props.get("phases"))
-            .unwrap_or(dd::line::PHASES);
+        // `linecode=` assigns the line's phase count from the code
+        // (Line.cpp FetchLineCode) exactly like `phases=`; properties
+        // apply in order, so the later of the two wins. Bus node lists
+        // materialize after the whole script parses (MakeBusList), so
+        // they always see the final count regardless of where the bus
+        // properties sit.
+        let explicit = self.usize_prop(props.get("phases"));
+        let from_code = props.get("linecode").and_then(|c| {
+            self.linecode_nconds
+                .get(&c.text.to_ascii_lowercase())
+                .copied()
+        });
+        let linecode_last = obj
+            .props
+            .iter()
+            .rev()
+            .find_map(|p| match p.name.as_deref() {
+                Some("phases") => Some(false),
+                Some("linecode") => Some(true),
+                _ => None,
+            })
+            .unwrap_or(false);
+        let phases = match (explicit, from_code) {
+            (Some(_), Some(n)) if linecode_last => n,
+            (Some(p), _) => p,
+            (None, Some(n)) => n,
+            (None, None) => dd::line::PHASES,
+        };
         let spec1 = bus_spec(props.get("bus1"), "");
         let spec2 = bus_spec(props.get("bus2"), "");
         // A line has no neutral conductor of its own: nconds == phases.

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -325,6 +325,51 @@ fn four_wire_line_keeps_the_neutral() {
     assert_eq!(la.terminal_map, vec!["1", "4"]);
 }
 
+/// BMOPFTools#332: a line without `phases=` takes its conductor count from
+/// the referenced linecode (FetchLineCode assigns NPhases), so a 4-wire bus
+/// list keeps the neutral and the map length matches the 4x4 matrices.
+#[test]
+fn line_conductor_count_follows_linecode() {
+    use powerio_dist::parse_dss_str;
+    let base = "Clear\n\
+                New Circuit.c basekv=0.4 pu=1.0 phases=3 bus1=src\n\
+                New Linecode.4w nphases=4 units=m\n\
+                ~ rmatrix=[0.5|0.02 0.5|0.02 0.02 0.5|0.02 0.02 0.02 0.5]\n";
+
+    let net = parse_dss_str(&format!(
+        "{base}New Line.l1 bus1=src.1.2.3.4 bus2=lb.1.2.3.4 linecode=4w length=500 units=m\n"
+    ));
+    let l = &net.lines[0];
+    assert_eq!(l.terminal_map_from, vec!["1", "2", "3", "4"]);
+    assert_eq!(l.terminal_map_to, vec!["1", "2", "3", "4"]);
+    let lb = net.buses.iter().find(|b| b.id == "lb").unwrap();
+    assert_eq!(lb.terminals, vec!["1", "2", "3", "4"]);
+
+    // No bus dot list: all four conductors default to nodes 1..=4.
+    let net = parse_dss_str(&format!(
+        "{base}New Line.l1 bus1=src bus2=lb linecode=4w length=500 units=m\n"
+    ));
+    assert_eq!(net.lines[0].terminal_map_to, vec!["1", "2", "3", "4"]);
+
+    // Properties apply in order; the later of `phases=`/`linecode=` wins.
+    let net = parse_dss_str(&format!(
+        "{base}New Line.l1 bus1=src.1.2.3.4 bus2=lb.1.2.3.4 linecode=4w phases=3 length=500 units=m\n"
+    ));
+    assert_eq!(net.lines[0].terminal_map_to, vec!["1", "2", "3"]);
+    let net = parse_dss_str(&format!(
+        "{base}New Line.l1 bus1=src.1.2.3.4 bus2=lb.1.2.3.4 phases=3 linecode=4w length=500 units=m\n"
+    ));
+    assert_eq!(net.lines[0].terminal_map_to, vec!["1", "2", "3", "4"]);
+
+    // A switch's linecode is ignored for impedance yet still fixes the
+    // conductor count.
+    let net = parse_dss_str(&format!(
+        "{base}New Line.s1 bus1=src.1.2.3.4 bus2=lb.1.2.3.4 linecode=4w switch=yes\n"
+    ));
+    assert_eq!(net.switches[0].terminal_map_to, vec!["1", "2", "3", "4"]);
+    assert_eq!(net.switches[0].i_max.as_ref().unwrap().len(), 4);
+}
+
 #[test]
 fn pvsystem_and_invcontrol_type_to_ibr_profile() {
     use powerio_dist::parse_dss_str;


### PR DESCRIPTION
## Summary

Fixes frederikgeth/BMOPFTools.jl#332: a 4-conductor line whose `bus1=….1.2.3.4` and linecode are 4-wire, with no explicit `phases=` on the line, imported with a 3-entry terminal map against 4x4 impedance matrices. Consumers that trust the map truncate to the top-left 3x3 block, which is not electrically equivalent to the 4-wire circuit (the reporter measured a ~34 A power flow residual at the OpenDSS solution on the deck below).

```
New Linecode.4w nphases=4
~ Rmatrix=[0.500|0.020 0.500|0.020 0.020 0.500|0.020 0.020 0.020 0.500]
New Line.l1 bus1=src.1.2.3.4 bus2=lb.1.2.3.4 linecode=4w length=500 units=m
```

Before: `terminal_map_from == ["1","2","3"]`. After: `["1","2","3","4"]`, matching OpenDSS.

## Engine semantics mirrored

- `linecode=` assigns the line's phase count from the code (Line.cpp `FetchLineCode`), exactly like `phases=`; properties apply in order, so the later of the two wins.
- Bus node lists materialize after the whole script parses (`MakeBusList`), so the dot list position relative to `phases=`/`linecode=` never matters.
- A switch's linecode is still ignored for impedance (dummy Z) yet fixes its conductor count; switches share the computation.

## Implementation

`Reader` gains `linecode_nconds` (name → conductor count, populated alongside `linecode_units`; linecodes already parse before lines). `line()` resolves the effective count from the last of `phases=`/`linecode=` in application order, falling back to the 3-phase default.

## Tests

New `line_conductor_count_follows_linecode` covers the issue deck, default node lists, both property orders, and the switch case. Full `powerio-dist` suite, fmt, and clippy pass. Verified end to end on BMOPFTools' `test/data/pf_comparison/pf_zip_3ph.dss` via `powerio convert --to bmopf-json`: the line now carries all four terminals.

No ABI or schema change; terminal map lengths were always data dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)