### PR TITLE
Add AC OPF problem instances to powerio-prob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   GOC3 operating point extraction, run only for parsed reader input through
   `from_parsed_balanced`.
 - Building a SCOPF instance from text requires an explicit source format.
+- Add AC OPF problem instances (#248): `powerio-prob` gains `AcOpfInstance`
+  and `build_ac_opf_instance`, carrying pi model branch data with separate tap
+  and shift, per terminal charging, bus shunts, active and reactive demand,
+  voltage bands, generator PQ bounds, and quadratic cost including the
+  constant term (`GenCost::quadratic_with_constant`). Relaxations such as SOC
+  forms consume the same instance. Matrix free; C ABI and Python exposure is
+  #249.
 - DSS reader: `linecode=` now sets a line's conductor count the way the
   engine's FetchLineCode does, the later of `phases=`/`linecode=` winning.
   A 4-wire line without an explicit `phases=` keeps its neutral instead of

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
 name = "powerio-prob"
 version = "0.7.0"
 dependencies = [
+ "num-complex",
  "powerio",
  "powerio-matrix",
  "serde",

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -3,7 +3,8 @@
 The `powerio-matrix` crate builds sparse matrices and graph outputs for common power system representations. The outputs are derived from a parsed `Network`. The builders take the densely indexed `IndexedNetwork`, which maps bus ids to a
 contiguous \\([0,n)\\).
 
-`powerio-prob` builds problem instances and its `matrix` feature projects those
+`powerio-prob` builds problem instances (matrix free DC OPF and AC OPF input
+data plus the GOC3 SCOPF instance) and its `matrix` feature projects those
 instances into sparse operators. The DC OPF bundle schema is in
 [the DC OPF bundle guide](https://eigenergy.github.io/powerio/guide/dcopf-bundle.html). Per-builder API detail is in the
 [crate docs](https://eigenergy.github.io/powerio/powerio_matrix/).

--- a/powerio-prob/Cargo.toml
+++ b/powerio-prob/Cargo.toml
@@ -30,6 +30,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
+num-complex.workspace = true
 serde_json.workspace = true
 tempfile = "3"
 

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -1,0 +1,350 @@
+use serde::{Deserialize, Serialize};
+
+use powerio::{BusId, Error, IndexedNetwork, Result};
+
+use crate::Units;
+
+/// Options for AC OPF instance assembly.
+///
+/// There is no convention enum: the branch pi model always carries taps,
+/// shifts, and charging.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcOpfOptions {
+    pub units: Units,
+    /// Skip non-self-loop branches with `r² + x² = 0`. If false, assembly
+    /// returns [`Error::ZeroImpedance`].
+    pub skip_zero_impedance: bool,
+}
+
+impl Default for AcOpfOptions {
+    fn default() -> Self {
+        Self {
+            units: Units::default(),
+            skip_zero_impedance: true,
+        }
+    }
+}
+
+/// Bus data in dense bus order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AcBusData {
+    /// Nodal active demand in the selected power unit.
+    pub p_d: Vec<f64>,
+    /// Nodal reactive demand in the selected power unit.
+    pub q_d: Vec<f64>,
+    /// Nodal shunt conductance in the selected admittance unit.
+    pub g_s: Vec<f64>,
+    /// Nodal shunt susceptance in the selected admittance unit.
+    pub b_s: Vec<f64>,
+    /// Voltage magnitude lower bound, per unit.
+    pub vm_min: Vec<f64>,
+    /// Voltage magnitude upper bound, per unit.
+    pub vm_max: Vec<f64>,
+    /// Case voltage magnitude, per unit: the raw initial guess, zero when the
+    /// source has none.
+    pub vm: Vec<f64>,
+}
+
+/// Branch data in active branch column order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AcBranchData {
+    pub from_bus: Vec<usize>,
+    pub to_bus: Vec<usize>,
+    /// Series conductance `r / (r² + x²)` in the selected admittance unit.
+    pub g: Vec<f64>,
+    /// Series susceptance `−x / (r² + x²)` in the selected admittance unit.
+    pub b: Vec<f64>,
+    /// Charging conductance at the from terminal.
+    pub g_fr: Vec<f64>,
+    /// Charging susceptance at the from terminal.
+    pub b_fr: Vec<f64>,
+    /// Charging conductance at the to terminal.
+    pub g_to: Vec<f64>,
+    /// Charging susceptance at the to terminal.
+    pub b_to: Vec<f64>,
+    /// Tap ratio magnitude; one for a line. Kept separate from `shift` so a
+    /// consumer stamps the complex tap itself.
+    pub tap: Vec<f64>,
+    /// Phase shift in radians.
+    pub shift: Vec<f64>,
+    /// Apparent power limit in the selected power unit. Zero means unlimited.
+    pub s_max: Vec<f64>,
+    /// Branch angle bounds in radians, as the source states them.
+    pub angle_min: Vec<f64>,
+    pub angle_max: Vec<f64>,
+    /// Branch column to source branch row.
+    pub source_rows: Vec<usize>,
+    /// Source branch rows omitted because `r² + x² = 0`.
+    pub skipped_zero_impedance: Vec<usize>,
+}
+
+/// Generator data in generator column order.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AcGeneratorData {
+    /// Generator column to dense bus index.
+    pub bus_of_gen: Vec<usize>,
+    /// Generator column to source generator row.
+    pub source_rows: Vec<usize>,
+    /// Quadratic objective diagonal in `0.5 * q * p^2 + c * p + c0`.
+    pub q: Vec<f64>,
+    /// Linear objective coefficient.
+    pub c: Vec<f64>,
+    /// Constant objective term. Unscaled in both unit systems: it carries no
+    /// power dimension.
+    pub c0: Vec<f64>,
+    pub pmax: Vec<f64>,
+    pub pmin: Vec<f64>,
+    pub qmax: Vec<f64>,
+    pub qmin: Vec<f64>,
+    /// Scheduled active output in the selected power unit.
+    pub pg: Vec<f64>,
+    /// Scheduled reactive output in the selected power unit.
+    pub qg: Vec<f64>,
+    /// Voltage magnitude setpoint, per unit; zero when the source has none.
+    pub vg: Vec<f64>,
+}
+
+/// Matrix free AC OPF input data on the branch pi model.
+///
+/// A problem instance is complete numerical input for one problem family. It
+/// is separate from the source network, a matrix projection, a solver
+/// formulation, and a solution. Relaxations of AC OPF, the SOC forms
+/// included, consume this same instance; the relaxation is a formulation
+/// choice made downstream.
+///
+/// Units follow [`Units`]. Under [`Units::PerUnit`], powers are per unit on
+/// `base_mva` and admittances are per unit on the system base. Under
+/// [`Units::Native`], powers stay in MW/MVAr and every admittance vector is
+/// scaled by `base_mva`, so power computed from admittances and per unit
+/// voltages lands in MW/MVAr. Voltage magnitudes are per unit and angles are
+/// radians in both systems.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AcOpfInstance {
+    pub name: String,
+    pub n_buses: usize,
+    pub n_source_generators: usize,
+    pub n_source_branches: usize,
+    pub base_mva: f64,
+    pub units: Units,
+    pub skip_zero_impedance: bool,
+    /// Dense bus index to external bus ID.
+    pub bus_ids: Vec<BusId>,
+    pub reference_buses: Vec<usize>,
+    pub buses: AcBusData,
+    pub generators: AcGeneratorData,
+    pub branches: AcBranchData,
+}
+
+impl AcOpfInstance {
+    #[must_use]
+    pub fn n_generators(&self) -> usize {
+        self.generators.q.len()
+    }
+
+    #[must_use]
+    pub fn n_branches(&self) -> usize {
+        self.branches.g.len()
+    }
+
+    /// Conventional voltage magnitude start: the case voltage, overwritten by
+    /// each generator's positive setpoint in generator column order (last
+    /// wins), with a non-positive case voltage falling back to 1.0.
+    ///
+    /// The result is not clamped to `[vm_min, vm_max]`; feasibility repair is
+    /// solver preparation and stays downstream.
+    #[must_use]
+    pub fn vm_setpoints(&self) -> Vec<f64> {
+        let mut vm: Vec<f64> = self
+            .buses
+            .vm
+            .iter()
+            .map(|&value| if value > 0.0 { value } else { 1.0 })
+            .collect();
+        for generator in 0..self.n_generators() {
+            let vg = self.generators.vg[generator];
+            if vg > 0.0 {
+                vm[self.generators.bus_of_gen[generator]] = vg;
+            }
+        }
+        vm
+    }
+}
+
+/// Build a matrix free AC OPF instance from an indexed network.
+#[allow(clippy::too_many_lines)]
+pub fn build_ac_opf_instance(
+    case: &IndexedNetwork,
+    options: &AcOpfOptions,
+) -> Result<AcOpfInstance> {
+    case.check_reference_coverage()?;
+
+    let n_buses = case.n();
+    let base = case.per_unit_base();
+    let (p_scale, y_scale) = options.units.power_scales(base);
+    let (q_scale, c_scale) = options.units.cost_scales(base);
+
+    let mut bus_of_gen = Vec::new();
+    let mut generator_rows = Vec::new();
+    let mut cost_q = Vec::new();
+    let mut cost_c = Vec::new();
+    let mut cost_c0 = Vec::new();
+    let mut pmax = Vec::new();
+    let mut pmin = Vec::new();
+    let mut qmax = Vec::new();
+    let mut qmin = Vec::new();
+    let mut pg = Vec::new();
+    let mut qg = Vec::new();
+    let mut vg = Vec::new();
+
+    for (source_row, generator) in case.in_service_gens() {
+        let bus = case.bus_index(generator.bus).ok_or(Error::UnknownBus {
+            bus_id: generator.bus,
+            element_index: source_row,
+        })?;
+        let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
+            gen_index: source_row,
+        })?;
+        let (q_raw, c_raw, c0_raw) =
+            cost.quadratic_with_constant()
+                .ok_or(Error::UnsupportedCostModel {
+                    gen_index: source_row,
+                    model: cost.model,
+                    ncost: cost.ncost,
+                })?;
+        bus_of_gen.push(bus);
+        generator_rows.push(source_row);
+        cost_q.push(q_raw * q_scale);
+        cost_c.push(c_raw * c_scale);
+        cost_c0.push(c0_raw);
+        pmax.push(generator.pmax * p_scale);
+        pmin.push(generator.pmin * p_scale);
+        qmax.push(generator.qmax * p_scale);
+        qmin.push(generator.qmin * p_scale);
+        pg.push(generator.pg * p_scale);
+        qg.push(generator.qg * p_scale);
+        vg.push(generator.vg);
+    }
+    if cost_q.is_empty() {
+        return Err(Error::NoGenerators);
+    }
+
+    let mut from_bus = Vec::new();
+    let mut to_bus = Vec::new();
+    let mut g = Vec::new();
+    let mut b = Vec::new();
+    let mut g_fr = Vec::new();
+    let mut b_fr = Vec::new();
+    let mut g_to = Vec::new();
+    let mut b_to = Vec::new();
+    let mut tap = Vec::new();
+    let mut shift = Vec::new();
+    let mut s_max = Vec::new();
+    let mut angle_min = Vec::new();
+    let mut angle_max = Vec::new();
+    let mut branch_rows = Vec::new();
+    let mut skipped_zero_impedance = Vec::new();
+
+    for (source_row, branch) in case.in_service_branches() {
+        let from = case.bus_index(branch.from).ok_or(Error::UnknownBus {
+            bus_id: branch.from,
+            element_index: source_row,
+        })?;
+        let to = case.bus_index(branch.to).ok_or(Error::UnknownBus {
+            bus_id: branch.to,
+            element_index: source_row,
+        })?;
+        if from == to {
+            continue;
+        }
+        let Some((series_g, series_b)) = branch.series_admittance(source_row)? else {
+            if options.skip_zero_impedance {
+                skipped_zero_impedance.push(source_row);
+                continue;
+            }
+            return Err(Error::ZeroImpedance { row: source_row });
+        };
+        let charging = branch.terminal_charging();
+        from_bus.push(from);
+        to_bus.push(to);
+        g.push(series_g * y_scale);
+        b.push(series_b * y_scale);
+        g_fr.push(charging.g_fr * y_scale);
+        b_fr.push(charging.b_fr * y_scale);
+        g_to.push(charging.g_to * y_scale);
+        b_to.push(charging.b_to * y_scale);
+        tap.push(branch.effective_tap());
+        shift.push(case.angle_radians(branch.shift));
+        s_max.push(branch.rate_a * p_scale);
+        angle_min.push(case.angle_radians(branch.angmin));
+        angle_max.push(case.angle_radians(branch.angmax));
+        branch_rows.push(source_row);
+    }
+
+    // Dense bus order is the position order of `network().buses`; the view
+    // already holds the star-lowered network when 3-winding expansion ran.
+    let network = case.network();
+    let mut vm_min = Vec::with_capacity(n_buses);
+    let mut vm_max = Vec::with_capacity(n_buses);
+    let mut vm = Vec::with_capacity(n_buses);
+    for bus in &network.buses {
+        vm_min.push(bus.vmin);
+        vm_max.push(bus.vmax);
+        vm.push(bus.vm);
+    }
+
+    Ok(AcOpfInstance {
+        name: case.name().to_owned(),
+        n_buses,
+        n_source_generators: case.generators().len(),
+        n_source_branches: case.branches().len(),
+        base_mva: case.base_mva(),
+        units: options.units,
+        skip_zero_impedance: options.skip_zero_impedance,
+        bus_ids: (0..n_buses).map(|index| case.bus_id(index)).collect(),
+        reference_buses: case.reference_bus_indices(),
+        buses: AcBusData {
+            p_d: case.pd().iter().map(|value| value * p_scale).collect(),
+            q_d: case.qd().iter().map(|value| value * p_scale).collect(),
+            g_s: case.gs().iter().map(|value| value * p_scale).collect(),
+            b_s: case.bs().iter().map(|value| value * p_scale).collect(),
+            vm_min,
+            vm_max,
+            vm,
+        },
+        generators: AcGeneratorData {
+            bus_of_gen,
+            source_rows: generator_rows,
+            q: cost_q,
+            c: cost_c,
+            c0: cost_c0,
+            pmax,
+            pmin,
+            qmax,
+            qmin,
+            pg,
+            qg,
+            vg,
+        },
+        branches: AcBranchData {
+            from_bus,
+            to_bus,
+            g,
+            b,
+            g_fr,
+            b_fr,
+            g_to,
+            b_to,
+            tap,
+            shift,
+            s_max,
+            angle_min,
+            angle_max,
+            source_rows: branch_rows,
+            skipped_zero_impedance,
+        },
+    })
+}

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -13,6 +13,27 @@ pub enum Units {
     Native,
 }
 
+impl Units {
+    /// `(power, admittance)` multipliers for source data on `base` MVA. MW
+    /// valued quantities (demand, bounds, limits, MW valued shunts) scale by
+    /// the first; per unit admittances and susceptances by the second.
+    pub(crate) fn power_scales(self, base: f64) -> (f64, f64) {
+        match self {
+            Self::PerUnit => (1.0 / base, 1.0),
+            Self::Native => (1.0, base),
+        }
+    }
+
+    /// `(quadratic, linear)` generator cost coefficient multipliers for the
+    /// same unit selection. The constant term never scales.
+    pub(crate) fn cost_scales(self, base: f64) -> (f64, f64) {
+        match self {
+            Self::PerUnit => (base * base, base),
+            Self::Native => (1.0, 1.0),
+        }
+    }
+}
+
 /// Options for DC OPF instance assembly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DcOpfOptions {
@@ -157,14 +178,8 @@ pub fn build_dc_opf_instance(
 
     let n_buses = case.n();
     let base = case.per_unit_base();
-    let (p_scale, b_scale) = match options.units {
-        Units::PerUnit => (1.0 / base, 1.0),
-        Units::Native => (1.0, base),
-    };
-    let (q_scale, c_scale) = match options.units {
-        Units::PerUnit => (base * base, base),
-        Units::Native => (1.0, 1.0),
-    };
+    let (p_scale, b_scale) = options.units.power_scales(base);
+    let (q_scale, c_scale) = options.units.cost_scales(base);
 
     let mut bus_of_gen = Vec::new();
     let mut generator_rows = Vec::new();

--- a/powerio-prob/src/lib.rs
+++ b/powerio-prob/src/lib.rs
@@ -3,12 +3,16 @@
 //! The default build provides index based data and depends only on `powerio`.
 //! Enable `matrix` to derive sparse operators from an instance.
 
+mod ac;
 mod dc;
 pub mod scopf;
 
 #[cfg(feature = "matrix")]
 pub mod matrix;
 
+pub use ac::{
+    AcBranchData, AcBusData, AcGeneratorData, AcOpfInstance, AcOpfOptions, build_ac_opf_instance,
+};
 pub use dc::{
     DcBranchData, DcGeneratorData, DcOpfInstance, DcOpfOptions, NodalGeneratorData, Units,
     build_dc_opf_instance,

--- a/powerio-prob/tests/acopf.rs
+++ b/powerio-prob/tests/acopf.rs
@@ -1,0 +1,454 @@
+use powerio::{
+    Branch, BranchCharging, Bus, BusId, BusType, Error, GenCost, Generator, IndexedNetwork,
+    Network, parse_matpower_file,
+};
+use powerio_prob::{AcOpfOptions, Units, build_ac_opf_instance};
+
+fn case9() -> Network {
+    parse_matpower_file("../tests/data/case9.m").expect("parse case9")
+}
+
+fn case14() -> Network {
+    parse_matpower_file("../tests/data/case14.m").expect("parse case14")
+}
+
+fn assert_close(left: f64, right: f64) {
+    assert!((left - right).abs() < 1e-12, "{left} != {right}");
+}
+
+fn bus(id: usize, kind: BusType) -> Bus {
+    Bus::new(BusId(id), kind, 230.0)
+}
+
+fn branch(from: usize, to: usize, r: f64, x: f64) -> Branch {
+    Branch::new(BusId(from), BusId(to), r, x)
+}
+
+fn generator(bus: usize, c2: f64, c1: f64, c0: f64) -> Generator {
+    let mut generator = Generator::new(BusId(bus));
+    generator.pmax = 100.0;
+    generator.pmin = 10.0;
+    generator.qmax = 40.0;
+    generator.qmin = -40.0;
+    generator.cost = Some(GenCost::new(2, 0.0, 0.0, vec![c2, c1, c0]));
+    generator
+}
+
+fn small_network() -> Network {
+    let mut network = Network::in_memory(
+        "small",
+        100.0,
+        vec![bus(10, BusType::Ref), bus(30, BusType::Pq)],
+        vec![branch(10, 30, 0.05, 0.2)],
+    );
+    network.generators.push(generator(10, 1.0, 2.0, 5.0));
+    network
+}
+
+#[test]
+fn instance_is_complete_and_indexed() {
+    let net = case9();
+    let view = IndexedNetwork::new(&net);
+    let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+
+    assert_eq!(problem.name, "case9");
+    assert_eq!(problem.n_buses, 9);
+    assert_eq!(problem.n_source_generators, net.generators.len());
+    assert_eq!(problem.n_source_branches, net.branches.len());
+    assert_eq!(problem.n_generators(), 3);
+    assert_eq!(problem.bus_ids.len(), problem.n_buses);
+    for vector in [
+        &problem.buses.p_d,
+        &problem.buses.q_d,
+        &problem.buses.g_s,
+        &problem.buses.b_s,
+        &problem.buses.vm_min,
+        &problem.buses.vm_max,
+        &problem.buses.vm,
+    ] {
+        assert_eq!(vector.len(), problem.n_buses);
+    }
+    for vector in [
+        &problem.generators.q,
+        &problem.generators.c,
+        &problem.generators.c0,
+        &problem.generators.pmax,
+        &problem.generators.pmin,
+        &problem.generators.qmax,
+        &problem.generators.qmin,
+        &problem.generators.pg,
+        &problem.generators.qg,
+        &problem.generators.vg,
+    ] {
+        assert_eq!(vector.len(), problem.n_generators());
+    }
+    for vector in [
+        &problem.branches.g,
+        &problem.branches.b,
+        &problem.branches.g_fr,
+        &problem.branches.b_fr,
+        &problem.branches.g_to,
+        &problem.branches.b_to,
+        &problem.branches.tap,
+        &problem.branches.shift,
+        &problem.branches.s_max,
+        &problem.branches.angle_min,
+        &problem.branches.angle_max,
+    ] {
+        assert_eq!(vector.len(), problem.n_branches());
+    }
+    assert!(
+        problem
+            .generators
+            .bus_of_gen
+            .iter()
+            .all(|&bus| bus < problem.n_buses)
+    );
+    assert!(
+        problem
+            .branches
+            .from_bus
+            .iter()
+            .chain(&problem.branches.to_bus)
+            .all(|&bus| bus < problem.n_buses)
+    );
+}
+
+#[test]
+fn case14_taps_shunt_and_series_admittance() {
+    let net = case14();
+    let view = IndexedNetwork::new(&net);
+    let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+
+    let mut taps: Vec<f64> = problem
+        .branches
+        .tap
+        .iter()
+        .copied()
+        .filter(|&tap| (tap - 1.0).abs() > 1e-12)
+        .collect();
+    taps.sort_by(f64::total_cmp);
+    for (tap, expected) in taps.iter().zip([0.932, 0.969, 0.978]) {
+        assert_close(*tap, expected);
+    }
+    assert_eq!(taps.len(), 3);
+    assert!(
+        problem
+            .branches
+            .shift
+            .iter()
+            .all(|&shift| shift.abs() < 1e-12)
+    );
+
+    let bus9 = problem
+        .bus_ids
+        .iter()
+        .position(|&id| id == BusId(9))
+        .expect("bus 9");
+    assert_close(problem.buses.b_s[bus9], 0.19);
+    assert_close(problem.buses.g_s[bus9], 0.0);
+
+    let first = &net.branches[0];
+    let z_squared = first.r * first.r + first.x * first.x;
+    assert_eq!(problem.branches.source_rows[0], 0);
+    assert_close(problem.branches.g[0], first.r / z_squared);
+    assert_close(problem.branches.b[0], -first.x / z_squared);
+    assert_close(problem.buses.vm[0], 1.06);
+}
+
+#[test]
+fn tap_and_shift_are_carried_separately() {
+    let mut net = small_network();
+    net.branches[0].tap = 1.25;
+    net.branches[0].shift = 10.0;
+    let view = IndexedNetwork::new(&net);
+    let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+
+    assert_close(problem.branches.tap[0], 1.25);
+    assert_close(problem.branches.shift[0], 10.0_f64.to_radians());
+    let z_squared = 0.05 * 0.05 + 0.2 * 0.2;
+    assert_close(problem.branches.g[0], 0.05 / z_squared);
+    assert_close(problem.branches.b[0], -0.2 / z_squared);
+}
+
+#[test]
+fn terminal_charging_split_and_asymmetric() {
+    let mut symmetric = small_network();
+    symmetric.branches[0].b = 0.10;
+    let problem = build_ac_opf_instance(&IndexedNetwork::new(&symmetric), &AcOpfOptions::default())
+        .expect("symmetric");
+    assert_close(problem.branches.b_fr[0], 0.05);
+    assert_close(problem.branches.b_to[0], 0.05);
+    assert_close(problem.branches.g_fr[0], 0.0);
+    assert_close(problem.branches.g_to[0], 0.0);
+
+    let mut asymmetric = small_network();
+    asymmetric.branches[0].charging = Some(BranchCharging::new(0.001, 0.03, 0.002, 0.07));
+    let problem =
+        build_ac_opf_instance(&IndexedNetwork::new(&asymmetric), &AcOpfOptions::default())
+            .expect("asymmetric");
+    assert_close(problem.branches.g_fr[0], 0.001);
+    assert_close(problem.branches.b_fr[0], 0.03);
+    assert_close(problem.branches.g_to[0], 0.002);
+    assert_close(problem.branches.b_to[0], 0.07);
+}
+
+#[test]
+fn per_unit_and_native_units_scale_consistently() {
+    let mut net = small_network();
+    net.branches[0].rate_a = 250.0;
+    net.loads.push(powerio::Load::new(BusId(30), 90.0, 30.0));
+    net.shunts.push(powerio::Shunt::new(BusId(30), 2.0, 19.0));
+    let view = IndexedNetwork::new(&net);
+    let native = build_ac_opf_instance(
+        &view,
+        &AcOpfOptions {
+            units: Units::Native,
+            ..AcOpfOptions::default()
+        },
+    )
+    .expect("native");
+    let per_unit = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("per unit");
+    let base = view.base_mva();
+
+    assert_eq!(native.units, Units::Native);
+    assert_eq!(per_unit.units, Units::PerUnit);
+    for (native_vector, per_unit_vector) in [
+        (&native.buses.p_d, &per_unit.buses.p_d),
+        (&native.buses.q_d, &per_unit.buses.q_d),
+        (&native.buses.g_s, &per_unit.buses.g_s),
+        (&native.buses.b_s, &per_unit.buses.b_s),
+        (&native.generators.pmax, &per_unit.generators.pmax),
+        (&native.generators.qmin, &per_unit.generators.qmin),
+        (&native.branches.g, &per_unit.branches.g),
+        (&native.branches.b, &per_unit.branches.b),
+        (&native.branches.b_fr, &per_unit.branches.b_fr),
+        (&native.branches.s_max, &per_unit.branches.s_max),
+    ] {
+        for (native_value, per_unit_value) in native_vector.iter().zip(per_unit_vector) {
+            assert_close(*native_value, per_unit_value * base);
+        }
+    }
+    assert_close(
+        per_unit.generators.q[0],
+        native.generators.q[0] * base * base,
+    );
+    assert_close(per_unit.generators.c[0], native.generators.c[0] * base);
+    assert_close(per_unit.generators.c0[0], native.generators.c0[0]);
+    assert_close(per_unit.buses.vm_min[0], native.buses.vm_min[0]);
+    assert_close(per_unit.buses.vm_max[0], native.buses.vm_max[0]);
+}
+
+#[test]
+fn cost_constant_term_is_kept() {
+    let net = small_network();
+    let problem =
+        build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default()).expect("build");
+    assert_close(problem.generators.c0[0], 5.0);
+}
+
+#[test]
+fn missing_and_unsupported_costs_are_distinct() {
+    let mut missing = small_network();
+    missing.generators[0].cost = None;
+    let error = build_ac_opf_instance(&IndexedNetwork::new(&missing), &AcOpfOptions::default())
+        .expect_err("missing cost");
+    assert!(matches!(error, Error::MissingGenCost { gen_index: 0 }));
+
+    let mut piecewise = small_network();
+    piecewise.generators[0].cost = Some(GenCost::with_ncost(
+        1,
+        0.0,
+        0.0,
+        2,
+        vec![0.0, 0.0, 1.0, 1.0],
+    ));
+    let error = build_ac_opf_instance(&IndexedNetwork::new(&piecewise), &AcOpfOptions::default())
+        .expect_err("unsupported cost");
+    assert!(matches!(
+        error,
+        Error::UnsupportedCostModel {
+            gen_index: 0,
+            model: 1,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn zero_impedance_skip_or_reject() {
+    let mut net = small_network();
+    net.branches.insert(0, branch(10, 30, 0.0, 0.0));
+    let view = IndexedNetwork::new(&net);
+    let skipped = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("skip");
+    assert_eq!(skipped.branches.skipped_zero_impedance, vec![0]);
+    assert_eq!(skipped.branches.source_rows, vec![1]);
+
+    let error = build_ac_opf_instance(
+        &view,
+        &AcOpfOptions {
+            skip_zero_impedance: false,
+            ..AcOpfOptions::default()
+        },
+    )
+    .expect_err("reject");
+    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+
+    // Zero resistance with nonzero reactance is a valid series element.
+    let mut inductive = small_network();
+    inductive.branches[0].r = 0.0;
+    let problem = build_ac_opf_instance(&IndexedNetwork::new(&inductive), &AcOpfOptions::default())
+        .expect("inductive");
+    assert_eq!(problem.branches.skipped_zero_impedance, Vec::<usize>::new());
+    assert_close(problem.branches.g[0], 0.0);
+    assert_close(problem.branches.b[0], -1.0 / 0.2);
+}
+
+#[test]
+fn out_of_service_exclusion() {
+    let mut net = case9();
+    net.generators[1].in_service = false;
+    net.branches[2].in_service = false;
+    let view = IndexedNetwork::new(&net);
+    let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+
+    assert_eq!(problem.n_generators(), 2);
+    assert!(!problem.generators.source_rows.contains(&1));
+    assert!(!problem.branches.source_rows.contains(&2));
+    assert_eq!(problem.bus_ids[0], view.bus_id(0));
+}
+
+#[test]
+fn vm_setpoints_follow_generator_voltage() {
+    let mut net = small_network();
+    net.buses[0].vm = 0.0;
+    net.buses[1].vm = 1.02;
+    net.generators[0].vg = 1.05;
+    let problem =
+        build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default()).expect("build");
+    let setpoints = problem.vm_setpoints();
+    assert_close(setpoints[0], 1.05);
+    assert_close(setpoints[1], 1.02);
+
+    // An out of band setpoint is carried unclamped; feasibility repair is
+    // solver preparation.
+    let mut wide = small_network();
+    wide.generators[0].vg = 1.5;
+    let problem = build_ac_opf_instance(&IndexedNetwork::new(&wide), &AcOpfOptions::default())
+        .expect("build");
+    assert_close(problem.vm_setpoints()[0], 1.5);
+
+    // A generator without a setpoint leaves the case voltage in place.
+    let mut unset = small_network();
+    unset.buses[0].vm = 1.01;
+    unset.generators[0].vg = 0.0;
+    let problem = build_ac_opf_instance(&IndexedNetwork::new(&unset), &AcOpfOptions::default())
+        .expect("build");
+    assert_close(problem.vm_setpoints()[0], 1.01);
+}
+
+#[test]
+fn normalized_network_builds_identical_instance() {
+    let net = case14();
+    let normalized = net.to_normalized().expect("normalize");
+    let raw =
+        build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default()).expect("raw");
+    let derived =
+        build_ac_opf_instance(&IndexedNetwork::new(&normalized), &AcOpfOptions::default())
+            .expect("normalized");
+
+    assert_eq!(raw.n_buses, derived.n_buses);
+    assert_eq!(raw.branches.source_rows, derived.branches.source_rows);
+    for (left, right) in [
+        (&raw.buses.p_d, &derived.buses.p_d),
+        (&raw.buses.b_s, &derived.buses.b_s),
+        (&raw.branches.g, &derived.branches.g),
+        (&raw.branches.b, &derived.branches.b),
+        (&raw.branches.b_fr, &derived.branches.b_fr),
+        (&raw.branches.shift, &derived.branches.shift),
+        (&raw.branches.s_max, &derived.branches.s_max),
+        (&raw.generators.q, &derived.generators.q),
+        (&raw.generators.c, &derived.generators.c),
+        (&raw.generators.pmax, &derived.generators.pmax),
+    ] {
+        for (raw_value, derived_value) in left.iter().zip(right) {
+            assert!(
+                (raw_value - derived_value).abs() < 1e-9,
+                "{raw_value} != {derived_value}"
+            );
+        }
+    }
+}
+
+#[test]
+fn serde_round_trip() {
+    let net = case9();
+    let view = IndexedNetwork::new(&net);
+    let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+    let json = serde_json::to_string(&problem).expect("serialize");
+    let back: powerio_prob::AcOpfInstance = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.name, problem.name);
+    assert_eq!(back.bus_ids, problem.bus_ids);
+    assert_eq!(back.generators.source_rows, problem.generators.source_rows);
+    assert_eq!(back.branches.source_rows, problem.branches.source_rows);
+    for (left, right) in back.branches.b.iter().zip(&problem.branches.b) {
+        assert!((left - right).abs() < 1e-12);
+    }
+}
+
+#[cfg(feature = "matrix")]
+mod matrix_tests {
+    use num_complex::Complex64;
+
+    use super::*;
+
+    /// Assemble a dense Y_bus from the instance with the standard pi model
+    /// stamp and compare it against the generic `build_ybus` on the same
+    /// network. This is the same algebra an AC consumer implements from the
+    /// carried fields.
+    #[test]
+    fn ybus_entrywise_cross_check() {
+        let net = case14();
+        let view = IndexedNetwork::new(&net);
+        let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
+        let n = problem.n_buses;
+
+        let mut dense = vec![vec![Complex64::new(0.0, 0.0); n]; n];
+        for e in 0..problem.n_branches() {
+            let from = problem.branches.from_bus[e];
+            let to = problem.branches.to_bus[e];
+            let series = Complex64::new(problem.branches.g[e], problem.branches.b[e]);
+            let charging_from = Complex64::new(problem.branches.g_fr[e], problem.branches.b_fr[e]);
+            let charging_to = Complex64::new(problem.branches.g_to[e], problem.branches.b_to[e]);
+            let tap = Complex64::from_polar(problem.branches.tap[e], problem.branches.shift[e]);
+            let tap_squared = problem.branches.tap[e] * problem.branches.tap[e];
+
+            dense[from][from] += (series + charging_from) / tap_squared;
+            dense[from][to] += -series / tap.conj();
+            dense[to][from] += -series / tap;
+            dense[to][to] += series + charging_to;
+        }
+        for (index, dense_row) in dense.iter_mut().enumerate() {
+            dense_row[index] += Complex64::new(problem.buses.g_s[index], problem.buses.b_s[index]);
+        }
+
+        let ybus = powerio_matrix::build_ybus(&view, &powerio_matrix::BuildOptions::default())
+            .expect("ybus");
+        for (row, dense_row) in dense.iter().enumerate() {
+            for (column, expected) in dense_row.iter().enumerate() {
+                let g_entry = ybus.g.get(row, column).copied().unwrap_or(0.0);
+                let b_entry = ybus.b.get(row, column).copied().unwrap_or(0.0);
+                assert!(
+                    (g_entry - expected.re).abs() < 1e-9,
+                    "G[{row}][{column}]: {g_entry} != {}",
+                    expected.re
+                );
+                assert!(
+                    (b_entry - expected.im).abs() < 1e-9,
+                    "B[{row}][{column}]: {b_entry} != {}",
+                    expected.im
+                );
+            }
+        }
+    }
+}

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::Error;
 use crate::geo::{GeoMeta, Location};
+use crate::{Error, Result};
 
 /// Source-format fields the neutral model doesn't name, kept for round-trip and
 /// cross-format passthrough. Keys are the field names; values are JSON scalars.
@@ -172,6 +172,15 @@ impl GenCost {
     /// `c = c1`. Linear rows (`ncost == 2`) give `q = 0`. Piecewise (model 1)
     /// or cubic and higher return `None`.
     pub fn quadratic(&self) -> Option<(f64, f64)> {
+        self.quadratic_with_constant().map(|(q, c, _)| (q, c))
+    }
+
+    /// `(q, c, c0)` for the quadratic cost `½ q p² + c p + c0` from a
+    /// polynomial (model 2) row, keeping the constant term that
+    /// [`quadratic`](Self::quadratic) drops. Linear rows (`ncost == 2`) give
+    /// `q = 0`; constant rows (`ncost == 1`) give `q = c = 0`. Piecewise
+    /// (model 1) or cubic and higher return `None`.
+    pub fn quadratic_with_constant(&self) -> Option<(f64, f64, f64)> {
         if self.model != 2 {
             return None;
         }
@@ -181,9 +190,9 @@ impl GenCost {
             return None;
         }
         match self.ncost {
-            3 => Some((2.0 * self.coeffs[0], self.coeffs[1])),
-            2 => Some((0.0, self.coeffs[0])),
-            1 => Some((0.0, 0.0)),
+            3 => Some((2.0 * self.coeffs[0], self.coeffs[1], self.coeffs[2])),
+            2 => Some((0.0, self.coeffs[0], self.coeffs[1])),
+            1 => Some((0.0, 0.0, self.coeffs[0])),
             _ => None,
         }
     }
@@ -786,6 +795,27 @@ impl Branch {
     pub fn terminal_charging(&self) -> BranchCharging {
         self.charging
             .unwrap_or_else(|| BranchCharging::from_total_b(self.b))
+    }
+
+    /// Series admittance `(g, b) = (r, −x) / (r² + x²)` of the branch pi
+    /// model, the primitive beside [`effective_tap`](Self::effective_tap) and
+    /// [`terminal_charging`](Self::terminal_charging). `Ok(None)` for a zero
+    /// impedance branch (`r² + x² = 0`); the caller decides whether that is a
+    /// skip or an error.
+    ///
+    /// # Errors
+    /// [`Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad
+    /// value cannot write NaN or a silent zero downstream. `row` only labels
+    /// the error.
+    pub fn series_admittance(&self, row: usize) -> Result<Option<(f64, f64)>> {
+        let denom = self.r * self.r + self.x * self.x;
+        if denom == 0.0 {
+            return Ok(None);
+        }
+        if !denom.is_finite() {
+            return Err(Error::NonFiniteSusceptance { row });
+        }
+        Ok(Some((self.r / denom, -self.x / denom)))
     }
 
     /// Total susceptance projection for MATPOWER shaped formats that only carry
@@ -2177,6 +2207,28 @@ mod tests {
 
     fn close(actual: f64, expected: f64) {
         assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
+    }
+
+    #[test]
+    fn quadratic_with_constant_keeps_c0_across_ncost() {
+        let full = GenCost::new(2, 0.0, 0.0, vec![1.5, 2.0, 5.0]);
+        assert_eq!(full.quadratic_with_constant(), Some((3.0, 2.0, 5.0)));
+        assert_eq!(full.quadratic(), Some((3.0, 2.0)));
+
+        let linear = GenCost::new(2, 0.0, 0.0, vec![2.0, 5.0]);
+        assert_eq!(linear.quadratic_with_constant(), Some((0.0, 2.0, 5.0)));
+
+        let constant = GenCost::new(2, 0.0, 0.0, vec![5.0]);
+        assert_eq!(constant.quadratic_with_constant(), Some((0.0, 0.0, 5.0)));
+
+        let piecewise = GenCost::new(1, 0.0, 0.0, vec![0.0, 0.0, 1.0, 1.0]);
+        assert_eq!(piecewise.quadratic_with_constant(), None);
+
+        let cubic = GenCost::new(2, 0.0, 0.0, vec![1.0, 1.0, 1.0, 1.0]);
+        assert_eq!(cubic.quadratic_with_constant(), None);
+
+        let truncated = GenCost::with_ncost(2, 0.0, 0.0, 3, vec![1.0]);
+        assert_eq!(truncated.quadratic_with_constant(), None);
     }
 
     fn bus(id: usize) -> Bus {


### PR DESCRIPTION
## What changed

- `powerio-prob` gains `AcOpfInstance` and `build_ac_opf_instance(&IndexedNetwork, &AcOpfOptions)`: matrix free AC OPF input data on the branch pi model, following the DC instance idiom. Per branch column: series g/b, per terminal charging, raw tap magnitude and shift kept separate, apparent power limit (zero means unlimited), angle bounds, source rows. Per bus: active and reactive demand, shunt admittance, voltage band, case voltage. Per generator: PQ bounds, scheduled output, voltage setpoint, quadratic cost including the constant term. `vm_setpoints()` derives the conventional voltage start, unclamped; feasibility repair stays downstream.
- `powerio` gains `Branch::series_admittance`, the pi model primitive beside `effective_tap` and `terminal_charging`, and `GenCost::quadratic_with_constant`; `quadratic()` now delegates to it.
- `Units::power_scales` / `Units::cost_scales` own the per unit vs native convention for both prob builders.

Rust only: no C ABI, Python, or schema changes. C and Python exposure is #249.

## Why

Relaxations of AC OPF, the SOC forms included, consume the same numerical input; the relaxation is a formulation choice made downstream. This gives the extraction one owner instead of every consumer walking the network itself.

## Checks

- `powerio-prob/tests/acopf.rs`: 13 cases, including a dense Y_bus assembled entrywise from the instance and cross-checked against `powerio_matrix::build_ybus` on case14, and a normalized network invariance test.
- `cargo test --workspace --all-features`, `scripts/ci-clippy.sh`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` green locally.

Closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
