### PR TITLE
Fix powerio-prob review findings before the first publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@
   constant term (`GenCost::quadratic_with_constant`). Relaxations such as SOC
   forms consume the same instance. Matrix free; C ABI and Python exposure is
   #249.
+- `powerio-prob` first publish review fixes: reserve membership sets now
+  assign zone indices from the same document order as the reserve rows
+  (sorted order previously crossed `n_p`/`n_q` between the two tables and
+  diverged from `src/goc3.jl` past nine zones); a GOC3 branch with
+  `r = x = 0` is rejected by name instead of writing NaN into the wire
+  rows; a missing `device_type` defaults to `producer`, the balanced
+  reader's rule; the AC instance folds self-loop branch admittance into
+  the bus shunt vectors, matching `build_ybus`; both instance builders
+  reject a non-positive base MVA before scaling; the DC OPF bundle
+  directory name stays confined to the output directory, and the bundle
+  manifest reports the powerio core version (`powerio::VERSION`, new).
+  SCOPF row structs and `DcOpfOutputs` are `#[non_exhaustive]`.
 - DSS reader: `linecode=` now sets a line's conductor count the way the
   engine's FetchLineCode does, the later of `phases=`/`linecode=` winning.
   A 4-wire line without an explicit `phases=` keeps its neutral instead of

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -33,9 +33,11 @@ pub struct AcBusData {
     pub p_d: Vec<f64>,
     /// Nodal reactive demand in the selected power unit.
     pub q_d: Vec<f64>,
-    /// Nodal shunt conductance in the selected admittance unit.
+    /// Nodal shunt conductance in the selected admittance unit. Includes the
+    /// folded pi model stamp of any self-loop branch, matching `build_ybus`.
     pub g_s: Vec<f64>,
-    /// Nodal shunt susceptance in the selected admittance unit.
+    /// Nodal shunt susceptance in the selected admittance unit. Includes the
+    /// folded pi model stamp of any self-loop branch, matching `build_ybus`.
     pub b_s: Vec<f64>,
     /// Voltage magnitude lower bound, per unit.
     pub vm_min: Vec<f64>,
@@ -181,6 +183,7 @@ pub fn build_ac_opf_instance(
     options: &AcOpfOptions,
 ) -> Result<AcOpfInstance> {
     case.check_reference_coverage()?;
+    case.network().check_base_mva()?;
 
     let n_buses = case.n();
     let base = case.per_unit_base();
@@ -232,6 +235,9 @@ pub fn build_ac_opf_instance(
         return Err(Error::NoGenerators);
     }
 
+    let mut g_s: Vec<f64> = case.gs().iter().map(|value| value * p_scale).collect();
+    let mut b_s: Vec<f64> = case.bs().iter().map(|value| value * p_scale).collect();
+
     let mut from_bus = Vec::new();
     let mut to_bus = Vec::new();
     let mut g = Vec::new();
@@ -257,9 +263,6 @@ pub fn build_ac_opf_instance(
             bus_id: branch.to,
             element_index: source_row,
         })?;
-        if from == to {
-            continue;
-        }
         let Some((series_g, series_b)) = branch.series_admittance(source_row)? else {
             if options.skip_zero_impedance {
                 skipped_zero_impedance.push(source_row);
@@ -268,6 +271,22 @@ pub fn build_ac_opf_instance(
             return Err(Error::ZeroImpedance { row: source_row });
         };
         let charging = branch.terminal_charging();
+        if from == to {
+            // A self-loop is not a flow element; its whole pi model stamp
+            // lands on the bus diagonal, exactly as `build_ybus` folds it.
+            // With t = tap·e^{jθ}: Yff + Yft + Ytf + Ytt
+            //   = (y + y_fr)/tap² + (y + y_to) − y·2cos(θ)/tap.
+            let tap = branch.effective_tap();
+            let tap_squared = tap * tap;
+            let cross = 2.0 * case.angle_radians(branch.shift).cos() / tap;
+            g_s[from] += ((series_g + charging.g_fr) / tap_squared + (series_g + charging.g_to)
+                - series_g * cross)
+                * y_scale;
+            b_s[from] += ((series_b + charging.b_fr) / tap_squared + (series_b + charging.b_to)
+                - series_b * cross)
+                * y_scale;
+            continue;
+        }
         from_bus.push(from);
         to_bus.push(to);
         g.push(series_g * y_scale);
@@ -309,8 +328,8 @@ pub fn build_ac_opf_instance(
         buses: AcBusData {
             p_d: case.pd().iter().map(|value| value * p_scale).collect(),
             q_d: case.qd().iter().map(|value| value * p_scale).collect(),
-            g_s: case.gs().iter().map(|value| value * p_scale).collect(),
-            b_s: case.bs().iter().map(|value| value * p_scale).collect(),
+            g_s,
+            b_s,
             vm_min,
             vm_max,
             vm,

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -175,6 +175,7 @@ pub fn build_dc_opf_instance(
     options: &DcOpfOptions,
 ) -> Result<DcOpfInstance> {
     case.check_reference_coverage()?;
+    case.network().check_base_mva()?;
 
     let n_buses = case.n();
     let base = case.per_unit_base();
@@ -233,6 +234,8 @@ pub fn build_dc_opf_instance(
             element_index: source_row,
         })?;
         if from == to {
+            // A self-loop carries no angle difference, so it contributes no
+            // DC flow, and its shift injection cancels at its own bus.
             continue;
         }
         if branch.x == 0.0 {

--- a/powerio-prob/src/matrix/bundle.rs
+++ b/powerio-prob/src/matrix/bundle.rs
@@ -35,6 +35,7 @@ pub struct DcOpfBundleOptions {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct DcOpfOutputs {
     pub dir: PathBuf,
     pub files: Vec<PathBuf>,
@@ -64,6 +65,29 @@ struct DcOpfMeta<'a> {
     patched_gen_costs: usize,
     files: Vec<String>,
     powerio_version: &'static str,
+}
+
+/// One path component derived from a case name. Case names come from source
+/// files, so separators and anything else outside `[A-Za-z0-9._-]` map to
+/// `_`, and a name that would resolve to the current or parent directory
+/// falls back to `case`. The bundle always lands under the caller's
+/// output directory.
+fn directory_component(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if cleaned.is_empty() || cleaned.chars().all(|c| c == '.') {
+        "case".to_owned()
+    } else {
+        cleaned
+    }
 }
 
 #[derive(Serialize)]
@@ -132,7 +156,9 @@ pub fn write_dcopf_bundle(
 ) -> Result<DcOpfOutputs> {
     let matrices = build_dc_opf_matrices(instance);
     let nodal = instance.nodal_generator_data()?;
-    let dir = out_dir.as_ref().join(format!("{}_dcopf", instance.name));
+    let dir = out_dir
+        .as_ref()
+        .join(format!("{}_dcopf", directory_component(&instance.name)));
     std::fs::create_dir_all(&dir)?;
 
     let mut files = Vec::new();
@@ -233,7 +259,7 @@ pub fn write_dcopf_bundle(
             .iter()
             .filter_map(|path| path.file_name()?.to_str().map(str::to_owned))
             .collect(),
-        powerio_version: env!("CARGO_PKG_VERSION"),
+        powerio_version: powerio::VERSION,
     };
     let meta_path = dir.join("dcopf_meta.json");
     let json = serde_json::to_string_pretty(&meta)

--- a/powerio-prob/src/scopf/goc3.rs
+++ b/powerio-prob/src/scopf/goc3.rs
@@ -109,9 +109,8 @@ pub(super) fn initial_status(obj: &Map<String, Value>) -> Result<&Map<String, Va
 // ---------------------------------------------------------------------------
 
 /// One GOC3 section's rows, keyed by `uid`. `uids()` preserves the source
-/// document order from [`Goc3Document`]; `sorted_uids()`
-/// is the lexicographic order `_goc3_ids` builds in `src/goc3.jl`
-/// (`sort(collect(keys(lookup)))`).
+/// document order from [`Goc3Document`]; every projection index derives from
+/// that one order.
 #[derive(Clone, Debug, Default)]
 pub(super) struct Goc3Section {
     order: Vec<String>,
@@ -146,19 +145,6 @@ impl Goc3Section {
 
     pub(super) fn uids(&self) -> &[String] {
         &self.order
-    }
-
-    pub(super) fn sorted_uids(&self) -> Vec<String> {
-        let mut ids = self.order.clone();
-        ids.sort();
-        ids
-    }
-
-    pub(super) fn index(&self, uid: &str) -> Result<usize> {
-        self.order
-            .iter()
-            .position(|candidate| candidate == uid)
-            .ok_or_else(|| json_error(format!("unknown uid `{uid}`")))
     }
 }
 
@@ -210,10 +196,8 @@ pub(super) struct Goc3Adapter {
     pub(super) sdd_ids_consumer: Vec<String>,
     pub(super) azr: Goc3Section,
     pub(super) azr_ts: Goc3Section,
-    pub(super) azr_ids: Vec<String>,
     pub(super) rzr: Goc3Section,
     pub(super) rzr_ts: Goc3Section,
-    pub(super) rzr_ids: Vec<String>,
 }
 
 impl Goc3Adapter {
@@ -316,9 +300,6 @@ impl Goc3Adapter {
             document.time_series_input_records("reactive_zonal_reserve"),
             "reactive_zonal_reserve time series",
         )?;
-        let azr_ids = azr.sorted_uids();
-        let rzr_ids = rzr.sorted_uids();
-
         Ok(Self {
             contingencies,
             dt,
@@ -334,10 +315,8 @@ impl Goc3Adapter {
             sdd_ids_consumer,
             azr,
             azr_ts,
-            azr_ids,
             rzr,
             rzr_ts,
-            rzr_ids,
         })
     }
 

--- a/powerio-prob/src/scopf/projection.rs
+++ b/powerio-prob/src/scopf/projection.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use powerio::BusId;
 use powerio::format::goc3::Goc3Document;
@@ -23,6 +23,15 @@ use super::types::{
 
 type Result<T> = ScopfResult<T>;
 
+/// The device class of a `simple_dispatchable_device` row. An absent
+/// `device_type` defaults to `producer`, the same rule the balanced GOC3
+/// reader applies in `device_rows`.
+fn sdd_device_type(obj: &Map<String, Value>) -> &str {
+    obj.get("device_type")
+        .and_then(Value::as_str)
+        .unwrap_or("producer")
+}
+
 fn validate_period_len(
     kind: &str,
     uid: &str,
@@ -43,7 +52,7 @@ impl Goc3Adapter {
         let mut rows = Vec::new();
         for uid in self.sdd_order() {
             let val = self.sdd.get(&uid)?;
-            if require_str(val, "device_type")? != device_type {
+            if sdd_device_type(val) != device_type {
                 continue;
             }
             let ts_val = self.sdd_ts.get(&uid)?;
@@ -68,12 +77,12 @@ impl Goc3Adapter {
 
     fn twt_variable_phase(&self) -> Result<Vec<ScopfVariablePhaseRow>> {
         let mut rows = Vec::new();
-        for uid in self.twt.uids() {
+        for (j_xf, uid) in self.twt.uids().iter().enumerate() {
             let val = self.twt.get(uid)?;
             let (lb, ub) = (require_num(val, "ta_lb")?, require_num(val, "ta_ub")?);
             if lb < ub {
                 rows.push(ScopfVariablePhaseRow {
-                    j_xf: self.twt.index(uid)?,
+                    j_xf,
                     phi_min: lb,
                     phi_max: ub,
                 });
@@ -85,15 +94,12 @@ impl Goc3Adapter {
 
     fn twt_fixed_phase(&self) -> Result<Vec<ScopfFixedPhaseRow>> {
         let mut rows = Vec::new();
-        for uid in self.twt.uids() {
+        for (j_xf, uid) in self.twt.uids().iter().enumerate() {
             let val = self.twt.get(uid)?;
             let (lb, ub) = (require_num(val, "ta_lb")?, require_num(val, "ta_ub")?);
             if lb >= ub {
                 let phi_o = require_num(initial_status(val)?, "ta")?;
-                rows.push(ScopfFixedPhaseRow {
-                    j_xf: self.twt.index(uid)?,
-                    phi_o,
-                });
+                rows.push(ScopfFixedPhaseRow { j_xf, phi_o });
             }
         }
         rows.sort_by_key(|r| r.j_xf);
@@ -102,12 +108,12 @@ impl Goc3Adapter {
 
     fn twt_variable_ratio(&self) -> Result<Vec<ScopfVariableRatioRow>> {
         let mut rows = Vec::new();
-        for uid in self.twt.uids() {
+        for (j_xf, uid) in self.twt.uids().iter().enumerate() {
             let val = self.twt.get(uid)?;
             let (lb, ub) = (require_num(val, "tm_lb")?, require_num(val, "tm_ub")?);
             if lb < ub {
                 rows.push(ScopfVariableRatioRow {
-                    j_xf: self.twt.index(uid)?,
+                    j_xf,
                     tau_min: lb,
                     tau_max: ub,
                 });
@@ -119,15 +125,12 @@ impl Goc3Adapter {
 
     fn twt_fixed_ratio(&self) -> Result<Vec<ScopfFixedRatioRow>> {
         let mut rows = Vec::new();
-        for uid in self.twt.uids() {
+        for (j_xf, uid) in self.twt.uids().iter().enumerate() {
             let val = self.twt.get(uid)?;
             let (lb, ub) = (require_num(val, "tm_lb")?, require_num(val, "tm_ub")?);
             if lb >= ub {
                 let tau_o = require_num(initial_status(val)?, "tm")?;
-                rows.push(ScopfFixedRatioRow {
-                    j_xf: self.twt.index(uid)?,
-                    tau_o,
-                });
+                rows.push(ScopfFixedRatioRow { j_xf, tau_o });
             }
         }
         rows.sort_by_key(|r| r.j_xf);
@@ -201,32 +204,34 @@ impl Goc3Adapter {
     fn sdd_rows(&self, device_type: &str) -> Result<Vec<ScopfDeviceRow>> {
         let mut rows = Vec::new();
         for uid in self.sdd_order() {
-            if require_str(self.sdd.get(&uid)?, "device_type")? == device_type {
+            if sdd_device_type(self.sdd.get(&uid)?) == device_type {
                 rows.push(self.sdd_row(&uid)?);
             }
         }
         Ok(rows)
     }
 
-    /// One (bus, zone, device) membership set: `ids` is the sorted reserve
-    /// zone uid list (`azr_ids`/`rzr_ids`), `uids_key` names the bus field
-    /// listing its zone uids, `device_type` filters the zone's devices. The
-    /// Rust equivalent of `reserve_set` in `src/goc3.jl`, iterating buses in
-    /// [`Goc3Adapter::bus_order`] and devices in
-    /// [`Goc3Adapter::devices_by_bus`] order (see the module-level order
-    /// note; `src/goc3.jl` iterates both as `Dict`s here).
+    /// One (bus, zone, device) membership set: `ids` is the reserve zone
+    /// section's uid list in document order, so the `zone_index` passed to
+    /// `mkrow` matches the `n_p`/`n_q` the reserve rows assign from the same
+    /// order. `uids_key` names the bus field listing its zone uids and
+    /// `device_type` filters the zone's devices. The Rust equivalent of
+    /// `reserve_set` in `src/goc3.jl`, iterating buses in `bus_order` and
+    /// devices in `devices_by_bus` order (`src/goc3.jl` iterates both as
+    /// `Dict`s here). `devices_by_bus`/`bus_order` are precomputed once by
+    /// the caller; four membership sets share them.
     fn reserve_set<R>(
         &self,
         ids: &[String],
         uids_key: &str,
         device_type: &str,
+        devices_by_bus: &BTreeMap<String, Vec<String>>,
+        bus_order: &[String],
         mkrow: impl Fn(BusId, usize, String) -> R,
     ) -> Result<Vec<R>> {
-        let devices_by_bus = self.devices_by_bus()?;
-        let bus_order = self.bus_order();
         let mut rows = Vec::new();
         for (zone_index, id) in ids.iter().enumerate() {
-            for bus_uid in &bus_order {
+            for bus_uid in bus_order {
                 let bus_obj = self.bus.get(bus_uid)?;
                 let member = bus_obj
                     .get(uids_key)
@@ -240,7 +245,7 @@ impl Goc3Adapter {
                 };
                 for dev_uid in devices {
                     let device = self.sdd.get(dev_uid)?;
-                    if require_str(device, "device_type")? == device_type {
+                    if sdd_device_type(device) == device_type {
                         rows.push(mkrow(
                             self.goc3_bus_id(bus_uid)?,
                             zone_index,
@@ -331,7 +336,7 @@ fn build_static_projection(tables: &Goc3Adapter) -> Result<ScopfStaticDataProjec
         .enumerate()
         .map(|(j_ln, uid)| {
             let val = tables.ac_line.get(uid)?;
-            let (g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to) = branch_admittance(val)?;
+            let (g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to) = branch_admittance(uid, val)?;
             Ok(ScopfAcLineRow {
                 j_ln,
                 uid: uid.clone(),
@@ -359,7 +364,7 @@ fn build_static_projection(tables: &Goc3Adapter) -> Result<ScopfStaticDataProjec
         .enumerate()
         .map(|(j_xf, uid)| {
             let val = tables.twt.get(uid)?;
-            let (g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to) = branch_admittance(val)?;
+            let (g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to) = branch_admittance(uid, val)?;
             Ok(ScopfTransformerRow {
                 j_xf,
                 uid: uid.clone(),
@@ -501,28 +506,38 @@ fn build_static_projection(tables: &Goc3Adapter) -> Result<ScopfStaticDataProjec
         .collect::<Result<_>>()?;
     reactive_reserve.sort_by_key(|r| r.n_q);
 
+    let devices_by_bus = tables.devices_by_bus()?;
+    let bus_order = tables.bus_order();
     let active_reserve_set_pr = tables.reserve_set(
-        &tables.azr_ids,
+        tables.azr.uids(),
         "active_reserve_uids",
         "producer",
+        &devices_by_bus,
+        &bus_order,
         |i, n_p, uid| ScopfActiveReserveSetRow { i, n_p, uid },
     )?;
     let active_reserve_set_cs = tables.reserve_set(
-        &tables.azr_ids,
+        tables.azr.uids(),
         "active_reserve_uids",
         "consumer",
+        &devices_by_bus,
+        &bus_order,
         |i, n_p, uid| ScopfActiveReserveSetRow { i, n_p, uid },
     )?;
     let reactive_reserve_set_pr = tables.reserve_set(
-        &tables.rzr_ids,
+        tables.rzr.uids(),
         "reactive_reserve_uids",
         "producer",
+        &devices_by_bus,
+        &bus_order,
         |i, n_q, uid| ScopfReactiveReserveSetRow { i, n_q, uid },
     )?;
     let reactive_reserve_set_cs = tables.reserve_set(
-        &tables.rzr_ids,
+        tables.rzr.uids(),
         "reactive_reserve_uids",
         "consumer",
+        &devices_by_bus,
+        &bus_order,
         |i, n_q, uid| ScopfReactiveReserveSetRow { i, n_q, uid },
     )?;
 
@@ -593,7 +608,7 @@ fn sdd_windows(
     let mut ind = 0usize;
     for uid in tables.sdd_order() {
         let val = tables.sdd.get(&uid)?;
-        if require_str(val, "device_type")? != device_type {
+        if sdd_device_type(val) != device_type {
             continue;
         }
         let req = require_field(val, "simple_dispatchable_device", &uid, req_key)?
@@ -790,8 +805,23 @@ fn build_price_blocks(
     }
 }
 
-fn b_sr(r: f64, x: f64) -> f64 {
-    -x / (x * x + r * r)
+/// Series admittance `(g_sr, b_sr) = (r, -x) / (r² + x²)` for one GOC3
+/// branch record. A zero or non-finite `r² + x²` is rejected by name instead
+/// of writing NaN into the instance; `src/goc3.jl` computes the same formula
+/// unguarded, so this is deliberately stricter than the Julia parser.
+fn series_terms(r: f64, x: f64, uid: &str) -> Result<(f64, f64)> {
+    let denom = x * x + r * r;
+    if denom == 0.0 {
+        return Err(json_error(format!(
+            "branch `{uid}` has zero series impedance (r = x = 0)"
+        )));
+    }
+    if !denom.is_finite() {
+        return Err(json_error(format!(
+            "branch `{uid}` has non-finite series impedance"
+        )));
+    }
+    Ok((r / denom, -x / denom))
 }
 
 /// Series admittance and terminal shunt parameters shared by AC lines and
@@ -802,9 +832,12 @@ fn b_sr(r: f64, x: f64) -> f64 {
 /// flag read straight from JSON, not an accumulated float, so the exact
 /// comparison is intentional.
 #[allow(clippy::type_complexity, clippy::float_cmp)]
-fn branch_admittance(val: &Map<String, Value>) -> Result<(f64, f64, f64, f64, f64, f64, f64)> {
+fn branch_admittance(
+    uid: &str,
+    val: &Map<String, Value>,
+) -> Result<(f64, f64, f64, f64, f64, f64, f64)> {
     let (r, x) = (require_num(val, "r")?, require_num(val, "x")?);
-    let g_sr = r / (x * x + r * r);
+    let (g_sr, b_sr) = series_terms(r, x, uid)?;
     let additional_shunt = require_num(val, "additional_shunt")? == 1.0;
     let (g_fr, g_to, b_fr, b_to) = if additional_shunt {
         (
@@ -816,15 +849,7 @@ fn branch_admittance(val: &Map<String, Value>) -> Result<(f64, f64, f64, f64, f6
     } else {
         (0.0, 0.0, 0.0, 0.0)
     };
-    Ok((
-        g_sr,
-        b_sr(r, x),
-        require_num(val, "b")?,
-        g_fr,
-        g_to,
-        b_fr,
-        b_to,
-    ))
+    Ok((g_sr, b_sr, require_num(val, "b")?, g_fr, g_to, b_fr, b_to))
 }
 
 /// One contingency index and its outaged component UIDs.
@@ -865,38 +890,40 @@ fn build_ac_contingency_survivors(tables: &Goc3Adapter) -> Result<ScopfAcConting
         let (ctg_idx, outaged) = contingency_outages(ctg_idx, ctg)?;
 
         let mut ln_rows = Vec::new();
-        for uid in tables.ac_line.uids() {
+        for (j_ln, uid) in tables.ac_line.uids().iter().enumerate() {
             if outaged.contains(uid.as_str()) {
                 continue;
             }
             let val = tables.ac_line.get(uid)?;
             let (r, x) = (require_num(val, "r")?, require_num(val, "x")?);
+            let (_, b_sr) = series_terms(r, x, uid)?;
             ln_rows.push(ScopfAcLineSurvivorRow {
                 ctg: ctg_idx,
-                j_ln: tables.ac_line.index(uid)?,
+                j_ln,
                 uid: uid.clone(),
                 to_bus: tables.goc3_bus_id(require_str(val, "to_bus")?)?,
                 fr_bus: tables.goc3_bus_id(require_str(val, "fr_bus")?)?,
-                b_sr: b_sr(r, x),
+                b_sr,
                 s_max_ctg: require_num(val, "mva_ub_em")?,
             });
         }
         ln.push(ln_rows);
 
         let mut xf_rows = Vec::new();
-        for uid in tables.twt.uids() {
+        for (j_xf, uid) in tables.twt.uids().iter().enumerate() {
             if outaged.contains(uid.as_str()) {
                 continue;
             }
             let val = tables.twt.get(uid)?;
             let (r, x) = (require_num(val, "r")?, require_num(val, "x")?);
+            let (_, b_sr) = series_terms(r, x, uid)?;
             xf_rows.push(ScopfTransformerSurvivorRow {
                 ctg: ctg_idx,
-                j_xf: tables.twt.index(uid)?,
+                j_xf,
                 uid: uid.clone(),
                 to_bus: tables.goc3_bus_id(require_str(val, "to_bus")?)?,
                 fr_bus: tables.goc3_bus_id(require_str(val, "fr_bus")?)?,
-                b_sr: b_sr(r, x),
+                b_sr,
                 s_max_ctg: require_num(val, "mva_ub_em")?,
             });
         }
@@ -914,7 +941,7 @@ fn build_dc_contingency_flows(tables: &Goc3Adapter) -> Result<Vec<ScopfDcConting
         let (ctg_idx, outaged) = contingency_outages(ctg_idx, ctg)?;
 
         for (t0, &dt) in tables.dt.iter().enumerate() {
-            for uid in tables.dc_line.uids() {
+            for (j_dc, uid) in tables.dc_line.uids().iter().enumerate() {
                 if outaged.contains(uid.as_str()) {
                     continue;
                 }
@@ -922,7 +949,7 @@ fn build_dc_contingency_flows(tables: &Goc3Adapter) -> Result<Vec<ScopfDcConting
                 rows.push(ScopfDcContingencyFlowRow {
                     flat_jtk_dc,
                     ctg: ctg_idx,
-                    j_dc: tables.dc_line.index(uid)?,
+                    j_dc,
                     to_bus: tables.goc3_bus_id(require_str(val, "to_bus")?)?,
                     fr_bus: tables.goc3_bus_id(require_str(val, "fr_bus")?)?,
                     t: t0,

--- a/powerio-prob/src/scopf/types.rs
+++ b/powerio-prob/src/scopf/types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// One bus row: `(i, uid, v_min, v_max)`.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfBusRow {
     pub i: BusId,
     pub uid: String,
@@ -12,6 +13,7 @@ pub struct ScopfBusRow {
 
 /// One shunt row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfShuntRow {
     pub uid: String,
     pub bus: BusId,
@@ -21,6 +23,7 @@ pub struct ScopfShuntRow {
 
 /// One AC line row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfAcLineRow {
     pub j_ln: usize,
     pub uid: String,
@@ -40,6 +43,7 @@ pub struct ScopfAcLineRow {
 
 /// One two winding transformer row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfTransformerRow {
     pub j_xf: usize,
     pub uid: String,
@@ -59,6 +63,7 @@ pub struct ScopfTransformerRow {
 
 /// One DC line row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfDcLineRow {
     pub j_dc: usize,
     pub uid: String,
@@ -73,6 +78,7 @@ pub struct ScopfDcLineRow {
 
 /// A transformer with a variable phase-shift control range (`vpd`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfVariablePhaseRow {
     pub j_xf: usize,
     pub phi_min: f64,
@@ -81,6 +87,7 @@ pub struct ScopfVariablePhaseRow {
 
 /// A transformer with a fixed phase shift (`fpd`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfFixedPhaseRow {
     pub j_xf: usize,
     pub phi_o: f64,
@@ -88,6 +95,7 @@ pub struct ScopfFixedPhaseRow {
 
 /// A transformer with a variable winding ratio control range (`vwr`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfVariableRatioRow {
     pub j_xf: usize,
     pub tau_min: f64,
@@ -96,6 +104,7 @@ pub struct ScopfVariableRatioRow {
 
 /// A transformer with a fixed winding ratio (`fwr`).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfFixedRatioRow {
     pub j_xf: usize,
     pub tau_o: f64,
@@ -106,6 +115,7 @@ pub struct ScopfFixedRatioRow {
 /// Producers and consumers share this layout. Vector fields use the internal
 /// zero based period order.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfDeviceRow {
     pub bus: BusId,
     pub uid: String,
@@ -145,6 +155,7 @@ pub struct ScopfDeviceRow {
 
 /// One active power zonal reserve row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfActiveReserveRow {
     pub n_p: usize,
     pub uid: String,
@@ -164,6 +175,7 @@ pub struct ScopfActiveReserveRow {
 
 /// One reactive (reactive-power) zonal reserve row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfReactiveReserveRow {
     pub n_q: usize,
     pub uid: String,
@@ -175,6 +187,7 @@ pub struct ScopfReactiveReserveRow {
 
 /// One (bus, active reserve zone, device) membership row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfActiveReserveSetRow {
     pub i: BusId,
     pub n_p: usize,
@@ -183,6 +196,7 @@ pub struct ScopfActiveReserveSetRow {
 
 /// One (bus, reactive reserve zone, device) membership row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfReactiveReserveSetRow {
     pub i: BusId,
     pub n_q: usize,
@@ -328,6 +342,7 @@ pub struct ScopfEnergyWindows {
 
 /// One flattened device, period, and price block row.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfPriceBlockRow {
     pub flat_k: usize,
     pub uid: String,
@@ -347,6 +362,7 @@ pub struct ScopfPriceBlocks {
 
 /// One AC line surviving a contingency.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfAcLineSurvivorRow {
     pub ctg: usize,
     pub j_ln: usize,
@@ -359,6 +375,7 @@ pub struct ScopfAcLineSurvivorRow {
 
 /// One transformer surviving a contingency.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfTransformerSurvivorRow {
     pub ctg: usize,
     pub j_xf: usize,
@@ -380,6 +397,7 @@ pub struct ScopfAcContingencySurvivors {
 
 /// One surviving DC line in one contingency and period.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ScopfDcContingencyFlowRow {
     pub flat_jtk_dc: usize,
     pub ctg: usize,

--- a/powerio-prob/tests/acopf.rs
+++ b/powerio-prob/tests/acopf.rs
@@ -408,7 +408,15 @@ mod matrix_tests {
     /// carried fields.
     #[test]
     fn ybus_entrywise_cross_check() {
-        let net = case14();
+        let mut net = case14();
+        // A self-loop with tap, shift, and charging: the instance folds it
+        // into the bus shunt vectors, `build_ybus` stamps it directly; the
+        // two must agree entrywise.
+        let mut self_loop = branch(5, 5, 0.02, 0.08);
+        self_loop.tap = 1.1;
+        self_loop.shift = 15.0;
+        self_loop.b = 0.04;
+        net.branches.push(self_loop);
         let view = IndexedNetwork::new(&net);
         let problem = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("build");
         let n = problem.n_buses;
@@ -451,4 +459,45 @@ mod matrix_tests {
             }
         }
     }
+}
+
+/// A self-loop's pi model stamp folds onto the bus diagonal, matching the
+/// Y_bus builder, and a zero base MVA is rejected before scaling.
+#[test]
+fn self_loop_folds_into_bus_shunt() {
+    let mut net = small_network();
+    let mut loop_branch = branch(30, 30, 0.05, 0.2);
+    loop_branch.tap = 1.25;
+    loop_branch.shift = 10.0;
+    loop_branch.b = 0.10;
+    net.branches.push(loop_branch);
+    let plain = build_ac_opf_instance(
+        &IndexedNetwork::new(&small_network()),
+        &AcOpfOptions::default(),
+    )
+    .expect("plain");
+    let folded = build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default())
+        .expect("folded");
+
+    // The self-loop is not a flow element and is not a skip.
+    assert_eq!(folded.n_branches(), plain.n_branches());
+    assert_eq!(folded.branches.skipped_zero_impedance, Vec::<usize>::new());
+
+    let z_squared = 0.05 * 0.05 + 0.2 * 0.2;
+    let (series_g, series_b) = (0.05 / z_squared, -0.2 / z_squared);
+    let (tap, shift) = (1.25_f64, 10.0_f64.to_radians());
+    let cross = 2.0 * shift.cos() / tap;
+    let g_add = (series_g / (tap * tap)) + series_g - series_g * cross;
+    let b_add = (0.05 + series_b) / (tap * tap) + (series_b + 0.05) - series_b * cross;
+    assert_close(folded.buses.g_s[1], plain.buses.g_s[1] + g_add);
+    assert_close(folded.buses.b_s[1], plain.buses.b_s[1] + b_add);
+}
+
+#[test]
+fn zero_base_mva_is_rejected() {
+    let mut net = small_network();
+    net.base_mva = 0.0;
+    let error = build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default())
+        .expect_err("zero base");
+    assert!(matches!(error, Error::InvalidBaseMva { .. }));
 }

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -216,6 +216,15 @@ fn zero_reactance_can_be_skipped_or_rejected() {
 }
 
 #[test]
+fn zero_base_mva_is_rejected() {
+    let mut net = small_network();
+    net.base_mva = 0.0;
+    let error = build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default())
+        .expect_err("zero base");
+    assert!(matches!(error, Error::InvalidBaseMva { .. }));
+}
+
+#[test]
 fn serde_round_trip() {
     let net = case9();
     let view = IndexedNetwork::new(&net);
@@ -260,6 +269,24 @@ mod matrix_tests {
         assert_eq!(matrices.incidence, incidence.a);
         assert_eq!(problem.branches.b, incidence.b);
         assert_eq!(problem.p_shift, incidence.p_shift);
+    }
+
+    #[test]
+    fn bundle_directory_name_is_confined_to_the_output_directory() {
+        let net = case9();
+        let mut problem =
+            build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default())
+                .expect("build");
+        problem.name = "../escape/../../attempt".to_owned();
+        let output = tempfile::tempdir().expect("tempdir");
+        let bundle = write_dcopf_bundle(&problem, output.path(), &DcOpfBundleOptions::default())
+            .expect("bundle");
+        let canonical = bundle.dir.canonicalize().expect("canonical bundle dir");
+        let root = output.path().canonicalize().expect("canonical out dir");
+        assert!(
+            canonical.starts_with(&root),
+            "{canonical:?} escaped {root:?}"
+        );
     }
 
     #[test]

--- a/powerio-prob/tests/scopf.rs
+++ b/powerio-prob/tests/scopf.rs
@@ -218,3 +218,86 @@ fn replace_exact_strings(value: &mut Value, replacements: &[(&str, &str)]) {
         Value::Null | Value::Bool(_) | Value::Number(_) => {}
     }
 }
+
+/// Append a clone of a section's first row under a new uid, in both the
+/// network section and, when present, its time series section.
+fn append_zone(doc: &mut Value, section: &str, uid: &str) {
+    for parent in ["network", "time_series_input"] {
+        if let Some(rows) = doc[parent][section].as_array_mut() {
+            let mut row = rows[0].clone();
+            row["uid"] = Value::from(uid);
+            rows.push(row);
+        }
+    }
+}
+
+/// Two zones whose document order differs from lexicographic order: the
+/// reserve rows and the membership sets must assign one zone index per zone.
+#[test]
+fn reserve_zone_indices_agree_across_tables() {
+    let mut doc: Value = serde_json::from_str(SMALL).expect("fixture json");
+    // "azq_99"/"rzq_99" sort before the existing zones but come second in
+    // document order.
+    append_zone(&mut doc, "active_zonal_reserve", "azq_99");
+    append_zone(&mut doc, "reactive_zonal_reserve", "rzq_99");
+    let bus1 = &mut doc["network"]["bus"][1];
+    bus1["active_reserve_uids"] = serde_json::json!(["azq_99"]);
+    bus1["reactive_reserve_uids"] = serde_json::json!(["rzq_99"]);
+    let text = serde_json::to_string(&doc).expect("serialize");
+
+    let instance = build_scopf_instance_from_str(&text, "goc3-json").expect("build");
+    let data = &instance.static_data;
+
+    let n_p_of = |uid: &str| {
+        data.active_reserve
+            .iter()
+            .find(|row| row.uid == uid)
+            .map(|row| row.n_p)
+            .expect("zone row")
+    };
+    let n_q_of = |uid: &str| {
+        data.reactive_reserve
+            .iter()
+            .find(|row| row.uid == uid)
+            .map(|row| row.n_q)
+            .expect("zone row")
+    };
+    assert_eq!(n_p_of("azr_00"), 0);
+    assert_eq!(n_p_of("azq_99"), 1);
+
+    // sd_00 (producer) sits at bus_00 in zone azr_00; sd_01 (consumer) sits
+    // at bus_01, now in zone azq_99/rzq_99. The membership sets must carry
+    // the same zone indices as the reserve rows.
+    assert_eq!(data.active_reserve_set_pr.len(), 1);
+    assert_eq!(data.active_reserve_set_pr[0].uid, "sd_00");
+    assert_eq!(data.active_reserve_set_pr[0].n_p, n_p_of("azr_00"));
+    assert_eq!(data.active_reserve_set_cs.len(), 1);
+    assert_eq!(data.active_reserve_set_cs[0].uid, "sd_01");
+    assert_eq!(data.active_reserve_set_cs[0].n_p, n_p_of("azq_99"));
+    assert_eq!(data.reactive_reserve_set_cs[0].n_q, n_q_of("rzq_99"));
+}
+
+#[test]
+fn zero_series_impedance_is_rejected() {
+    let mut doc: Value = serde_json::from_str(SMALL).expect("fixture json");
+    doc["network"]["ac_line"][0]["r"] = Value::from(0.0);
+    doc["network"]["ac_line"][0]["x"] = Value::from(0.0);
+    let text = serde_json::to_string(&doc).expect("serialize");
+    let error = build_scopf_instance_from_str(&text, "goc3-json").expect_err("zero impedance");
+    assert!(error.to_string().contains("zero series impedance"));
+}
+
+/// The balanced GOC3 reader defaults an absent `device_type` to `producer`;
+/// the SCOPF projection follows the same rule instead of erroring.
+#[test]
+fn missing_device_type_defaults_to_producer() {
+    let mut doc: Value = serde_json::from_str(SMALL).expect("fixture json");
+    doc["network"]["simple_dispatchable_device"][0]
+        .as_object_mut()
+        .expect("device object")
+        .remove("device_type");
+    let text = serde_json::to_string(&doc).expect("serialize");
+    let instance = build_scopf_instance_from_str(&text, "goc3-json").expect("build");
+    assert_eq!(instance.static_data.prod[0].uid, "sd_00");
+    assert_eq!(instance.lengths.l_j_pr, 1);
+}

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -33,6 +33,10 @@
 //! # Ok::<(), powerio::Error>(())
 //! ```
 
+/// The powerio crate version, for provenance fields written by downstream
+/// crates whose own version can drift from the core's.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod dc;
 pub mod error;
 pub mod format;


### PR DESCRIPTION
## What changed

Fixes from the pre-publish review of `powerio-prob` (sonnet 5 review workflow, findings verified by hand against the code and `src/goc3.jl`):

- Reserve membership sets (`active_reserve_set_pr/cs`, `reactive_reserve_set_pr/cs`) now take their zone index from the reserve section's document order, the same order that assigns `n_p`/`n_q` in the reserve rows. The sorted uid lists crossed indices between the two tables whenever document order was not alphabetical, and diverged from `src/goc3.jl` past nine zones (`prz_10` sorts before `prz_2`). Regression test with two zones out of lexicographic order.
- GOC3 branch records with `r = x = 0` are rejected with the offending uid instead of writing NaN into the static and survivor rows (`series_terms`, shared by both paths). Stricter than `src/goc3.jl`, which computes the same formula unguarded.
- A `simple_dispatchable_device` without `device_type` defaults to `producer` in the SCOPF projection, the balanced reader's rule; the projection previously errored while every other GOC3 consumer accepted the document.
- `build_ac_opf_instance` folds a self-loop branch's whole pi model stamp into the bus shunt vectors, matching `build_ybus` (validated entrywise in the Y_bus cross-check with a tapped, shifted self-loop). `build_dc_opf_instance` keeps dropping self-loops and now says why (no angle difference, shift injection cancels).
- Both instance builders call `check_base_mva` before scaling; a zero base previously produced Inf/NaN under per unit and silently zeroed costs.
- `write_dcopf_bundle` sanitizes the case name before joining it into the output path, so bundles stay under the caller's output directory.
- The bundle manifest's `powerio_version` reports the powerio core version through the new `powerio::VERSION` const.
- `#[non_exhaustive]` on the SCOPF row structs and `DcOpfOutputs`. The options structs stay literal constructible on purpose.
- `Goc3Section::index` (linear rescan per row) is gone; the survivor and transformer loops use their enumerate position. `reserve_set` shares one `devices_by_bus`/`bus_order` precomputation across its four calls.

Deferred with an issue: #252 (wire renumbering keyed off bare field names).

## Checks

- New tests: two-zone reserve index agreement, zero impedance rejection, `device_type` default, self-loop fold plus the extended Y_bus entrywise cross-check, zero base MVA rejection in both builders, bundle path confinement.
- `cargo test --workspace --all-features` (46 suites), `scripts/ci-clippy.sh`, `cargo fmt --all --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
