### PR TITLE
Type the SCOPF wire renumbering and parse GOC3 once per read

### DIFF
--- a/docs/src/dcopf-bundle.md
+++ b/docs/src/dcopf-bundle.md
@@ -45,22 +45,26 @@ Market files and `dcopf_meta.json`.
 
 ## Vectors
 
-Bus-indexed (length \\(n\\)): `pd` (load), `q`/`c` (cost diag/linear), `pmax`/`pmin`
+Bus-indexed (length \\(n\\)): `pd` (load), `q`/`c`/`c0` (cost diag/linear/constant),
+`pmax`/`pmin`
 (generation bounds), `e_r` (reference indicator: \\(1\\) at every reference bus, else \\(0\\)),
 `p_shift` (phase shift injection, all zero unless `Matpower` + shifters).
 Branch-indexed (length \\(m\\)): `b` (susceptances), `fmax` (thermal limits; \\(0\\) means
 unlimited per MATPOWER), and the radian limits `angle_min` and `angle_max`.
 Generator space data
-(length \\(n_{\mathrm{gen}}\\)): `q_gen`, `c_gen`, `pmax_gen`, and `pmin_gen`.
+(length \\(n_{\mathrm{gen}}\\)): `q_gen`, `c_gen`, `c0_gen`, `pmax_gen`, and `pmin_gen`.
 
-Generator space is canonical. The nodal `q`, `c`, `pmax`, and `pmin` files are
-written only when each bus has at most one generator. The writer returns an
-error when several generators share a bus because summing their quadratic or
-linear costs would change the objective.
+The constant cost terms `c0`/`c0_gen` do not move the argmin; they exist so a
+consumer reporting objective values reconstructs the full cost.
+
+Generator space is canonical. The nodal `q`, `c`, `c0`, `pmax`, and `pmin`
+files are written only when each bus has at most one generator. The writer
+returns an error when several generators share a bus because summing their
+quadratic or linear costs would change the objective.
 
 ## Manifest (`dcopf_meta.json`)
 
-Schema `powerio.dcopf` version `0.2.0` writes Matrix Market files plus
+Schema `powerio.dcopf` version `0.3.0` writes Matrix Market files plus
 structured metadata:
 
 - `dimensions`: `n_buses`, `n_source_branches`, `n_branch_columns`,

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -265,10 +265,30 @@ impl ElementUpdate {
     }
 }
 
-pub(crate) fn goc3_operating_points_from_str(
-    text: &str,
+/// Derive the operating point series a retained source document carries, if
+/// any. The format dispatch lives here so package assembly stays format
+/// agnostic; GOC3 is the one document kind with a time series today.
+pub(crate) fn operating_points_from_document(
+    document: &powerio::SourceDocument,
 ) -> serde_json::Result<Option<OperatingPointSeries>> {
-    let document = Goc3Document::parse(text).map_err(|error| json_error(error.to_string()))?;
+    match document {
+        powerio::SourceDocument::Goc3(document) => goc3_operating_points(document),
+        _ => Ok(None),
+    }
+}
+
+/// Diagnostic code for a document whose series extraction failed, named per
+/// format alongside the dispatch above.
+pub(crate) fn operating_points_drop_code(document: &powerio::SourceDocument) -> &'static str {
+    match document {
+        powerio::SourceDocument::Goc3(_) => "READ.GOC3.OPERATING_POINTS_DROPPED",
+        _ => "READ.OPERATING_POINTS_DROPPED",
+    }
+}
+
+fn goc3_operating_points(
+    document: &Goc3Document,
+) -> serde_json::Result<Option<OperatingPointSeries>> {
     let network = document
         .network()
         .map_err(|error| json_error(error.to_string()))?;
@@ -305,20 +325,20 @@ pub(crate) fn goc3_operating_points_from_str(
         .and_then(Value::as_f64)
         .unwrap_or(100.0);
 
-    add_goc3_device_updates(&document, &device_ts, base_mva, &mut points)?;
-    add_goc3_status_updates(&document, "ac_line", "branches", 0, &mut points)?;
+    add_goc3_device_updates(document, &device_ts, base_mva, &mut points)?;
+    add_goc3_status_updates(document, "ac_line", "branches", 0, &mut points)?;
     let line_count = document
         .network_records("ac_line")
         .map_err(|error| json_error(error.to_string()))?
         .len();
     add_goc3_status_updates(
-        &document,
+        document,
         "two_winding_transformer",
         "branches",
         line_count,
         &mut points,
     )?;
-    add_goc3_status_updates(&document, "dc_line", "hvdc", 0, &mut points)?;
+    add_goc3_status_updates(document, "dc_line", "hvdc", 0, &mut points)?;
 
     Ok(Some(OperatingPointSeries {
         time_axis: TimeAxis {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use powerio::{
     BalancedNetwork, BusId, NORMALIZED_SOLVER_TABLES_PASS, NormalizedSolverTables,
-    SolverTableUnits, SourceFormat,
+    SolverTableUnits, SourceDocument, SourceFormat,
 };
 use powerio_dist::{DistSourceFormat, MulticonductorNetwork};
 
@@ -19,7 +19,7 @@ use crate::lowering::{
 use crate::model::{ModelKind, ModelPayload};
 use crate::operating::{
     OperatingPointSeries, apply_operating_point_to_model, check_series_identities,
-    goc3_operating_points_from_str,
+    operating_points_drop_code, operating_points_from_document,
 };
 use crate::provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,
@@ -289,27 +289,27 @@ impl NetworkPackage {
     }
 
     /// Wrap the result of a balanced case reader. Reader adapters can attach
-    /// source data that is not part of the balanced network model.
+    /// source data that is not part of the balanced network model; an
+    /// operating point series derives from the reader's own parse, handed
+    /// forward as [`powerio::Parsed::document`].
     pub fn from_parsed_balanced(parsed: powerio::Parsed) -> Self {
-        let source_format = parsed.network.source_format;
-        let retained_source = parsed.network.source.clone();
         let mut package = Self::from_balanced_with_read_warnings(
             parsed.network,
             READ_TRANSMISSION_PARSE_WARNING,
             parsed.warnings,
         );
-        if source_format == SourceFormat::Goc3Json {
-            package.attach_goc3_operating_points(retained_source.as_deref().map(String::as_str));
+        if let Some(document) = &parsed.document {
+            package.attach_operating_points(document);
         }
         package
     }
 
-    fn attach_goc3_operating_points(&mut self, source: Option<&str>) {
-        match source.map(goc3_operating_points_from_str) {
-            Some(Ok(series)) => self.operating_points = series,
-            Some(Err(error)) => {
+    fn attach_operating_points(&mut self, document: &SourceDocument) {
+        match operating_points_from_document(document) {
+            Ok(series) => self.operating_points = series,
+            Err(error) => {
                 self.diagnostics.push(StructuredDiagnostic::new(
-                    "READ.GOC3.OPERATING_POINTS_DROPPED",
+                    operating_points_drop_code(document),
                     DiagnosticSeverity::Warning,
                     DiagnosticStage::Read,
                     format!(
@@ -319,7 +319,6 @@ impl NetworkPackage {
                 ));
                 self.validation = ValidationSummary::from_diagnostics(&self.diagnostics);
             }
-            None => {}
         }
     }
 

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -343,6 +343,21 @@ fn balanced_package_constructor_does_not_run_source_adapters() {
     assert!(pkg.operating_points().is_none());
 }
 
+/// The operating point series derives from the document the reader already
+/// parsed (`Parsed::document`), never from a second parse of the retained
+/// source text: stripping the text must not change the outcome.
+#[test]
+fn goc3_operating_points_derive_from_the_reader_parse() {
+    let mut parsed = powerio::parse_str(GOC3_PACKAGE_SRC, "goc3-json").expect("parse goc3");
+    assert!(matches!(
+        parsed.document,
+        Some(powerio::SourceDocument::Goc3(_))
+    ));
+    parsed.network.source = None;
+    let pkg = NetworkPackage::from_parsed_balanced(parsed);
+    assert!(pkg.operating_points().is_some());
+}
+
 #[test]
 fn goc3_operating_points_follow_parser_row_assignment() {
     // A device without a uid still occupies a payload row; the extractor

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -62,10 +62,14 @@ pub struct DcGeneratorData {
     pub bus_of_gen: Vec<usize>,
     /// Generator column to source generator row.
     pub source_rows: Vec<usize>,
-    /// Quadratic objective diagonal in `0.5 * q * p^2 + c * p`.
+    /// Quadratic objective diagonal in `0.5 * q * p^2 + c * p + c0`.
     pub q: Vec<f64>,
     /// Linear objective coefficient.
     pub c: Vec<f64>,
+    /// Constant objective term. Unscaled in both unit systems: it carries no
+    /// power dimension. It does not move the argmin, but a consumer reporting
+    /// or comparing objective values needs it.
+    pub c0: Vec<f64>,
     pub pmax: Vec<f64>,
     pub pmin: Vec<f64>,
 }
@@ -97,6 +101,7 @@ pub struct DcBranchData {
 pub struct NodalGeneratorData {
     pub q: Vec<f64>,
     pub c: Vec<f64>,
+    pub c0: Vec<f64>,
     pub pmax: Vec<f64>,
     pub pmin: Vec<f64>,
 }
@@ -147,6 +152,7 @@ impl DcOpfInstance {
         let mut occupied = vec![false; self.n_buses];
         let mut q = vec![0.0; self.n_buses];
         let mut c = vec![0.0; self.n_buses];
+        let mut c0 = vec![0.0; self.n_buses];
         let mut pmax = vec![0.0; self.n_buses];
         let mut pmin = vec![0.0; self.n_buses];
 
@@ -160,11 +166,18 @@ impl DcOpfInstance {
             occupied[bus] = true;
             q[bus] = self.generators.q[generator];
             c[bus] = self.generators.c[generator];
+            c0[bus] = self.generators.c0[generator];
             pmax[bus] = self.generators.pmax[generator];
             pmin[bus] = self.generators.pmin[generator];
         }
 
-        Ok(NodalGeneratorData { q, c, pmax, pmin })
+        Ok(NodalGeneratorData {
+            q,
+            c,
+            c0,
+            pmax,
+            pmin,
+        })
     }
 }
 
@@ -186,6 +199,7 @@ pub fn build_dc_opf_instance(
     let mut generator_rows = Vec::new();
     let mut q = Vec::new();
     let mut c = Vec::new();
+    let mut c0 = Vec::new();
     let mut pmax = Vec::new();
     let mut pmin = Vec::new();
 
@@ -197,15 +211,18 @@ pub fn build_dc_opf_instance(
         let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
             gen_index: source_row,
         })?;
-        let (q_raw, c_raw) = cost.quadratic().ok_or(Error::UnsupportedCostModel {
-            gen_index: source_row,
-            model: cost.model,
-            ncost: cost.ncost,
-        })?;
+        let (q_raw, c_raw, c0_raw) =
+            cost.quadratic_with_constant()
+                .ok_or(Error::UnsupportedCostModel {
+                    gen_index: source_row,
+                    model: cost.model,
+                    ncost: cost.ncost,
+                })?;
         bus_of_gen.push(bus);
         generator_rows.push(source_row);
         q.push(q_raw * q_scale);
         c.push(c_raw * c_scale);
+        c0.push(c0_raw);
         pmax.push(generator.pmax * p_scale);
         pmin.push(generator.pmin * p_scale);
     }
@@ -289,6 +306,7 @@ pub fn build_dc_opf_instance(
             source_rows: generator_rows,
             q,
             c,
+            c0,
             pmax,
             pmin,
         },

--- a/powerio-prob/src/matrix/bundle.rs
+++ b/powerio-prob/src/matrix/bundle.rs
@@ -10,7 +10,7 @@ use crate::{DcOpfInstance, Units};
 use super::build_dc_opf_matrices;
 
 const DCOPF_SCHEMA: &str = "powerio.dcopf";
-const DCOPF_SCHEMA_VERSION: &str = "0.2.0";
+const DCOPF_SCHEMA_VERSION: &str = "0.3.0";
 
 /// Cost policy information recorded in a bundle manifest.
 #[derive(Debug, Clone)]
@@ -178,6 +178,7 @@ pub fn write_dcopf_bundle(
     put_vec(&dir, "e_r.mtx", &matrices.reference_selector, &mut files)?;
     put_vec(&dir, "q.mtx", &nodal.q, &mut files)?;
     put_vec(&dir, "c.mtx", &nodal.c, &mut files)?;
+    put_vec(&dir, "c0.mtx", &nodal.c0, &mut files)?;
     put_vec(&dir, "pmax.mtx", &nodal.pmax, &mut files)?;
     put_vec(&dir, "pmin.mtx", &nodal.pmin, &mut files)?;
     put_vec(&dir, "fmax.mtx", &instance.branches.f_max, &mut files)?;
@@ -197,6 +198,7 @@ pub fn write_dcopf_bundle(
 
     put_vec(&dir, "q_gen.mtx", &instance.generators.q, &mut files)?;
     put_vec(&dir, "c_gen.mtx", &instance.generators.c, &mut files)?;
+    put_vec(&dir, "c0_gen.mtx", &instance.generators.c0, &mut files)?;
     put_vec(&dir, "pmax_gen.mtx", &instance.generators.pmax, &mut files)?;
     put_vec(&dir, "pmin_gen.mtx", &instance.generators.pmin, &mut files)?;
 

--- a/powerio-prob/src/scopf/wire.rs
+++ b/powerio-prob/src/scopf/wire.rs
@@ -1,8 +1,29 @@
 //! Versioned Julia compatibility wire format.
+//!
+//! The conversion is structural: every struct that reaches the wire classifies
+//! each of its fields as a 0-based internal index (renumbered to 1-based), a
+//! renamed field (Julia spells some names in Greek or uppercase), or a value
+//! passed through unchanged. The classification destructures the struct
+//! exhaustively, so a field added in `types.rs` fails to compile until it is
+//! classified here: a new index field cannot be silently missed, and a value
+//! field reusing an index name (`t`, `m`, `j_ln`, ...) in another struct is
+//! never bumped.
 
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use super::error::ScopfError;
+use super::types::{
+    ScopfAcContingencySurvivors, ScopfAcLineRow, ScopfAcLineSurvivorRow, ScopfActiveReserveRow,
+    ScopfActiveReserveSetRow, ScopfBusRow, ScopfDcContingencyFlowRow, ScopfDcLineRow,
+    ScopfDeviceRow, ScopfEnergyWindowMaxCsRow, ScopfEnergyWindowMaxPrRow,
+    ScopfEnergyWindowMinCsRow, ScopfEnergyWindowMinPrRow, ScopfEnergyWindowPeriodMaxCsRow,
+    ScopfEnergyWindowPeriodMaxPrRow, ScopfEnergyWindowPeriodMinCsRow,
+    ScopfEnergyWindowPeriodMinPrRow, ScopfEnergyWindows, ScopfFixedPhaseRow, ScopfFixedRatioRow,
+    ScopfLengths, ScopfPriceBlockRow, ScopfPriceBlocks, ScopfReactiveReserveRow,
+    ScopfReactiveReserveSetRow, ScopfShuntRow, ScopfStaticData, ScopfTransformerRow,
+    ScopfTransformerSurvivorRow, ScopfVariablePhaseRow, ScopfVariableRatioRow,
+};
 use super::{ScopfInstance, ScopfResult};
 
 pub const SCOPF_WIRE_SCHEMA: &str = "powerio.scopf.julia";
@@ -16,76 +37,242 @@ struct WireEnvelope {
     instance: Value,
 }
 
+/// Wire conversion of one serialized object: the fields holding 0-based
+/// internal indices and the fields renamed on the wire.
+trait WireFields: Serialize {
+    /// Serialized names of the fields holding 0-based internal indices.
+    /// External identity (`BusId`, `uid`) is never listed.
+    const INDEX_FIELDS: &'static [&'static str] = &[];
+    /// `(internal, wire)` name pairs.
+    const RENAMED_FIELDS: &'static [(&'static str, &'static str)] = &[];
+}
+
+/// Classify every field of one struct that reaches the wire. The generated function
+/// destructures the struct exhaustively, so this fails to compile whenever a
+/// field is added, removed, or renamed in `types.rs` without reclassifying it.
+macro_rules! wire_fields {
+    ($row:ident {
+        index: [$($index:ident),* $(,)?],
+        values: [$($value:ident),* $(,)?]
+        $(, renamed: [$($from:ident => $to:literal),+ $(,)?])? $(,)?
+    }) => {
+        impl WireFields for $row {
+            const INDEX_FIELDS: &'static [&'static str] = &[$(stringify!($index)),*];
+            $(const RENAMED_FIELDS: &'static [(&'static str, &'static str)] =
+                &[$((stringify!($from), $to)),+];)?
+        }
+        const _: () = {
+            #[allow(dead_code)]
+            fn classified(row: $row) {
+                let $row { $($index: _,)* $($value: _,)* $($($from: _,)+)? } = row;
+            }
+        };
+    };
+}
+
+wire_fields!(ScopfBusRow {
+    index: [],
+    values: [i, uid, v_min, v_max],
+});
+wire_fields!(ScopfShuntRow {
+    index: [],
+    values: [uid, bus, g_sh, b_sh],
+});
+wire_fields!(ScopfAcLineRow {
+    index: [j_ln],
+    values: [
+        uid, to_bus, fr_bus, c_su, c_sd, s_max, g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to
+    ],
+});
+wire_fields!(ScopfTransformerRow {
+    index: [j_xf],
+    values: [
+        uid, to_bus, fr_bus, c_su, c_sd, s_max, g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to
+    ],
+});
+wire_fields!(ScopfDcLineRow {
+    index: [j_dc],
+    values: [
+        uid, pdc_max, qdc_fr_min, qdc_to_min, qdc_fr_max, qdc_to_max, to_bus, fr_bus
+    ],
+});
+wire_fields!(ScopfVariablePhaseRow {
+    index: [j_xf],
+    values: [phi_min, phi_max],
+});
+wire_fields!(ScopfFixedPhaseRow {
+    index: [j_xf],
+    values: [phi_o],
+});
+wire_fields!(ScopfVariableRatioRow {
+    index: [j_xf],
+    values: [tau_min, tau_max],
+});
+wire_fields!(ScopfFixedRatioRow {
+    index: [j_xf],
+    values: [tau_o],
+});
+wire_fields!(ScopfDeviceRow {
+    index: [],
+    values: [
+        bus,
+        uid,
+        c_on,
+        c_su,
+        c_sd,
+        p_ru,
+        p_rd,
+        p_ru_su,
+        p_rd_sd,
+        c_rgu,
+        c_rgd,
+        c_scr,
+        c_nsc,
+        c_rru_on,
+        c_rru_off,
+        c_rrd_on,
+        c_rrd_off,
+        c_qru,
+        c_qrd,
+        p_rgu_max,
+        p_rgd_max,
+        p_scr_max,
+        p_nsc_max,
+        p_rru_on_max,
+        p_rru_off_max,
+        p_rrd_on_max,
+        p_rrd_off_max,
+        p_0,
+        q_0,
+        p_max,
+        p_min,
+        q_max,
+        q_min,
+        sus
+    ],
+});
+wire_fields!(ScopfActiveReserveRow {
+    index: [n_p],
+    values: [uid, c_rgu, c_rgd, c_scr, c_nsc, c_rru, c_rrd, p_rru_min, p_rrd_min],
+    renamed: [
+        sigma_rgu => "σ_rgu",
+        sigma_rgd => "σ_rgd",
+        sigma_scr => "σ_scr",
+        sigma_nsc => "σ_nsc",
+    ],
+});
+wire_fields!(ScopfReactiveReserveRow {
+    index: [n_q],
+    values: [uid, c_qru, c_qrd, q_qru_min, q_qrd_min],
+});
+wire_fields!(ScopfActiveReserveSetRow {
+    index: [n_p],
+    values: [i, uid],
+});
+wire_fields!(ScopfReactiveReserveSetRow {
+    index: [n_q],
+    values: [i, uid],
+});
+wire_fields!(ScopfLengths {
+    index: [],
+    values: [],
+    renamed: [
+        l_j_xf => "L_J_xf",
+        l_j_ln => "L_J_ln",
+        l_j_ac => "L_J_ac",
+        l_j_dc => "L_J_dc",
+        l_j_br => "L_J_br",
+        l_j_cs => "L_J_cs",
+        l_j_pr => "L_J_pr",
+        l_j_cspr => "L_J_cspr",
+        l_j_sh => "L_J_sh",
+        i => "I",
+        l_t => "L_T",
+        l_n_p => "L_N_p",
+        l_n_q => "L_N_q",
+    ],
+});
+wire_fields!(ScopfEnergyWindowMaxPrRow {
+    index: [w_en_max_pr_ind],
+    values: [uid, a_en_max_start, a_en_max_end, e_max],
+});
+wire_fields!(ScopfEnergyWindowMaxCsRow {
+    index: [w_en_max_cs_ind],
+    values: [uid, a_en_max_start, a_en_max_end, e_max],
+});
+wire_fields!(ScopfEnergyWindowMinPrRow {
+    index: [w_en_min_pr_ind],
+    values: [uid, a_en_min_start, a_en_min_end, e_min],
+});
+wire_fields!(ScopfEnergyWindowMinCsRow {
+    index: [w_en_min_cs_ind],
+    values: [uid, a_en_min_start, a_en_min_end, e_min],
+});
+wire_fields!(ScopfEnergyWindowPeriodMaxPrRow {
+    index: [w_en_max_pr_ind, t],
+    values: [uid, dt],
+});
+wire_fields!(ScopfEnergyWindowPeriodMaxCsRow {
+    index: [w_en_max_cs_ind, t],
+    values: [uid, dt],
+});
+wire_fields!(ScopfEnergyWindowPeriodMinPrRow {
+    index: [w_en_min_pr_ind, t],
+    values: [uid, dt],
+});
+wire_fields!(ScopfEnergyWindowPeriodMinCsRow {
+    index: [w_en_min_cs_ind, t],
+    values: [uid, dt],
+});
+wire_fields!(ScopfPriceBlockRow {
+    index: [flat_k, t, m],
+    values: [uid, c_en, p_max],
+});
+wire_fields!(ScopfAcLineSurvivorRow {
+    index: [ctg, j_ln],
+    values: [uid, to_bus, fr_bus, b_sr, s_max_ctg],
+});
+wire_fields!(ScopfTransformerSurvivorRow {
+    index: [ctg, j_xf],
+    values: [uid, to_bus, fr_bus, b_sr, s_max_ctg],
+});
+wire_fields!(ScopfDcContingencyFlowRow {
+    index: [flat_jtk_dc, ctg, j_dc, t],
+    values: [to_bus, fr_bus, dt],
+});
+
 /// Convert an internal instance to the versioned 1-based Julia wire format.
 pub fn to_wire_value(instance: &ScopfInstance) -> ScopfResult<Value> {
-    let mut value = serde_json::to_value(instance)?;
-    rename_fields(&mut value);
-    increment_indices(&mut value);
+    let ScopfInstance {
+        static_data,
+        lengths,
+        energy_windows,
+        price_blocks,
+        ac_contingency_survivors,
+        dc_contingency_flows,
+    } = instance;
+    let mut wire = Map::new();
+    wire.insert("static".to_owned(), wire_static(static_data)?);
+    wire.insert("lengths".to_owned(), wire_object(lengths)?);
+    wire.insert(
+        "energy_windows".to_owned(),
+        wire_energy_windows(energy_windows)?,
+    );
+    wire.insert("price_blocks".to_owned(), wire_price_blocks(price_blocks)?);
+    wire.insert(
+        "ac_contingency_survivors".to_owned(),
+        wire_survivors(ac_contingency_survivors)?,
+    );
+    wire.insert(
+        "dc_contingency_flows".to_owned(),
+        wire_rows(dc_contingency_flows)?,
+    );
     Ok(serde_json::to_value(WireEnvelope {
         schema: SCOPF_WIRE_SCHEMA,
         schema_version: SCOPF_WIRE_VERSION,
         index_base: 1,
-        instance: value,
+        instance: Value::Object(wire),
     })?)
-}
-
-fn rename_fields(value: &mut Value) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                rename_fields(value);
-            }
-        }
-        Value::Object(object) => {
-            let is_lengths = object.contains_key("l_j_xf") && object.contains_key("l_t");
-            for (source, target) in [
-                ("static_data", "static"),
-                ("sigma_rgu", "σ_rgu"),
-                ("sigma_rgd", "σ_rgd"),
-                ("sigma_scr", "σ_scr"),
-                ("sigma_nsc", "σ_nsc"),
-                ("w_en_max_pr", "W_en_max_pr"),
-                ("w_en_max_cs", "W_en_max_cs"),
-                ("w_en_min_pr", "W_en_min_pr"),
-                ("w_en_min_cs", "W_en_min_cs"),
-                ("t_w_en_max_pr", "T_w_en_max_pr"),
-                ("t_w_en_max_cs", "T_w_en_max_cs"),
-                ("t_w_en_min_pr", "T_w_en_min_pr"),
-                ("t_w_en_min_cs", "T_w_en_min_cs"),
-            ] {
-                rename_key(object, source, target);
-            }
-            if is_lengths {
-                for (source, target) in [
-                    ("l_j_xf", "L_J_xf"),
-                    ("l_j_ln", "L_J_ln"),
-                    ("l_j_ac", "L_J_ac"),
-                    ("l_j_dc", "L_J_dc"),
-                    ("l_j_br", "L_J_br"),
-                    ("l_j_cs", "L_J_cs"),
-                    ("l_j_pr", "L_J_pr"),
-                    ("l_j_cspr", "L_J_cspr"),
-                    ("l_j_sh", "L_J_sh"),
-                    ("i", "I"),
-                    ("l_t", "L_T"),
-                    ("l_n_p", "L_N_p"),
-                    ("l_n_q", "L_N_q"),
-                ] {
-                    rename_key(object, source, target);
-                }
-            }
-            for value in object.values_mut() {
-                rename_fields(value);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn rename_key(object: &mut Map<String, Value>, source: &str, target: &str) {
-    if let Some(value) = object.remove(source) {
-        object.insert(target.to_owned(), value);
-    }
 }
 
 /// Serialize an internal instance as the versioned 1-based Julia wire format.
@@ -93,46 +280,140 @@ pub fn to_wire_json(instance: &ScopfInstance) -> ScopfResult<String> {
     Ok(serde_json::to_string(&to_wire_value(instance)?)?)
 }
 
-fn increment_indices(value: &mut Value) {
-    match value {
-        Value::Array(values) => {
-            for value in values {
-                increment_indices(value);
-            }
-        }
-        Value::Object(object) => increment_object(object),
-        _ => {}
-    }
+fn wire_static(data: &ScopfStaticData) -> ScopfResult<Value> {
+    let ScopfStaticData {
+        bus,
+        shunt,
+        acl_branch,
+        acx_branch,
+        vpd,
+        fpd,
+        vwr,
+        fwr,
+        dc_branch,
+        prod,
+        cons,
+        active_reserve,
+        reactive_reserve,
+        active_reserve_set_pr,
+        active_reserve_set_cs,
+        reactive_reserve_set_pr,
+        reactive_reserve_set_cs,
+    } = data;
+    let mut object = Map::new();
+    object.insert("bus".to_owned(), wire_rows(bus)?);
+    object.insert("shunt".to_owned(), wire_rows(shunt)?);
+    object.insert("acl_branch".to_owned(), wire_rows(acl_branch)?);
+    object.insert("acx_branch".to_owned(), wire_rows(acx_branch)?);
+    object.insert("vpd".to_owned(), wire_rows(vpd)?);
+    object.insert("fpd".to_owned(), wire_rows(fpd)?);
+    object.insert("vwr".to_owned(), wire_rows(vwr)?);
+    object.insert("fwr".to_owned(), wire_rows(fwr)?);
+    object.insert("dc_branch".to_owned(), wire_rows(dc_branch)?);
+    object.insert("prod".to_owned(), wire_rows(prod)?);
+    object.insert("cons".to_owned(), wire_rows(cons)?);
+    object.insert("active_reserve".to_owned(), wire_rows(active_reserve)?);
+    object.insert("reactive_reserve".to_owned(), wire_rows(reactive_reserve)?);
+    object.insert(
+        "active_reserve_set_pr".to_owned(),
+        wire_rows(active_reserve_set_pr)?,
+    );
+    object.insert(
+        "active_reserve_set_cs".to_owned(),
+        wire_rows(active_reserve_set_cs)?,
+    );
+    object.insert(
+        "reactive_reserve_set_pr".to_owned(),
+        wire_rows(reactive_reserve_set_pr)?,
+    );
+    object.insert(
+        "reactive_reserve_set_cs".to_owned(),
+        wire_rows(reactive_reserve_set_cs)?,
+    );
+    Ok(Value::Object(object))
 }
 
-fn increment_object(object: &mut Map<String, Value>) {
-    for (key, value) in object {
-        if is_internal_index(key)
-            && let Some(index) = value.as_u64()
-        {
-            *value = Value::from(index + 1);
-            continue;
-        }
-        increment_indices(value);
-    }
+fn wire_energy_windows(windows: &ScopfEnergyWindows) -> ScopfResult<Value> {
+    let ScopfEnergyWindows {
+        w_en_max_pr,
+        w_en_max_cs,
+        w_en_min_pr,
+        w_en_min_cs,
+        t_w_en_max_pr,
+        t_w_en_max_cs,
+        t_w_en_min_pr,
+        t_w_en_min_cs,
+    } = windows;
+    let mut object = Map::new();
+    object.insert("W_en_max_pr".to_owned(), wire_rows(w_en_max_pr)?);
+    object.insert("W_en_max_cs".to_owned(), wire_rows(w_en_max_cs)?);
+    object.insert("W_en_min_pr".to_owned(), wire_rows(w_en_min_pr)?);
+    object.insert("W_en_min_cs".to_owned(), wire_rows(w_en_min_cs)?);
+    object.insert("T_w_en_max_pr".to_owned(), wire_rows(t_w_en_max_pr)?);
+    object.insert("T_w_en_max_cs".to_owned(), wire_rows(t_w_en_max_cs)?);
+    object.insert("T_w_en_min_pr".to_owned(), wire_rows(t_w_en_min_pr)?);
+    object.insert("T_w_en_min_cs".to_owned(), wire_rows(t_w_en_min_cs)?);
+    Ok(Value::Object(object))
 }
 
-fn is_internal_index(key: &str) -> bool {
-    matches!(
-        key,
-        "j_ln"
-            | "j_xf"
-            | "j_dc"
-            | "n_p"
-            | "n_q"
-            | "t"
-            | "m"
-            | "ctg"
-            | "flat_k"
-            | "flat_jtk_dc"
-            | "w_en_max_pr_ind"
-            | "w_en_max_cs_ind"
-            | "w_en_min_pr_ind"
-            | "w_en_min_cs_ind"
-    )
+fn wire_price_blocks(blocks: &ScopfPriceBlocks) -> ScopfResult<Value> {
+    let ScopfPriceBlocks { producer, consumer } = blocks;
+    let mut object = Map::new();
+    object.insert("producer".to_owned(), wire_rows(producer)?);
+    object.insert("consumer".to_owned(), wire_rows(consumer)?);
+    Ok(Value::Object(object))
+}
+
+fn wire_survivors(survivors: &ScopfAcContingencySurvivors) -> ScopfResult<Value> {
+    let ScopfAcContingencySurvivors { ln, xf } = survivors;
+    let mut object = Map::new();
+    object.insert("ln".to_owned(), wire_nested_rows(ln)?);
+    object.insert("xf".to_owned(), wire_nested_rows(xf)?);
+    Ok(Value::Object(object))
+}
+
+fn wire_rows<R: WireFields>(rows: &[R]) -> ScopfResult<Value> {
+    rows.iter()
+        .map(wire_object)
+        .collect::<ScopfResult<Vec<_>>>()
+        .map(Value::from)
+}
+
+fn wire_nested_rows<R: WireFields>(groups: &[Vec<R>]) -> ScopfResult<Value> {
+    groups
+        .iter()
+        .map(|group| wire_rows(group))
+        .collect::<ScopfResult<Vec<_>>>()
+        .map(Value::from)
+}
+
+/// Serialize one struct, renumber its declared index fields, apply its wire
+/// renames. The declared fields always exist in the serialized object (the
+/// classification is compile-checked against the struct), so a miss here means
+/// a `serde` attribute changed the serialized name; fail loudly.
+fn wire_object<R: WireFields>(row: &R) -> ScopfResult<Value> {
+    let mut value = serde_json::to_value(row)?;
+    let Some(object) = value.as_object_mut() else {
+        return Err(ScopfError::invalid(
+            "wire struct did not serialize to a JSON object",
+        ));
+    };
+    for &field in R::INDEX_FIELDS {
+        let index = object
+            .get_mut(field)
+            .ok_or_else(|| ScopfError::invalid(format!("index field `{field}` not serialized")))?;
+        let Some(zero_based) = index.as_u64() else {
+            return Err(ScopfError::invalid(format!(
+                "index field `{field}` is not an unsigned integer"
+            )));
+        };
+        *index = Value::from(zero_based + 1);
+    }
+    for &(from, to) in R::RENAMED_FIELDS {
+        let renamed = object
+            .remove(from)
+            .ok_or_else(|| ScopfError::invalid(format!("renamed field `{from}` not serialized")))?;
+        object.insert(to.to_owned(), renamed);
+    }
+    Ok(value)
 }

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -24,7 +24,7 @@ fn generator(bus: usize, c2: f64, c1: f64) -> Generator {
     let mut generator = Generator::new(BusId(bus));
     generator.pmax = 100.0;
     generator.pmin = 10.0;
-    generator.cost = Some(GenCost::new(2, 0.0, 0.0, vec![c2, c1, 0.0]));
+    generator.cost = Some(GenCost::new(2, 0.0, 0.0, vec![c2, c1, 5.0]));
     generator
 }
 
@@ -121,8 +121,20 @@ fn per_unit_and_native_units_scale_all_power_coefficients() {
         native.generators.q[0] * base * base,
     );
     assert_close(per_unit.generators.c[0], native.generators.c[0] * base);
+    // The constant term carries no power dimension, so it never rescales.
+    assert_close(per_unit.generators.c0[0], native.generators.c0[0]);
     assert_close(native.branches.b[0], per_unit.branches.b[0] * base);
     assert_close(native.branches.f_max[0], per_unit.branches.f_max[0] * base);
+}
+
+#[test]
+fn cost_constant_term_is_kept() {
+    let net = small_network();
+    let problem =
+        build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default()).expect("build");
+    assert_close(problem.generators.c0[0], 5.0);
+    let nodal = problem.nodal_generator_data().expect("nodal");
+    assert_close(nodal.c0[problem.generators.bus_of_gen[0]], 5.0);
 }
 
 #[test]
@@ -315,7 +327,12 @@ mod matrix_tests {
         )
         .expect("manifest json");
         assert_eq!(manifest["schema"], "powerio.dcopf");
-        assert_eq!(manifest["schema_version"], "0.2.0");
+        assert_eq!(manifest["schema_version"], "0.3.0");
+        let c0_gen =
+            powerio_matrix::io::read_vector_mtx(bundle.dir.join("c0_gen.mtx")).expect("c0_gen");
+        assert_eq!(c0_gen, problem.generators.c0);
+        let c0 = powerio_matrix::io::read_vector_mtx(bundle.dir.join("c0.mtx")).expect("c0");
+        assert_eq!(c0, problem.nodal_generator_data().expect("nodal").c0);
         assert_eq!(manifest["dimensions"]["n_buses"], problem.n_buses);
         assert_eq!(
             manifest["dimensions"]["n_generators"],

--- a/powerio-prob/tests/scopf.rs
+++ b/powerio-prob/tests/scopf.rs
@@ -111,6 +111,17 @@ fn julia_wire_adapter_is_versioned_and_one_based() {
             .is_some()
     );
     assert!(wire["instance"]["lengths"].get("L_J_ln").is_some());
+    // Renumbering is per declared field: counts and value fields pass
+    // through unchanged even where a name doubles as an index elsewhere
+    // (`p_max` on price blocks vs devices, `L_T` vs `t`).
+    assert_eq!(
+        wire["instance"]["lengths"]["L_T"],
+        u64::try_from(instance.lengths.l_t).expect("period count")
+    );
+    assert_eq!(
+        wire["instance"]["price_blocks"]["producer"][0]["p_max"],
+        instance.price_blocks.producer[0].p_max
+    );
 }
 
 #[test]

--- a/powerio/src/format/goc3.rs
+++ b/powerio/src/format/goc3.rs
@@ -33,10 +33,9 @@ impl Goc3Document {
     /// Parse one GOC3 JSON document.
     pub fn parse(text: &str) -> Result<Self> {
         let value: Value = serde_json::from_str(text).map_err(|error| bad(error.to_string()))?;
-        let root = value
-            .as_object()
-            .cloned()
-            .ok_or_else(|| bad("top level is not a JSON object"))?;
+        let Value::Object(root) = value else {
+            return Err(bad("top level is not a JSON object"));
+        };
         Ok(Self { root })
     }
 
@@ -134,17 +133,24 @@ impl Goc3BusMap {
 /// Parse a GO Challenge 3 JSON input file.
 pub fn parse_goc3_json(content: &str) -> Result<super::Parsed> {
     let mut warnings = Vec::new();
-    let network = parse_goc3_source(Arc::new(content.to_owned()), None, &mut warnings)?;
-    Ok(super::Parsed { network, warnings })
+    let (network, document) = parse_goc3_source(Arc::new(content.to_owned()), None, &mut warnings)?;
+    Ok(super::Parsed {
+        network,
+        warnings,
+        document: Some(super::SourceDocument::Goc3(document)),
+    })
 }
 
+/// Parse GOC3 source text into the balanced network plus the document the
+/// parse went through, so the caller hands the document forward instead of
+/// letting downstream adapters reparse the retained text.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn parse_goc3_source(
     source: Arc<String>,
     name_hint: Option<&str>,
     warnings: &mut Vec<String>,
-) -> Result<Network> {
-    let document = Goc3Document::parse(&source)?;
+) -> Result<(Network, Arc<Goc3Document>)> {
+    let document = Arc::new(Goc3Document::parse(&source)?);
     let root = document.root();
     let network = document.network()?;
 
@@ -259,7 +265,7 @@ pub(crate) fn parse_goc3_source(
         source: Some(source),
     };
     net.check_references(FMT)?;
-    Ok(net)
+    Ok((net, document))
 }
 
 fn read_buses(network: &Map<String, Value>) -> Result<(Vec<Bus>, Goc3BusMap)> {

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -408,10 +408,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
         // The binary reader is total (no fidelity warnings); wrap its network
         // in the shared [`Parsed`] shape.
         let network = powerworld::parse_pwb(&bytes, stem)?;
-        return Ok(Parsed {
-            network,
-            warnings: Vec::new(),
-        });
+        return Ok(Parsed::without_document(network, Vec::new()));
     }
     if from.is_some_and(is_pslf_name) || (from.is_none() && ext.as_deref() == Some("epc")) {
         let text = std::fs::read_to_string(path)?;
@@ -419,7 +416,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
         let mut warnings = Vec::new();
         let network = pslf::parse_pslf_source(Arc::new(text), stem, &mut warnings)?;
         reject_empty_case(&network, "PSLF .epc")?;
-        return Ok(Parsed { network, warnings });
+        return Ok(Parsed::without_document(network, warnings));
     }
     // Settle the format before touching the file: an unmapped or binary
     // extension must surface as UnknownFormat, not as the UTF-8 read error
@@ -475,6 +472,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
 /// readers that report fidelity loss append to it.
 fn read_source(source: Arc<String>, fmt: TargetFormat, name_hint: Option<&str>) -> Result<Parsed> {
     let mut warnings = Vec::new();
+    let mut document = None;
     let net = match fmt {
         TargetFormat::Matpower => matpower::parse_matpower_source(source, name_hint),
         TargetFormat::PowerModelsJson => {
@@ -494,13 +492,19 @@ fn read_source(source: Arc<String>, fmt: TargetFormat, name_hint: Option<&str>) 
         // PSLF read normally enters through the `is_pslf_name`/`.epc` fast path in
         // parse_file / parse_str; this arm keeps the funnel total.
         TargetFormat::Pslf => pslf::parse_pslf_source(source, name_hint, &mut warnings),
-        TargetFormat::Goc3Json => goc3::parse_goc3_source(source, name_hint, &mut warnings),
+        TargetFormat::Goc3Json => {
+            goc3::parse_goc3_source(source, name_hint, &mut warnings).map(|(net, goc3)| {
+                document = Some(SourceDocument::Goc3(goc3));
+                net
+            })
+        }
         TargetFormat::SurgeJson => surge::parse_surge_source(source, name_hint, &mut warnings),
     }?;
     reject_empty_case(&net, fmt.label())?;
     Ok(Parsed {
         network: net,
         warnings,
+        document,
     })
 }
 
@@ -591,7 +595,7 @@ pub fn parse_str(text: &str, format: &str) -> Result<Parsed> {
         let mut warnings = Vec::new();
         let network = pslf::parse_pslf_source(Arc::new(text.to_owned()), None, &mut warnings)?;
         reject_empty_case(&network, "PSLF .epc")?;
-        return Ok(Parsed { network, warnings });
+        return Ok(Parsed::without_document(network, warnings));
     }
     let fmt = target_format_from_name(format).ok_or_else(|| unknown_source_format(format))?;
     read_source(Arc::new(text.to_owned()), fmt, None)
@@ -610,6 +614,30 @@ pub fn parse_str(text: &str, format: &str) -> Result<Parsed> {
 pub struct Parsed {
     pub network: Network,
     pub warnings: Vec<String>,
+    /// The source document for formats whose downstream adapters reuse the
+    /// reader's parse (see [`SourceDocument`]); `None` for every other format.
+    pub document: Option<SourceDocument>,
+}
+
+impl Parsed {
+    /// Wrap a reader result for a format without a shared source document.
+    pub(crate) fn without_document(network: Network, warnings: Vec<String>) -> Self {
+        Self {
+            network,
+            warnings,
+            document: None,
+        }
+    }
+}
+
+/// A format's source document, parsed once by the reader and handed forward so
+/// downstream adapters derive their data from the same parse instead of
+/// reparsing the retained source text. Today that is the GOC3 document, which
+/// the operating point extractor in `powerio-pkg` consumes.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SourceDocument {
+    Goc3(Arc<goc3::Goc3Document>),
 }
 
 /// Output of a conversion: the serialized text plus any fidelity warnings:

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -28,7 +28,7 @@ const MAX_I_KA: f64 = 99_999.0;
 pub fn parse_pandapower_json(content: &str) -> Result<Parsed> {
     let mut warnings = Vec::new();
     let network = parse_pandapower_source(Arc::new(content.to_owned()), None, &mut warnings)?;
-    Ok(Parsed { network, warnings })
+    Ok(Parsed::without_document(network, warnings))
 }
 
 #[allow(clippy::too_many_lines)] // direct table-to-Network mapper; split helpers obscure column mapping

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -30,7 +30,7 @@ pub struct PypsaCsvOutputs {
 pub fn read_pypsa_csv_folder(path: impl AsRef<Path>) -> Result<Parsed> {
     let mut warnings = Vec::new();
     let network = read_pypsa_csv_folder_inner(path.as_ref(), &mut warnings)?;
-    Ok(Parsed { network, warnings })
+    Ok(Parsed::without_document(network, warnings))
 }
 
 #[allow(clippy::too_many_lines)] // direct static-component CSV mapper; each block is one PyPSA table

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -461,7 +461,7 @@ fn lcc_terminal_obj(bus: BusId, in_service: bool) -> Value {
 pub fn parse_surge_json(content: &str) -> Result<Parsed> {
     let mut warnings = Vec::new();
     let network = parse_surge_source(Arc::new(content.to_owned()), None, &mut warnings)?;
-    Ok(Parsed { network, warnings })
+    Ok(Parsed::without_document(network, warnings))
 }
 
 pub(crate) fn parse_surge_source(

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -52,14 +52,14 @@ pub use dc::DcConvention;
 pub use error::{ElementCounts, Error, ErrorCategory, Result, ScenarioMismatch};
 pub use format::{
     Conversion, DisplayData, DisplayFormat, Parsed, PwdDisplay, PwdSubstation, PypsaCsvOutputs,
-    TargetFormat, WriteOptions, convert_file, convert_file_with_options, convert_str,
-    convert_str_with_options, display_format_from_name, parse_display_bytes, parse_display_file,
-    parse_egret_json, parse_file, parse_goc3_json, parse_matpower, parse_matpower_file,
-    parse_pandapower_json, parse_powermodels_json, parse_powerworld, parse_pslf, parse_psse,
-    parse_str, parse_surge_json, read_pypsa_csv_folder, target_format_from_name, write_as,
-    write_as_with_options, write_dir, write_egret_json, write_matpower, write_pandapower_json,
-    write_powermodels_json, write_powerworld, write_pslf, write_psse, write_psse_rev,
-    write_pypsa_csv_folder, write_surge_json,
+    SourceDocument, TargetFormat, WriteOptions, convert_file, convert_file_with_options,
+    convert_str, convert_str_with_options, display_format_from_name, parse_display_bytes,
+    parse_display_file, parse_egret_json, parse_file, parse_goc3_json, parse_matpower,
+    parse_matpower_file, parse_pandapower_json, parse_powermodels_json, parse_powerworld,
+    parse_pslf, parse_psse, parse_str, parse_surge_json, read_pypsa_csv_folder,
+    target_format_from_name, write_as, write_as_with_options, write_dir, write_egret_json,
+    write_matpower, write_pandapower_json, write_powermodels_json, write_powerworld, write_pslf,
+    write_psse, write_psse_rev, write_pypsa_csv_folder, write_surge_json,
 };
 pub use gen_cost::{GenCostPatch, GenCostPolicyReport, MissingGenCostPolicy, parse_gen_cost_csv};
 pub use geo::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};


### PR DESCRIPTION
Closes #252. Closes #250.

## Wire renumbering (#252)

The Julia wire adapter renumbered 0-based indices by matching bare key names (`t`, `m`, `j_ln`, ...) anywhere in the serialized `ScopfInstance` tree. The conversion is now structural: every struct that reaches the wire classifies each field as an internal index, a renamed field, or a value, through an exhaustive destructure generated by `wire_fields!`. A field added to `types.rs` fails to compile until classified, so a new index field cannot be silently missed, and a value field reusing an index name in another struct is never renumbered. The tree-wide rename walk (including the `is_lengths` heuristic) is gone; renames apply at their declared structs. Wire output is byte identical on the GOC3 fixture.

## GOC3 single parse (#250)

`NetworkPackage::from_parsed_balanced` reparsed retained GOC3 text the reader had already parsed. The reader now hands its document forward as `Parsed::document` (`SourceDocument::Goc3`), and the operating point series derives from that document; the second full JSON parse is gone. `operating.rs` owns the document dispatch, so package assembly stays format agnostic. `Goc3Document::parse` also stops deep copying the parsed root. A regression test strips the retained text and asserts the series still attaches.

## DC OPF constant cost term

`DcOpfInstance` drops the constant cost term that `AcOpfInstance` carries; a consumer reporting objective values needs it (tellegen backs `DcNetwork::from_network` with this instance). `DcGeneratorData`/`NodalGeneratorData` gain `c0`, the DC OPF bundle writes `c0.mtx`/`c0_gen.mtx`, and the bundle schema bumps to 0.3.0.