### PR TITLE
Add the geographic document and balanced coordinate harvest

### DIFF
--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -47,36 +47,95 @@ Balanced networks use `powerio::geo::{Location, CoordsKind, CoordinateSpace,
 GeoMeta, Canvas}` through `Network.geo` and `Bus.location`. Multiconductor
 networks use the matching `powerio_dist::geo` types through `DistNetwork.geo`
 and `DistBus.location`. A package serialization test keeps the two JSON shapes
-identical.
+identical. Branches carry optional polyline routing (`Branch.route`,
+`DistLine.route`) when a source provides intermediate geometry; endpoint only
+rendering derives from the bus locations.
 
 The coordinate space belongs to the network. For geographic coordinates,
 `x` is longitude and `y` is latitude in GeoJSON axis order. A missing CRS in a
 geographic space means EPSG:4326. `kind` records whether coordinates came from
 the source, a generated layout, a manual edit, or a derived transform.
 
-## Distribution formats
+## Harvest and emit
 
-The distribution readers currently provide coordinate data:
+Readers promote coordinates into `location` and stamp the space; promotion
+removes the raw keys from `extras`. Writers emit from `location`.
 
-| Format | Input | Coordinate space |
+| Format | Fields | Space |
 | --- | --- | --- |
+| PowerWorld aux | `Latitude:1`/`Longitude:1` bus columns (`SubNum` stays in extras: it is identity rather than geometry) | geographic |
+| pandapower | bus `geo` GeoJSON Point strings | geographic |
+| PyPSA | `buses.csv` `x`/`y` | geographic |
 | OpenDSS | `Buscoords` | unknown; a diagnostic identifies values within longitude and latitude bounds |
-| BMOPF JSON | `longitude` and `latitude` fields used by BMOPFTools | geographic |
+| BMOPF JSON | `longitude`/`latitude` (the BMOPFTools sideload convention; writing is opt in via `BmopfWriteOptions::sideload_coordinates`) | geographic |
 
-The OpenDSS writer emits a `Buscoords` file. The BMOPF schema rejects
-coordinate properties, so the BMOPF writer drops them with a warning by
-default. `BmopfWriteOptions::sideload_coordinates` writes the BMOPFTools
-`longitude` and `latitude` extension.
+MATPOWER, PSS/E, PowerModels, egret, GOC3, PSLF, and Surge carry no geometry.
+Writing a located case to one of them reports the dropped locations, the same
+behavior `base_frequency` has; `powerio geo extract` writes the sidecar as the
+escape hatch.
 
-Balanced network readers do not yet populate these fields. That work is
-tracked in [#183](https://github.com/eigenergy/powerio/issues/183).
+## The geographic document
+
+Coordinates also arrive and leave as files of their own: a `Buscoords` CSV
+next to a DSS master, a GeoJSON export from a GIS tool, a layout computed by a
+renderer. The container is `GeoLayer`, surfaced as `DisplayData::Geo` beside
+the PowerWorld `.pwd` display path.
+
+The canonical wire form is a GeoJSON FeatureCollection with one foreign
+member, suggested extension `.geo.json`:
+
+```json
+{
+  "type": "FeatureCollection",
+  "powerio_geo": { "version": "0.1.0", "space": "geographic", "kind": "source" },
+  "features": [
+    { "type": "Feature",
+      "geometry": { "type": "Point", "coordinates": [-80.05, 34.20] },
+      "properties": { "target": "bus", "id": "312", "uid": "buses:11" } },
+    { "type": "Feature",
+      "geometry": { "type": "LineString", "coordinates": [[-80.05, 34.20], [-80.10, 34.30]] },
+      "properties": { "target": "branch", "uid": "branches:4", "from": "312", "to": "410" } }
+  ]
+}
+```
+
+When the space is geographic this is valid RFC 7946 GeoJSON, so GIS tools open
+it directly.
+
+Reading is tolerant; writing is canonical. `GeoLayer::parse_bytes` takes bytes
+plus a file name hint and touches no filesystem. It accepts headerless
+buscoords CSV (`bus, x, y`), CSV and JSON records with aliased field names
+(`bus_i`/`bus`/`id`, `lat`/`latitude`/`y`, `lon`/`lng`/`longitude`/`x`, branch
+endpoint pairs), and GeoJSON Point and LineString features. Features reference
+elements by up to three key fields, matched in order: `uid`, then `id`, then
+case insensitive `name`. Branch routes additionally fall back to the unordered
+`(from, to)` bus pair. A bare integer branch id is accepted on read as a
+1-based positional row alias and never written; the durable identity is the
+payload `uid`.
+
+`Network::geo_layer()` extracts, and `Network::apply_geo_layer(&layer)`
+applies and returns a `GeoApplyReport` with matched and unmatched counts. The
+multiconductor equivalents attach through `powerio-pkg` (`dist_geo_layer`,
+`apply_dist_geo_layer`). The CLI wraps the same surface:
+
+```console
+$ powerio geo extract case.aux -o case.geo.json
+$ powerio geo apply case.m layout.csv -o placed.m
+$ powerio geo convert buscoords.csv -o case.geo.json
+```
 
 ## PowerWorld display files
 
-The `.pwd` reader returns `DisplayData::PowerWorld` with a `PwdDisplay`. The
-decoded data contains canvas dimensions, a timestamp, and substation symbols
-with number, name, and diagram coordinates. It does not attach those symbols to
-a parsed network.
+The `.pwd` reader returns `DisplayData::PowerWorld` with a `PwdDisplay`: canvas
+dimensions, a timestamp, and substation symbols with number, name, and diagram
+coordinates.
+
+Three helpers connect it to the geo model. `geo_layer_from_pwd` lifts the
+substation symbols into a diagram space `GeoLayer` (also reachable as
+`powerio geo extract case.pwd`); `apply_substation_points` joins those points
+onto buses through the `SubNum` extras key; and `pwd_mercator_to_lonlat` is a
+documented, approximate inverse of the projection PowerWorld's auto generated
+layouts use, for consumers that want to place a diagram on a map.
 
 Rust uses `parse_display_file` and `parse_display_bytes`. Python exposes the
 same names and returns `DisplayData(kind="powerworld", data=PwdDisplay(...))`.
@@ -89,8 +148,10 @@ coordinates. Python exposes `dist_net.graph()`, and the C `dist` feature
 exposes `pio_dist_graph_json`. Graph topology and geographic placement remain
 separate data.
 
-Standalone geographic documents, balanced coordinate readers, and direct C and
-Python coordinate helpers are tracked in
-[#180](https://github.com/eigenergy/powerio/issues/180),
-[#182](https://github.com/eigenergy/powerio/issues/182), and
-[#183](https://github.com/eigenergy/powerio/issues/183).
+PowerIO stores and transports coordinates; it does not compute them. Synthetic
+layout of a coordinate free case is renderer math and stays in the consumer,
+which can write the result back with `kind = synthetic` so the provenance
+survives.
+
+C and Python bindings for the geographic document are tracked in
+[#185](https://github.com/eigenergy/powerio/issues/185).

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -216,6 +216,53 @@ enum Command {
         #[arg(long)]
         gen_cost_csv: Option<PathBuf>,
     },
+    /// Extract, apply, or normalize standalone geographic layers (.geo.json).
+    Geo {
+        #[command(subcommand)]
+        command: GeoCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum GeoCommand {
+    /// Extract a case's coordinates as a canonical .geo.json layer.
+    Extract {
+        /// Input case file (transmission or distribution).
+        input: PathBuf,
+        /// Output file; `-` or omitted writes to stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Override the inferred input format.
+        #[arg(long, value_enum)]
+        from: Option<FormatArg>,
+    },
+    /// Apply a geographic sidecar onto a case and write the case back.
+    Apply {
+        /// Input case file (transmission or distribution).
+        input: PathBuf,
+        /// Geographic sidecar: GeoJSON, aliased CSV/JSON records, or
+        /// headerless buscoords CSV.
+        layer: PathBuf,
+        /// Output case file; `-` or omitted writes to stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+        /// Target case format; defaults to the input's own format.
+        #[arg(long, value_enum)]
+        to: Option<FormatArg>,
+        /// Override the inferred input format.
+        #[arg(long, value_enum)]
+        from: Option<FormatArg>,
+    },
+    /// Normalize a tolerant geographic sidecar to the canonical .geo.json
+    /// form.
+    Convert {
+        /// Input sidecar: GeoJSON, aliased CSV/JSON records, or headerless
+        /// buscoords CSV.
+        input: PathBuf,
+        /// Output file; `-` or omitted writes to stdout.
+        #[arg(short, long)]
+        output: Option<PathBuf>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
@@ -536,6 +583,8 @@ impl From<TopologyArg> for Topology {
     }
 }
 
+// A flat dispatch: one arm per subcommand, each delegating immediately.
+#[expect(clippy::too_many_lines)]
 fn main() -> anyhow::Result<()> {
     install_tracing();
     let cli = Cli::parse();
@@ -636,6 +685,25 @@ fn main() -> anyhow::Result<()> {
                 gen_cost_csv.as_deref(),
             ),
         ),
+        Command::Geo { command } => run_geo(command),
+    }
+}
+
+fn run_geo(command: GeoCommand) -> anyhow::Result<()> {
+    match command {
+        GeoCommand::Extract {
+            input,
+            output,
+            from,
+        } => run_geo_extract(&input, output.as_deref(), from),
+        GeoCommand::Apply {
+            input,
+            layer,
+            output,
+            to,
+            from,
+        } => run_geo_apply(&input, &layer, output.as_deref(), to, from),
+        GeoCommand::Convert { input, output } => run_geo_convert(&input, output.as_deref()),
     }
 }
 
@@ -1373,12 +1441,23 @@ fn run_convert(
     for w in &warnings {
         eprintln!("fidelity: {w}");
     }
+    write_conversion_output(&text, &sidecars, output)
+}
+
+/// Write conversion `text` to `output` (stdout on `-` or `None`), placing any
+/// `sidecars` next to it. Sidecars cannot follow text to stdout; they are
+/// reported instead.
+fn write_conversion_output(
+    text: &str,
+    sidecars: &[powerio_dist::ConversionSidecar],
+    output: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
     match output {
         Some(p) if p.as_os_str() != "-" => {
-            std::fs::write(p, &text).with_context(|| format!("writing {}", p.display()))?;
+            std::fs::write(p, text).with_context(|| format!("writing {}", p.display()))?;
             eprintln!("wrote {}", p.display());
             let base = p.parent().unwrap_or_else(|| std::path::Path::new("."));
-            for sidecar in &sidecars {
+            for sidecar in sidecars {
                 let path = base.join(&sidecar.path);
                 if let Some(parent) = path.parent() {
                     std::fs::create_dir_all(parent)
@@ -1390,7 +1469,7 @@ fn run_convert(
             }
         }
         _ => {
-            for sidecar in &sidecars {
+            for sidecar in sidecars {
                 eprintln!(
                     "fidelity: sidecar `{}` was not written because output is stdout",
                     sidecar.path
@@ -1400,6 +1479,157 @@ fn run_convert(
         }
     }
     Ok(())
+}
+
+/// Whether the geo command's case input is a distribution case: `--from`
+/// decides when given, else the extension and JSON markers.
+fn geo_input_is_dist(input: &std::path::Path, from: Option<FormatArg>) -> anyhow::Result<bool> {
+    if let Some(f) = from {
+        return Ok(f.distribution().is_some());
+    }
+    looks_like_distribution_input(input)
+}
+
+fn run_geo_extract(
+    input: &std::path::Path,
+    output: Option<&std::path::Path>,
+    from: Option<FormatArg>,
+) -> anyhow::Result<()> {
+    // A `.pwd` display file promotes to a diagram space layer with
+    // substation targets; apply it onto a case with `geo apply`.
+    if from.is_none()
+        && input
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("pwd"))
+    {
+        let display = powerio_matrix::parse_display_file(input, None)
+            .with_context(|| format!("reading {}", input.display()))?;
+        let powerio_matrix::DisplayData::PowerWorld(display) = display else {
+            anyhow::bail!("{} did not parse as a .pwd display", input.display());
+        };
+        let layer = powerio_matrix::geo::geo_layer_from_pwd(&display);
+        if layer.features.is_empty() {
+            anyhow::bail!("{} carries no substation symbols", input.display());
+        }
+        return write_conversion_output(&layer.to_geojson(), &[], output);
+    }
+    let layer = if geo_input_is_dist(input, from)? {
+        let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
+            .with_context(|| format!("reading {}", input.display()))?;
+        for w in &net.warnings {
+            eprintln!("parse: {w}");
+        }
+        powerio_pkg::dist_geo_layer(&net)
+    } else {
+        read_network(input, from)?.geo_layer()
+    };
+    if layer.features.is_empty() {
+        anyhow::bail!("{} carries no coordinates to extract", input.display());
+    }
+    write_conversion_output(&layer.to_geojson(), &[], output)
+}
+
+// Both family branches follow the same five steps (parse, apply, drop the
+// retained source so a same-format write re-serializes the placed case,
+// resolve the target, serialize); they stay separate because the two model
+// families have distinct parse and write APIs.
+fn run_geo_apply(
+    input: &std::path::Path,
+    layer_path: &std::path::Path,
+    output: Option<&std::path::Path>,
+    to: Option<FormatArg>,
+    from: Option<FormatArg>,
+) -> anyhow::Result<()> {
+    let bytes = std::fs::read(layer_path)
+        .with_context(|| format!("reading layer {}", layer_path.display()))?;
+    let parsed = powerio_matrix::geo::GeoLayer::parse_bytes(
+        &bytes,
+        layer_path.file_name().and_then(|n| n.to_str()),
+    )
+    .with_context(|| format!("parsing layer {}", layer_path.display()))?;
+    for w in &parsed.warnings {
+        eprintln!("layer: {w}");
+    }
+    let (text, sidecars, warnings) = if geo_input_is_dist(input, from)? {
+        let mut net = powerio_dist::parse_file(input, from.map(FormatArg::name))
+            .with_context(|| format!("reading {}", input.display()))?;
+        for w in &net.warnings {
+            eprintln!("parse: {w}");
+        }
+        report_geo_apply(&powerio_pkg::apply_dist_geo_layer(&mut net, &parsed.layer));
+        net.source = None;
+        let target = match to {
+            Some(f) => f.distribution().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`{}` is not a distribution text target; a distribution case writes \
+                     back to dss, pmd-json, or bmopf-json",
+                    f.name()
+                )
+            })?,
+            None => net
+                .source_format
+                .map(|f| f.name().parse())
+                .transpose()?
+                .ok_or_else(|| anyhow::anyhow!("the input carries no source format; pass --to"))?,
+        };
+        let conv = net.to_format(target);
+        (conv.text, conv.sidecars, conv.warnings)
+    } else {
+        let mut net = read_network(input, from)?;
+        report_geo_apply(&net.apply_geo_layer(&parsed.layer));
+        net.source = None;
+        let target = match to {
+            Some(f) => f.transmission().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "`{}` is not a transmission text target here; apply writes a single \
+                     case file (use `convert` for pypsa-csv and gridfm outputs)",
+                    f.name()
+                )
+            })?,
+            None => powerio_matrix::target_format_from_name(&format!("{:?}", net.source_format))
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "`{:?}` has no write target; pass --to to choose one",
+                        net.source_format
+                    )
+                })?,
+        };
+        let conv = net
+            .to_format(target)
+            .with_context(|| format!("serializing to {target}"))?;
+        (conv.text, Vec::new(), conv.warnings)
+    };
+    for w in &warnings {
+        eprintln!("fidelity: {w}");
+    }
+    write_conversion_output(&text, &sidecars, output)
+}
+
+fn report_geo_apply(report: &powerio_matrix::geo::GeoApplyReport) {
+    eprintln!(
+        "applied: {} bus point(s), {} branch route(s), {} unmatched feature(s)",
+        report.matched_buses, report.matched_branches, report.unmatched_features
+    );
+    for note in &report.notes {
+        eprintln!("note: {note}");
+    }
+}
+
+fn run_geo_convert(
+    input: &std::path::Path,
+    output: Option<&std::path::Path>,
+) -> anyhow::Result<()> {
+    let bytes = std::fs::read(input).with_context(|| format!("reading {}", input.display()))?;
+    let parsed = powerio_matrix::geo::GeoLayer::parse_bytes(
+        &bytes,
+        input.file_name().and_then(|n| n.to_str()),
+    )
+    .with_context(|| format!("parsing {}", input.display()))?;
+    for w in &parsed.warnings {
+        eprintln!("layer: {w}");
+    }
+    write_conversion_output(&parsed.layer.to_geojson(), &[], output)
 }
 
 /// Write `input` out as a PyPSA CSV folder (a directory target, so it never

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -531,6 +531,7 @@ impl Reader<'_> {
                 terminal_map_to: strings(o.get("terminal_map_to")),
                 linecode: string(o.get("linecode")),
                 length: o.get("length").map_or(f64::NAN, f),
+                route: None,
                 extras: take_extras(
                     o,
                     &known,

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -196,11 +196,25 @@ impl DistTargetFormat {
 impl DistNetwork {
     /// Writes the network in `format`, bypassing byte exact source echo.
     pub fn to_canonical_format(&self, format: DistTargetFormat) -> Conversion {
-        match format {
+        let mut conv = match format {
             DistTargetFormat::Dss => crate::dss::write_dss(self),
             DistTargetFormat::BmopfJson => crate::bmopf::write_bmopf_json(self),
             DistTargetFormat::PmdJson => crate::pmd::write_pmd_json(self),
+        };
+        // No distribution format carries line routes; report the loss the
+        // way bus locations already do (`.pio.json` keeps them).
+        let routed = self
+            .lines
+            .iter()
+            .filter(|line| line.route.is_some())
+            .count();
+        if routed > 0 {
+            conv.warnings.push(format!(
+                "{routed} line route(s) dropped: {} has no polyline field",
+                format.name()
+            ));
         }
+        conv
     }
 
     /// Writes the network in `format`.

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -871,6 +871,7 @@ impl Reader<'_> {
             terminal_map_to: map_to,
             linecode,
             length: length * length_factor,
+            route: None,
             extras,
         });
     }

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -2264,6 +2264,7 @@ mod tests {
             terminal_map_to: strings(&["1"]),
             linecode: "lc".into(),
             length: 1.0,
+            route: None,
             extras: Extras::new(),
         });
         let out2 = write_dss(&net2);

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -147,6 +147,12 @@ pub struct DistLine {
     pub linecode: String,
     /// Meters.
     pub length: f64,
+    /// Polyline route in the network's coordinate space (`DistNetwork.geo`),
+    /// present only when a source provides intermediate geometry.
+    /// `#[serde(default)]` so JSON written before the field existed still
+    /// deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<Vec<Location>>,
     pub extras: Extras,
 }
 
@@ -169,6 +175,7 @@ impl DistLine {
             terminal_map_to,
             linecode: linecode.into(),
             length,
+            route: None,
             extras: Extras::new(),
         }
     }

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -469,6 +469,7 @@ impl Reader<'_> {
                 terminal_map_to: ints_as_strings(o.get("t_connections")),
                 linecode,
                 length: o.get("length").map_or(f64::NAN, |v| restore("length", v)),
+                route: None,
                 extras,
             });
         }

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -39,12 +39,13 @@ pub use powerio::{
     NormalizeOptions, NormalizedNetwork, POWER_MODELS_ANGLE_BOUND_PAD, Parsed, PwdDisplay,
     PwdSubstation, PypsaCsvOutputs, Result, ScenarioMismatch, Shunt, SourceFormat, Storage,
     TargetFormat, WriteOptions, convert_file, convert_file_with_options, convert_str,
-    convert_str_with_options, display_format_from_name, error, format, gen_cost, indexed, network,
-    parse_display_bytes, parse_display_file, parse_file, parse_gen_cost_csv, parse_matpower,
-    parse_matpower_file, parse_pandapower_json, parse_powermodels_json, parse_powerworld,
-    parse_pslf, parse_psse, parse_str, read_pypsa_csv_folder, target_format_from_name, write_as,
-    write_as_with_options, write_egret_json, write_matpower, write_pandapower_json,
-    write_powermodels_json, write_powerworld, write_psse, write_pypsa_csv_folder,
+    convert_str_with_options, display_format_from_name, error, format, gen_cost, geo, indexed,
+    network, parse_display_bytes, parse_display_file, parse_file, parse_gen_cost_csv,
+    parse_matpower, parse_matpower_file, parse_pandapower_json, parse_powermodels_json,
+    parse_powerworld, parse_pslf, parse_psse, parse_str, read_pypsa_csv_folder,
+    target_format_from_name, write_as, write_as_with_options, write_egret_json, write_matpower,
+    write_pandapower_json, write_powermodels_json, write_powerworld, write_psse,
+    write_pypsa_csv_folder,
 };
 
 /// Compressed sparse row matrix used by the projection builders.

--- a/powerio-pkg/src/geo.rs
+++ b/powerio-pkg/src/geo.rs
@@ -1,0 +1,238 @@
+//! Geographic layer glue for the multiconductor model.
+//!
+//! `powerio_dist` cannot depend on `powerio`, so the [`GeoLayer`] extract and
+//! apply for [`MulticonductorNetwork`] live here, where both model crates are
+//! visible. The apply pass itself (`apply_geo_features`) is shared with the
+//! balanced network; this module supplies the string keyed row lookups and
+//! the mirrored type conversions. The parity test in this crate keeps the
+//! mirrored geo types' JSON shapes identical, so the conversions are direct
+//! field maps with a serde fallback for variants added on one side first.
+
+use std::collections::HashMap;
+
+use powerio::geo::{GeoApplyTarget, apply_geo_features};
+use powerio::{CoordinateSpace, ElementKey, GeoApplyReport, GeoFeature, GeoGeometry, GeoLayer};
+use powerio_dist::MulticonductorNetwork;
+
+/// Extract a multiconductor network's coordinates as a standalone
+/// [`GeoLayer`]: one point per located bus, one route per routed line, keyed
+/// by the string bus and line names plus the payload row uids.
+#[must_use]
+pub fn dist_geo_layer(net: &MulticonductorNetwork) -> GeoLayer {
+    let mut features = Vec::new();
+    for (row, bus) in net.buses.iter().enumerate() {
+        let Some(location) = bus.location else {
+            continue;
+        };
+        features.push(GeoFeature {
+            target: powerio::GeoTarget::Bus,
+            key: ElementKey {
+                uid: Some(format!("buses:{row}")),
+                id: Some(bus.id.clone()),
+                name: Some(bus.id.clone()),
+                index: None,
+            },
+            geometry: GeoGeometry::Point([location.x, location.y]),
+            from: None,
+            to: None,
+            kind: location.kind.and_then(kind_to_balanced),
+        });
+    }
+    for (row, line) in net.lines.iter().enumerate() {
+        let Some(route) = &line.route else {
+            continue;
+        };
+        features.push(GeoFeature {
+            target: powerio::GeoTarget::Branch,
+            key: ElementKey {
+                uid: Some(format!("lines:{row}")),
+                id: Some(line.name.clone()),
+                name: Some(line.name.clone()),
+                index: None,
+            },
+            geometry: GeoGeometry::LineString(
+                route.iter().map(|point| [point.x, point.y]).collect(),
+            ),
+            from: Some(line.bus_from.clone()),
+            to: Some(line.bus_to.clone()),
+            kind: None,
+        });
+    }
+    let meta = mirror::<_, powerio::GeoMeta>(net.geo.as_ref());
+    GeoLayer {
+        space: meta
+            .as_ref()
+            .map_or(CoordinateSpace::Unknown, |geo| geo.space.clone()),
+        kind: meta.and_then(|geo| geo.kind),
+        features,
+    }
+}
+
+/// Apply a [`GeoLayer`] onto a multiconductor network: matched bus points
+/// land in `DistBus.location`, matched line routes in `DistLine.route`, and
+/// the layer's space becomes the network's `geo` when anything matched.
+/// Matching follows [`ElementKey`], with the string ids matched case
+/// insensitively (OpenDSS names are case insensitive).
+pub fn apply_dist_geo_layer(net: &mut MulticonductorNetwork, layer: &GeoLayer) -> GeoApplyReport {
+    let mut target = DistApply {
+        buses: DistBusIndex::new(net),
+        lines: DistLineIndex::new(net),
+        net,
+    };
+    let report = apply_geo_features(layer, &mut target);
+    if report.matched_buses > 0 || report.matched_branches > 0 {
+        net.geo = mirror(Some(&powerio::GeoMeta {
+            space: layer.space.clone(),
+            kind: layer.kind,
+        }));
+    }
+    report
+}
+
+/// The multiconductor network as an apply target.
+struct DistApply<'a> {
+    net: &'a mut MulticonductorNetwork,
+    buses: DistBusIndex,
+    lines: DistLineIndex,
+}
+
+impl GeoApplyTarget for DistApply<'_> {
+    fn bus_row(&self, key: &ElementKey) -> Option<usize> {
+        key.uid
+            .as_ref()
+            .and_then(|uid| self.buses.rows.get(uid))
+            .or_else(|| lookup_lower(&self.buses.rows, key.id.as_deref()))
+            .or_else(|| lookup_lower(&self.buses.rows, key.name.as_deref()))
+            .copied()
+    }
+
+    fn branch_row(&self, feature: &GeoFeature) -> Option<usize> {
+        feature
+            .key
+            .uid
+            .as_ref()
+            .and_then(|uid| self.lines.rows.get(uid).copied())
+            .or_else(|| {
+                lookup_lower(&self.lines.rows, feature.key.id.as_deref())
+                    .or_else(|| lookup_lower(&self.lines.rows, feature.key.name.as_deref()))
+                    .copied()
+            })
+            .or_else(|| {
+                // Positional row alias, 1-based.
+                feature
+                    .key
+                    .index
+                    .and_then(|index| index.checked_sub(1))
+                    .filter(|row| *row < self.net.lines.len())
+            })
+            .or_else(|| {
+                let from = feature.from.as_deref()?;
+                let to = feature.to.as_deref()?;
+                self.lines.pairs.get(&name_pair(from, to)).copied()
+            })
+    }
+
+    fn place_bus(&mut self, row: usize, point: [f64; 2], kind: Option<powerio::CoordsKind>) {
+        self.net.buses[row].location = Some(powerio_dist::Location {
+            x: point[0],
+            y: point[1],
+            kind: kind.and_then(kind_to_dist),
+        });
+    }
+
+    fn place_branch(&mut self, row: usize, path: &[[f64; 2]], kind: Option<powerio::CoordsKind>) {
+        let kind = kind.and_then(kind_to_dist);
+        self.net.lines[row].route = Some(
+            path.iter()
+                .map(|[x, y]| powerio_dist::Location { x: *x, y: *y, kind })
+                .collect(),
+        );
+    }
+
+    fn substation_note(&self, count: usize) -> String {
+        format!(
+            "{count} substation feature(s) not applied: the multiconductor model has no \
+             substation join"
+        )
+    }
+}
+
+/// Bus row lookups: payload row uid plus the lowercased string id.
+struct DistBusIndex {
+    rows: HashMap<String, usize>,
+}
+
+impl DistBusIndex {
+    fn new(net: &MulticonductorNetwork) -> Self {
+        let mut rows = HashMap::new();
+        for (row, bus) in net.buses.iter().enumerate() {
+            rows.insert(format!("buses:{row}"), row);
+            rows.entry(bus.id.to_ascii_lowercase()).or_insert(row);
+        }
+        Self { rows }
+    }
+}
+
+/// Line row lookups: payload row uid, lowercased name, and the unordered
+/// endpoint pair.
+struct DistLineIndex {
+    rows: HashMap<String, usize>,
+    pairs: HashMap<(String, String), usize>,
+}
+
+impl DistLineIndex {
+    fn new(net: &MulticonductorNetwork) -> Self {
+        let mut rows = HashMap::new();
+        let mut pairs = HashMap::new();
+        for (row, line) in net.lines.iter().enumerate() {
+            rows.insert(format!("lines:{row}"), row);
+            rows.entry(line.name.to_ascii_lowercase()).or_insert(row);
+            pairs
+                .entry(name_pair(&line.bus_from, &line.bus_to))
+                .or_insert(row);
+        }
+        Self { rows, pairs }
+    }
+}
+
+fn lookup_lower<'a>(rows: &'a HashMap<String, usize>, key: Option<&str>) -> Option<&'a usize> {
+    rows.get(&key?.to_ascii_lowercase())
+}
+
+fn name_pair(a: &str, b: &str) -> (String, String) {
+    let a = a.to_ascii_lowercase();
+    let b = b.to_ascii_lowercase();
+    if b < a { (b, a) } else { (a, b) }
+}
+
+/// Direct variant maps between the mirrored provenance enums; both are
+/// `#[non_exhaustive]`, so a variant added on one side first goes through the
+/// shared JSON shape instead of being dropped silently.
+fn kind_to_balanced(kind: powerio_dist::CoordsKind) -> Option<powerio::CoordsKind> {
+    match kind {
+        powerio_dist::CoordsKind::Source => Some(powerio::CoordsKind::Source),
+        powerio_dist::CoordsKind::Synthetic => Some(powerio::CoordsKind::Synthetic),
+        powerio_dist::CoordsKind::Manual => Some(powerio::CoordsKind::Manual),
+        powerio_dist::CoordsKind::Derived => Some(powerio::CoordsKind::Derived),
+        _ => mirror(Some(&kind)),
+    }
+}
+
+fn kind_to_dist(kind: powerio::CoordsKind) -> Option<powerio_dist::CoordsKind> {
+    match kind {
+        powerio::CoordsKind::Source => Some(powerio_dist::CoordsKind::Source),
+        powerio::CoordsKind::Synthetic => Some(powerio_dist::CoordsKind::Synthetic),
+        powerio::CoordsKind::Manual => Some(powerio_dist::CoordsKind::Manual),
+        powerio::CoordsKind::Derived => Some(powerio_dist::CoordsKind::Derived),
+        _ => mirror(Some(&kind)),
+    }
+}
+
+/// Convert between the mirrored geo types through their shared JSON shape.
+/// Reserved for the once-per-call `GeoMeta` conversion and the enum fallback
+/// arms; the per element paths use the direct maps above.
+fn mirror<S: serde::Serialize, T: serde::de::DeserializeOwned>(value: Option<&S>) -> Option<T> {
+    serde_json::to_value(value?)
+        .ok()
+        .and_then(|json| serde_json::from_value(json).ok())
+}

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -36,6 +36,7 @@
 //!
 
 pub mod diagnostics;
+pub mod geo;
 pub mod lowering;
 pub mod model;
 pub mod operating;
@@ -46,6 +47,7 @@ pub mod summary;
 pub mod validation;
 
 pub use diagnostics::{DiagnosticCode, DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
+pub use geo::{apply_dist_geo_layer, dist_geo_layer};
 pub use lowering::{
     LoweringRecord, MulticonductorToBalancedError, MulticonductorToBalancedLowering,
     MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -48,7 +48,7 @@ pub const PIO_PAYLOAD_BALANCED_SCHEMA_URL: &str =
 /// the minor; field moves or removals bump the major. Versioned independently
 /// of the envelope: [`PIO_PACKAGE_SCHEMA_VERSION`] covers the package
 /// bookkeeping, this covers the network tables a consumer computes on.
-pub const PIO_PAYLOAD_BALANCED_SCHEMA_VERSION: &str = "1.1.0";
+pub const PIO_PAYLOAD_BALANCED_SCHEMA_VERSION: &str = "1.2.0";
 
 /// The declared schema URL for the multiconductor payload
 /// (`model.multiconductor_network`).
@@ -57,7 +57,7 @@ pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_URL: &str =
 
 /// The multiconductor payload schema version (semver); the same policy as
 /// [`PIO_PAYLOAD_BALANCED_SCHEMA_VERSION`].
-pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.1.0";
+pub const PIO_PAYLOAD_MULTICONDUCTOR_SCHEMA_VERSION: &str = "1.2.0";
 
 pub const READ_TRANSMISSION_PARSE_WARNING: &str = "READ.TRANSMISSION.PARSE_WARNING";
 pub const READ_GRIDFM_FIDELITY_WARNING: &str = "READ.GRIDFM.FIDELITY_WARNING";

--- a/powerio-pkg/tests/geo.rs
+++ b/powerio-pkg/tests/geo.rs
@@ -1,0 +1,100 @@
+//! GeoLayer glue for the multiconductor model: extract and apply through
+//! `powerio-pkg`, where both model crates are visible.
+
+use powerio::{CoordinateSpace, CoordsKind, GeoLayer, GeoTarget};
+use powerio_pkg::{apply_dist_geo_layer, dist_geo_layer};
+
+const MASTER: &str = "New Circuit.c1 bus1=sourcebus basekv=12.47\n\
+     New Line.l1 bus1=sourcebus bus2=loadbus length=1 units=km\n";
+
+fn dist_network() -> powerio_dist::MulticonductorNetwork {
+    powerio_dist::parse_str(MASTER, "dss").expect("parse dss")
+}
+
+#[test]
+fn dist_layer_extracts_and_applies_by_name() {
+    let mut net = dist_network();
+    let bus_row = net
+        .buses
+        .iter()
+        .position(|bus| bus.id == "sourcebus")
+        .expect("sourcebus");
+    net.buses[bus_row].location = Some(powerio_dist::Location {
+        x: -89.6,
+        y: 40.6,
+        kind: Some(powerio_dist::CoordsKind::Manual),
+    });
+    net.lines[0].route = Some(vec![
+        powerio_dist::Location {
+            x: -89.6,
+            y: 40.6,
+            kind: None,
+        },
+        powerio_dist::Location {
+            x: -89.2,
+            y: 39.9,
+            kind: None,
+        },
+    ]);
+    net.geo = Some(powerio_dist::GeoMeta {
+        space: powerio_dist::CoordinateSpace::Geographic { crs: None },
+        kind: None,
+    });
+
+    let layer = dist_geo_layer(&net);
+    let point = layer
+        .features
+        .iter()
+        .find(|f| f.target == GeoTarget::Bus)
+        .expect("bus feature");
+    assert_eq!(point.key.id.as_deref(), Some("sourcebus"));
+    assert_eq!(point.key.uid.as_deref(), Some(&*format!("buses:{bus_row}")));
+    assert_eq!(point.kind, Some(CoordsKind::Manual));
+    let route = layer
+        .features
+        .iter()
+        .find(|f| f.target == GeoTarget::Branch)
+        .expect("line feature");
+    assert_eq!(route.key.name.as_deref(), Some("l1"));
+    assert_eq!(route.from.as_deref(), Some("sourcebus"));
+
+    // The canonical wire form round trips into a fresh parse of the same
+    // master, matching case insensitively on the OpenDSS names.
+    let round = GeoLayer::parse_bytes(layer.to_geojson().as_bytes(), None)
+        .expect("reparse")
+        .layer;
+    let mut bare = dist_network();
+    let report = apply_dist_geo_layer(&mut bare, &round);
+    assert_eq!(report.matched_buses, 1);
+    assert_eq!(report.matched_branches, 1);
+    assert_eq!(report.unmatched_features, 0);
+    let applied = bare.buses[bus_row].location.expect("applied location");
+    assert!((applied.x - -89.6).abs() < 1e-12);
+    assert_eq!(applied.kind, Some(powerio_dist::CoordsKind::Manual));
+    assert!(bare.lines[0].route.is_some());
+    assert!(matches!(
+        bare.geo.as_ref().expect("geo meta").space,
+        powerio_dist::CoordinateSpace::Geographic { .. }
+    ));
+}
+
+#[test]
+fn dist_apply_reads_a_buscoords_sidecar() {
+    let mut net = dist_network();
+    let parsed = GeoLayer::parse_bytes(b"SourceBus, -89.6, 40.6\nLoadBus, -89.2, 39.9\n", None)
+        .expect("parse buscoords");
+    assert!(matches!(
+        parsed.layer.space,
+        CoordinateSpace::Geographic { .. }
+    ));
+    let report = apply_dist_geo_layer(&mut net, &parsed.layer);
+    assert_eq!(report.matched_buses, 2);
+    assert!(
+        net.buses
+            .iter()
+            .find(|bus| bus.id == "loadbus")
+            .expect("loadbus")
+            .location
+            .is_some()
+    );
+}

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -591,6 +591,7 @@ fn read_branch(v: &Value) -> Result<Branch> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/format/goc3.rs
+++ b/powerio/src/format/goc3.rs
@@ -380,6 +380,7 @@ fn read_branches(
                 control: shifter_control(obj, transformer),
                 solution: None,
                 uid: item_uid(item, obj),
+                route: None,
                 extras: extras(
                     obj,
                     &[

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -208,6 +208,7 @@ pub(super) fn branch_row(row: &[f64], i: usize) -> Result<Branch> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -169,6 +169,10 @@ impl FromStr for TargetFormat {
 pub enum DisplayFormat {
     /// PowerWorld oneline display `.pwd`.
     PowerWorld,
+    /// The standalone geographic document ([`crate::geo::GeoLayer`]):
+    /// canonical `.geo.json`, read tolerantly from GeoJSON, aliased CSV/JSON
+    /// records, and headerless buscoords CSV.
+    GeoJson,
 }
 
 impl DisplayFormat {
@@ -177,6 +181,7 @@ impl DisplayFormat {
     pub fn extension(self) -> &'static str {
         match self {
             DisplayFormat::PowerWorld => "pwd",
+            DisplayFormat::GeoJson => crate::geo::GEO_LAYER_EXTENSION,
         }
     }
 
@@ -185,6 +190,7 @@ impl DisplayFormat {
     pub fn label(self) -> &'static str {
         match self {
             DisplayFormat::PowerWorld => "PowerWorld .pwd",
+            DisplayFormat::GeoJson => "geo layer",
         }
     }
 
@@ -193,6 +199,7 @@ impl DisplayFormat {
     pub fn token(self) -> &'static str {
         match self {
             DisplayFormat::PowerWorld => "powerworld-display",
+            DisplayFormat::GeoJson => "geojson",
         }
     }
 }
@@ -212,11 +219,13 @@ impl FromStr for DisplayFormat {
 }
 
 /// Map a display format name to a [`DisplayFormat`], or `None` if unrecognized.
-/// Accepts `pwd`, `powerworld-pwd`, and `powerworld-display`.
+/// Accepts `pwd`, `powerworld-pwd`, and `powerworld-display`; `geojson`,
+/// `geo-json`, and `geo` name the geographic layer.
 #[must_use]
 pub fn display_format_from_name(name: &str) -> Option<DisplayFormat> {
     Some(match name.to_ascii_lowercase().as_str() {
         "pwd" | "powerworld-pwd" | "powerworld-display" => DisplayFormat::PowerWorld,
+        "geojson" | "geo-json" | "geo" => DisplayFormat::GeoJson,
         _ => return None,
     })
 }
@@ -258,12 +267,15 @@ pub fn target_format_from_name(name: &str) -> Option<TargetFormat> {
 }
 
 /// Output of a display parse. PowerWorld `.pwd` produces
-/// [`DisplayData::PowerWorld`].
+/// [`DisplayData::PowerWorld`]; a geographic sidecar produces
+/// [`DisplayData::Geo`].
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum DisplayData {
     /// PowerWorld oneline display data.
     PowerWorld(PwdDisplay),
+    /// A standalone geographic layer.
+    Geo(crate::geo::GeoLayer),
 }
 
 impl DisplayData {
@@ -272,6 +284,7 @@ impl DisplayData {
     pub fn format(&self) -> DisplayFormat {
         match self {
             DisplayData::PowerWorld(_) => DisplayFormat::PowerWorld,
+            DisplayData::Geo(_) => DisplayFormat::GeoJson,
         }
     }
 }
@@ -296,6 +309,11 @@ pub fn parse_display_bytes(bytes: &[u8], format: &str) -> Result<DisplayData> {
         DisplayFormat::PowerWorld => Ok(DisplayData::PowerWorld(powerworld::parse_pwd_display(
             bytes,
         )?)),
+        // The tolerant reader's own notes are available through
+        // `GeoLayer::parse_bytes` for callers that want them.
+        DisplayFormat::GeoJson => Ok(DisplayData::Geo(
+            crate::geo::GeoLayer::parse_bytes(bytes, None)?.layer,
+        )),
     }
 }
 
@@ -323,6 +341,20 @@ pub fn parse_display_file(
             .as_deref()
         {
             Some("pwd") => DisplayFormat::PowerWorld,
+            Some("geojson") => DisplayFormat::GeoJson,
+            // `.geo.json` is the canonical layer name; a bare `.json` stays
+            // ambiguous (it is usually a case file).
+            Some("json")
+                if path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        name.to_ascii_lowercase()
+                            .ends_with(crate::geo::GEO_LAYER_EXTENSION)
+                    }) =>
+            {
+                DisplayFormat::GeoJson
+            }
             other => {
                 return Err(Error::UnknownFormat(format!(
                     "cannot infer display format from file extension {other:?}; \
@@ -336,6 +368,10 @@ pub fn parse_display_file(
         DisplayFormat::PowerWorld => Ok(DisplayData::PowerWorld(powerworld::parse_pwd_display(
             &bytes,
         )?)),
+        DisplayFormat::GeoJson => Ok(DisplayData::Geo(
+            crate::geo::GeoLayer::parse_bytes(&bytes, path.file_name().and_then(|n| n.to_str()))?
+                .layer,
+        )),
     }
 }
 
@@ -505,6 +541,26 @@ fn read_source(source: Arc<String>, fmt: TargetFormat, name_hint: Option<&str>) 
         network: net,
         warnings,
         document,
+    })
+}
+
+/// Geographic metadata for a reader that harvested longitude/latitude
+/// coordinates: `Some` once any bus carries a location, so a case without
+/// coordinates serializes exactly as before. The space is stamped geographic
+/// only when every point fits longitude/latitude bounds; a source that
+/// violates its format's own convention (projected meters in a pandapower
+/// `geo` column) reads as unknown instead of claiming WGS84.
+pub(crate) fn geographic_meta(buses: &[Bus]) -> Option<crate::geo::GeoMeta> {
+    let mut located = buses.iter().filter_map(|bus| bus.location).peekable();
+    located.peek()?;
+    let in_bounds = located.all(|location| location.x.abs() <= 180.0 && location.y.abs() <= 90.0);
+    Some(crate::geo::GeoMeta {
+        space: if in_bounds {
+            crate::geo::CoordinateSpace::Geographic { crs: None }
+        } else {
+            crate::geo::CoordinateSpace::Unknown
+        },
+        kind: None,
     })
 }
 
@@ -735,6 +791,7 @@ pub fn write_as(net: &Network, format: TargetFormat) -> Result<Conversion> {
     warn_normalized_tap(net, format, &mut conv);
     warn_missing_reference(net, format, &mut conv);
     warn_dropped_frequency(net, format, &mut conv);
+    warn_dropped_locations(net, format, &mut conv);
     warn_psse_downgrade(net, format, &mut conv);
     warn_dropped_transformer_charging(net, format, &mut conv);
     Ok(conv)
@@ -852,6 +909,31 @@ fn warn_dropped_frequency(net: &Network, format: TargetFormat, conv: &mut Conver
             net.base_frequency,
             format.label(),
             crate::network::DEFAULT_BASE_FREQUENCY
+        ));
+    }
+}
+
+/// Warn when the case carries bus locations and the target has no geometry
+/// concept. PowerWorld aux (`Latitude:1`/`Longitude:1`) and pandapower
+/// (`geo`) carry them, and the PyPSA folder writer (`x`/`y`) has its own
+/// path; MATPOWER, PSS/E, PowerModels, egret, PSLF, and Surge have nowhere to
+/// put them, matching the `base_frequency` behavior. `powerio geo extract`
+/// writes the sidecar as the escape hatch.
+fn warn_dropped_locations(net: &Network, format: TargetFormat, conv: &mut Conversion) {
+    let carries_locations = matches!(
+        format,
+        TargetFormat::PowerWorld | TargetFormat::PandapowerJson
+    );
+    if carries_locations {
+        return;
+    }
+    let n = net.buses.iter().filter(|b| b.location.is_some()).count();
+    let routed = net.branches.iter().filter(|b| b.route.is_some()).count();
+    if n > 0 || routed > 0 {
+        conv.warnings.push(format!(
+            "{n} bus location(s) and {routed} branch route(s) dropped: {} has no \
+             coordinate field (write a .geo.json sidecar to keep them)",
+            format.label()
         ));
     }
 }

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -121,7 +121,7 @@ pub(crate) fn parse_pandapower_source(
             zone: row.usize_or("zone", 1),
             name: row.string("name"),
             uid: None,
-            location: None,
+            location: read_bus_geo(row.get("geo")),
             extras: Extras::default(),
         });
     }
@@ -359,6 +359,7 @@ pub(crate) fn parse_pandapower_source(
                 control: None,
                 solution: None,
                 uid: None,
+                route: None,
                 extras: Extras::default(),
             });
         }
@@ -495,6 +496,7 @@ pub(crate) fn parse_pandapower_source(
                 control: None,
                 solution: None,
                 uid: None,
+                route: None,
                 extras: Extras::default(),
             });
         }
@@ -635,7 +637,7 @@ pub(crate) fn parse_pandapower_source(
         name,
         base_mva,
         base_frequency: f_hz,
-        geo: None,
+        geo: super::geographic_meta(&buses),
         buses,
         loads,
         shunts,
@@ -878,7 +880,7 @@ fn bus_frame(net: &Network, warnings: &mut Vec<String>) -> Value {
             Value::String("b".into()),
             Value::from(b.zone as u64),
             Value::Bool(b.kind != BusType::Isolated),
-            Value::Null,
+            write_bus_geo(b.location),
             jnum(b.vmin),
             jnum(b.vmax),
         ]);
@@ -1599,6 +1601,45 @@ impl Row<'_> {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     }
+}
+
+/// The written `geo` cell: pandapower 3 stores a GeoJSON Point string per
+/// bus, null when the bus has no location. A non-finite coordinate has no
+/// GeoJSON representation and writes null too. The fixed shape is formatted
+/// directly; a `Value` tree per bus would be needless churn.
+fn write_bus_geo(location: Option<crate::geo::Location>) -> Value {
+    match location {
+        Some(location) if location.x.is_finite() && location.y.is_finite() => {
+            Value::String(format!(
+                r#"{{"type": "Point", "coordinates": [{}, {}]}}"#,
+                location.x, location.y
+            ))
+        }
+        _ => Value::Null,
+    }
+}
+
+/// The bus `geo` cell: a GeoJSON Point, serialized as a string (pandapower 3)
+/// or carried as an object. Anything else (null, LineStrings, malformed
+/// JSON) reads as no location.
+fn read_bus_geo(cell: Option<&Value>) -> Option<crate::geo::Location> {
+    let cell = cell?;
+    let owned;
+    let geometry = match cell {
+        Value::String(text) => {
+            owned = serde_json::from_str::<Value>(text).ok()?;
+            &owned
+        }
+        Value::Object(_) => cell,
+        _ => return None,
+    };
+    if geometry.get("type").and_then(Value::as_str) != Some("Point") {
+        return None;
+    }
+    let coordinates = geometry.get("coordinates")?.as_array()?;
+    let x = coordinates.first().and_then(value_f64)?;
+    let y = coordinates.get(1).and_then(value_f64)?;
+    (x.is_finite() && y.is_finite()).then_some(crate::geo::Location { x, y, kind: None })
 }
 
 fn read_frame(root: &Map<String, Value>, name: &str) -> Result<Option<DataFrame>> {
@@ -2889,6 +2930,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -689,6 +689,7 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64) -> Branch {
             qt: f(v, "qt") * pscale,
         }),
         uid: None,
+        route: None,
         extras: extras_excluding(
             v,
             &[

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -144,7 +144,7 @@ pub(crate) fn parse_powerworld_source(
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
-        geo: None,
+        geo: super::super::geographic_meta(&buses),
         buses,
         loads,
         shunts,
@@ -433,15 +433,16 @@ fn read_bus(r: &Row) -> Result<Bus> {
         })? as usize;
     let name = first(r, &["BusName", "Name"]).map(ToString::to_string);
     let mut extras = Extras::new();
-    // Substation identity and coordinates ride on the bus row in complete
-    // case exports (`Latitude:1`/`Longitude:1` are the substation's).
+    // Substation identity rides on the bus row in complete case exports.
+    // The substation coordinates (`Latitude:1`/`Longitude:1`) promote into
+    // the typed location and leave extras; `SubNum` stays, it is identity
+    // rather than geometry, as do the bus's own bare `Latitude`/`Longitude`.
+    let location = bus_location(r);
     keep_extras(
         r,
         &[
             "SubNum",
             "SubNumber",
-            "Latitude:1",
-            "Longitude:1",
             "Latitude",
             "Longitude",
             "OwnerNum",
@@ -450,6 +451,9 @@ fn read_bus(r: &Row) -> Result<Bus> {
         ],
         &mut extras,
     );
+    if location.is_none() {
+        keep_extras(r, &["Latitude:1", "Longitude:1"], &mut extras);
+    }
     Ok(Bus {
         id: BusId(id),
         kind: bus_kind(r),
@@ -467,8 +471,20 @@ fn read_bus(r: &Row) -> Result<Bus> {
         zone: uid_alias(r, &["ZoneNum", "ZoneNumber"])?,
         name,
         uid: None,
-        location: None,
+        location,
         extras,
+    })
+}
+
+/// The promoted geographic location: the substation `Latitude:1`/
+/// `Longitude:1` pair, when both parse finite.
+fn bus_location(r: &Row) -> Option<crate::geo::Location> {
+    let lat = first(r, &["Latitude:1"])?.parse::<f64>().ok()?;
+    let lon = first(r, &["Longitude:1"])?.parse::<f64>().ok()?;
+    (lat.is_finite() && lon.is_finite()).then_some(crate::geo::Location {
+        x: lon,
+        y: lat,
+        kind: None,
     })
 }
 
@@ -608,6 +624,7 @@ fn read_branch(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Branch> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras,
     })
 }
@@ -648,10 +665,19 @@ pub fn write_powerworld(net: &Network) -> Conversion {
     let _ = writeln!(s, "// baseMVA {}", net.base_mva);
     let _ = writeln!(s);
 
+    // The coordinate columns appear only when the case carries locations, so
+    // a case without geometry writes exactly as before. A located case still
+    // writes `""` for the odd bus without a point; the reader leaves those
+    // unpromoted.
+    let write_locations = net.buses.iter().any(|b| b.location.is_some());
     block(
         &mut s,
         "Bus",
-        "[BusNum, BusName, BusNomVolt, BusPUVolt, BusAngle, AreaNum, ZoneNum, BusVMax, BusVMin, BusCat]",
+        if write_locations {
+            "[BusNum, BusName, BusNomVolt, BusPUVolt, BusAngle, AreaNum, ZoneNum, BusVMax, BusVMin, BusCat, Latitude:1, Longitude:1]"
+        } else {
+            "[BusNum, BusName, BusNomVolt, BusPUVolt, BusAngle, AreaNum, ZoneNum, BusVMax, BusVMin, BusCat]"
+        },
         |rows| {
             for b in &net.buses {
                 let raw_name = b.name.as_deref().unwrap_or("");
@@ -659,7 +685,7 @@ pub fn write_powerworld(net: &Network) -> Conversion {
                 if matches!(name, std::borrow::Cow::Owned(_)) {
                     sanitized_names += 1;
                 }
-                rows.push(format!(
+                let mut row = format!(
                     "{} \"{}\" {} {} {} {} {} {} {} \"{}\"",
                     b.id,
                     name,
@@ -671,7 +697,16 @@ pub fn write_powerworld(net: &Network) -> Conversion {
                     n(b.vmax),
                     n(b.vmin),
                     bus_cat(b.kind)
-                ));
+                );
+                if write_locations {
+                    match b.location {
+                        Some(location) => {
+                            let _ = write!(row, " {} {}", n(location.y), n(location.x));
+                        }
+                        None => row.push_str(" \"\" \"\""),
+                    }
+                }
+                rows.push(row);
             }
         },
     );

--- a/powerio/src/format/powerworld/pwb.rs
+++ b/powerio/src/format/powerworld/pwb.rs
@@ -1764,6 +1764,7 @@ fn read_standard_branch_head(
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras,
     };
     Ok((br, c.pos, flags))
@@ -1850,6 +1851,7 @@ fn read_step_up_transformer_head(
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras,
     };
     Ok((

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -522,6 +522,7 @@ fn read_branch(rec: &Record) -> Result<Branch> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras,
     })
 }
@@ -641,6 +642,7 @@ fn read_transformer(rec: &Record) -> Result<TransformerRecord> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         extras,
     }))
 }
@@ -1858,6 +1860,7 @@ end
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         });
 

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -1868,6 +1868,7 @@ fn read_branch(f: &[String], raw_rev: u32) -> Result<Branch> {
         control: None,
         solution: None,
         uid: None,
+        route: None,
         // Capture CKT (field 2) so parallel circuits stay distinct on write-back.
         extras: device_extras(f, 2),
     })
@@ -1962,6 +1963,7 @@ fn read_transformer(
         control,
         solution: None,
         uid: None,
+        route: None,
         extras: Extras::new(),
     })
 }
@@ -2350,6 +2352,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::default(),
         }
     }
@@ -2375,6 +2378,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -106,7 +106,15 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
             zone: 1,
             name: bus_name,
             uid: None,
-            location: None,
+            // PyPSA `x`/`y` are longitude/latitude; both must be present, so
+            // a folder without the columns keeps `location = None`.
+            location: match (
+                row.f("x").filter(|v| v.is_finite()),
+                row.f("y").filter(|v| v.is_finite()),
+            ) {
+                (Some(x), Some(y)) => Some(crate::geo::Location { x, y, kind: None }),
+                _ => None,
+            },
             extras: Extras::default(),
         });
     }
@@ -234,6 +242,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 control: None,
                 solution: None,
                 uid: None,
+                route: None,
                 extras: Extras::default(),
             });
         }
@@ -280,6 +289,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
                 control: None,
                 solution: None,
                 uid: None,
+                route: None,
                 extras: Extras::default(),
             });
         }
@@ -400,7 +410,7 @@ fn read_pypsa_csv_folder_inner(path: &Path, warnings: &mut Vec<String>) -> Resul
         name,
         base_mva,
         base_frequency: crate::network::DEFAULT_BASE_FREQUENCY,
-        geo: None,
+        geo: super::geographic_meta(&buses),
         buses,
         loads,
         shunts,
@@ -652,9 +662,18 @@ fn network_csv(net: &Network) -> String {
 }
 
 fn buses_csv(net: &Network, key_of: &HashMap<BusId, String>) -> String {
-    let mut s = String::from("name,v_nom,v_mag_pu_set,v_mag_pu_min,v_mag_pu_max\n");
+    // The coordinate columns appear only when the case carries locations, so
+    // a case without geometry writes exactly as before. PyPSA defaults a
+    // missing cell to 0, so a located case writes empty cells for the odd
+    // bus without a point.
+    let write_locations = net.buses.iter().any(|b| b.location.is_some());
+    let mut s = String::from(if write_locations {
+        "name,v_nom,v_mag_pu_set,v_mag_pu_min,v_mag_pu_max,x,y\n"
+    } else {
+        "name,v_nom,v_mag_pu_set,v_mag_pu_min,v_mag_pu_max\n"
+    });
     for b in &net.buses {
-        let _ = writeln!(
+        let _ = write!(
             s,
             "{},{},{},{},{}",
             key_for(key_of, b.id),
@@ -663,6 +682,15 @@ fn buses_csv(net: &Network, key_of: &HashMap<BusId, String>) -> String {
             b.vmin,
             b.vmax
         );
+        if write_locations {
+            match b.location {
+                Some(location) => {
+                    let _ = write!(s, ",{},{}", location.x, location.y);
+                }
+                None => s.push_str(",,"),
+            }
+        }
+        s.push('\n');
     }
     s
 }
@@ -1204,6 +1232,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::default(),
         }
     }
@@ -1229,6 +1258,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::default(),
         }
     }

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -721,6 +721,7 @@ fn read_branch(value: &Value) -> Result<Branch> {
         control: None,
         solution: read_branch_solution(obj)?,
         uid: None,
+        route: None,
         extras: Extras::new(),
     })
 }

--- a/powerio/src/geo/layer.rs
+++ b/powerio/src/geo/layer.rs
@@ -1,0 +1,1065 @@
+//! The standalone geographic document.
+//!
+//! Coordinates arrive and leave as files of their own: a `Buscoords` CSV next
+//! to a DSS master, a GeoJSON export from a GIS tool, a layout computed by a
+//! renderer. [`GeoLayer`] is the container. Reading is tolerant (headerless
+//! buscoords CSV, aliased CSV/JSON records, GeoJSON Point/LineString); writing
+//! is canonical (a GeoJSON FeatureCollection with the `powerio_geo` foreign
+//! member). The reader takes bytes plus a name hint and touches no filesystem,
+//! so wasm consumers parse untrusted browser input through it directly.
+
+use std::collections::HashMap;
+
+use serde_json::{Map, Value, json};
+
+use super::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};
+use crate::network::{BusId, Network};
+use crate::{Error, Result};
+
+/// Version of the `powerio_geo` foreign member this crate writes.
+pub const GEO_LAYER_VERSION: &str = "0.1.0";
+
+/// Suggested extension for the canonical document.
+pub const GEO_LAYER_EXTENSION: &str = "geo.json";
+
+const FMT: &str = "geo layer";
+
+/// A standalone geographic document: element points and routes in one
+/// coordinate space, keyed by element identity rather than embedded in a case.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeoLayer {
+    /// Coordinate space of every feature.
+    pub space: CoordinateSpace,
+    /// Default provenance, stamped into the `powerio_geo` member on write.
+    pub kind: Option<CoordsKind>,
+    pub features: Vec<GeoFeature>,
+}
+
+/// One point or route in a [`GeoLayer`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeoFeature {
+    pub target: GeoTarget,
+    pub key: ElementKey,
+    pub geometry: GeoGeometry,
+    /// Endpoint bus references for a branch, the unordered fallback identity.
+    pub from: Option<String>,
+    pub to: Option<String>,
+    /// Per feature provenance when it differs from the layer default.
+    pub kind: Option<CoordsKind>,
+}
+
+/// The element family a feature places.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GeoTarget {
+    Bus,
+    Branch,
+    /// PowerWorld substations, joined onto buses through the `SubNum` extras
+    /// key by [`super::apply_substation_points`].
+    Substation,
+}
+
+impl GeoTarget {
+    fn token(self) -> &'static str {
+        match self {
+            GeoTarget::Bus => "bus",
+            GeoTarget::Branch => "branch",
+            GeoTarget::Substation => "substation",
+        }
+    }
+}
+
+/// Feature geometry: a point or a polyline route.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GeoGeometry {
+    Point([f64; 2]),
+    LineString(Vec<[f64; 2]>),
+}
+
+/// Element identity for one feature. Matching tries `uid`, then `id`, then
+/// case insensitive `name`; branches additionally fall back to the unordered
+/// `(from, to)` bus pair. `index` is a positional row alias (1-based, the
+/// MATPOWER row convention) accepted on read and never written; the durable
+/// identity is the payload `uid` (`buses:3`, `branches:7`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ElementKey {
+    pub uid: Option<String>,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub index: Option<usize>,
+}
+
+/// Output of a tolerant geo read: the layer plus the reader's notes on
+/// records it could not use.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct GeoParsed {
+    pub layer: GeoLayer,
+    pub warnings: Vec<String>,
+}
+
+/// Result of applying a [`GeoLayer`] to a network.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
+pub struct GeoApplyReport {
+    pub matched_buses: usize,
+    pub matched_branches: usize,
+    pub unmatched_features: usize,
+    pub notes: Vec<String>,
+}
+
+impl GeoLayer {
+    /// Tolerant read of a geographic sidecar from bytes. `name_hint` (a file
+    /// name) picks CSV against JSON when present; otherwise the content is
+    /// sniffed. Accepts headerless buscoords CSV (`bus,x,y`), CSV and JSON
+    /// records with aliased field names, and GeoJSON Point/LineString
+    /// features. Rejects input carrying no usable coordinates.
+    pub fn parse_bytes(bytes: &[u8], name_hint: Option<&str>) -> Result<GeoParsed> {
+        // Windows exports lead with a UTF-8 BOM; serde_json rejects it.
+        let bytes = bytes
+            .strip_prefix(b"\xef\xbb\xbf".as_slice())
+            .unwrap_or(bytes);
+        let mut parsed = GeoParsed {
+            layer: GeoLayer {
+                space: CoordinateSpace::Unknown,
+                kind: None,
+                features: Vec::new(),
+            },
+            warnings: Vec::new(),
+        };
+        let mut declared_space = false;
+        let hint_ext = name_hint
+            .and_then(|name| name.rsplit('.').next())
+            .map(str::to_ascii_lowercase);
+        let looks_json = match hint_ext.as_deref() {
+            Some("csv") => false,
+            Some("json" | "geojson") => true,
+            _ => sniff_json(bytes),
+        };
+        if looks_json {
+            let value: Value = serde_json::from_slice(bytes)
+                .map_err(|error| bad(format!("invalid JSON: {error}")))?;
+            if let Some(features) = feature_collection(&value) {
+                declared_space = read_powerio_geo_member(&value, &mut parsed.layer);
+                for feature in features {
+                    read_geojson_feature(feature, &mut parsed);
+                }
+            } else {
+                let mut records = Vec::new();
+                collect_records(&value, &mut records);
+                for record in records {
+                    read_record(&record, &mut parsed);
+                }
+            }
+        } else {
+            let text = String::from_utf8_lossy(bytes);
+            read_csv(&text, &mut parsed);
+        }
+        if parsed.layer.features.is_empty() {
+            return Err(bad("no bus coordinates or branch routes found"));
+        }
+        if !declared_space {
+            parsed.layer.space = inferred_space(&parsed.layer);
+        }
+        Ok(parsed)
+    }
+
+    /// Serialize the canonical wire form: a GeoJSON FeatureCollection with the
+    /// `powerio_geo` foreign member. Valid RFC 7946 GeoJSON when the space is
+    /// geographic, so GIS tools open it directly.
+    #[must_use]
+    pub fn to_geojson(&self) -> String {
+        let mut member = Map::new();
+        member.insert("version".to_owned(), json!(GEO_LAYER_VERSION));
+        let detail = match &self.space {
+            CoordinateSpace::Geographic { crs } | CoordinateSpace::Projected { crs } => {
+                crs.as_ref().map(crs_entry)
+            }
+            CoordinateSpace::Diagram { canvas } => canvas.as_ref().map(canvas_entry),
+            _ => None,
+        };
+        member.insert("space".to_owned(), json!(self.space.token()));
+        if let Some((key, value)) = detail {
+            member.insert(key.to_owned(), value);
+        }
+        if let Some(kind) = self.kind {
+            member.insert("kind".to_owned(), kind_value(kind));
+        }
+        let features: Vec<Value> = self.features.iter().map(feature_value).collect();
+        let document = json!({
+            "type": "FeatureCollection",
+            "powerio_geo": Value::Object(member),
+            "features": features,
+        });
+        // Serializing an in-memory `Value` does not fail; `Display` is the
+        // infallible (compact) fallback.
+        serde_json::to_string_pretty(&document).unwrap_or_else(|_| document.to_string())
+    }
+}
+
+fn crs_entry(crs: &String) -> (&'static str, Value) {
+    ("crs", json!(crs))
+}
+
+fn canvas_entry(canvas: &Canvas) -> (&'static str, Value) {
+    (
+        "canvas",
+        serde_json::to_value(canvas).unwrap_or(Value::Null),
+    )
+}
+
+fn kind_value(kind: CoordsKind) -> Value {
+    serde_json::to_value(kind).unwrap_or(Value::Null)
+}
+
+fn feature_value(feature: &GeoFeature) -> Value {
+    let mut properties = Map::new();
+    properties.insert("target".to_owned(), json!(feature.target.token()));
+    if let Some(uid) = &feature.key.uid {
+        properties.insert("uid".to_owned(), json!(uid));
+    }
+    if let Some(id) = &feature.key.id {
+        properties.insert("id".to_owned(), json!(id));
+    }
+    if let Some(name) = &feature.key.name {
+        properties.insert("name".to_owned(), json!(name));
+    }
+    if let Some(from) = &feature.from {
+        properties.insert("from".to_owned(), json!(from));
+    }
+    if let Some(to) = &feature.to {
+        properties.insert("to".to_owned(), json!(to));
+    }
+    if let Some(kind) = feature.kind {
+        properties.insert("kind".to_owned(), kind_value(kind));
+    }
+    let geometry = match &feature.geometry {
+        GeoGeometry::Point(point) => json!({"type": "Point", "coordinates": point}),
+        GeoGeometry::LineString(path) => json!({"type": "LineString", "coordinates": path}),
+    };
+    json!({"type": "Feature", "geometry": geometry, "properties": Value::Object(properties)})
+}
+
+// ---------------------------------------------------------------------------
+// Tolerant reading
+// ---------------------------------------------------------------------------
+
+/// Alias tables, matched on keys normalized to lowercase alphanumeric. These
+/// port the sidecar vocabulary tellegen's renderer accepted, so a file that
+/// loaded there loads here.
+const BUS_ID_ALIASES: &[&str] = &["busi", "bus", "busid", "busnumber", "number", "id"];
+const LAT_ALIASES: &[&str] = &["lat", "latitude", "y"];
+const LON_ALIASES: &[&str] = &["lon", "lng", "longitude", "x"];
+const FROM_ALIASES: &[&str] = &["fbus", "from", "frombus"];
+const TO_ALIASES: &[&str] = &["tbus", "to", "tobus"];
+const BRANCH_ID_ALIASES: &[&str] = &["branch", "branchid", "branchnumber", "catsid", "id"];
+const PATH_ALIASES: &[&str] = &["path", "geometry", "coordinates"];
+const FROM_LAT_ALIASES: &[&str] = &["lat1", "fromlat"];
+const FROM_LON_ALIASES: &[&str] = &["lon1", "lng1", "fromlon", "fromlng"];
+const TO_LAT_ALIASES: &[&str] = &["lat2", "tolat"];
+const TO_LON_ALIASES: &[&str] = &["lon2", "lng2", "tolon", "tolng"];
+const NAME_ALIASES: &[&str] = &["name", "busname"];
+
+fn bad(message: impl Into<String>) -> Error {
+    Error::FormatRead {
+        format: FMT,
+        message: message.into(),
+    }
+}
+
+fn sniff_json(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace() && *byte != 0xEF && *byte != 0xBB && *byte != 0xBF)
+        .is_some_and(|byte| byte == b'{' || byte == b'[')
+}
+
+fn normalize_key(key: &str) -> String {
+    key.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// A record read from CSV or JSON, with normalized keys.
+struct Record {
+    fields: HashMap<String, Value>,
+}
+
+impl Record {
+    fn value(&self, aliases: &[&str]) -> Option<&Value> {
+        aliases.iter().find_map(|alias| self.fields.get(*alias))
+    }
+
+    fn number(&self, aliases: &[&str]) -> Option<f64> {
+        value_number(self.value(aliases)?)
+    }
+
+    fn string(&self, aliases: &[&str]) -> Option<String> {
+        match self.value(aliases)? {
+            Value::String(text) => {
+                let trimmed = text.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_owned())
+            }
+            Value::Number(number) => Some(number.to_string()),
+            _ => None,
+        }
+    }
+}
+
+fn value_number(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(number) => number.as_f64().filter(|v| v.is_finite()),
+        Value::String(text) => {
+            let trimmed = text.trim().trim_matches(|c| c == '\'' || c == '"');
+            trimmed.parse::<f64>().ok().filter(|v| v.is_finite())
+        }
+        _ => None,
+    }
+}
+
+fn feature_collection(value: &Value) -> Option<&Vec<Value>> {
+    value.get("features")?.as_array()
+}
+
+/// Read the `powerio_geo` foreign member into the layer; `true` when a space
+/// was declared.
+fn read_powerio_geo_member(value: &Value, layer: &mut GeoLayer) -> bool {
+    let Some(member) = value.get("powerio_geo").and_then(Value::as_object) else {
+        return false;
+    };
+    layer.kind = member.get("kind").and_then(read_kind);
+    let crs = member.get("crs").and_then(Value::as_str).map(str::to_owned);
+    let canvas = member
+        .get("canvas")
+        .and_then(|canvas| serde_json::from_value(canvas.clone()).ok());
+    match member.get("space").and_then(Value::as_str) {
+        Some("geographic") => layer.space = CoordinateSpace::Geographic { crs },
+        Some("projected") => layer.space = CoordinateSpace::Projected { crs },
+        Some("diagram") => layer.space = CoordinateSpace::Diagram { canvas },
+        Some(_) => layer.space = CoordinateSpace::Unknown,
+        None => return false,
+    }
+    true
+}
+
+fn read_kind(value: &Value) -> Option<CoordsKind> {
+    serde_json::from_value(value.clone()).ok()
+}
+
+fn read_geojson_feature(feature: &Value, parsed: &mut GeoParsed) {
+    let Some(geometry) = feature.get("geometry").and_then(Value::as_object) else {
+        return;
+    };
+    let properties = feature
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let record = Record {
+        fields: properties
+            .into_iter()
+            .map(|(key, value)| (normalize_key(&key), value))
+            .collect(),
+    };
+    let target = record.string(&["target"]);
+    let kind = record.value(&["kind"]).and_then(read_kind);
+    match geometry.get("type").and_then(Value::as_str) {
+        Some("Point") => {
+            let Some(point) = geometry.get("coordinates").and_then(coordinate) else {
+                parsed
+                    .warnings
+                    .push("skipped a Point feature with unusable coordinates".to_owned());
+                return;
+            };
+            let target = match target.as_deref() {
+                Some("substation") => GeoTarget::Substation,
+                _ => GeoTarget::Bus,
+            };
+            parsed.layer.features.push(GeoFeature {
+                target,
+                key: point_key(&record),
+                geometry: GeoGeometry::Point(point),
+                from: None,
+                to: None,
+                kind,
+            });
+        }
+        Some("LineString") => {
+            let path = geometry
+                .get("coordinates")
+                .and_then(Value::as_array)
+                .map(|raw| coordinate_path(raw))
+                .unwrap_or_default();
+            if path.len() < 2 {
+                parsed
+                    .warnings
+                    .push("skipped a LineString feature with fewer than 2 points".to_owned());
+                return;
+            }
+            push_branch_feature(&record, path, parsed);
+        }
+        Some(other) => {
+            // Truncate the echoed type name: it is attacker controlled, and
+            // unbounded distinct warnings would defeat the dedup below.
+            let shown: String = other.chars().take(32).collect();
+            push_once(
+                &mut parsed.warnings,
+                format!("skipped unsupported GeoJSON geometry `{shown}`"),
+            );
+        }
+        None => {}
+    }
+}
+
+/// Key for a point record: the payload `uid`, an aliased id, and a name.
+fn point_key(record: &Record) -> ElementKey {
+    ElementKey {
+        uid: record.string(&["uid"]),
+        id: record.string(BUS_ID_ALIASES),
+        name: record.string(NAME_ALIASES),
+        index: None,
+    }
+}
+
+/// Key for a branch record. A bare unsigned integer id is a positional row
+/// alias (read only); everything else matches by string id or name.
+fn branch_key(record: &Record) -> ElementKey {
+    let id = record.string(BRANCH_ID_ALIASES);
+    let index = id
+        .as_deref()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|_| record.string(&["uid"]).is_none());
+    ElementKey {
+        uid: record.string(&["uid"]),
+        id,
+        name: record.string(NAME_ALIASES),
+        index,
+    }
+}
+
+fn push_branch_feature(record: &Record, path: Vec<[f64; 2]>, parsed: &mut GeoParsed) {
+    let from = record.string(FROM_ALIASES);
+    let to = record.string(TO_ALIASES);
+    let key = branch_key(record);
+    if key.uid.is_none()
+        && key.id.is_none()
+        && key.name.is_none()
+        && (from.is_none() || to.is_none())
+    {
+        push_once(
+            &mut parsed.warnings,
+            "skipped a branch route with no id, uid, name, or endpoint pair".to_owned(),
+        );
+        return;
+    }
+    parsed.layer.features.push(GeoFeature {
+        target: GeoTarget::Branch,
+        key,
+        geometry: GeoGeometry::LineString(path),
+        from,
+        to,
+        kind: record.value(&["kind"]).and_then(read_kind),
+    });
+}
+
+fn coordinate(raw: &Value) -> Option<[f64; 2]> {
+    let items = raw.as_array()?;
+    let x = value_number(items.first()?)?;
+    let y = value_number(items.get(1)?)?;
+    Some([x, y])
+}
+
+fn coordinate_path(raw: &[Value]) -> Vec<[f64; 2]> {
+    raw.iter().filter_map(coordinate).collect()
+}
+
+/// Flatten arbitrary JSON into candidate records: arrays recurse, an object
+/// whose values contain arrays of objects yields those, and a plain object is
+/// itself one record. Depth is bounded by the parsed document.
+fn collect_records(value: &Value, out: &mut Vec<Record>) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                collect_records(item, out);
+            }
+        }
+        Value::Object(object) => {
+            let before = out.len();
+            for nested in object.values() {
+                if let Value::Array(items) = nested {
+                    for item in items {
+                        if item.is_object() {
+                            collect_records(item, out);
+                        }
+                    }
+                }
+            }
+            if out.len() == before {
+                out.push(Record {
+                    fields: object
+                        .iter()
+                        .map(|(key, value)| (normalize_key(key), value.clone()))
+                        .collect(),
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+/// One aliased record can carry a bus point, a branch route, or both.
+fn read_record(record: &Record, parsed: &mut GeoParsed) {
+    read_point_record(record, parsed);
+    read_branch_record(record, parsed);
+}
+
+fn read_point_record(record: &Record, parsed: &mut GeoParsed) {
+    let key = point_key(record);
+    if key.uid.is_none() && key.id.is_none() && key.name.is_none() {
+        return;
+    }
+    let (Some(lon), Some(lat)) = (record.number(LON_ALIASES), record.number(LAT_ALIASES)) else {
+        return;
+    };
+    parsed.layer.features.push(GeoFeature {
+        target: GeoTarget::Bus,
+        key,
+        geometry: GeoGeometry::Point([lon, lat]),
+        from: None,
+        to: None,
+        kind: None,
+    });
+}
+
+fn read_branch_record(record: &Record, parsed: &mut GeoParsed) {
+    let path = record_path(record);
+    if path.len() < 2 {
+        return;
+    }
+    push_branch_feature(record, path, parsed);
+}
+
+fn record_path(record: &Record) -> Vec<[f64; 2]> {
+    if let Some(Value::Array(raw)) = record.value(PATH_ALIASES) {
+        return coordinate_path(raw);
+    }
+    let endpoints = (
+        record.number(FROM_LON_ALIASES),
+        record.number(FROM_LAT_ALIASES),
+        record.number(TO_LON_ALIASES),
+        record.number(TO_LAT_ALIASES),
+    );
+    if let (Some(lon1), Some(lat1), Some(lon2), Some(lat2)) = endpoints {
+        return vec![[lon1, lat1], [lon2, lat2]];
+    }
+    Vec::new()
+}
+
+// ---------------------------------------------------------------------------
+// CSV
+// ---------------------------------------------------------------------------
+
+fn read_csv(text: &str, parsed: &mut GeoParsed) {
+    let rows = csv_rows(text);
+    let Some(first) = rows.first() else { return };
+    let has_header = first
+        .iter()
+        .any(|cell| is_known_alias(&normalize_key(cell)));
+    if has_header {
+        let headers: Vec<String> = first.iter().map(|cell| normalize_key(cell)).collect();
+        for cells in &rows[1..] {
+            let record = Record {
+                fields: headers
+                    .iter()
+                    .zip(cells)
+                    .map(|(header, cell)| (header.clone(), Value::String(cell.clone())))
+                    .collect(),
+            };
+            read_record(&record, parsed);
+        }
+    } else {
+        // Headerless buscoords: `bus, x, y` (the OpenDSS sidecar layout).
+        for cells in &rows {
+            read_buscoords_row(cells, parsed);
+        }
+    }
+}
+
+fn is_known_alias(normalized: &str) -> bool {
+    [
+        BUS_ID_ALIASES,
+        LAT_ALIASES,
+        LON_ALIASES,
+        FROM_ALIASES,
+        TO_ALIASES,
+        BRANCH_ID_ALIASES,
+        PATH_ALIASES,
+        NAME_ALIASES,
+        FROM_LAT_ALIASES,
+        FROM_LON_ALIASES,
+        TO_LAT_ALIASES,
+        TO_LON_ALIASES,
+        &["uid", "target", "kind"],
+    ]
+    .iter()
+    .any(|aliases| aliases.contains(&normalized))
+}
+
+fn read_buscoords_row(cells: &[String], parsed: &mut GeoParsed) {
+    // Buscoords in the wild are comma or whitespace separated; a row that
+    // arrived as one comma-free cell splits on whitespace.
+    let split: Vec<String>;
+    let cells = if cells.len() == 1 && cells[0].split_whitespace().count() >= 3 {
+        split = cells[0].split_whitespace().map(str::to_owned).collect();
+        &split
+    } else {
+        cells
+    };
+    if cells.len() < 3 {
+        push_once(
+            &mut parsed.warnings,
+            "skipped a buscoords row with fewer than 3 columns".to_owned(),
+        );
+        return;
+    }
+    let bus = cells[0].trim();
+    let x = cells[1]
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite());
+    let y = cells[2]
+        .trim()
+        .parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite());
+    let (Some(x), Some(y)) = (x, y) else {
+        push_once(
+            &mut parsed.warnings,
+            "skipped a buscoords row with unparseable coordinates".to_owned(),
+        );
+        return;
+    };
+    if bus.is_empty() {
+        return;
+    }
+    parsed.layer.features.push(GeoFeature {
+        target: GeoTarget::Bus,
+        key: ElementKey {
+            uid: None,
+            id: Some(bus.to_owned()),
+            name: Some(bus.to_owned()),
+            index: None,
+        },
+        geometry: GeoGeometry::Point([x, y]),
+        from: None,
+        to: None,
+        kind: None,
+    });
+}
+
+/// RFC-style quoted CSV split into trimmed cells; blank rows dropped.
+/// Deliberately separate from the strict case-file CSV reader in
+/// `format::pypsa`: this one parses untrusted sidecars, so malformed quoting
+/// degrades instead of erroring.
+fn csv_rows(text: &str) -> Vec<Vec<String>> {
+    let mut rows = Vec::new();
+    let mut row: Vec<String> = Vec::new();
+    let mut cell = String::new();
+    let mut quoted = false;
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        if quoted {
+            if c == '"' && chars.peek() == Some(&'"') {
+                cell.push('"');
+                chars.next();
+            } else if c == '"' {
+                quoted = false;
+            } else {
+                cell.push(c);
+            }
+            continue;
+        }
+        match c {
+            '"' => quoted = true,
+            ',' => {
+                row.push(std::mem::take(&mut cell));
+                cell.clear();
+            }
+            '\n' => {
+                row.push(std::mem::take(&mut cell));
+                rows.push(std::mem::take(&mut row));
+            }
+            '\r' => {}
+            _ => cell.push(c),
+        }
+    }
+    if !cell.is_empty() || !row.is_empty() {
+        row.push(cell);
+        rows.push(row);
+    }
+    rows.retain(|row| row.iter().any(|cell| !cell.trim().is_empty()));
+    for row in &mut rows {
+        for cell in row.iter_mut() {
+            // Reallocate only when there is whitespace to strip.
+            let trimmed = cell.trim();
+            if trimmed.len() != cell.len() {
+                *cell = trimmed.to_owned();
+            }
+        }
+    }
+    rows
+}
+
+/// Without a declared space, coordinates that all fit longitude and latitude
+/// bounds read as geographic; anything else stays unknown.
+fn inferred_space(layer: &GeoLayer) -> CoordinateSpace {
+    let mut points = layer.features.iter().flat_map(|feature| {
+        let slice: &[[f64; 2]] = match &feature.geometry {
+            GeoGeometry::Point(point) => std::slice::from_ref(point),
+            GeoGeometry::LineString(path) => path,
+        };
+        slice.iter()
+    });
+    if points.all(|[x, y]| x.abs() <= 180.0 && y.abs() <= 90.0) {
+        CoordinateSpace::Geographic { crs: None }
+    } else {
+        CoordinateSpace::Unknown
+    }
+}
+
+/// Reader notes are bounded: the dedup scan is linear, so an unbounded
+/// number of distinct notes from adversarial input would go quadratic.
+const MAX_READER_NOTES: usize = 16;
+
+fn push_once(warnings: &mut Vec<String>, warning: String) {
+    if warnings.len() >= MAX_READER_NOTES {
+        return;
+    }
+    if !warnings.contains(&warning) {
+        warnings.push(warning);
+        if warnings.len() == MAX_READER_NOTES {
+            warnings.push("further reader notes suppressed".to_owned());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extract and apply on the balanced network
+// ---------------------------------------------------------------------------
+
+impl Network {
+    /// Extract this network's coordinates as a standalone [`GeoLayer`]:
+    /// one point per located bus, one route per routed branch. The layer
+    /// carries the network's coordinate space and default provenance.
+    #[must_use]
+    pub fn geo_layer(&self) -> GeoLayer {
+        let mut features = Vec::new();
+        for (row, bus) in self.buses.iter().enumerate() {
+            let Some(location) = bus.location else {
+                continue;
+            };
+            features.push(GeoFeature {
+                target: GeoTarget::Bus,
+                key: ElementKey {
+                    uid: Some(payload_uid("buses", row, bus.uid.as_deref())),
+                    id: Some(bus.id.to_string()),
+                    name: bus.name.clone(),
+                    index: None,
+                },
+                geometry: GeoGeometry::Point([location.x, location.y]),
+                from: None,
+                to: None,
+                kind: location.kind,
+            });
+        }
+        for (row, branch) in self.branches.iter().enumerate() {
+            let Some(route) = &branch.route else {
+                continue;
+            };
+            features.push(GeoFeature {
+                target: GeoTarget::Branch,
+                key: ElementKey {
+                    uid: Some(payload_uid("branches", row, branch.uid.as_deref())),
+                    id: None,
+                    name: None,
+                    index: None,
+                },
+                geometry: GeoGeometry::LineString(
+                    route.iter().map(|point| [point.x, point.y]).collect(),
+                ),
+                from: Some(branch.from.to_string()),
+                to: Some(branch.to.to_string()),
+                kind: None,
+            });
+        }
+        GeoLayer {
+            space: self
+                .geo
+                .as_ref()
+                .map_or(CoordinateSpace::Unknown, |geo| geo.space.clone()),
+            kind: self.geo.as_ref().and_then(|geo| geo.kind),
+            features,
+        }
+    }
+
+    /// Apply a [`GeoLayer`] onto this network: matched bus points land in
+    /// `Bus.location`, matched branch routes in `Branch.route`, and the
+    /// layer's space becomes the network's [`GeoMeta`] when anything matched.
+    /// Matching follows [`ElementKey`]. Substation features are not applied
+    /// here; join them through [`super::apply_substation_points`].
+    pub fn apply_geo_layer(&mut self, layer: &GeoLayer) -> GeoApplyReport {
+        let mut target = BalancedApply {
+            buses: BalancedBusIndex::new(self),
+            branches: BalancedBranchIndex::new(self),
+            net: self,
+        };
+        let mut report = apply_geo_features(layer, &mut target);
+        if report.matched_buses > 0 || report.matched_branches > 0 {
+            note_space_change(&mut report, self.geo.as_ref(), &layer.space);
+            self.geo = Some(GeoMeta {
+                space: layer.space.clone(),
+                kind: layer.kind,
+            });
+        }
+        report
+    }
+}
+
+/// Note when an apply moves the network to a different coordinate space, so
+/// replacing (say) geographic locations with diagram points is never silent.
+pub(super) fn note_space_change(
+    report: &mut GeoApplyReport,
+    previous: Option<&GeoMeta>,
+    space: &CoordinateSpace,
+) {
+    if let Some(previous) = previous {
+        if previous.space != *space {
+            report.notes.push(format!(
+                "the network's coordinate space changed from {} to {}",
+                previous.space.token(),
+                space.token()
+            ));
+        }
+    }
+}
+
+/// The model half of one [`apply_geo_features`] pass: how a feature key
+/// resolves to a row, and how a matched point or route lands on the model.
+pub trait GeoApplyTarget {
+    fn bus_row(&self, key: &ElementKey) -> Option<usize>;
+    fn branch_row(&self, feature: &GeoFeature) -> Option<usize>;
+    fn place_bus(&mut self, row: usize, point: [f64; 2], kind: Option<CoordsKind>);
+    fn place_branch(&mut self, row: usize, path: &[[f64; 2]], kind: Option<CoordsKind>);
+    /// Report note for substation features this target cannot place.
+    fn substation_note(&self, count: usize) -> String;
+}
+
+/// One apply pass over a layer's features. The model-specific lookups and
+/// placements come from the [`GeoApplyTarget`]; the feature dispatch, match
+/// counting, and substation bookkeeping live here, so the balanced network
+/// and the multiconductor glue in `powerio-pkg` report identically.
+pub fn apply_geo_features(layer: &GeoLayer, target: &mut impl GeoApplyTarget) -> GeoApplyReport {
+    let mut report = GeoApplyReport::default();
+    let mut substations = 0usize;
+    for feature in &layer.features {
+        match (&feature.target, &feature.geometry) {
+            (GeoTarget::Bus, GeoGeometry::Point(point)) => {
+                if let Some(row) = target.bus_row(&feature.key) {
+                    target.place_bus(row, *point, feature.kind);
+                    report.matched_buses += 1;
+                } else {
+                    report.unmatched_features += 1;
+                }
+            }
+            (GeoTarget::Branch, GeoGeometry::LineString(path)) => {
+                if let Some(row) = target.branch_row(feature) {
+                    target.place_branch(row, path, feature.kind);
+                    report.matched_branches += 1;
+                } else {
+                    report.unmatched_features += 1;
+                }
+            }
+            (GeoTarget::Substation, _) => substations += 1,
+            _ => report.unmatched_features += 1,
+        }
+    }
+    if substations > 0 {
+        report.unmatched_features += substations;
+        report.notes.push(target.substation_note(substations));
+    }
+    report
+}
+
+/// The balanced network as an apply target.
+struct BalancedApply<'a> {
+    net: &'a mut Network,
+    buses: BalancedBusIndex,
+    branches: BalancedBranchIndex,
+}
+
+impl GeoApplyTarget for BalancedApply<'_> {
+    fn bus_row(&self, key: &ElementKey) -> Option<usize> {
+        self.buses.row_for(key)
+    }
+
+    fn branch_row(&self, feature: &GeoFeature) -> Option<usize> {
+        self.branches.row_for(feature, self.net.branches.len())
+    }
+
+    fn place_bus(&mut self, row: usize, point: [f64; 2], kind: Option<CoordsKind>) {
+        self.net.buses[row].location = Some(Location {
+            x: point[0],
+            y: point[1],
+            kind,
+        });
+    }
+
+    fn place_branch(&mut self, row: usize, path: &[[f64; 2]], kind: Option<CoordsKind>) {
+        self.net.branches[row].route = Some(
+            path.iter()
+                .map(|[x, y]| Location { x: *x, y: *y, kind })
+                .collect(),
+        );
+    }
+
+    fn substation_note(&self, count: usize) -> String {
+        format!("{count} substation feature(s) not applied; join them with apply_substation_points")
+    }
+}
+
+/// Bus row lookups for one apply pass: by uid (element uid and payload row
+/// uid), external id, and case insensitive name.
+struct BalancedBusIndex {
+    ids: HashMap<BusId, usize>,
+    uids: HashMap<String, usize>,
+    names: HashMap<String, usize>,
+}
+
+impl BalancedBusIndex {
+    fn new(net: &Network) -> Self {
+        let mut index = Self {
+            ids: HashMap::new(),
+            uids: HashMap::new(),
+            names: HashMap::new(),
+        };
+        for (row, bus) in net.buses.iter().enumerate() {
+            index.ids.insert(bus.id, row);
+            index
+                .uids
+                .insert(payload_uid("buses", row, bus.uid.as_deref()), row);
+            if let Some(uid) = &bus.uid {
+                index.uids.insert(uid.clone(), row);
+            }
+            if let Some(name) = &bus.name {
+                index.names.entry(name.to_ascii_lowercase()).or_insert(row);
+            }
+        }
+        index
+    }
+
+    fn row_for(&self, key: &ElementKey) -> Option<usize> {
+        key.uid
+            .as_ref()
+            .and_then(|uid| self.uids.get(uid))
+            .or_else(|| {
+                // A numeric id is the external BusId; a string id (one wire
+                // form serves the string-keyed multiconductor model too)
+                // matches the bus name.
+                let id = key.id.as_ref()?;
+                match id.parse::<usize>() {
+                    Ok(id) => self.ids.get(&BusId(id)),
+                    Err(_) => self.names.get(&id.to_ascii_lowercase()),
+                }
+            })
+            .or_else(|| {
+                key.name
+                    .as_ref()
+                    .and_then(|name| self.names.get(&name.to_ascii_lowercase()))
+            })
+            .copied()
+    }
+}
+
+/// Branch row lookups for one apply pass: by uid, positional row alias, and
+/// the unordered endpoint pair.
+struct BalancedBranchIndex {
+    uids: HashMap<String, usize>,
+    pairs: HashMap<(BusId, BusId), usize>,
+}
+
+impl BalancedBranchIndex {
+    fn new(net: &Network) -> Self {
+        let mut index = Self {
+            uids: HashMap::new(),
+            pairs: HashMap::new(),
+        };
+        for (row, branch) in net.branches.iter().enumerate() {
+            index
+                .uids
+                .insert(payload_uid("branches", row, branch.uid.as_deref()), row);
+            if let Some(uid) = &branch.uid {
+                index.uids.insert(uid.clone(), row);
+            }
+            index
+                .pairs
+                .entry(ordered_pair(branch.from, branch.to))
+                .or_insert(row);
+        }
+        index
+    }
+
+    fn row_for(&self, feature: &GeoFeature, branches: usize) -> Option<usize> {
+        feature
+            .key
+            .uid
+            .as_ref()
+            .and_then(|uid| self.uids.get(uid).copied())
+            .or_else(|| {
+                // Balanced branches have no external id or name of their own;
+                // a foreign record's id/name still matches a source uid, the
+                // documented uid -> id -> name order.
+                feature
+                    .key
+                    .id
+                    .as_ref()
+                    .and_then(|id| self.uids.get(id))
+                    .or_else(|| {
+                        feature
+                            .key
+                            .name
+                            .as_ref()
+                            .and_then(|name| self.uids.get(name))
+                    })
+                    .copied()
+            })
+            .or_else(|| {
+                // Positional row alias, 1-based (MATPOWER rows).
+                feature
+                    .key
+                    .index
+                    .and_then(|index| index.checked_sub(1))
+                    .filter(|row| *row < branches)
+            })
+            .or_else(|| {
+                let from = feature.from.as_ref()?.parse::<usize>().ok()?;
+                let to = feature.to.as_ref()?.parse::<usize>().ok()?;
+                self.pairs
+                    .get(&ordered_pair(BusId(from), BusId(to)))
+                    .copied()
+            })
+    }
+}
+
+/// The payload row uid (`buses:3`), preferring the element's own uid. The same
+/// identity `powerio-pkg` stamps on payload rows, so a layer written from a
+/// package round-trips.
+fn payload_uid(table: &str, row: usize, uid: Option<&str>) -> String {
+    uid.map_or_else(|| format!("{table}:{row}"), str::to_owned)
+}
+
+fn ordered_pair(a: BusId, b: BusId) -> (BusId, BusId) {
+    if b.0 < a.0 { (b, a) } else { (a, b) }
+}

--- a/powerio/src/geo/mod.rs
+++ b/powerio/src/geo/mod.rs
@@ -1,4 +1,17 @@
-//! Typed coordinate metadata for the balanced model.
+//! Typed coordinate metadata for the balanced model, and the standalone
+//! geographic document ([`GeoLayer`]) that carries coordinates as a file of
+//! their own.
+
+mod layer;
+mod pwd;
+
+pub use layer::{
+    ElementKey, GEO_LAYER_EXTENSION, GEO_LAYER_VERSION, GeoApplyReport, GeoApplyTarget, GeoFeature,
+    GeoGeometry, GeoLayer, GeoParsed, GeoTarget, apply_geo_features,
+};
+pub use pwd::{
+    PWD_MERCATOR_K, apply_substation_points, geo_layer_from_pwd, pwd_mercator_to_lonlat,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -62,6 +75,20 @@ pub enum CoordinateSpace {
     },
     /// The source did not declare a coordinate space.
     Unknown,
+}
+
+impl CoordinateSpace {
+    /// The wire token naming the space family (`geographic`, `projected`,
+    /// `diagram`, `unknown`), as the `powerio_geo` member spells it.
+    #[must_use]
+    pub fn token(&self) -> &'static str {
+        match self {
+            CoordinateSpace::Geographic { .. } => "geographic",
+            CoordinateSpace::Projected { .. } => "projected",
+            CoordinateSpace::Diagram { .. } => "diagram",
+            _ => "unknown",
+        }
+    }
 }
 
 /// Diagram canvas metadata.

--- a/powerio/src/geo/pwd.rs
+++ b/powerio/src/geo/pwd.rs
@@ -1,0 +1,149 @@
+//! PowerWorld `.pwd` display promotion into the geo model.
+//!
+//! The `.pwd` reader decodes substation symbols in diagram coordinates.
+//! [`geo_layer_from_pwd`] lifts them into a diagram space [`GeoLayer`];
+//! [`apply_substation_points`] joins those points onto buses through the
+//! `SubNum` extras key; [`pwd_mercator_to_lonlat`] is the documented,
+//! approximate inverse of the projection PowerWorld's auto generated layouts
+//! use, for consumers that want to place a diagram on a map.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use super::layer::{ElementKey, GeoApplyReport, GeoFeature, GeoGeometry, GeoLayer, GeoTarget};
+use super::{Canvas, CoordinateSpace, GeoMeta, Location};
+use crate::format::PwdDisplay;
+use crate::network::Network;
+
+/// Scale of PowerWorld's auto generated layouts: `x = K·lon` and
+/// `y = K·mercdeg(lat)`, with the Mercator ordinate expressed in degrees.
+pub const PWD_MERCATOR_K: f64 = 535.816_08;
+
+/// Approximate inverse of the projection PowerWorld's auto generated layouts
+/// use (verified against ACTIVSg200/2000 to within ~0.02 degrees): longitude
+/// is `x / K`, latitude the inverse Gudermannian of `y / K`. Hand edited
+/// diagrams drift from this, so treat the result as approximate.
+#[must_use]
+pub fn pwd_mercator_to_lonlat(x: f64, y: f64) -> (f64, f64) {
+    let lon = x / PWD_MERCATOR_K;
+    let lat = ((y / PWD_MERCATOR_K).to_radians().sinh())
+        .atan()
+        .to_degrees();
+    (lon, lat)
+}
+
+/// Lift decoded `.pwd` substation symbols into a diagram space [`GeoLayer`]
+/// with substation targets keyed by substation number.
+#[must_use]
+pub fn geo_layer_from_pwd(display: &PwdDisplay) -> GeoLayer {
+    GeoLayer {
+        space: CoordinateSpace::Diagram {
+            canvas: Some(Canvas {
+                width: Some(f64::from(display.canvas_width)),
+                height: Some(f64::from(display.canvas_height)),
+                units: None,
+            }),
+        },
+        kind: None,
+        features: display
+            .substations
+            .iter()
+            .map(|substation| GeoFeature {
+                target: GeoTarget::Substation,
+                key: ElementKey {
+                    uid: None,
+                    id: Some(substation.number.to_string()),
+                    name: (!substation.name.is_empty()).then(|| substation.name.clone()),
+                    index: None,
+                },
+                geometry: GeoGeometry::Point([substation.x, substation.y]),
+                from: None,
+                to: None,
+                kind: None,
+            })
+            .collect(),
+    }
+}
+
+/// Join a layer's substation points onto buses through the `SubNum` (or
+/// `SubNumber`) extras key: every bus in a matched substation takes the
+/// substation's point, and the layer's space becomes the network's
+/// [`GeoMeta`] when anything matched. Replaced locations and a coordinate
+/// space change are reported in the notes rather than happening silently.
+pub fn apply_substation_points(net: &mut Network, layer: &GeoLayer) -> GeoApplyReport {
+    let mut report = GeoApplyReport::default();
+    // Substation number -> bus rows, built once for the whole pass.
+    let mut rows_by_substation: HashMap<String, Vec<usize>> = HashMap::new();
+    for (row, bus) in net.buses.iter().enumerate() {
+        if let Some(substation) = bus_substation(bus) {
+            rows_by_substation.entry(substation).or_default().push(row);
+        }
+    }
+    let mut replaced = 0usize;
+    for feature in &layer.features {
+        let (GeoTarget::Substation, GeoGeometry::Point(point)) =
+            (&feature.target, &feature.geometry)
+        else {
+            continue;
+        };
+        let rows = feature
+            .key
+            .id
+            .as_deref()
+            .and_then(|number| rows_by_substation.get(number));
+        let Some(rows) = rows else {
+            report.unmatched_features += 1;
+            continue;
+        };
+        for &row in rows {
+            let bus = &mut net.buses[row];
+            if bus.location.is_some() {
+                replaced += 1;
+            }
+            bus.location = Some(Location {
+                x: point[0],
+                y: point[1],
+                kind: feature.kind,
+            });
+            report.matched_buses += 1;
+        }
+    }
+    if report.matched_buses > 0 {
+        if replaced > 0 {
+            report
+                .notes
+                .push(format!("replaced {replaced} existing bus location(s)"));
+        }
+        super::layer::note_space_change(&mut report, net.geo.as_ref(), &layer.space);
+        net.geo = Some(GeoMeta {
+            space: layer.space.clone(),
+            kind: layer.kind,
+        });
+    }
+    report
+}
+
+/// The bus's substation number from extras, normalized to a string
+/// (PowerWorld exports carry it as a number or a numeric string).
+fn bus_substation(bus: &crate::network::Bus) -> Option<String> {
+    let value = bus
+        .extras
+        .get("SubNum")
+        .or_else(|| bus.extras.get("SubNumber"))?;
+    match value {
+        Value::Number(number) => Some(number.to_string()),
+        Value::String(text) => {
+            let trimmed = text.trim();
+            (!trimmed.is_empty()).then(|| {
+                // "12.0" and "12" name the same substation.
+                trimmed
+                    .parse::<f64>()
+                    .ok()
+                    .filter(|v| v.fract() == 0.0 && v.abs() < 1e15)
+                    .map_or_else(|| trimmed.to_owned(), |v| format!("{v:.0}"))
+            })
+        }
+        _ => None,
+    }
+}

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -62,7 +62,11 @@ pub use format::{
     write_psse, write_psse_rev, write_pypsa_csv_folder, write_surge_json,
 };
 pub use gen_cost::{GenCostPatch, GenCostPolicyReport, MissingGenCostPolicy, parse_gen_cost_csv};
-pub use geo::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};
+pub use geo::{
+    Canvas, CoordinateSpace, CoordsKind, ElementKey, GeoApplyReport, GeoFeature, GeoGeometry,
+    GeoLayer, GeoMeta, GeoParsed, GeoTarget, Location, apply_substation_points, geo_layer_from_pwd,
+    pwd_mercator_to_lonlat,
+};
 pub use indexed::{ConnectivityReport, IndexCore, IndexedNetwork};
 pub use network::{
     Area, BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet,

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -633,6 +633,12 @@ pub struct Branch {
     /// Stable row identity; see [`Bus::uid`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uid: Option<String>,
+    /// Polyline route in the network's coordinate space (`Network.geo`),
+    /// present only when a source provides intermediate geometry; endpoint
+    /// only rendering derives from the bus locations. `#[serde(default)]` so
+    /// JSON written before the field existed still deserializes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route: Option<Vec<Location>>,
     pub extras: Extras,
 }
 
@@ -768,6 +774,7 @@ impl Branch {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         }
     }
@@ -1439,6 +1446,7 @@ impl Transformer3W {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         };
         let branches = [
@@ -1682,7 +1690,7 @@ impl Network {
         }
         for (i, br) in self.branches.iter().enumerate() {
             #[rustfmt::skip]
-            let Branch { from: _, to: _, r, x, b, charging, rate_a, rate_b, rate_c, rating_sets, current_ratings, tap, shift, in_service: _, angmin, angmax, control: _, solution, uid: _, extras: _ } = br;
+            let Branch { from: _, to: _, r, x, b, charging, rate_a, rate_b, rate_c, rating_sets, current_ratings, tap, shift, in_service: _, angmin, angmax, control: _, solution, uid: _, route: _, extras: _ } = br;
             let fields = [
                 ("r", *r),
                 ("x", *x),
@@ -2357,6 +2365,7 @@ mod tests {
             }),
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         }
     }
@@ -2464,6 +2473,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         };
         // A non-finite generator capability reports at its exact key path

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -727,6 +727,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         };
         // Bus 3 is isolated, so to_normalized drops it.

--- a/powerio/src/operations.rs
+++ b/powerio/src/operations.rs
@@ -500,6 +500,7 @@ impl Network {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         });
         self.buses.retain(|b| b.id != m);
@@ -596,6 +597,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -814,6 +814,7 @@ mod tests {
             control: None,
             solution: None,
             uid: None,
+            route: None,
             extras: Extras::new(),
         }
     }

--- a/powerio/tests/geo_formats.rs
+++ b/powerio/tests/geo_formats.rs
@@ -1,0 +1,195 @@
+//! Coordinate harvest and emit in the balanced formats (#183): PowerWorld aux
+//! `Latitude:1`/`Longitude:1`, pandapower bus `geo` Point strings, PyPSA
+//! `buses.csv` x/y, and the dropped-location warning for formats with no
+//! geometry concept.
+
+use std::path::PathBuf;
+
+use powerio::{
+    CoordinateSpace, Location, TargetFormat, parse_file, parse_pandapower_json, parse_str,
+    read_pypsa_csv_folder, write_pandapower_json, write_powerworld, write_pypsa_csv_folder,
+};
+
+fn data(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../tests/data")
+        .join(name)
+}
+
+fn tmp_dir(label: &str) -> PathBuf {
+    let p = std::env::temp_dir().join(format!("powerio-{label}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&p);
+    p
+}
+
+#[test]
+fn aux_promotes_substation_coordinates_into_locations() {
+    let net = parse_file(data("powerworld/ACTIVSg200.aux"), None)
+        .unwrap()
+        .network;
+    assert!(matches!(
+        net.geo.as_ref().expect("geo meta").space,
+        CoordinateSpace::Geographic { crs: None }
+    ));
+    // Bus 1 sits in substation 1 (CREVE COEUR, 40.642116 / -89.59956).
+    let bus = &net.buses[0];
+    let location = bus.location.expect("bus 1 location");
+    assert!((location.y - 40.642_116).abs() < 1e-6, "{}", location.y);
+    assert!((location.x - -89.599_56).abs() < 1e-6, "{}", location.x);
+    // Promotion removes the raw keys; substation identity stays.
+    assert!(!bus.extras.contains_key("Latitude:1"));
+    assert!(!bus.extras.contains_key("Longitude:1"));
+    assert!(bus.extras.contains_key("SubNum"));
+}
+
+#[test]
+fn aux_writes_locations_back_and_round_trips() {
+    let net = parse_file(data("powerworld/ACTIVSg200.aux"), None)
+        .unwrap()
+        .network;
+    let conv = write_powerworld(&net);
+    assert!(conv.text.contains("Latitude:1"));
+    let back = parse_str(&conv.text, "powerworld").unwrap().network;
+    assert_eq!(back.buses[0].location, net.buses[0].location);
+}
+
+#[test]
+fn aux_without_locations_writes_the_old_header() {
+    let mut net = parse_file(data("powerworld/ACTIVSg200.aux"), None)
+        .unwrap()
+        .network;
+    for bus in &mut net.buses {
+        bus.location = None;
+    }
+    assert!(!write_powerworld(&net).text.contains("Latitude:1"));
+}
+
+#[test]
+fn pandapower_geo_points_round_trip() {
+    // The vendored pandapower 3.2.2 export carries a null geo column.
+    let mut net = parse_file(data("pandapower/example.json"), None)
+        .unwrap()
+        .network;
+    assert!(net.buses.iter().all(|b| b.location.is_none()));
+    assert!(net.geo.is_none());
+
+    net.buses[0].location = Some(Location {
+        x: 7.09,
+        y: 50.73,
+        kind: None,
+    });
+    // Same-format writes echo the retained source byte for byte; drop it to
+    // exercise the canonical writer.
+    net.source = None;
+    let out = write_pandapower_json(&net);
+    let back = parse_pandapower_json(&out.text).unwrap().network;
+    let location = back.buses[0].location.expect("harvested location");
+    assert!((location.x - 7.09).abs() < 1e-12);
+    assert!((location.y - 50.73).abs() < 1e-12);
+    assert!(back.buses[1].location.is_none());
+    assert!(matches!(
+        back.geo.as_ref().expect("geo meta").space,
+        CoordinateSpace::Geographic { crs: None }
+    ));
+}
+
+#[test]
+fn out_of_bounds_coordinates_read_as_unknown_space() {
+    let mut net = parse_file(data("pandapower/example.json"), None)
+        .unwrap()
+        .network;
+    // Projected meters in a geo column violate the format convention; the
+    // reader keeps the points and declines the geographic claim.
+    net.buses[0].location = Some(Location {
+        x: 350_000.0,
+        y: 5_800_000.0,
+        kind: None,
+    });
+    net.source = None;
+    let out = write_pandapower_json(&net);
+    let back = parse_pandapower_json(&out.text).unwrap().network;
+    assert!(back.buses[0].location.is_some());
+    assert!(matches!(
+        back.geo.as_ref().expect("geo meta").space,
+        CoordinateSpace::Unknown
+    ));
+}
+
+#[test]
+fn pypsa_bus_xy_round_trips() {
+    let mut net = read_pypsa_csv_folder(data("pypsa/example"))
+        .unwrap()
+        .network;
+    assert!(net.buses.iter().all(|b| b.location.is_none()));
+
+    net.buses[0].location = Some(Location {
+        x: 10.4,
+        y: 63.4,
+        kind: None,
+    });
+    let out = tmp_dir("geo-pypsa-csv");
+    write_pypsa_csv_folder(&net, &out).unwrap();
+    let back = read_pypsa_csv_folder(&out).unwrap().network;
+    let location = back.buses[0].location.expect("harvested location");
+    assert!((location.x - 10.4).abs() < 1e-12);
+    assert!((location.y - 63.4).abs() < 1e-12);
+    assert!(back.buses[1].location.is_none());
+    let _ = std::fs::remove_dir_all(&out);
+}
+
+#[test]
+fn formats_without_geometry_report_dropped_locations() {
+    let net = parse_file(data("powerworld/ACTIVSg200.aux"), None)
+        .unwrap()
+        .network;
+    assert!(net.buses[0].location.is_some());
+    for format in [
+        TargetFormat::Matpower,
+        TargetFormat::Psse { rev: 33 },
+        TargetFormat::PowerModelsJson,
+        TargetFormat::EgretJson,
+        TargetFormat::Pslf,
+        TargetFormat::SurgeJson,
+    ] {
+        let conv = net.to_format(format).unwrap();
+        assert!(
+            conv.warnings
+                .iter()
+                .any(|w| w.contains("location") && w.contains("dropped")),
+            "{format:?} did not warn: {:?}",
+            conv.warnings
+        );
+    }
+    // Formats with a coordinate representation stay silent.
+    for format in [TargetFormat::PowerWorld, TargetFormat::PandapowerJson] {
+        let conv = net.to_format(format).unwrap();
+        assert!(
+            !conv.warnings.iter().any(|w| w.contains("dropped: ")),
+            "{format:?} warned: {:?}",
+            conv.warnings
+        );
+    }
+}
+
+#[test]
+fn locations_and_routes_survive_the_model_snapshot() {
+    let mut net = parse_file(data("powerworld/ACTIVSg200.aux"), None)
+        .unwrap()
+        .network;
+    net.branches[0].route = Some(vec![
+        Location {
+            x: -89.6,
+            y: 40.6,
+            kind: None,
+        },
+        Location {
+            x: -89.2,
+            y: 39.9,
+            kind: None,
+        },
+    ]);
+    let back = powerio::Network::from_json(&net.to_json().unwrap()).unwrap();
+    assert_eq!(back.buses[0].location, net.buses[0].location);
+    assert_eq!(back.branches[0].route, net.branches[0].route);
+    assert_eq!(back.geo, net.geo);
+}

--- a/powerio/tests/geo_layer.rs
+++ b/powerio/tests/geo_layer.rs
@@ -1,0 +1,382 @@
+//! GeoLayer: tolerant reads, canonical writes, extract/apply, and the
+//! PowerWorld `.pwd` promotion.
+
+use powerio::{
+    Bus, BusId, BusType, CoordinateSpace, CoordsKind, GeoGeometry, GeoLayer, GeoTarget, Location,
+    Network, apply_substation_points, geo_layer_from_pwd, parse_display_file,
+    pwd_mercator_to_lonlat,
+};
+
+fn parse(bytes: &[u8], hint: Option<&str>) -> powerio::GeoParsed {
+    GeoLayer::parse_bytes(bytes, hint).expect("parse geo layer")
+}
+
+fn small_network() -> Network {
+    let mut bus1 = Bus::new(BusId(1), BusType::Ref, 230.0);
+    bus1.name = Some("North".to_owned());
+    let mut bus2 = Bus::new(BusId(2), BusType::Pq, 230.0);
+    bus2.name = Some("South".to_owned());
+    let branch = powerio::Branch::new(BusId(1), BusId(2), 0.01, 0.1);
+    let mut net = Network::in_memory("small", 100.0, vec![bus1, bus2], vec![branch]);
+    net.generators.push(powerio::Generator::new(BusId(1)));
+    net
+}
+
+// ---------------------------------------------------------------------------
+// Tolerant reads
+// ---------------------------------------------------------------------------
+
+#[test]
+fn headerless_buscoords_csv_reads_as_bus_points() {
+    let parsed = parse(b"b1, -89.6, 40.6\nb2, -89.2, 39.8\n", None);
+    assert_eq!(parsed.layer.features.len(), 2);
+    let feature = &parsed.layer.features[0];
+    assert_eq!(feature.target, GeoTarget::Bus);
+    assert_eq!(feature.key.id.as_deref(), Some("b1"));
+    assert_eq!(feature.geometry, GeoGeometry::Point([-89.6, 40.6]));
+    // All points fit lon/lat bounds, so the space reads geographic.
+    assert!(matches!(
+        parsed.layer.space,
+        CoordinateSpace::Geographic { .. }
+    ));
+}
+
+#[test]
+fn whitespace_separated_buscoords_read() {
+    let parsed = parse(b"b1 -89.6 40.6\nb2 -89.2 39.8\n", None);
+    assert_eq!(parsed.layer.features.len(), 2);
+}
+
+#[test]
+fn projected_buscoords_read_as_unknown_space() {
+    let parsed = parse(b"b1, 653800.0, 3626000.0\n", None);
+    assert!(matches!(parsed.layer.space, CoordinateSpace::Unknown));
+}
+
+#[test]
+fn aliased_csv_header_reads_points_and_branch_segments() {
+    let text = "Bus Number,Latitude,Longitude\n312,34.2,-80.05\n410,34.3,-80.10\n";
+    let parsed = parse(text.as_bytes(), Some("layout.csv"));
+    assert_eq!(parsed.layer.features.len(), 2);
+    assert_eq!(parsed.layer.features[0].key.id.as_deref(), Some("312"));
+
+    let branch_csv = "from_bus,to_bus,lat1,lon1,lat2,lon2\n312,410,34.2,-80.05,34.3,-80.10\n";
+    let parsed = parse(branch_csv.as_bytes(), Some("routes.csv"));
+    let branch = parsed
+        .layer
+        .features
+        .iter()
+        .find(|f| f.target == GeoTarget::Branch)
+        .expect("branch feature");
+    assert_eq!(branch.from.as_deref(), Some("312"));
+    assert_eq!(branch.to.as_deref(), Some("410"));
+    assert_eq!(
+        branch.geometry,
+        GeoGeometry::LineString(vec![[-80.05, 34.2], [-80.10, 34.3]])
+    );
+}
+
+#[test]
+fn json_records_read_with_aliases() {
+    let text = r#"[{"bus_i": 312, "lat": "34.2", "lng": "-80.05"}]"#;
+    let parsed = parse(text.as_bytes(), None);
+    assert_eq!(parsed.layer.features.len(), 1);
+    assert_eq!(parsed.layer.features[0].key.id.as_deref(), Some("312"));
+
+    // Records nested under an object key (the PowerModels-style dict).
+    let nested = r#"{"buses": [{"id": "1", "x": -80.0, "y": 34.0}]}"#;
+    let parsed = parse(nested.as_bytes(), None);
+    assert_eq!(parsed.layer.features.len(), 1);
+}
+
+#[test]
+fn geojson_features_read_points_and_linestrings() {
+    let text = r#"{
+      "type": "FeatureCollection",
+      "features": [
+        {"type": "Feature",
+         "geometry": {"type": "Point", "coordinates": [-80.05, 34.2]},
+         "properties": {"bus": "312"}},
+        {"type": "Feature",
+         "geometry": {"type": "LineString", "coordinates": [[-80.05, 34.2], [-80.1, 34.3]]},
+         "properties": {"from": "312", "to": "410"}}
+      ]
+    }"#;
+    let parsed = parse(text.as_bytes(), None);
+    assert_eq!(parsed.layer.features.len(), 2);
+    assert_eq!(parsed.layer.features[0].target, GeoTarget::Bus);
+    assert_eq!(parsed.layer.features[1].target, GeoTarget::Branch);
+}
+
+#[test]
+fn positional_branch_id_is_a_read_only_row_alias() {
+    let text = r#"[{"branch": 1, "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}]"#;
+    let parsed = parse(text.as_bytes(), None);
+    let feature = &parsed.layer.features[0];
+    assert_eq!(feature.key.index, Some(1));
+
+    let mut net = small_network();
+    let report = net.apply_geo_layer(&parsed.layer);
+    assert_eq!(report.matched_branches, 1);
+    assert!(net.branches[0].route.is_some());
+
+    // Never written: the canonical form carries the payload uid instead.
+    let round = parse(net.geo_layer().to_geojson().as_bytes(), None);
+    let branch = round
+        .layer
+        .features
+        .iter()
+        .find(|f| f.target == GeoTarget::Branch)
+        .expect("branch feature");
+    assert_eq!(branch.key.index, None);
+    assert_eq!(branch.key.uid.as_deref(), Some("branches:0"));
+}
+
+// ---------------------------------------------------------------------------
+// Canonical write
+// ---------------------------------------------------------------------------
+
+#[test]
+fn canonical_write_round_trips_space_kind_and_keys() {
+    let mut net = small_network();
+    net.buses[0].location = Some(Location {
+        x: -80.05,
+        y: 34.2,
+        kind: Some(CoordsKind::Manual),
+    });
+    net.buses[1].location = Some(Location {
+        x: -80.1,
+        y: 34.3,
+        kind: None,
+    });
+    net.branches[0].route = Some(vec![
+        Location {
+            x: -80.05,
+            y: 34.2,
+            kind: None,
+        },
+        Location {
+            x: -80.1,
+            y: 34.3,
+            kind: None,
+        },
+    ]);
+    net.geo = Some(powerio::GeoMeta {
+        space: CoordinateSpace::Geographic { crs: None },
+        kind: Some(CoordsKind::Synthetic),
+    });
+
+    let layer = net.geo_layer();
+    assert_eq!(layer.kind, Some(CoordsKind::Synthetic));
+    let text = layer.to_geojson();
+    let document: serde_json::Value = serde_json::from_str(&text).expect("valid JSON");
+    assert_eq!(document["type"], "FeatureCollection");
+    assert_eq!(document["powerio_geo"]["space"], "geographic");
+    assert_eq!(document["powerio_geo"]["kind"], "synthetic");
+
+    let round = parse(text.as_bytes(), Some("case.geo.json"));
+    assert_eq!(round.layer, layer);
+
+    // Applying onto a coordinate-free copy restores every location.
+    let mut bare = small_network();
+    let report = bare.apply_geo_layer(&round.layer);
+    assert_eq!(report.matched_buses, 2);
+    assert_eq!(report.matched_branches, 1);
+    assert_eq!(report.unmatched_features, 0);
+    assert_eq!(
+        bare.buses[0].location.unwrap().kind,
+        Some(CoordsKind::Manual)
+    );
+    assert_eq!(bare.geo, net.geo);
+}
+
+#[test]
+fn provenance_stamping_survives_the_wire() {
+    // A consumer exporting a hand layout stamps `kind = manual`.
+    let mut layer = small_network().geo_layer();
+    layer.features.push(powerio::GeoFeature {
+        target: GeoTarget::Bus,
+        key: powerio::ElementKey {
+            id: Some("1".to_owned()),
+            ..Default::default()
+        },
+        geometry: GeoGeometry::Point([-80.0, 34.0]),
+        from: None,
+        to: None,
+        kind: None,
+    });
+    layer.kind = Some(CoordsKind::Manual);
+    let round = parse(layer.to_geojson().as_bytes(), None);
+    assert_eq!(round.layer.kind, Some(CoordsKind::Manual));
+}
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+#[test]
+fn apply_matches_by_id_name_and_pair_and_counts_misses() {
+    let text = r#"[
+      {"bus": "1", "lat": 34.2, "lon": -80.05},
+      {"bus_i": "south", "lat": 34.3, "lon": -80.1},
+      {"bus": "77", "lat": 34.4, "lon": -80.2},
+      {"from_bus": 2, "to_bus": 1, "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}
+    ]"#;
+    let parsed = parse(text.as_bytes(), None);
+    let mut net = small_network();
+    let report = net.apply_geo_layer(&parsed.layer);
+    // "1" matches by external id, "south" case insensitively by name, "77"
+    // misses; the branch record matches the unordered (from, to) pair.
+    assert_eq!(report.matched_buses, 2);
+    assert_eq!(report.matched_branches, 1);
+    assert_eq!(report.unmatched_features, 1);
+    assert!(net.buses[0].location.is_some());
+    assert!(net.buses[1].location.is_some());
+    assert!(net.branches[0].route.is_some());
+}
+
+#[test]
+fn bom_prefixed_json_reads() {
+    let mut bytes = b"\xef\xbb\xbf".to_vec();
+    bytes.extend_from_slice(br#"[{"bus": "1", "lat": 34.2, "lon": -80.05}]"#);
+    let parsed = parse(&bytes, None);
+    assert_eq!(parsed.layer.features.len(), 1);
+}
+
+#[test]
+fn branch_routes_match_source_uids_arriving_as_id_or_name() {
+    let mut net = small_network();
+    net.branches[0].uid = Some("line-1".to_owned());
+    let text =
+        r#"[{"branch": "line-1", "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}]"#;
+    let report = net.apply_geo_layer(&parse(text.as_bytes(), None).layer);
+    assert_eq!(report.matched_branches, 1);
+    assert!(net.branches[0].route.is_some());
+}
+
+#[test]
+fn apply_matches_source_uids() {
+    let mut net = small_network();
+    net.buses[0].uid = Some("bus_00".to_owned());
+    let text = r#"[{"uid": "bus_00", "id": "999", "lat": 34.2, "lon": -80.05}]"#;
+    let report = net.apply_geo_layer(&parse(text.as_bytes(), None).layer);
+    assert_eq!(report.matched_buses, 1);
+    assert!(net.buses[0].location.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// PowerWorld .pwd promotion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pwd_promotes_to_a_diagram_layer_and_joins_on_subnum() {
+    let display = parse_display_file("../tests/data/powerworld/ACTIVSg200.pwd", None)
+        .expect("parse .pwd display");
+    let powerio::DisplayData::PowerWorld(display) = display else {
+        panic!("expected PowerWorld display data");
+    };
+    let layer = geo_layer_from_pwd(&display);
+    assert!(matches!(
+        layer.space,
+        CoordinateSpace::Diagram { canvas: Some(_) }
+    ));
+    assert!(!layer.features.is_empty());
+    assert!(
+        layer
+            .features
+            .iter()
+            .all(|f| f.target == GeoTarget::Substation)
+    );
+
+    // The aux sibling carries SubNum per bus; the join places every bus whose
+    // substation has a symbol.
+    let net = powerio::parse_file("../tests/data/powerworld/ACTIVSg200.aux", None)
+        .expect("parse aux")
+        .network;
+    let mut net = net;
+    let report = apply_substation_points(&mut net, &layer);
+    assert!(report.matched_buses > 0);
+    assert!(matches!(
+        net.geo.as_ref().expect("geo meta").space,
+        CoordinateSpace::Diagram { .. }
+    ));
+    // The aux reader already placed geographic locations; replacing them with
+    // diagram points is reported rather than silent.
+    assert!(
+        report
+            .notes
+            .iter()
+            .any(|note| note.contains("replaced") || note.contains("coordinate space changed")),
+        "{:?}",
+        report.notes
+    );
+}
+
+#[test]
+fn pwd_mercator_inverse_lands_near_the_aux_coordinates() {
+    let display = parse_display_file("../tests/data/powerworld/ACTIVSg200.pwd", None)
+        .expect("parse .pwd display");
+    let powerio::DisplayData::PowerWorld(display) = display else {
+        panic!("expected PowerWorld display data");
+    };
+    // Substation 1 (CREVE COEUR) sits at 40.642116, -89.59956 in the aux
+    // export; the auto generated diagram is Mercator scaled by K.
+    let substation = display
+        .substations
+        .iter()
+        .find(|s| s.number == 1)
+        .expect("substation 1");
+    let (lon, lat) = pwd_mercator_to_lonlat(substation.x, substation.y);
+    assert!((lon - -89.599_56).abs() < 0.05, "lon {lon}");
+    assert!((lat - 40.642_116).abs() < 0.05, "lat {lat}");
+}
+
+// ---------------------------------------------------------------------------
+// Untrusted input never panics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn malformed_inputs_error_without_panicking() {
+    let cases: &[&[u8]] = &[
+        b"",
+        b"{",
+        b"[1, 2",
+        b"\xff\xfe\x00garbage",
+        b"not,a,geo\nfile,at,all\n",
+        b"bus,x\nb1,1\n",
+        br#"{"features": "not an array"}"#,
+        br#"{"features": [{"geometry": {"type": "Point", "coordinates": "x"}}]}"#,
+        br#"{"features": [{"geometry": {"type": "Polygon", "coordinates": []}}]}"#,
+        br#"[{"bus": "1", "lat": "nope", "lon": "-80"}]"#,
+        br#"[{"lat": 1.0, "lon": 2.0}]"#,
+        br#"{"type": "FeatureCollection", "powerio_geo": 7, "features": []}"#,
+        br#"[{"branch": "b", "path": [[0]]}]"#,
+    ];
+    for bytes in cases {
+        let result = GeoLayer::parse_bytes(bytes, None);
+        assert!(
+            result.is_err(),
+            "expected an error for {:?}",
+            String::from_utf8_lossy(bytes)
+        );
+    }
+}
+
+#[test]
+fn tolerant_reader_skips_bad_records_but_keeps_good_ones() {
+    let text = r#"[
+      {"bus": "1", "lat": 34.2, "lon": -80.05},
+      {"bus": "2", "lat": null, "lon": -80.1},
+      {"bus": "", "lat": 34.4, "lon": -80.2}
+    ]"#;
+    let parsed = parse(text.as_bytes(), None);
+    assert_eq!(parsed.layer.features.len(), 1);
+}
+
+#[test]
+fn oversized_coordinate_values_read_but_stay_unknown_space() {
+    let parsed = parse(b"b1, 1e308, -1e308\n", None);
+    assert!(matches!(parsed.layer.space, CoordinateSpace::Unknown));
+    // Non-finite coordinates are dropped, so an all-inf file errors.
+    assert!(GeoLayer::parse_bytes(b"b1, inf, nan\n", None).is_err());
+}

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -196,7 +196,7 @@ def test_package_declares_payload_schema_and_row_identity():
     doc = json.loads(pkg.to_json())
     assert doc["schema_version"] == "0.1.1"
     assert doc["payload_schema"].endswith("/pio-payload-balanced/1")
-    assert doc["payload_schema_version"] == "1.1.0"
+    assert doc["payload_schema_version"] == "1.2.0"
     # Every payload row carries an identity; case9 has no source uids, so they
     # are synthesized from the build position.
     assert doc["model"]["balanced_network"]["generators"][0]["uid"] == "generators:0"


### PR DESCRIPTION
Closes #183. Closes #184.

Stacked on #254; retarget to `main` after it merges.

## The geographic document (#184)

`GeoLayer`/`ElementKey` land in `powerio::geo`. Reading is tolerant and takes bytes plus a name hint with no filesystem access (the wasm consumer parses untrusted browser input through it): headerless buscoords CSV, aliased CSV/JSON records (the alias vocabulary tellegen's sidecar reader accepted), GeoJSON Point/LineString, and a 1-based positional branch index accepted on read only. Writing is canonical: a GeoJSON FeatureCollection with the `powerio_geo` foreign member (`.geo.json`), valid RFC 7946 when geographic, keyed by the payload row uid.

`DisplayFormat::GeoJson`/`DisplayData::Geo` route through the display parse entry points. `Network::geo_layer()` and `apply_geo_layer() -> GeoApplyReport` extract and apply; matching resolves uid, then id, then case insensitive name, with the unordered endpoint pair as the branch fallback. The apply pass itself (`apply_geo_features`/`GeoApplyTarget`) is shared with the multiconductor glue in powerio-pkg (`dist_geo_layer`/`apply_dist_geo_layer`), so both families dispatch and report identically. `Branch.route`/`DistLine.route` carry polyline routing; both payload schemas bump to 1.2.0.

The `.pwd` promotion ships as `geo_layer_from_pwd` (diagram space, substation targets), `apply_substation_points` (SubNum join through extras, indexed, with replaced-location and space-change notes), and the public `pwd_mercator_to_lonlat` (the approximate inverse of PowerWorld's auto layout projection; the constant moves here from tellegen). The CLI gains `powerio geo extract | apply | convert`; apply drops the retained source so a same-format write re-serializes the placed case, and `geo extract` on a `.pwd` emits the diagram layer directly.

The tolerant reader is hardened as an untrusted input parser: BOM tolerated, reader notes bounded (a distinct-warning flood from adversarial geometry types was quadratic), non-finite coordinates rejected, no panics on the malformed-input corpus in `tests/geo_layer.rs`.

## Harvest and emit (#183)

PowerWorld aux promotes `Latitude:1`/`Longitude:1` into `Bus.location` (promotion removes the raw keys; `SubNum` stays: identity rather than geometry) and writes the columns back when the case carries locations. pandapower reads bus `geo` GeoJSON Point strings and writes them in place of today's null. PyPSA reads and writes `buses.csv` `x`/`y`. Readers stamp the geographic space only when every point fits longitude/latitude bounds; out-of-convention data reads as unknown. Writers with no geometry concept (MATPOWER, PSS/E, PowerModels, egret, PSLF, Surge) warn that locations were dropped, matching the `base_frequency` behavior, and the distribution writers report dropped line routes the same way.