### PR TITLE
cli: recursive case discovery; JSON parser hardening; 0.7.2 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.7.2
+
+- CLI case discovery is recursive and covers every supported format (#260):
+  `powerio batch` and the TUI walk the input directory for `.m`, `.raw`,
+  `.aux`, `.epc`, `.pwb`, `.json`, and `.dss` files, matched case
+  insensitively, pruning hidden directories and the output directory. A file
+  that fails to load during a scan is skipped with a warning instead of
+  aborting the run, and the no-cases error names the supported extensions.
+  Distribution cases (`.dss`, BMOPF/PMD JSON) parse to the multiconductor
+  model and go through the explicit `lower_multiconductor_to_balanced` pass,
+  whose approximations and dropped fields surface as warnings.
+- A leading UTF-8 byte order mark no longer defeats the JSON classifier or
+  any text reader. `classify_json_text`, the transmission read funnel, the
+  distribution parsers (including `.dss` and redirected files), the PMD/BMOPF
+  JSON split, `Network::from_json`, and `Package::from_json` all strip it,
+  and the parse warnings itemize the removal (a same-format echo returns the
+  text without the mark).
+- `parse_str_with_name`: `parse_str` plus the name hint role the file stem
+  plays in `parse_file`. The CLI now reads and classifies a `.json` case
+  once and hands the text straight to the typed parser; a batch scan
+  previously read each `.json` twice and DOM-parsed it three times.
+- A nameless distribution case loaded by the CLI takes its file stem as the
+  network name, so batch exports no longer collide on the lowering's
+  `lowered-multiconductor` fallback.
+- JSON reader hardening from a review pass over the family:
+  - PowerModels: a status field written as a JSON boolean (`"br_status":
+    false`) reads out of service instead of in service; `baseMVA` must be
+    finite and positive; gencost rows padded to the MATPOWER matrix width are
+    trimmed to the declared `ncost` before the per-unit unscale; an
+    out-of-range cost model number passes through unscaled instead of
+    wrapping into the piecewise/polynomial rescale.
+  - pandapower: a trafo `sn_mva` of zero or below falls back to the system
+    base instead of dividing the impedance by zero; string cells can no
+    longer smuggle `"inf"`/`"nan"` into numeric columns.
+  - egret: a polynomial cost exponent key is bounded, so a few bytes of JSON
+    can no longer demand an arbitrarily large allocation or index out of
+    bounds.
+  - GOC3: a duplicate `simple_dispatchable_device` uid is rejected instead of
+    silently taking another device's time series bounds and cost.
+  - Surge: a float bus reference too large for an index is rejected like the
+    equivalent integer instead of saturating to `usize::MAX`.
+  - BMOPF: matrix key indices and winding counts are bounded (a crafted
+    document could previously demand gigabytes or quadratic work), a missing
+    line `length` warns instead of propagating NaN silently, and the `meta`
+    block is kept in extras instead of dropped.
+  - PMD: a `data_model` other than ENGINEERING (the index based MATHEMATICAL
+    model) is rejected instead of being misread as ENGINEERING.
+  - `.pio.json`: a semver build tag containing a hyphen (`1.0.0+build-x`) no
+    longer fails the schema version check.
+
 ## 0.7.1
 
 - The SCOPF Julia wire conversion is structural (#252): every struct reaching

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "powerio",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "approx",
  "arrow",
@@ -2081,7 +2081,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-prob"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2105,7 +2105,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
  "ratatui",
  "serde_json",
  "sprs",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -39,11 +39,11 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.7.1" }
-powerio-matrix = { path = "powerio-matrix", version = "0.7.1" }
-powerio-prob = { path = "powerio-prob", version = "0.7.1" }
-powerio-dist = { path = "powerio-dist", version = "0.7.1" }
-powerio-pkg = { path = "powerio-pkg", version = "0.7.1" }
+powerio = { path = "powerio", version = "0.7.2" }
+powerio-matrix = { path = "powerio-matrix", version = "0.7.2" }
+powerio-prob = { path = "powerio-prob", version = "0.7.2" }
+powerio-dist = { path = "powerio-dist", version = "0.7.2" }
+powerio-pkg = { path = "powerio-pkg", version = "0.7.2" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -36,5 +36,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 walkdir = "2"
 serde_json.workspace = true
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/powerio-cli/src/cases.rs
+++ b/powerio-cli/src/cases.rs
@@ -1,0 +1,254 @@
+//! Case file discovery, family inference, and loading, shared by the CLI
+//! subcommands and the TUI.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use powerio_matrix::format::routing::{Detection, JsonClass, SourceFormat as DetectedFormat};
+use powerio_matrix::network::Network;
+use powerio_pkg::{MulticonductorToBalancedOptions, lower_multiconductor_to_balanced};
+
+/// Extensions (lowercase) that identify a transmission case file.
+pub const TRANSMISSION_EXTENSIONS: &[&str] = &["m", "raw", "aux", "epc", "pwb"];
+
+/// Extensions (lowercase) that identify a distribution case file. `.pwd` is
+/// the PowerWorld display sibling with no case data and stays excluded.
+pub const DISTRIBUTION_EXTENSIONS: &[&str] = &["dss"];
+
+/// `.json` carries no family signal; the shared JSON shape classifier decides.
+const JSON_EXTENSION: &str = "json";
+
+/// Extension list for error and empty-state messages; a unit test keeps it in
+/// sync with the constants above.
+pub const CASE_EXTENSIONS_LABEL: &str = ".m, .raw, .aux, .epc, .pwb, .json, .dss";
+
+/// Infer the case family from clear extensions or, for `.json`, the shared
+/// JSON shape classifier. `Some(true)` is distribution, `Some(false)` is
+/// transmission, and `None` means the extension carries no family signal.
+pub fn infer_input_family(input: &Path) -> anyhow::Result<Option<bool>> {
+    let ext = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let Some(ext) = ext.as_deref() else {
+        return Ok(None);
+    };
+    if TRANSMISSION_EXTENSIONS.contains(&ext) {
+        return Ok(Some(false));
+    }
+    if DISTRIBUTION_EXTENSIONS.contains(&ext) {
+        return Ok(Some(true));
+    }
+    if ext != JSON_EXTENSION {
+        return Ok(None);
+    }
+    let text = std::fs::read_to_string(input)
+        .with_context(|| format!("reading JSON format markers from {}", input.display()))?;
+    match powerio_matrix::format::routing::classify_json_text(&text) {
+        JsonClass::Package => anyhow::bail!(
+            "{} is a .pio.json package envelope, not a case file; the `package` \
+             subcommand writes envelopes, and the bindings read them \
+             (powerio.Package.from_json in Python, read_package in Julia)",
+            input.display()
+        ),
+        JsonClass::Case(Detection::Known(DetectedFormat::Distribution(_))) => Ok(Some(true)),
+        JsonClass::Case(Detection::Known(DetectedFormat::Transmission(_))) => Ok(Some(false)),
+        JsonClass::Case(Detection::Ambiguous) => anyhow::bail!(
+            "ambiguous JSON markers in {}; pass --from to choose a format",
+            input.display()
+        ),
+        JsonClass::Case(Detection::Unknown) => anyhow::bail!(
+            "cannot infer JSON format for {}; pass --from to choose a format",
+            input.display()
+        ),
+        JsonClass::Case(Detection::Known(_)) => anyhow::bail!(
+            "unrecognized JSON format family in {}; pass --from to choose a format",
+            input.display()
+        ),
+    }
+}
+
+pub fn looks_like_distribution_input(input: &Path) -> anyhow::Result<bool> {
+    Ok(infer_input_family(input)?.unwrap_or(false))
+}
+
+/// Recursively list case files under `root`, sorted by path. Hidden entries
+/// are pruned, as is the `exclude` directory subtree (the batch output dir,
+/// so a rerun never rediscovers its own exports) unless it is `root` itself.
+/// A missing or unreadable `root` yields an empty list.
+pub fn discover_cases(root: &Path, exclude: Option<&Path>) -> Vec<PathBuf> {
+    let excluded = exclude
+        .and_then(|p| p.canonicalize().ok())
+        .filter(|p| root.canonicalize().ok().as_ref() != Some(p));
+    let mut cases: Vec<PathBuf> = walkdir::WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|e| !is_hidden(e) && !is_excluded_dir(e, excluded.as_deref()))
+        .filter_map(std::result::Result::ok)
+        .filter(|e| e.file_type().is_file() && has_case_extension(e.path()))
+        .map(walkdir::DirEntry::into_path)
+        .collect();
+    cases.sort();
+    cases
+}
+
+fn is_hidden(entry: &walkdir::DirEntry) -> bool {
+    entry.depth() > 0
+        && entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| n.starts_with('.'))
+}
+
+fn is_excluded_dir(entry: &walkdir::DirEntry, excluded: Option<&Path>) -> bool {
+    let Some(excluded) = excluded else {
+        return false;
+    };
+    entry.file_type().is_dir() && entry.path().canonicalize().is_ok_and(|p| p == excluded)
+}
+
+fn has_case_extension(path: &Path) -> bool {
+    let Some(ext) = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase)
+    else {
+        return false;
+    };
+    let ext = ext.as_str();
+    TRANSMISSION_EXTENSIONS.contains(&ext)
+        || DISTRIBUTION_EXTENSIONS.contains(&ext)
+        || ext == JSON_EXTENSION
+}
+
+/// A case loaded to the transmission model, whatever family it came from.
+pub struct LoadedCase {
+    pub network: Network,
+    pub warnings: Vec<String>,
+}
+
+/// Load one case file as a transmission [`Network`]. Distribution inputs
+/// (`.dss`, BMOPF/PMD `.json`) parse to the multiconductor model and go
+/// through the explicit balanced lowering pass, whose approximations and
+/// dropped fields surface as warnings. A `.dss` redirect fragment (no voltage
+/// source) fails the lowering preflight, so a recursive scan skips it instead
+/// of exporting a partial feeder.
+pub fn load_network(path: &Path) -> anyhow::Result<LoadedCase> {
+    let distribution = infer_input_family(path)?
+        .ok_or_else(|| anyhow::anyhow!("cannot infer a case format for {}", path.display()))?;
+    if distribution {
+        let net = powerio_dist::parse_file(path, None)
+            .with_context(|| format!("parse {}", path.display()))?;
+        let lowered =
+            lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+                .map_err(|e| {
+                    let diagnostics = e
+                        .diagnostics
+                        .iter()
+                        .map(|d| d.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    anyhow::anyhow!("lower {} to balanced: {diagnostics}", path.display())
+                })?;
+        let mut warnings = net.warnings;
+        warnings.extend(
+            (lowered.record.approximations.iter())
+                .chain(&lowered.record.dropped_fields)
+                .map(|s| format!("lowering: {s}")),
+        );
+        Ok(LoadedCase {
+            network: lowered.network,
+            warnings,
+        })
+    } else {
+        let parsed = powerio_matrix::parse_file(path, None)
+            .with_context(|| format!("parse {}", path.display()))?;
+        Ok(LoadedCase {
+            network: parsed.network,
+            warnings: parsed.warnings,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "").unwrap();
+    }
+
+    #[test]
+    fn discovers_recursively_sorted_and_prunes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for rel in [
+            "case1.m",
+            "a/case2.json",
+            "a/net.aux",
+            "a/b/c/deep.raw",
+            "a/b/c/w.pwb",
+            "a/b/c/sys.epc",
+            "a/b/feeder.dss",
+            "notes.txt",
+            "display.pwd",
+            ".hidden.m",
+            ".git/skip.m",
+            "out/case1_meta.json",
+        ] {
+            touch(&root.join(rel));
+        }
+        let found = discover_cases(root, Some(&root.join("out")));
+        let expected: Vec<PathBuf> = [
+            "a/b/c/deep.raw",
+            "a/b/c/sys.epc",
+            "a/b/c/w.pwb",
+            "a/b/feeder.dss",
+            "a/case2.json",
+            "a/net.aux",
+            "case1.m",
+        ]
+        .iter()
+        .map(|rel| root.join(rel))
+        .collect();
+        assert_eq!(found, expected);
+    }
+
+    #[test]
+    fn extension_match_ignores_case() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        for rel in ["CASE.M", "net.RAW", "feeder.DSS", "case.Json", "w.PwB"] {
+            touch(&root.join(rel));
+        }
+        assert_eq!(discover_cases(root, None).len(), 5);
+    }
+
+    #[test]
+    fn exclude_equal_to_root_is_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("case1.m"));
+        assert_eq!(discover_cases(root, Some(root)), vec![root.join("case1.m")]);
+    }
+
+    #[test]
+    fn missing_root_yields_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(discover_cases(&tmp.path().join("nope"), None).is_empty());
+    }
+
+    #[test]
+    fn label_lists_every_extension() {
+        for ext in TRANSMISSION_EXTENSIONS
+            .iter()
+            .chain(DISTRIBUTION_EXTENSIONS)
+            .chain(std::iter::once(&JSON_EXTENSION))
+        {
+            assert!(
+                CASE_EXTENSIONS_LABEL.contains(&format!(".{ext}")),
+                "label is missing .{ext}"
+            );
+        }
+    }
+}

--- a/powerio-cli/src/cases.rs
+++ b/powerio-cli/src/cases.rs
@@ -44,26 +44,36 @@ pub fn infer_input_family(input: &Path) -> anyhow::Result<Option<bool>> {
     }
     let text = std::fs::read_to_string(input)
         .with_context(|| format!("reading JSON format markers from {}", input.display()))?;
-    match powerio_matrix::format::routing::classify_json_text(&text) {
+    match classify_case_json(&text, input)? {
+        DetectedFormat::Distribution(_) => Ok(Some(true)),
+        DetectedFormat::Transmission(_) => Ok(Some(false)),
+        other => anyhow::bail!(
+            "unrecognized JSON format family `{}` in {}; pass --from to choose a format",
+            other.name(),
+            input.display()
+        ),
+    }
+}
+
+/// Classify `.json` case text to its detected format, turning the non-case
+/// outcomes (package envelope, ambiguous markers, no markers) into errors
+/// that name the fix.
+fn classify_case_json(text: &str, path: &Path) -> anyhow::Result<DetectedFormat> {
+    match powerio_matrix::format::routing::classify_json_text(text) {
+        JsonClass::Case(Detection::Known(format)) => Ok(format),
         JsonClass::Package => anyhow::bail!(
             "{} is a .pio.json package envelope, not a case file; the `package` \
              subcommand writes envelopes, and the bindings read them \
              (powerio.Package.from_json in Python, read_package in Julia)",
-            input.display()
+            path.display()
         ),
-        JsonClass::Case(Detection::Known(DetectedFormat::Distribution(_))) => Ok(Some(true)),
-        JsonClass::Case(Detection::Known(DetectedFormat::Transmission(_))) => Ok(Some(false)),
         JsonClass::Case(Detection::Ambiguous) => anyhow::bail!(
             "ambiguous JSON markers in {}; pass --from to choose a format",
-            input.display()
+            path.display()
         ),
         JsonClass::Case(Detection::Unknown) => anyhow::bail!(
             "cannot infer JSON format for {}; pass --from to choose a format",
-            input.display()
-        ),
-        JsonClass::Case(Detection::Known(_)) => anyhow::bail!(
-            "unrecognized JSON format family in {}; pass --from to choose a format",
-            input.display()
+            path.display()
         ),
     }
 }
@@ -132,41 +142,92 @@ pub struct LoadedCase {
 /// dropped fields surface as warnings. A `.dss` redirect fragment (no voltage
 /// source) fails the lowering preflight, so a recursive scan skips it instead
 /// of exporting a partial feeder.
+///
+/// A `.json` case is read and classified once; the classifier's verdict names
+/// the exact format, so the typed parse is the only other pass over the text.
 pub fn load_network(path: &Path) -> anyhow::Result<LoadedCase> {
-    let distribution = infer_input_family(path)?
-        .ok_or_else(|| anyhow::anyhow!("cannot infer a case format for {}", path.display()))?;
-    if distribution {
-        let net = powerio_dist::parse_file(path, None)
-            .with_context(|| format!("parse {}", path.display()))?;
-        let lowered =
-            lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
-                .map_err(|e| {
-                    let diagnostics = e
-                        .diagnostics
-                        .iter()
-                        .map(|d| d.message.as_str())
-                        .collect::<Vec<_>>()
-                        .join("; ");
-                    anyhow::anyhow!("lower {} to balanced: {diagnostics}", path.display())
-                })?;
-        let mut warnings = net.warnings;
-        warnings.extend(
-            (lowered.record.approximations.iter())
-                .chain(&lowered.record.dropped_fields)
-                .map(|s| format!("lowering: {s}")),
-        );
-        Ok(LoadedCase {
-            network: lowered.network,
-            warnings,
-        })
-    } else {
-        let parsed = powerio_matrix::parse_file(path, None)
-            .with_context(|| format!("parse {}", path.display()))?;
-        Ok(LoadedCase {
-            network: parsed.network,
-            warnings: parsed.warnings,
-        })
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let stem = path.file_stem().and_then(|s| s.to_str());
+    match ext.as_deref() {
+        Some(JSON_EXTENSION) => {
+            let text = std::fs::read_to_string(path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            match classify_case_json(&text, path)? {
+                DetectedFormat::Distribution(format) => {
+                    let net = powerio_dist::parse_str(&text, format.name())
+                        .with_context(|| format!("parse {}", path.display()))?;
+                    lower_to_balanced(net, stem, path)
+                }
+                DetectedFormat::Transmission(format) => {
+                    let parsed =
+                        powerio_matrix::format::parse_str_with_name(&text, format.name(), stem)
+                            .with_context(|| format!("parse {}", path.display()))?;
+                    Ok(LoadedCase {
+                        network: parsed.network,
+                        warnings: parsed.warnings,
+                    })
+                }
+                other => anyhow::bail!(
+                    "unrecognized JSON format family `{}` in {}; pass --from to choose a format",
+                    other.name(),
+                    path.display()
+                ),
+            }
+        }
+        Some(ext) if DISTRIBUTION_EXTENSIONS.contains(&ext) => {
+            let net = powerio_dist::parse_file(path, None)
+                .with_context(|| format!("parse {}", path.display()))?;
+            lower_to_balanced(net, stem, path)
+        }
+        Some(ext) if TRANSMISSION_EXTENSIONS.contains(&ext) => {
+            let parsed = powerio_matrix::parse_file(path, None)
+                .with_context(|| format!("parse {}", path.display()))?;
+            Ok(LoadedCase {
+                network: parsed.network,
+                warnings: parsed.warnings,
+            })
+        }
+        _ => anyhow::bail!("cannot infer a case format for {}", path.display()),
     }
+}
+
+/// Lower a parsed multiconductor network to the balanced model. A nameless
+/// case takes its file stem as the network name first (the role the stem
+/// plays for transmission formats); otherwise every nameless case in a batch
+/// lowers to the same `lowered-multiconductor` fallback and the exports
+/// overwrite each other.
+fn lower_to_balanced(
+    mut net: powerio_dist::DistNetwork,
+    stem: Option<&str>,
+    path: &Path,
+) -> anyhow::Result<LoadedCase> {
+    if net.name.is_none() {
+        net.name = stem.map(str::to_owned);
+    }
+    let lowered =
+        lower_multiconductor_to_balanced(&net, MulticonductorToBalancedOptions::default())
+            .map_err(|e| {
+                let diagnostics = e
+                    .diagnostics
+                    .iter()
+                    .map(|d| d.message.as_str())
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                anyhow::anyhow!("lower {} to balanced: {diagnostics}", path.display())
+            })?;
+    let mut warnings = net.warnings;
+    warnings.extend(
+        (lowered.record.approximations.iter())
+            .chain(&lowered.record.dropped_fields)
+            .map(|s| format!("lowering: {s}")),
+    );
+    Ok(LoadedCase {
+        network: lowered.network,
+        warnings,
+    })
 }
 
 #[cfg(test)]
@@ -236,6 +297,23 @@ mod tests {
     fn missing_root_yields_empty() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(discover_cases(&tmp.path().join("nope"), None).is_empty());
+    }
+
+    #[test]
+    fn nameless_distribution_json_takes_the_file_stem_name() {
+        let dss = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/data/dist/micro/fourwire_linecode.dss"
+        );
+        let conv = powerio_dist::convert_file(dss, powerio_dist::DistTargetFormat::BmopfJson, None)
+            .unwrap();
+        let mut doc: serde_json::Value = serde_json::from_str(&conv.text).unwrap();
+        doc.as_object_mut().unwrap().remove("name");
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("myfeeder.json");
+        std::fs::write(&path, doc.to_string()).unwrap();
+        let loaded = load_network(&path).unwrap();
+        assert_eq!(loaded.network.name, "myfeeder");
     }
 
     #[test]

--- a/powerio-cli/src/cases.rs
+++ b/powerio-cli/src/cases.rs
@@ -216,7 +216,13 @@ fn lower_to_balanced(
                     .map(|d| d.message.as_str())
                     .collect::<Vec<_>>()
                     .join("; ");
-                anyhow::anyhow!("lower {} to balanced: {diagnostics}", path.display())
+                if diagnostics.is_empty() {
+                    // Diagnostics should always be present on a refusal, but
+                    // an empty list must not render a bare trailing colon.
+                    anyhow::anyhow!("lower {} to balanced: {e}", path.display())
+                } else {
+                    anyhow::anyhow!("lower {} to balanced: {diagnostics}", path.display())
+                }
             })?;
     let mut warnings = net.warnings;
     warnings.extend(

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand, ValueEnum};
-use powerio_matrix::format::routing::{Detection, JsonClass, SourceFormat as DetectedFormat};
 use powerio_matrix::io::gridfm::{GridfmOptions, numbered_snapshots, write_gridfm_batch};
 use powerio_matrix::matrix::{BuildOptions, DcConvention, Scheme, sddm_check};
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
@@ -20,7 +19,10 @@ use powerio_pkg::{NetworkPackage, Origin, READ_GRIDFM_FIDELITY_WARNING, SourceDe
 use powerio_prob::matrix::{DcOpfBundleMetadata, DcOpfBundleOptions, write_dcopf_bundle};
 use powerio_prob::{DcOpfOptions, Units, build_dc_opf_instance};
 use serde_json::json;
+mod cases;
 mod tui;
+
+use cases::{infer_input_family, looks_like_distribution_input};
 
 const SUMMARY_SCHEMA_VERSION: &str = "0.1";
 
@@ -35,16 +37,18 @@ struct Cli {
 enum Command {
     /// Launch the interactive TUI (default if no subcommand is given).
     Tui {
-        /// Directory holding `.m` MATPOWER cases.
+        /// Directory scanned recursively for case files (.m, .raw, .aux,
+        /// .epc, .pwb, .json, .dss).
         #[arg(short, long)]
         data_dir: Option<PathBuf>,
         /// Default output directory for batch exports.
         #[arg(short, long)]
         out_dir: Option<PathBuf>,
     },
-    /// Batch export matrix datasets for every `.m` case in a directory.
+    /// Batch export matrix datasets for every case file under a directory.
     Batch {
-        /// Input directory (or single `.m` file).
+        /// Input directory (scanned recursively for case files) or a single
+        /// case file.
         #[arg(short, long)]
         input: PathBuf,
         /// Output directory.
@@ -757,25 +761,18 @@ fn run_batch(
     rhs: RhsKind,
     seed: u64,
 ) -> anyhow::Result<()> {
-    let cases: Vec<PathBuf> = if input.is_file() {
-        vec![input.to_path_buf()]
+    let (found, scanned) = if input.is_file() {
+        (vec![input.to_path_buf()], false)
     } else {
-        walkdir::WalkDir::new(input)
-            .max_depth(2)
-            .into_iter()
-            .filter_map(std::result::Result::ok)
-            .filter(|e| e.file_type().is_file())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .is_some_and(|x| x.eq_ignore_ascii_case("m"))
-            })
-            .map(|e| e.path().to_path_buf())
-            .collect()
+        (cases::discover_cases(input, Some(output)), true)
     };
 
-    if cases.is_empty() {
-        anyhow::bail!("no `.m` files found under {}", input.display());
+    if found.is_empty() {
+        anyhow::bail!(
+            "no case files ({}) found under {}",
+            cases::CASE_EXTENSIONS_LABEL,
+            input.display()
+        );
     }
 
     let pipeline = Pipeline {
@@ -789,19 +786,40 @@ fn run_batch(
         source_file: None,
     };
 
-    for case_path in &cases {
-        let mpc = powerio_matrix::parse_matpower_file(case_path)
-            .with_context(|| format!("parse {}", case_path.display()))?;
+    let mut exported = 0usize;
+    for case_path in &found {
+        let loaded = match cases::load_network(case_path) {
+            Ok(loaded) => loaded,
+            // A recursive scan sweeps up files that merely share an extension
+            // with a case format (stray .json in particular); skip them
+            // instead of aborting the run.
+            Err(e) if scanned => {
+                tracing::warn!(case = %case_path.display(), error = format!("{e:#}"), "skipping");
+                continue;
+            }
+            Err(e) => return Err(e),
+        };
+        for w in &loaded.warnings {
+            tracing::warn!(case = %case_path.display(), "{w}");
+        }
         let mut p = pipeline.clone();
         p.source_file = Some(case_path.clone());
         let outputs = p
-            .run(&mpc, output)
+            .run(&loaded.network, output)
             .with_context(|| format!("export {}", case_path.display()))?;
+        exported += 1;
         tracing::info!(
             case = %outputs.case_name,
             n = outputs.metadata.n_buses,
             files = outputs.files.len(),
             "exported"
+        );
+    }
+    if exported == 0 {
+        anyhow::bail!(
+            "no files under {} loaded as case files ({})",
+            input.display(),
+            cases::CASE_EXTENSIONS_LABEL
         );
     }
     Ok(())
@@ -1325,50 +1343,6 @@ fn looks_like_gridfm_dir(input: &Path) -> bool {
                 .count()
                 == 1
         })
-}
-
-fn looks_like_distribution_input(input: &Path) -> anyhow::Result<bool> {
-    Ok(infer_input_family(input)?.unwrap_or(false))
-}
-
-/// Infer the case family from clear extensions or, for `.json`, the shared
-/// JSON shape classifier. `Some(true)` is distribution, `Some(false)` is
-/// transmission, and `None` means the extension carries no family signal.
-fn infer_input_family(input: &Path) -> anyhow::Result<Option<bool>> {
-    let ext = input
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(str::to_ascii_lowercase);
-    match ext.as_deref() {
-        Some("m" | "raw" | "aux" | "epc" | "pwb") => return Ok(Some(false)),
-        Some("dss") => return Ok(Some(true)),
-        Some("json") => {}
-        _ => return Ok(None),
-    }
-    let text = std::fs::read_to_string(input)
-        .with_context(|| format!("reading JSON format markers from {}", input.display()))?;
-    match powerio_matrix::format::routing::classify_json_text(&text) {
-        JsonClass::Package => anyhow::bail!(
-            "{} is a .pio.json package envelope, not a case file; the `package` \
-             subcommand writes envelopes, and the bindings read them \
-             (powerio.Package.from_json in Python, read_package in Julia)",
-            input.display()
-        ),
-        JsonClass::Case(Detection::Known(DetectedFormat::Distribution(_))) => Ok(Some(true)),
-        JsonClass::Case(Detection::Known(DetectedFormat::Transmission(_))) => Ok(Some(false)),
-        JsonClass::Case(Detection::Ambiguous) => anyhow::bail!(
-            "ambiguous JSON markers in {}; pass --from to choose a format",
-            input.display()
-        ),
-        JsonClass::Case(Detection::Unknown) => anyhow::bail!(
-            "cannot infer JSON format for {}; pass --from to choose a format",
-            input.display()
-        ),
-        JsonClass::Case(Detection::Known(_)) => anyhow::bail!(
-            "unrecognized JSON format family in {}; pass --from to choose a format",
-            input.display()
-        ),
-    }
 }
 
 fn run_convert(

--- a/powerio-cli/src/tui/app.rs
+++ b/powerio-cli/src/tui/app.rs
@@ -207,32 +207,24 @@ impl App {
     }
 
     pub fn refresh_cases(&mut self) {
-        let mut entries = walkdir::WalkDir::new(&self.data_dir)
-            .max_depth(2)
+        // The discovered order is already sorted by path, which groups
+        // subfolders; display names keep the relative path and extension so
+        // same-stem cases in different formats stay distinguishable.
+        self.cases = crate::cases::discover_cases(&self.data_dir, Some(&self.out_dir))
             .into_iter()
-            .filter_map(std::result::Result::ok)
-            .filter(|e| e.file_type().is_file())
-            .filter(|e| {
-                e.path()
-                    .extension()
-                    .is_some_and(|x| x.eq_ignore_ascii_case("m"))
-            })
-            .map(|e| {
-                let path = e.path().to_path_buf();
+            .map(|path| {
                 let display_name = path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("?")
-                    .to_string();
+                    .strip_prefix(&self.data_dir)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .into_owned();
                 CaseEntry {
                     path,
                     display_name,
                     parsed: ParseStatus::NotLoaded,
                 }
             })
-            .collect::<Vec<_>>();
-        entries.sort_by(|a, b| a.display_name.cmp(&b.display_name));
-        self.cases = entries;
+            .collect();
         if self.selected >= self.cases.len() {
             self.selected = self.cases.len().saturating_sub(1);
         }
@@ -241,24 +233,28 @@ impl App {
     pub fn parse_selected(&mut self) {
         if let Some(entry) = self.cases.get_mut(self.selected) {
             if matches!(entry.parsed, ParseStatus::NotLoaded) {
-                entry.parsed = match powerio_matrix::parse_matpower_file(&entry.path) {
-                    Ok(case) => ParseStatus::Loaded {
-                        n_buses: case.buses.len(),
-                        n_branches: case.branches.len(),
-                        base_mva: case.base_mva,
-                    },
-                    Err(e) => ParseStatus::Failed(e.to_string()),
+                entry.parsed = match crate::cases::load_network(&entry.path) {
+                    Ok(loaded) => {
+                        self.log.push_parse_warnings(&entry.path, &loaded.warnings);
+                        ParseStatus::Loaded {
+                            n_buses: loaded.network.buses.len(),
+                            n_branches: loaded.network.branches.len(),
+                            base_mva: loaded.network.base_mva,
+                        }
+                    }
+                    Err(e) => ParseStatus::Failed(format!("{e:#}")),
                 };
             }
         }
     }
 
-    pub fn open_inspect(&mut self) -> powerio_matrix::Result<()> {
+    pub fn open_inspect(&mut self) -> anyhow::Result<()> {
         let Some(entry) = self.cases.get(self.selected) else {
             return Ok(());
         };
-        let case = powerio_matrix::parse_matpower_file(&entry.path)?;
-        self.inspect = Some(self.build_inspect(case)?);
+        let loaded = crate::cases::load_network(&entry.path)?;
+        self.log.push_parse_warnings(&entry.path, &loaded.warnings);
+        self.inspect = Some(self.build_inspect(loaded.network)?);
         self.previous_screen = self.screen;
         self.screen = Screen::Inspect;
         Ok(())

--- a/powerio-cli/src/tui/log_pane.rs
+++ b/powerio-cli/src/tui/log_pane.rs
@@ -30,6 +30,12 @@ impl LogBuf {
         g.push_back(line.into());
     }
 
+    pub fn push_parse_warnings(&self, path: &std::path::Path, warnings: &[String]) {
+        for w in warnings {
+            self.push(format!("WARN  parse {}: {w}", path.display()));
+        }
+    }
+
     pub fn snapshot(&self) -> Vec<String> {
         self.inner
             .lock()

--- a/powerio-cli/src/tui/mod.rs
+++ b/powerio-cli/src/tui/mod.rs
@@ -288,21 +288,18 @@ fn spawn_batch(app: &mut App) {
         app.set_status("nothing to export");
         return;
     }
-    let paths: Vec<PathBuf> = targets
-        .iter()
-        .filter_map(|i| app.cases.get(*i).map(|c| c.path.clone()))
-        .collect();
-    app.batch = paths
-        .iter()
-        .map(|p| BatchJob {
-            case_name: p
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("?")
-                .to_string(),
-            progress: BatchProgress::Pending,
-        })
-        .collect();
+    let mut paths = Vec::with_capacity(targets.len());
+    let mut jobs = Vec::with_capacity(targets.len());
+    for i in &targets {
+        if let Some(c) = app.cases.get(*i) {
+            paths.push(c.path.clone());
+            jobs.push(BatchJob {
+                case_name: c.display_name.clone(),
+                progress: BatchProgress::Pending,
+            });
+        }
+    }
+    app.batch = jobs;
     let pipeline = Pipeline {
         matrices: app.matrices_to_export.clone(),
         options: powerio_matrix::matrix::BuildOptions {
@@ -324,14 +321,17 @@ fn spawn_batch(app: &mut App) {
                 case_idx: i,
                 progress: BatchProgress::Running(0.05),
             });
-            let parsed = match powerio_matrix::parse_matpower_file(path) {
-                Ok(p) => p,
+            let loaded = match crate::cases::load_network(path) {
+                Ok(loaded) => {
+                    log.push_parse_warnings(path, &loaded.warnings);
+                    loaded
+                }
                 Err(e) => {
                     let _ = tx.send(WorkerEvent::Progress {
                         case_idx: i,
-                        progress: BatchProgress::Failed(format!("parse: {e}")),
+                        progress: BatchProgress::Failed(format!("parse: {e:#}")),
                     });
-                    log.push(format!("ERROR parse {}: {e}", path.display()));
+                    log.push(format!("ERROR parse {}: {e:#}", path.display()));
                     continue;
                 }
             };
@@ -341,7 +341,7 @@ fn spawn_batch(app: &mut App) {
             });
             let mut p = pipeline.clone();
             p.source_file = Some(path.clone());
-            match p.run(&parsed, &out_dir) {
+            match p.run(&loaded.network, &out_dir) {
                 Ok(out) => {
                     log.push(format!(
                         "INFO  exported {} ({} files)",
@@ -531,5 +531,34 @@ mod tests {
             let next = app.inspect.as_ref().unwrap().kind;
             assert_ne!(initial, next);
         }
+    }
+
+    #[test]
+    fn refresh_cases_on_missing_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = App::new(
+            tmp.path().join("nope"),
+            std::env::temp_dir(),
+            LogBuf::default(),
+        );
+        app.refresh_cases();
+        assert!(app.cases.is_empty());
+    }
+
+    #[test]
+    fn refresh_cases_uses_relative_display_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("sub")).unwrap();
+        std::fs::write(tmp.path().join("case9.m"), "").unwrap();
+        std::fs::write(tmp.path().join("sub").join("case9.raw"), "").unwrap();
+        let mut app = App::new(
+            tmp.path().to_path_buf(),
+            std::env::temp_dir(),
+            LogBuf::default(),
+        );
+        app.refresh_cases();
+        let names: Vec<_> = app.cases.iter().map(|c| c.display_name.as_str()).collect();
+        let sub = format!("sub{}case9.raw", std::path::MAIN_SEPARATOR);
+        assert_eq!(names, ["case9.m", sub.as_str()]);
     }
 }

--- a/powerio-cli/src/tui/screens.rs
+++ b/powerio-cli/src/tui/screens.rs
@@ -251,7 +251,10 @@ fn draw_browse_detail(frame: &mut Frame, app: &App, area: Rect) {
         v
     } else {
         vec![Line::from(Span::styled(
-            "No `.m` cases found in data directory.",
+            format!(
+                "No case files ({}) found in data directory.",
+                crate::cases::CASE_EXTENSIONS_LABEL
+            ),
             warn(),
         ))]
     };

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -263,3 +263,162 @@ fn family_mismatch_exits_before_writing_output() {
         out_path.display()
     );
 }
+
+#[test]
+fn batch_scans_directory_recursively_and_skips_unparseable_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let nested = root.join("a").join("b").join("c");
+    std::fs::create_dir_all(&nested).unwrap();
+    std::fs::copy(repo_file("tests/data/case9.m"), nested.join("case9.m")).unwrap();
+    std::fs::copy(
+        repo_file("tests/data/dist/micro/fourwire_linecode.dss"),
+        root.join("feeder.dss"),
+    )
+    .unwrap();
+    std::fs::write(root.join("junk.json"), r#"{"not": "a case"}"#).unwrap();
+    let hidden = root.join(".hidden");
+    std::fs::create_dir_all(&hidden).unwrap();
+    std::fs::copy(repo_file("tests/data/case14.m"), hidden.join("case14.m")).unwrap();
+    let out_dir = root.join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    std::fs::copy(repo_file("tests/data/case30.m"), out_dir.join("case30.m")).unwrap();
+
+    let out = run(&[
+        "batch",
+        "-i",
+        root.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert_success(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(out_dir.join("case9_bprime.mtx").is_file(), "{stderr}");
+    // Output files are named by the circuit name inside the case (the dss
+    // fixture's circuit is "fourwire"), not by the file stem.
+    assert!(
+        out_dir.join("fourwire_bprime.mtx").is_file(),
+        "lowered dss case missing:\n{stderr}"
+    );
+    assert!(stderr.contains("junk.json"), "no skip warning:\n{stderr}");
+    assert!(
+        !out_dir.join("case14_bprime.mtx").exists(),
+        "hidden directory was scanned:\n{stderr}"
+    );
+    assert!(
+        !out_dir.join("case30_bprime.mtx").exists(),
+        "output directory was scanned:\n{stderr}"
+    );
+}
+
+#[test]
+fn batch_scan_discovers_bmopf_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let json_path = root.join("sub").join("feeder.json");
+    std::fs::create_dir_all(json_path.parent().unwrap()).unwrap();
+    let dss = repo_file("tests/data/dist/micro/fourwire_linecode.dss");
+    let out = run(&[
+        "convert",
+        dss.to_str().unwrap(),
+        "--to",
+        "bmopf-json",
+        "-o",
+        json_path.to_str().unwrap(),
+    ]);
+    assert_success(&out);
+
+    let out_dir = root.join("out");
+    let out = run(&[
+        "batch",
+        "-i",
+        root.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert_success(&out);
+    assert!(
+        out_dir.join("fourwire_bprime.mtx").is_file(),
+        "bmopf json case missing:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn batch_scan_skips_unlowerable_dss_but_explicit_input_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let dss = repo_file("tests/data/dist/micro/xfmr_single_phase.dss");
+    std::fs::copy(&dss, root.join("xfmr.dss")).unwrap();
+    std::fs::copy(repo_file("tests/data/case9.m"), root.join("case9.m")).unwrap();
+    let out_dir = root.join("out");
+
+    let out = run(&[
+        "batch",
+        "-i",
+        root.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert_success(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out_dir.join("case9_bprime.mtx").is_file(), "{stderr}");
+    assert!(stderr.contains("xfmr.dss"), "no skip warning:\n{stderr}");
+
+    let out = run(&[
+        "batch",
+        "-i",
+        dss.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("lower") && stderr.contains("balanced"),
+        "expected a lowering diagnostic:\n{stderr}"
+    );
+}
+
+#[test]
+fn batch_scan_with_no_case_files_reports_supported_extensions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("notes.txt"), "nothing here").unwrap();
+
+    let out = run(&[
+        "batch",
+        "-i",
+        root.to_str().unwrap(),
+        "-o",
+        root.to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no case files") && stderr.contains(".epc"),
+        "expected the extension list:\n{stderr}"
+    );
+}
+
+#[test]
+fn batch_scan_where_nothing_loads_fails() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::write(root.join("junk.json"), r#"{"not": "a case"}"#).unwrap();
+
+    let out = run(&[
+        "batch",
+        "-i",
+        root.to_str().unwrap(),
+        "-o",
+        root.join("out").to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("loaded as case files"),
+        "expected the zero-loaded error:\n{stderr}"
+    );
+}

--- a/powerio-dist/Cargo.toml
+++ b/powerio-dist/Cargo.toml
@@ -30,6 +30,7 @@ schemars = { workspace = true, optional = true }
 [dev-dependencies]
 # Draft 2020-12 validation against the vendored BMOPF schema in tests.
 jsonschema = { version = "0.46", default-features = false }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -153,13 +153,20 @@ fn config(v: Option<&Value>, what: &str, warnings: &mut Vec<String>) -> Configur
     }
 }
 
+/// The largest conductor index a `prefix_i_j` matrix key may carry. The
+/// largest index seen sizes a dense n×n allocation in [`flat_matrix`], so an
+/// unbounded key (a few bytes of JSON) could demand gigabytes; no physical
+/// conductor bundle comes near this bound. An oversized index makes the key
+/// unrecognized, so it lands in extras with the malformed-key warning.
+const MAX_MATRIX_INDEX: usize = 64;
+
 /// Parses the `_i_j` tail of a `prefix_i_j` matrix key (1 based). None
 /// when the key is not a well formed entry for this prefix.
 fn matrix_indices(key: &str, prefix: &str) -> Option<(usize, usize)> {
     let rest = key.strip_prefix(prefix)?.strip_prefix('_')?;
     let (i, j) = rest.split_once('_')?;
     let (i, j) = (i.parse::<usize>().ok()?, j.parse::<usize>().ok()?);
-    (i >= 1 && j >= 1).then_some((i, j))
+    (i >= 1 && j >= 1 && i <= MAX_MATRIX_INDEX && j <= MAX_MATRIX_INDEX).then_some((i, j))
 }
 
 /// Collects `prefix_i_j` keys into a square matrix; `n` is the largest
@@ -253,8 +260,16 @@ impl Reader<'_> {
                 "shunt" => self.shunts(items),
                 "voltage_source" => self.sources(items),
                 "transformer" => self.transformers(items),
-                // `meta` is provenance, not network data; the writer regenerates it.
-                "name" | "meta" => {}
+                "name" => {}
+                // `meta` is provenance (license, authors, generator tool),
+                // with no typed slot in the model. Stash it whole, the way the
+                // PMD reader stashes `pmd_settings`, so a read keeps it; the
+                // BMOPF writer still regenerates its own `meta` block.
+                "meta" => {
+                    self.net
+                        .extras
+                        .insert("bmopf_meta".into(), Value::Object(items.clone()));
+                }
                 other => {
                     self.net.warnings.push(format!(
                         "top level `{other}` is outside the schema; kept untyped"
@@ -523,6 +538,17 @@ impl Reader<'_> {
                 "terminal_map_from",
                 "terminal_map_to",
             ];
+            // The schema requires `length`; a missing one becomes NaN in the
+            // model, which every impedance computation downstream inherits,
+            // so name the gap the way the transformer reader names a missing
+            // s_rating instead of letting the NaN travel silently.
+            let length = o.get("length").map_or(f64::NAN, f);
+            if !length.is_finite() {
+                self.net.warnings.push(format!(
+                    "line {name}: `length` missing or non-finite; impedances derived from \
+                     this line are undefined"
+                ));
+            }
             self.net.lines.push(DistLine {
                 name: name.clone(),
                 bus_from: string(o.get("bus_from")),
@@ -530,7 +556,7 @@ impl Reader<'_> {
                 terminal_map_from: strings(o.get("terminal_map_from")),
                 terminal_map_to: strings(o.get("terminal_map_to")),
                 linecode: string(o.get("linecode")),
-                length: o.get("length").map_or(f64::NAN, f),
+                length,
                 route: None,
                 extras: take_extras(
                     o,
@@ -963,13 +989,29 @@ impl Reader<'_> {
         }
     }
 
+    /// Cap the winding list a document supplies. The short circuit pair
+    /// enumeration is quadratic in the winding count, so an unbounded count
+    /// would be a quadratic blowup from a linear document; no physical
+    /// transformer comes near the cap.
+    fn bounded_windings<'a>(&mut self, name: &str, items: &'a [Value]) -> &'a [Value] {
+        const MAX_WINDINGS: usize = 64;
+        if items.len() > MAX_WINDINGS {
+            self.net.warnings.push(format!(
+                "transformer {name}: {} windings exceed the supported maximum of \
+                 {MAX_WINDINGS}; the rest are ignored",
+                items.len()
+            ));
+        }
+        &items[..items.len().min(MAX_WINDINGS)]
+    }
+
     fn n_winding_transformer(&mut self, name: &str, o: &Map<String, Value>) -> DistTransformer {
         let known = ["windings", "x_sc", "s_rating", "g_no_load", "b_no_load"];
         let s = o.get("s_rating").map_or(f64::NAN, f);
         let mut windings = Vec::new();
         let mut delta_rolls = Map::new();
         if let Some(items) = o.get("windings").and_then(Value::as_array) {
-            for (idx, item) in items.iter().enumerate() {
+            for (idx, item) in self.bounded_windings(name, items).iter().enumerate() {
                 let Some(w) = item.as_object() else {
                     self.net.warnings.push(format!(
                         "transformer {name}: winding {} is not an object; skipped",

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -97,6 +97,9 @@ fn has_top_level_key(text: &str, key: &str) -> bool {
 /// Distribution parser policy for `.json`: PMD carries `data_model`; otherwise
 /// it is routed to BMOPF so the BMOPF reader can give the parse error or warning.
 fn infer_distribution_json_format(text: &str) -> DistTargetFormat {
+    // A leading byte order mark would fail the DOM parse here and silently
+    // send a PMD document down the BMOPF fallback; classify without it.
+    let text = text.trim_start_matches('\u{feff}');
     if has_top_level_key(text, "data_model") {
         DistTargetFormat::PmdJson
     } else {
@@ -104,13 +107,31 @@ fn infer_distribution_json_format(text: &str) -> DistTargetFormat {
     }
 }
 
+/// The warning every parse path pushes when it removes a byte order mark.
+pub(crate) const BOM_WARNING: &str =
+    "leading UTF-8 byte order mark removed; a same-format write returns the text without it";
+
+/// Parse `text` as `format`, stripping a leading UTF-8 byte order mark first:
+/// Windows tooling saves case files with one, and both serde_json and the DSS
+/// tokenizer treat it as garbage in the first token. The retained source loses
+/// the mark, so a same-format echo differs by exactly those three bytes; the
+/// warning itemizes that.
+fn parse_text(text: &str, format: DistTargetFormat) -> crate::Result<DistNetwork> {
+    let stripped = text.trim_start_matches('\u{feff}');
+    let mut net = match format {
+        DistTargetFormat::Dss => crate::dss::parse_dss_str(stripped),
+        DistTargetFormat::BmopfJson => crate::bmopf::parse_bmopf_str(stripped)?,
+        DistTargetFormat::PmdJson => crate::pmd::parse_pmd_str(stripped)?,
+    };
+    if stripped.len() != text.len() {
+        net.warnings.push(BOM_WARNING.to_owned());
+    }
+    Ok(net)
+}
+
 /// Parses `text` in the named format (see [`dist_target_from_name`]).
 pub fn parse_str(text: &str, format: &str) -> crate::Result<DistNetwork> {
-    match format.parse::<DistTargetFormat>()? {
-        DistTargetFormat::Dss => Ok(crate::dss::parse_dss_str(text)),
-        DistTargetFormat::BmopfJson => crate::bmopf::parse_bmopf_str(text),
-        DistTargetFormat::PmdJson => crate::pmd::parse_pmd_str(text),
-    }
+    parse_text(text, format.parse::<DistTargetFormat>()?)
 }
 
 /// Parses `path`, taking the format from `from` when given, the `.dss`
@@ -134,19 +155,14 @@ pub fn parse_file(
             "dss" => DistTargetFormat::Dss,
             "json" => {
                 let text = read(path)?;
-                return if infer_distribution_json_format(&text) == DistTargetFormat::PmdJson {
-                    crate::pmd::parse_pmd_str(&text)
-                } else {
-                    crate::bmopf::parse_bmopf_str(&text)
-                };
+                return parse_text(&text, infer_distribution_json_format(&text));
             }
             other => return Err(crate::Error::UnknownFormat(other.to_string())),
         }
     };
     match format {
         DistTargetFormat::Dss => crate::dss::parse_dss_file(path),
-        DistTargetFormat::BmopfJson => crate::bmopf::parse_bmopf_str(&read(path)?),
-        DistTargetFormat::PmdJson => crate::pmd::parse_pmd_str(&read(path)?),
+        DistTargetFormat::BmopfJson | DistTargetFormat::PmdJson => parse_text(&read(path)?, format),
     }
 }
 
@@ -263,6 +279,28 @@ mod tests {
         assert_eq!(
             infer_distribution_json_format("{not json"),
             DistTargetFormat::BmopfJson
+        );
+        // A byte order mark must not push a PMD document down the BMOPF
+        // fallback.
+        assert_eq!(
+            infer_distribution_json_format("\u{feff}{\"data_model\": \"ENGINEERING\"}"),
+            DistTargetFormat::PmdJson
+        );
+    }
+
+    #[test]
+    fn byte_order_mark_is_stripped_and_warned() {
+        let dss = "\u{feff}clear\nnew circuit.c basekv=12.47 bus1=src\n";
+        let net = parse_str(dss, "dss").unwrap();
+        assert!(
+            net.warnings.iter().any(|w| w.contains("byte order mark")),
+            "warnings: {:?}",
+            net.warnings
+        );
+        assert!(
+            net.source
+                .as_ref()
+                .is_some_and(|s| !s.starts_with('\u{feff}'))
         );
     }
 

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -54,6 +54,32 @@ fn strip_bom_owned(text: String) -> String {
     }
 }
 
+/// A redirect loader that strips a leading byte order mark from every file it
+/// reads and records which files carried one, so each strip can be itemized
+/// as a warning instead of happening silently.
+fn bom_stripping_loader(
+    stripped_paths: &mut Vec<String>,
+) -> impl FnMut(&Path) -> std::io::Result<String> + '_ {
+    |p: &Path| {
+        std::fs::read_to_string(p).map(|text| {
+            if text.starts_with('\u{feff}') {
+                stripped_paths.push(p.display().to_string());
+            }
+            strip_bom_owned(text)
+        })
+    }
+}
+
+fn warn_stripped_boms(net: &mut DistNetwork, root_had_bom: bool, stripped_paths: Vec<String>) {
+    if root_had_bom {
+        net.warnings.push(crate::convert::BOM_WARNING.to_owned());
+    }
+    for path in stripped_paths {
+        net.warnings
+            .push(format!("{path}: {}", crate::convert::BOM_WARNING));
+    }
+}
+
 /// Parses a `.dss` file, following includes, into the canonical model.
 pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
     let path = path.as_ref();
@@ -63,13 +89,14 @@ pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
     })?;
     let had_bom = text.starts_with('\u{feff}');
     let text = strip_bom_owned(text);
-    let raw = parse_raw_with(&text, &path.display().to_string(), &mut |p: &Path| {
-        std::fs::read_to_string(p).map(strip_bom_owned)
-    });
+    let mut stripped_paths = Vec::new();
+    let raw = parse_raw_with(
+        &text,
+        &path.display().to_string(),
+        &mut bom_stripping_loader(&mut stripped_paths),
+    );
     let mut net = network_from_raw(&raw, Arc::new(text));
-    if had_bom {
-        net.warnings.push(crate::convert::BOM_WARNING.to_owned());
-    }
+    warn_stripped_boms(&mut net, had_bom, stripped_paths);
     Ok(net)
 }
 
@@ -77,13 +104,14 @@ pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
 /// directory.
 pub fn parse_dss_str(text: &str) -> DistNetwork {
     let stripped = text.trim_start_matches('\u{feff}');
-    let raw = parse_raw_with(stripped, "<string>", &mut |p: &Path| {
-        std::fs::read_to_string(p).map(strip_bom_owned)
-    });
+    let mut stripped_paths = Vec::new();
+    let raw = parse_raw_with(
+        stripped,
+        "<string>",
+        &mut bom_stripping_loader(&mut stripped_paths),
+    );
     let mut net = network_from_raw(&raw, Arc::new(stripped.to_string()));
-    if stripped.len() != text.len() {
-        net.warnings.push(crate::convert::BOM_WARNING.to_owned());
-    }
+    warn_stripped_boms(&mut net, stripped.len() != text.len(), stripped_paths);
     net
 }
 

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -45,6 +45,15 @@ const TYPED_DSS_CLASSES: &[&str] = &[
     "regcontrol",
 ];
 
+/// Drop a leading UTF-8 byte order mark: the tokenizer would read it as part
+/// of the first command word. Redirected files are stripped the same way.
+fn strip_bom_owned(text: String) -> String {
+    match text.strip_prefix('\u{feff}') {
+        Some(stripped) => stripped.to_owned(),
+        None => text,
+    }
+}
+
 /// Parses a `.dss` file, following includes, into the canonical model.
 pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
     let path = path.as_ref();
@@ -52,17 +61,30 @@ pub fn parse_dss_file(path: impl AsRef<Path>) -> Result<DistNetwork> {
         path: path.display().to_string(),
         source,
     })?;
+    let had_bom = text.starts_with('\u{feff}');
+    let text = strip_bom_owned(text);
     let raw = parse_raw_with(&text, &path.display().to_string(), &mut |p: &Path| {
-        std::fs::read_to_string(p)
+        std::fs::read_to_string(p).map(strip_bom_owned)
     });
-    Ok(network_from_raw(&raw, Arc::new(text)))
+    let mut net = network_from_raw(&raw, Arc::new(text));
+    if had_bom {
+        net.warnings.push(crate::convert::BOM_WARNING.to_owned());
+    }
+    Ok(net)
 }
 
 /// Parses `.dss` text; `Redirect`/`Compile` resolve relative to the working
 /// directory.
 pub fn parse_dss_str(text: &str) -> DistNetwork {
-    let raw = parse_raw_with(text, "<string>", &mut |p: &Path| std::fs::read_to_string(p));
-    network_from_raw(&raw, Arc::new(text.to_string()))
+    let stripped = text.trim_start_matches('\u{feff}');
+    let raw = parse_raw_with(stripped, "<string>", &mut |p: &Path| {
+        std::fs::read_to_string(p).map(strip_bom_owned)
+    });
+    let mut net = network_from_raw(&raw, Arc::new(stripped.to_string()));
+    if stripped.len() != text.len() {
+        net.warnings.push(crate::convert::BOM_WARNING.to_owned());
+    }
+    net
 }
 
 /// Lowers an executed raw script into the typed model.

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -40,6 +40,23 @@ pub fn parse_pmd_str(text: &str) -> Result<DistNetwork> {
             message: "top level is not an object".into(),
         });
     };
+    // This reader types the ENGINEERING model only. The MATHEMATICAL model
+    // shares the `data_model` marker but is index based and structurally
+    // unrelated; interpreting its sections as ENGINEERING would silently
+    // build a wrong network.
+    if let Some(dm) = doc.get("data_model").and_then(Value::as_str) {
+        if !dm.eq_ignore_ascii_case("ENGINEERING") {
+            return Err(Error::Json {
+                format: "PMD",
+                message: format!(
+                    "`data_model` is `{dm}`; this reader supports the ENGINEERING model \
+                     (convert MATHEMATICAL output back with \
+                     PowerModelsDistribution.transform_solution or export the ENGINEERING \
+                     model)"
+                ),
+            });
+        }
+    }
     let mut net = DistNetwork {
         source: Some(Arc::new(text.to_string())),
         source_format: Some(DistSourceFormat::PmdJson),

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -2338,3 +2338,51 @@ fn reader_is_liberal_where_the_writer_is_strict() {
     assert!(out.warnings.iter().any(|w| w.contains("note")));
     assert!(!out.text.contains("hand edited"));
 }
+
+#[test]
+fn oversized_matrix_key_is_bounded_and_warned() {
+    // The largest matrix index seen sizes a dense allocation; an unbounded
+    // key would demand gigabytes from a few bytes of JSON. Out-of-bounds
+    // indices fall out of the matrix grammar and land in extras, warned.
+    let net = powerio_dist::parse_str(
+        r#"{"linecode":{"lc":{"R_series_100000_1":1.0}}}"#,
+        "bmopf-json",
+    )
+    .unwrap();
+    assert!(
+        net.warnings.iter().any(|w| w.contains("R_series_100000_1")),
+        "warnings: {:?}",
+        net.warnings
+    );
+}
+
+#[test]
+fn winding_count_is_bounded() {
+    let windings: Vec<serde_json::Value> = (0..65)
+        .map(|i| {
+            serde_json::json!({
+                "bus": format!("b{i}"), "terminal_map": ["1", "2", "3"], "v_nom": 1000.0
+            })
+        })
+        .collect();
+    let doc = serde_json::json!({
+        "transformer": {"n_winding": {"t1": {"windings": windings, "s_rating": 1000.0}}}
+    });
+    let net = powerio_dist::parse_str(&doc.to_string(), "bmopf-json").unwrap();
+    assert!(
+        net.warnings.iter().any(|w| w.contains("supported maximum")),
+        "warnings: {:?}",
+        net.warnings
+    );
+    assert_eq!(net.transformers.len(), 1);
+}
+
+#[test]
+fn meta_block_is_kept_in_extras() {
+    let net = powerio_dist::parse_str(
+        r#"{"bus":{"b1":{}},"meta":{"license":"CC-BY-4.0"}}"#,
+        "bmopf-json",
+    )
+    .unwrap();
+    assert!(net.extras.contains_key("bmopf_meta"), "{:?}", net.extras);
+}

--- a/powerio-dist/tests/dss_bom.rs
+++ b/powerio-dist/tests/dss_bom.rs
@@ -1,0 +1,38 @@
+//! Byte order mark handling across the DSS read paths: the strip must be
+//! itemized for the root file and for every redirected file.
+
+#[test]
+fn redirected_file_bom_strip_is_itemized() {
+    let tmp = tempfile::tempdir().unwrap();
+    let linecodes = tmp.path().join("linecodes.dss");
+    std::fs::write(
+        &linecodes,
+        "\u{feff}new linecode.lc1 nphases=3 r1=0.1 x1=0.2\n",
+    )
+    .unwrap();
+    let master = tmp.path().join("master.dss");
+    std::fs::write(
+        &master,
+        format!(
+            "\u{feff}clear\nnew circuit.c basekv=12.47 bus1=src\nredirect {}\n",
+            linecodes.display()
+        ),
+    )
+    .unwrap();
+
+    let net = powerio_dist::parse_dss_file(&master).unwrap();
+    let bom_warnings: Vec<_> = net
+        .warnings
+        .iter()
+        .filter(|w| w.contains("byte order mark"))
+        .collect();
+    // One warning for the root file, one naming the redirected file.
+    assert_eq!(bom_warnings.len(), 2, "warnings: {:?}", net.warnings);
+    assert!(
+        bom_warnings.iter().any(|w| w.contains("linecodes.dss")),
+        "warnings: {:?}",
+        net.warnings
+    );
+    // The linecode from the redirected file still parsed.
+    assert!(net.linecodes.iter().any(|lc| lc.name == "lc1"));
+}

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -650,3 +650,13 @@ fn null_suffix_restoration() {
     // ampacity bound means no bound, so i_max is None.
     assert!(net.linecodes[0].i_max.is_none());
 }
+
+#[test]
+fn mathematical_data_model_is_rejected() {
+    // The MATHEMATICAL model shares the `data_model` marker but is index
+    // based; interpreting its sections as ENGINEERING would silently build a
+    // wrong network.
+    let err = powerio_dist::parse_str(r#"{"data_model":"MATHEMATICAL","bus":{}}"#, "pmd-json")
+        .unwrap_err();
+    assert!(err.to_string().contains("ENGINEERING"), "got: {err}");
+}

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -42,10 +42,10 @@ pub use powerio::{
     convert_str_with_options, display_format_from_name, error, format, gen_cost, geo, indexed,
     network, parse_display_bytes, parse_display_file, parse_file, parse_gen_cost_csv,
     parse_matpower, parse_matpower_file, parse_pandapower_json, parse_powermodels_json,
-    parse_powerworld, parse_pslf, parse_psse, parse_str, read_pypsa_csv_folder,
-    target_format_from_name, write_as, write_as_with_options, write_egret_json, write_matpower,
-    write_pandapower_json, write_powermodels_json, write_powerworld, write_psse,
-    write_pypsa_csv_folder,
+    parse_powerworld, parse_pslf, parse_psse, parse_str, parse_str_with_name,
+    read_pypsa_csv_folder, target_format_from_name, write_as, write_as_with_options,
+    write_egret_json, write_matpower, write_pandapower_json, write_powermodels_json,
+    write_powerworld, write_psse, write_pypsa_csv_folder,
 };
 
 /// Compressed sparse row matrix used by the projection builders.

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -702,7 +702,8 @@ impl NetworkPackage {
 
     /// Deserialize from `.pio.json`.
     pub fn from_json(text: &str) -> serde_json::Result<Self> {
-        let pkg: Self = serde_json::from_str(text)?;
+        // Tolerate a leading UTF-8 byte order mark, as the format readers do.
+        let pkg: Self = serde_json::from_str(text.trim_start_matches('\u{feff}'))?;
         if !Self::supports_schema_version(&pkg.schema_version) {
             return Err(<serde_json::Error as serde::de::Error>::custom(format!(
                 "unsupported .pio.json schema_version {}; this reader supports major version {}",
@@ -914,22 +915,21 @@ fn schema_major(version: &str) -> Option<u64> {
     // Accept a semver core `MAJOR.MINOR.PATCH` with an optional prerelease
     // (`-...`) or build (`+...`) tag: same-major additive versions load, so a
     // forward-compatible writer that stamps e.g. `0.2.0-rc.1` is not rejected.
-    let (core, suffix) = match version.split_once('-') {
-        Some((core, rest)) => match rest.split_once('+') {
-            Some((pre, build)) => (core, Some((Some(pre), Some(build)))),
-            None => (core, Some((Some(rest), None))),
-        },
-        None => match version.split_once('+') {
-            Some((core, build)) => (core, Some((None, Some(build)))),
-            None => (version, None),
-        },
+    // Split the build tag off first: `+` cannot appear in a prerelease, but a
+    // hyphen is legal inside build metadata (`1.0.0+build-x`), so splitting on
+    // `-` first would cut inside the build tag and reject a valid version.
+    let (rest, build) = match version.split_once('+') {
+        Some((rest, build)) => (rest, Some(build)),
+        None => (version, None),
     };
-    if let Some((pre, build)) = suffix {
-        if pre.is_some_and(|s| !valid_semver_suffix(s))
-            || build.is_some_and(|s| !valid_semver_suffix(s))
-        {
-            return None;
-        }
+    let (core, pre) = match rest.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (rest, None),
+    };
+    if pre.is_some_and(|s| !valid_semver_suffix(s))
+        || build.is_some_and(|s| !valid_semver_suffix(s))
+    {
+        return None;
     }
     let mut parts = core.split('.');
     let major = parts.next()?;
@@ -2266,4 +2266,20 @@ fn multiconductor_source_maps(
         }
     }
     entries
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn schema_major_parses_semver_suffixes() {
+        assert_eq!(super::schema_major("1.2.3"), Some(1));
+        assert_eq!(super::schema_major("1.0.0-rc.1"), Some(1));
+        // A hyphen inside build metadata is legal semver; splitting on `-`
+        // first used to cut inside the build tag and reject the version.
+        assert_eq!(super::schema_major("1.0.0+build-x"), Some(1));
+        assert_eq!(super::schema_major("1.0.0-rc-1+b-2"), Some(1));
+        assert_eq!(super::schema_major("1.0"), None);
+        assert_eq!(super::schema_major("1.0.0-"), None);
+        assert_eq!(super::schema_major("01.0.0"), None);
+    }
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -703,7 +703,15 @@ impl NetworkPackage {
     /// Deserialize from `.pio.json`.
     pub fn from_json(text: &str) -> serde_json::Result<Self> {
         // Tolerate a leading UTF-8 byte order mark, as the format readers do.
-        let pkg: Self = serde_json::from_str(text.trim_start_matches('\u{feff}'))?;
+        // Name the format in the error: a document the JSON classifier calls a
+        // package envelope (right `model_kind` and `model` markers) can still
+        // fail here on a missing required field, and the bare serde message
+        // ("missing field `producer`") does not say what it failed to be.
+        let pkg: Self = serde_json::from_str(text.trim_start_matches('\u{feff}')).map_err(|e| {
+            <serde_json::Error as serde::de::Error>::custom(format!(
+                "invalid .pio.json package envelope: {e}"
+            ))
+        })?;
         if !Self::supports_schema_version(&pkg.schema_version) {
             return Err(<serde_json::Error as serde::de::Error>::custom(format!(
                 "unsupported .pio.json schema_version {}; this reader supports major version {}",
@@ -2277,9 +2285,21 @@ mod tests {
         // A hyphen inside build metadata is legal semver; splitting on `-`
         // first used to cut inside the build tag and reject the version.
         assert_eq!(super::schema_major("1.0.0+build-x"), Some(1));
+        assert_eq!(super::schema_major("0.2.0+2026-07-21"), Some(0));
         assert_eq!(super::schema_major("1.0.0-rc-1+b-2"), Some(1));
         assert_eq!(super::schema_major("1.0"), None);
         assert_eq!(super::schema_major("1.0.0-"), None);
         assert_eq!(super::schema_major("01.0.0"), None);
+    }
+
+    #[test]
+    fn envelope_shaped_rejection_names_the_format() {
+        // Classifier-recognized envelope markers with a missing required
+        // field: the failure must say what the document failed to be.
+        let err = super::NetworkPackage::from_json(
+            r#"{"model_kind":"balanced","model":{"kind":"balanced"}}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains(".pio.json"), "got: {err}");
     }
 }

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -658,10 +658,16 @@ fn read_cost(p_cost: &Value, startup: f64, shutdown: f64) -> Option<GenCost> {
     let m = p_cost.as_object()?;
     match m.get("cost_curve_type").and_then(Value::as_str)? {
         "polynomial" => {
+            // The exponent keys size the coefficient vector below; an
+            // unbounded key (a few bytes of JSON) would drive an arbitrarily
+            // large allocation. No physical cost curve goes past a handful of
+            // terms; keys beyond the cap are dropped like non-numeric ones.
+            const MAX_COST_EXPONENT: usize = 64;
             let values = m.get("values")?.as_object()?;
             let pairs: Vec<(usize, f64)> = values
                 .iter()
                 .filter_map(|(k, c)| Some((k.parse().ok()?, c.as_f64()?)))
+                .filter(|(e, _)| *e <= MAX_COST_EXPONENT)
                 .collect();
             let max_exp = pairs.iter().map(|(e, _)| *e).max()?;
             let mut coeffs = vec![0.0; max_exp + 1]; // index 0 = highest order
@@ -701,6 +707,26 @@ fn read_cost(p_cost: &Value, startup: f64, shutdown: f64) -> Option<GenCost> {
 mod tests {
     use super::*;
     use crate::network::BusType;
+
+    #[test]
+    fn oversized_cost_exponent_is_dropped_not_allocated() {
+        // The exponent key sizes the coefficient vector; unbounded it would be
+        // an allocation of that many f64s from a few bytes of JSON, and a key
+        // at usize::MAX would wrap `max_exp + 1` to zero and index out of
+        // bounds.
+        let all_oversized: Value = serde_json::json!({
+            "cost_curve_type": "polynomial",
+            "values": {"100000000000": 5.0, "18446744073709551615": 1.0}
+        });
+        assert!(read_cost(&all_oversized, 0.0, 0.0).is_none());
+
+        let mixed: Value = serde_json::json!({
+            "cost_curve_type": "polynomial",
+            "values": {"2": 3.0, "100000000000": 1.0}
+        });
+        let cost = read_cost(&mixed, 0.0, 0.0).unwrap();
+        assert_eq!(cost.coeffs, vec![3.0, 0.0, 0.0]);
+    }
 
     fn fixture(name: &str) -> String {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/powerio/src/format/goc3.rs
+++ b/powerio/src/format/goc3.rs
@@ -92,6 +92,11 @@ impl Goc3Document {
     }
 
     /// Map bus UIDs to the external bus IDs assigned by the balanced reader.
+    ///
+    /// Uid uniqueness is validated by the parse that produced this document
+    /// (`read_buses` rejects a duplicate bus uid), so the map here cannot
+    /// silently collapse entries; a document constructed another way has no
+    /// such guarantee.
     pub fn bus_ids(&self) -> Result<HashMap<String, BusId>> {
         bus_id_by_uid(&section(self.network()?, "bus")?)
     }
@@ -623,9 +628,21 @@ fn device_rows(network: &Map<String, Value>) -> Result<Vec<Goc3DeviceRecord<'_>>
     let mut rows = Vec::new();
     let mut generators = 0usize;
     let mut loads = 0usize;
+    // Time-series bounds and costs are joined back onto devices by uid
+    // (`device_time_series` is last-write-wins on its map), so a repeated uid
+    // would silently hand one device the other's series; reject it the way
+    // `read_buses` rejects a repeated bus uid.
+    let mut seen_uids = std::collections::HashSet::new();
     for item in section(network, "simple_dispatchable_device")? {
         let obj = item_object(item, "simple_dispatchable_device")?;
         let uid = item_uid(item, obj);
+        if let Some(uid) = &uid {
+            if !seen_uids.insert(uid.clone()) {
+                return Err(bad(format!(
+                    "duplicate simple_dispatchable_device uid `{uid}`"
+                )));
+            }
+        }
         let (table, row) = match string(obj, "device_type").unwrap_or("producer") {
             "producer" => {
                 generators += 1;
@@ -928,4 +945,25 @@ fn records<'a>(parent: &'a Map<String, Value>, name: &'static str) -> Result<Vec
             })
             .collect()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_device_uid_is_rejected() {
+        // Time-series bounds and costs join back onto devices by uid; a
+        // repeated uid would silently hand one device the other's series.
+        let network: Map<String, Value> = serde_json::from_str(
+            r#"{"simple_dispatchable_device":[
+                {"uid":"sd1","device_type":"producer"},
+                {"uid":"sd1","device_type":"consumer"}]}"#,
+        )
+        .unwrap();
+        let Err(err) = device_rows(&network) else {
+            panic!("duplicate uid must be rejected")
+        };
+        assert!(err.to_string().contains("duplicate"), "got: {err}");
+    }
 }

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -462,7 +462,8 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
         let text = std::fs::read_to_string(path)?;
         let stem = path.file_stem().and_then(|s| s.to_str());
         let mut warnings = Vec::new();
-        let network = pslf::parse_pslf_source(Arc::new(text), stem, &mut warnings)?;
+        let source = strip_bom(Arc::new(text), &mut warnings);
+        let network = pslf::parse_pslf_source(source, stem, &mut warnings)?;
         reject_empty_case(&network, "PSLF .epc")?;
         return Ok(Parsed::without_document(network, warnings));
     }
@@ -521,6 +522,22 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
     read_source(Arc::new(text), fmt, stem)
 }
 
+/// Strip a leading UTF-8 byte order mark before the reader sees the text.
+/// Windows tooling saves case files with one, and every text reader here
+/// (serde_json first among them) treats it as garbage in the first token. The
+/// retained source loses the mark, so a same-format echo differs by exactly
+/// those three bytes; the warning itemizes that per the fidelity policy.
+fn strip_bom(source: Arc<String>, warnings: &mut Vec<String>) -> Arc<String> {
+    let Some(stripped) = source.strip_prefix('\u{feff}') else {
+        return source;
+    };
+    warnings.push(
+        "leading UTF-8 byte order mark removed; a same-format write returns the text without it"
+            .to_owned(),
+    );
+    Arc::new(stripped.to_owned())
+}
+
 /// Read an owned `source` buffer as `fmt`, using `name_hint` (e.g. the file
 /// stem) when the format carries no name of its own. The single format→reader
 /// map: [`parse_file`] and [`parse_str`] both funnel through it, so every format
@@ -530,6 +547,7 @@ pub fn parse_file(path: impl AsRef<std::path::Path>, from: Option<&str>) -> Resu
 /// readers that report fidelity loss append to it.
 fn read_source(source: Arc<String>, fmt: TargetFormat, name_hint: Option<&str>) -> Result<Parsed> {
     let mut warnings = Vec::new();
+    let source = strip_bom(source, &mut warnings);
     let mut document = None;
     let net = match fmt {
         TargetFormat::Matpower => matpower::parse_matpower_source(source, name_hint),
@@ -673,14 +691,26 @@ fn transmission_json_target(format: TransmissionFormat) -> Result<TargetFormat> 
 /// [`Error::UnknownFormat`] if `format` is unrecognized; the reader's own
 /// [`Error`] on malformed input.
 pub fn parse_str(text: &str, format: &str) -> Result<Parsed> {
+    parse_str_with_name(text, format, None)
+}
+
+/// [`parse_str`] with a name hint for formats that carry no name of their own
+/// (the role the file stem plays in [`parse_file`]). Lets a caller that already
+/// read a file's text keep the stem-derived case name without going back
+/// through the filesystem.
+///
+/// # Errors
+/// As [`parse_str`].
+pub fn parse_str_with_name(text: &str, format: &str, name_hint: Option<&str>) -> Result<Parsed> {
     if is_pslf_name(format) {
         let mut warnings = Vec::new();
-        let network = pslf::parse_pslf_source(Arc::new(text.to_owned()), None, &mut warnings)?;
+        let source = strip_bom(Arc::new(text.to_owned()), &mut warnings);
+        let network = pslf::parse_pslf_source(source, name_hint, &mut warnings)?;
         reject_empty_case(&network, "PSLF .epc")?;
         return Ok(Parsed::without_document(network, warnings));
     }
     let fmt = target_format_from_name(format).ok_or_else(|| unknown_source_format(format))?;
-    read_source(Arc::new(text.to_owned()), fmt, None)
+    read_source(Arc::new(text.to_owned()), fmt, name_hint)
 }
 
 /// Output of a parse: the network plus the reader's fidelity warnings,
@@ -1368,6 +1398,26 @@ mod tests {
         // A genuinely unknown token still echoes plainly.
         let err = parse_str("anything", "nonesuch").unwrap_err();
         assert!(err.to_string().contains("nonesuch"));
+    }
+
+    #[test]
+    fn byte_order_mark_is_stripped_and_warned() {
+        let case = "\u{feff}function mpc = t\n\
+                    mpc.version = '2';\n\
+                    mpc.baseMVA = 100;\n\
+                    mpc.bus = [1 3 0 0 0 0 1 1.0 0 345 1 1.1 0.9;];\n\
+                    mpc.gen = [];\n\
+                    mpc.branch = [];\n";
+        let parsed = parse_str(case, "matpower").unwrap();
+        assert_eq!(parsed.network.buses.len(), 1);
+        assert!(
+            parsed
+                .warnings
+                .iter()
+                .any(|w| w.contains("byte order mark")),
+            "warnings: {:?}",
+            parsed.warnings
+        );
     }
 
     #[test]

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -370,7 +370,12 @@ pub(crate) fn parse_pandapower_source(
         for row in trafo_frame.rows() {
             let from = bus_ref("trafo", &row, "hv_bus", &bus_of_pp)?;
             let to = bus_ref("trafo", &row, "lv_bus", &bus_of_pp)?;
-            let sn = row.f_or("sn_mva", base_mva);
+            // `sn` divides the impedance below; a zero, negative, or
+            // non-finite rating would put NaN/Inf straight into Branch.r/x.
+            let sn = row
+                .f_finite("sn_mva")
+                .filter(|v| *v > 0.0)
+                .unwrap_or(base_mva);
             let par = parallel_or_one(&row);
             let pfe_mw = row.f_or("pfe_kw", 0.0) * 1e-3 * par;
             let g_mag = pfe_mw / base_mva;
@@ -1903,7 +1908,10 @@ fn written_kv(base_kv: f64) -> f64 {
 fn value_f64(v: &Value) -> Option<f64> {
     match v {
         Value::Number(_) => v.as_f64(),
-        Value::String(s) => s.parse().ok(),
+        // `f64::from_str` accepts "nan"/"inf"/"-infinity"; a string cell must
+        // not smuggle a non-finite value into a numeric column that a JSON
+        // number could never carry.
+        Value::String(s) => s.parse().ok().filter(|f: &f64| f.is_finite()),
         _ => None,
     }
 }

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -832,7 +832,12 @@ fn read_cost(v: &Value, base_mva: f64, per_unit: bool) -> GenCost {
     // before the per-unit unscale, as `cost_to_pu` does on the way out, so
     // padding can't read as a higher-degree polynomial and mis-scale every
     // coefficient.
-    let declared_ncost = v.get("ncost").and_then(Value::as_u64).map(|n| n as usize);
+    // Fallible conversion: an ncost beyond usize (32-bit targets) reads as
+    // undeclared instead of truncating into a small in-range value.
+    let declared_ncost = v
+        .get("ncost")
+        .and_then(Value::as_u64)
+        .and_then(|n| usize::try_from(n).ok());
     if let Some(n) = declared_ncost {
         let keep = if model == 1 { n.saturating_mul(2) } else { n };
         if keep < coeffs_raw.len() {
@@ -855,7 +860,9 @@ fn read_cost(v: &Value, base_mva: f64, per_unit: bool) -> GenCost {
         model,
         startup: f(v, "startup"),
         shutdown: f(v, "shutdown"),
-        ncost: declared_ncost.unwrap_or(default_ncost),
+        // Clamp to what the coefficients can back: an ncost declared beyond
+        // the vector length would make the GenCost internally inconsistent.
+        ncost: declared_ncost.map_or(default_ncost, |n| n.min(default_ncost)),
         coeffs,
     }
 }

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -450,13 +450,17 @@ pub(crate) fn parse_powermodels_json_source(
         message: "top level is not a JSON object".into(),
     })?;
 
-    let base_mva =
-        root.get("baseMVA")
-            .and_then(Value::as_f64)
-            .ok_or_else(|| Error::FormatRead {
-                format: FMT,
-                message: "missing numeric `baseMVA`".into(),
-            })?;
+    // `baseMVA` is every per-unit divisor here; zero, negative, or non-finite
+    // would silently poison the scaled quantities with NaN/Inf or flipped
+    // signs, so reject it at the door.
+    let base_mva = root
+        .get("baseMVA")
+        .and_then(Value::as_f64)
+        .filter(|b| b.is_finite() && *b > 0.0)
+        .ok_or_else(|| Error::FormatRead {
+            format: FMT,
+            message: "missing, nonpositive, or non-finite numeric `baseMVA`".into(),
+        })?;
     let per_unit = root
         .get("per_unit")
         .and_then(Value::as_bool)
@@ -544,9 +548,16 @@ fn f_or(v: &Value, key: &str, default: f64) -> f64 {
 fn uid(v: &Value, key: &str) -> usize {
     v.get(key).and_then(Value::as_u64).unwrap_or(0) as usize
 }
-/// A 0/1 status field; absent ⇒ in service.
+/// A 0/1 status field; absent ⇒ in service. Some producers write a JSON
+/// boolean instead of the MATPOWER 0/1 number; `as_f64` returns `None` for a
+/// bool, so without the explicit arm a `false` here would read back as in
+/// service.
 fn flag(v: &Value, key: &str) -> bool {
-    v.get(key).and_then(Value::as_f64) != Some(0.0)
+    match v.get(key) {
+        Some(Value::Bool(b)) => *b,
+        Some(value) => value.as_f64() != Some(0.0),
+        None => true,
+    }
 }
 
 fn bustype(code: i64) -> BusType {
@@ -804,12 +815,30 @@ fn read_gen(v: &Value, pscale: f64, base_mva: f64, per_unit: bool) -> Generator 
 fn read_cost(v: &Value, base_mva: f64, per_unit: bool) -> GenCost {
     // Keep non-numeric entries as NaN rather than dropping them: silently filtering
     // would shift every later coefficient's polynomial degree.
-    let coeffs_raw: Vec<f64> = v
+    let mut coeffs_raw: Vec<f64> = v
         .get("cost")
         .and_then(Value::as_array)
         .map(|a| a.iter().map(|c| c.as_f64().unwrap_or(f64::NAN)).collect())
         .unwrap_or_default();
-    let model = v.get("model").and_then(Value::as_u64).unwrap_or(2) as u8;
+    // An out-of-range model number must not wrap into 1/2 (`as u8` turns 257
+    // into Piecewise and rescales coefficients that were never per-unit);
+    // saturate into the unknown-model passthrough instead.
+    let model = v
+        .get("model")
+        .and_then(Value::as_u64)
+        .map_or(2, |m| u8::try_from(m).unwrap_or(u8::MAX));
+    // MATPOWER pads gencost rows to the matrix width with trailing zeros, and
+    // third-party JSON can retain that padding. Trim to the declared ncost
+    // before the per-unit unscale, as `cost_to_pu` does on the way out, so
+    // padding can't read as a higher-degree polynomial and mis-scale every
+    // coefficient.
+    let declared_ncost = v.get("ncost").and_then(Value::as_u64).map(|n| n as usize);
+    if let Some(n) = declared_ncost {
+        let keep = if model == 1 { n.saturating_mul(2) } else { n };
+        if keep < coeffs_raw.len() {
+            coeffs_raw.truncate(keep);
+        }
+    }
     let k = coeffs_raw.len();
     // Undo PowerModels' per-unit cost scaling for the neutral MW basis (the
     // inverse of the writer's per-unit rescale); a non-per-unit source is read
@@ -826,10 +855,7 @@ fn read_cost(v: &Value, base_mva: f64, per_unit: bool) -> GenCost {
         model,
         startup: f(v, "startup"),
         shutdown: f(v, "shutdown"),
-        ncost: v
-            .get("ncost")
-            .and_then(Value::as_u64)
-            .map_or(default_ncost, |n| n as usize),
+        ncost: declared_ncost.unwrap_or(default_ncost),
         coeffs,
     }
 }
@@ -961,6 +987,68 @@ mod tests {
 
     fn approx(a: f64, b: f64) -> bool {
         (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1.0)
+    }
+
+    #[test]
+    fn boolean_status_fields_read_out_of_service() {
+        let doc = r#"{"baseMVA":100.0,"per_unit":true,
+            "bus":{"1":{"bus_i":1,"bus_type":3,"vm":1.0,"va":0.0,"base_kv":345.0},
+                   "2":{"bus_i":2,"bus_type":1,"vm":1.0,"va":0.0,"base_kv":345.0}},
+            "branch":{"1":{"f_bus":1,"t_bus":2,"br_r":0.01,"br_x":0.1,"br_status":false}},
+            "gen":{"1":{"gen_bus":1,"pg":0.5,"gen_status":false}}}"#;
+        let net = parse_powermodels_json(doc).unwrap();
+        assert!(
+            !net.branches[0].in_service,
+            "br_status: false must read out of service"
+        );
+        assert!(
+            !net.generators[0].in_service,
+            "gen_status: false must read out of service"
+        );
+    }
+
+    #[test]
+    fn nonpositive_base_mva_is_rejected() {
+        for base in ["0.0", "-100.0", "1e999"] {
+            let doc = format!(
+                r#"{{"baseMVA":{base},"bus":{{"1":{{"bus_i":1,"bus_type":3,"vm":1.0,"va":0.0,"base_kv":345.0}}}}}}"#
+            );
+            assert!(
+                parse_powermodels_json(&doc).is_err(),
+                "baseMVA {base} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn padded_cost_rows_trim_to_ncost_before_unscaling() {
+        // MATPOWER pads gencost rows to the matrix width; the trailing zero
+        // here is padding, and ncost declares the real quadratic. Untrimmed,
+        // the per-unit unscale would treat the row as cubic and divide every
+        // coefficient by an extra factor of base.
+        let v: Value = serde_json::json!({
+            "gen_bus": 1, "model": 2, "ncost": 3,
+            "cost": [1.0, 1.0, 1.0, 0.0]
+        });
+        let cost = read_cost(&v, 100.0, true);
+        assert_eq!(cost.ncost, 3);
+        assert_eq!(cost.coeffs.len(), 3);
+        assert!(approx(cost.coeffs[0], 1e-4));
+        assert!(approx(cost.coeffs[1], 1e-2));
+        assert!(approx(cost.coeffs[2], 1.0));
+    }
+
+    #[test]
+    fn out_of_range_cost_model_does_not_wrap_into_rescaling() {
+        // 257 as u8 would wrap to 1 (piecewise) and rescale coefficients that
+        // were never per-unit; it must saturate into the unknown-model
+        // passthrough instead.
+        let v: Value = serde_json::json!({
+            "gen_bus": 1, "model": 257,
+            "cost": [10.0, 5.0]
+        });
+        let cost = read_cost(&v, 100.0, true);
+        assert_eq!(cost.coeffs, vec![10.0, 5.0]);
     }
 
     #[test]

--- a/powerio/src/format/routing.rs
+++ b/powerio/src/format/routing.rs
@@ -187,7 +187,9 @@ pub enum JsonClass {
 /// Ambiguous means the document contains strong markers from both domains, so
 /// the caller must ask the user for an explicit format.
 pub fn classify_json_text(text: &str) -> JsonClass {
-    let Ok(shape) = JsonShape::try_from(text) else {
+    // Windows tooling saves JSON with a UTF-8 byte order mark, which
+    // serde_json rejects; strip it so a BOM never hides the format.
+    let Ok(shape) = JsonShape::try_from(text.trim_start_matches('\u{feff}')) else {
         return JsonClass::Case(Detection::Unknown);
     };
     if matches!(
@@ -514,6 +516,16 @@ mod tests {
                 "{alias}"
             );
         }
+    }
+
+    #[test]
+    fn classifies_json_with_leading_byte_order_mark() {
+        assert_eq!(
+            classify_json_text("\u{feff}{\"baseMVA\":100.0,\"bus\":{},\"branch\":{}}"),
+            JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+                TransmissionFormat::PowerModelsJson
+            )))
+        );
     }
 
     #[test]

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -1351,8 +1351,13 @@ fn value_to_usize(value: &Value, key: &str) -> Result<usize> {
                     Err(format_error(format!("`{key}` must be nonnegative")))
                 }
             } else if let Some(value) = number.as_f64() {
-                if value >= 0.0 && value.fract() == 0.0 {
+                // Mirror the integer branches' "too large" rejection: a float
+                // beyond usize would otherwise saturate to usize::MAX and read
+                // as a confusing unknown-bus reference later.
+                if value >= 0.0 && value.fract() == 0.0 && value < usize::MAX as f64 {
                     Ok(value as usize)
+                } else if value >= usize::MAX as f64 {
+                    Err(format_error(format!("`{key}` integer is too large")))
                 } else {
                     Err(format_error(format!("`{key}` must be an integer")))
                 }
@@ -1407,6 +1412,19 @@ fn string_not_default(obj: &Map<String, Value>, key: &str, default: &str) -> boo
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn float_index_beyond_usize_is_rejected() {
+        // 1e20 backs into the f64 branch (too large for as_u64) and would
+        // saturate to usize::MAX under `as usize`; it must get the same "too
+        // large" rejection the integer branches give.
+        let err = value_to_usize(&serde_json::json!(1e20), "from_bus").unwrap_err();
+        assert!(err.to_string().contains("too large"), "got: {err}");
+        assert_eq!(
+            value_to_usize(&serde_json::json!(3.0), "from_bus").unwrap(),
+            3
+        );
+    }
 
     #[test]
     fn rejects_bad_envelope() {

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -57,10 +57,11 @@ pub use format::{
     convert_str, convert_str_with_options, display_format_from_name, parse_deepmind_opfdata_json,
     parse_display_bytes, parse_display_file, parse_egret_json, parse_file, parse_goc3_json,
     parse_matpower, parse_matpower_file, parse_pandapower_json, parse_powermodels_json,
-    parse_powerworld, parse_pslf, parse_psse, parse_str, parse_surge_json, read_pypsa_csv_folder,
-    target_format_from_name, write_as, write_as_with_options, write_dir, write_egret_json,
-    write_matpower, write_pandapower_json, write_powermodels_json, write_powerworld, write_pslf,
-    write_psse, write_psse_rev, write_pypsa_csv_folder, write_surge_json,
+    parse_powerworld, parse_pslf, parse_psse, parse_str, parse_str_with_name, parse_surge_json,
+    read_pypsa_csv_folder, target_format_from_name, write_as, write_as_with_options, write_dir,
+    write_egret_json, write_matpower, write_pandapower_json, write_powermodels_json,
+    write_powerworld, write_pslf, write_psse, write_psse_rev, write_pypsa_csv_folder,
+    write_surge_json,
 };
 pub use gen_cost::{GenCostPatch, GenCostPolicyReport, MissingGenCostPolicy, parse_gen_cost_csv};
 pub use geo::{

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -1921,6 +1921,8 @@ impl Network {
     /// on it) can't hand back a network the file readers would have rejected
     /// (the same no-buses guard `read_source` applies to every parse path).
     pub fn from_json(text: &str) -> crate::Result<Network> {
+        // Tolerate a leading UTF-8 byte order mark, as the format readers do.
+        let text = text.trim_start_matches('\u{feff}');
         let net: Network = serde_json::from_str(text).map_err(|e| Error::FormatRead {
             format: "JSON",
             message: e.to_string(),


### PR DESCRIPTION
## What

`batch` and the TUI browser scanned for `.m` files only, at `max_depth(2)`, and `batch` bailed with ``no `.m` files found`` on folders holding other supported formats. This change:

- Discovery recurses without a depth cap over `.m`, `.raw`, `.aux`, `.epc`, `.pwb`, `.json`, `.dss`. Extension matching is case-insensitive; hidden entries and the output directory subtree are pruned; results are sorted.
- Discovery, family inference (`infer_input_family`, moved out of `main.rs`), and loading live in one `cases` module shared by `batch` and the TUI, so the extension list exists in one place.
- Distribution inputs (`.dss`, BMOPF/PMD `.json`, auto-detected by the shared JSON shape classifier) parse to the multiconductor model and go through `powerio_pkg::lower_multiconductor_to_balanced` before the matrix pipeline. Lowering approximations and dropped fields surface as warnings.
- Scan mode skips files that fail to load, with a warning (stray `.json` cannot abort a run); an explicit single-file input keeps the hard error. A scan that loads nothing still errors.
- TUI case names are paths relative to the data directory, so `psse/case14.raw` and `case14.m` stay distinguishable; the batch job list reuses them.

## JSON parser review pass (second commit)

A review of the JSON reader family and the shared classifier, with the direct fixes applied here and the behavior-changing remainder filed as #262/#263. This commit also bumps the workspace to 0.7.2 and adds the changelog section, so the release tag can go on main once this merges.

- **BOM tolerance**: a leading UTF-8 byte order mark defeated `classify_json_text` and every text reader (`expected value at line 1 column 1`). The classifier, the transmission read funnel, the distribution parsers (including `.dss` and redirected files), the PMD/BMOPF split, `Network::from_json`, and `Package::from_json` now strip it; each strip is an itemized fidelity warning, since a same-format echo returns the text without the mark.
- **One read, one classification**: `parse_str_with_name` joins the format hub (`parse_str` plus the name-hint role the file stem plays in `parse_file`), and `cases::load_network` reads a `.json` once and hands the text straight to the typed parser. A batch scan previously read each `.json` twice and DOM-parsed it three times; on OPFData-sized files that dominated the load time.
- **Stem naming for nameless distribution cases**: `name` is optional in the BMOPF schema, and every nameless case lowered to the name `lowered-multiconductor`, so two of them in one batch overwrote each other's exports.
- **Robustness against crafted or malformed documents**: bounded allocations in the egret polynomial cost reader (a ~100-byte document could demand an arbitrarily large vector, and a `usize::MAX` exponent key indexed out of bounds) and the BMOPF matrix/winding readers (gigabyte allocations and quadratic work from small documents); the Surge float bus reference no longer saturates to `usize::MAX`.
- **Correctness**: PowerModels boolean status fields read out of service (previously `"br_status": false` read as in service), `baseMVA` must be finite and positive, padded gencost rows trim to `ncost` before the per-unit unscale, and an out-of-range cost model passes through unscaled instead of wrapping into the rescale; pandapower trafo `sn_mva = 0` no longer divides impedance by zero and string cells cannot smuggle `"inf"`/`"nan"` into numeric columns; GOC3 rejects duplicate `simple_dispatchable_device` uids instead of silently swapping time series; PMD rejects the MATHEMATICAL `data_model` instead of misreading it as ENGINEERING; BMOPF warns on a missing line `length` and keeps `meta` in extras; the `.pio.json` semver check accepts build metadata containing a hyphen.

## Notes

- Feeders the lowering preflight refuses (transformers, closed switches) skip with the structured diagnostic; extending the pass is #261, with corrected acceptance criteria (IEEE 13 additionally has single and two phase laterals, which no balanced lowering can carry).
- Pre-existing, more visible now: pipeline outputs are named by circuit name, so the same case in two formats (e.g. `ACTIVSg200.aux` + `.pwb`) overwrites its own exports in one batch run.
- `verify`, `dcopf`, and `sensitivities` remain MATPOWER-only.
- The bmopf-report example networks exercise the new path end to end: the ENWL example parses, lowers, and batches (stem-named exports); the IEEE 13 example is refused with the itemized diagnostics.

## Testing

- Unit tests for discovery (recursion, sorted order, pruning, capitalization), the extension-label sync, and the file-stem naming of a nameless BMOPF case.
- Regression tests for every reader fix: BOM classification/parse/warning at all three layers, PowerModels boolean status and `baseMVA` and cost trim/wrap, egret exponent bound, Surge float index, GOC3 duplicate uid, BMOPF matrix/winding bounds and `meta` stash, PMD MATHEMATICAL rejection, package semver suffixes.
- Integration tests: recursive batch with skip warnings, BMOPF `.json` discovery, unlowerable `.dss` skip vs explicit-input failure, empty-scan and nothing-loads errors.
- `cargo fmt --check`, `scripts/ci-clippy.sh`, and `cargo test --workspace` (1079 tests; `powerio-py` linked in CI) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
