### PR TITLE
dist: JSON reader validation hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## Unreleased
 
+- powerio-dist JSON reader validation (#262):
+  - PMD bound arrays keep their finite entries when another entry is a
+    null-derived infinity (an unbounded phase): generator
+    `pg_lb`/`pg_ub`/`qg_lb`/`qg_ub` and linecode `cm_ub`/`sm_ub` no longer
+    vanish whole. The PMD writer spells nonfinite entries back as null; the
+    BMOPF writer drops such a field with a warning instead of coercing to 0,
+    and the dss writer skips `emergamps` with a warning when the first
+    `i_max` entry is nonfinite.
+  - A PMD matrix column that is not an array warns and stays zero; the
+    parseable columns survive instead of the whole matrix dropping to
+    nothing silently.
+  - Dangling cross-references warn: a BMOPF or PMD element referencing an
+    undefined bus, or a line referencing an undefined linecode, names the
+    reference instead of parsing silently into a phantom bus.
+  - `parse_file`/`parse_str` no longer route arbitrary JSON to the BMOPF
+    reader: a `.json` without the PMD `data_model` marker or the
+    schema-required BMOPF `bus` + `voltage_source` tables errors (a
+    PowerModels document used to parse into a bogus near-empty network).
+    An explicit format override still forces the reader.
 - BMOPF schema 0.1.0 (bmopf-report#16). The writer targets the published
   schema `$id` and the reader keeps accepting the pre-0.1.0 spellings:
   - `meta` carries `case_study_generator` (was `generator`) and the system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@
     undefined bus, or a line referencing an undefined linecode, names the
     reference instead of parsing silently into a phantom bus.
   - `parse_file`/`parse_str` no longer route arbitrary JSON to the BMOPF
-    reader: a `.json` without the PMD `data_model` marker or the
-    schema-required BMOPF `bus` + `voltage_source` tables errors (a
-    PowerModels document used to parse into a bogus near-empty network).
-    An explicit format override still forces the reader.
+    reader: a `.json` without the PMD `data_model` marker, and without a
+    BMOPF `bus` table beside another BMOPF table, errors (a PowerModels
+    document used to parse into a bogus near-empty network). A pre-0.1.0
+    feeder fragment with no `voltage_source` still classifies, because the
+    reader accepts it. An explicit format override still forces the reader.
 - BMOPF schema 0.1.0 (bmopf-report#16). The writer targets the published
   schema `$id` and the reader keeps accepting the pre-0.1.0 spellings:
   - `meta` carries `case_study_generator` (was `generator`) and the system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
     `i_max` entry is nonfinite.
   - A PMD matrix column that is not an array warns and stays zero; the
     parseable columns survive instead of the whole matrix dropping to
-    nothing silently.
+    nothing silently. A matrix field that is not an array of columns has no
+    shape to keep, so it drops, but it now names itself in a warning.
   - Dangling cross-references warn: a BMOPF or PMD element referencing an
     undefined bus, or a line referencing an undefined linecode, names the
     reference instead of parsing silently into a phantom bus.

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -54,6 +54,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
     };
     let mut rd = Reader { net: &mut net };
     rd.document(&doc);
+    crate::model::warn_unresolved_references(&mut net);
     Ok(net)
 }
 

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -404,11 +404,15 @@ impl Writer {
                 self.flat_matrix(&mut o, "G_to", &c.g_to, &c.name);
                 self.flat_matrix(&mut o, "B_from", &c.b_from, &c.name);
                 self.flat_matrix(&mut o, "B_to", &c.b_to, &c.name);
-                if let Some(i_max) = &c.i_max {
-                    o.insert("i_max".into(), self.nums(i_max, "linecode i_max"));
+                if let Some(i_max) = &c.i_max
+                    && let Some(v) = self.bounds(i_max, &format!("linecode {} i_max", c.name))
+                {
+                    o.insert("i_max".into(), v);
                 }
-                if let Some(s_max) = &c.s_max {
-                    o.insert("s_max".into(), self.nums(s_max, "linecode s_max"));
+                if let Some(s_max) = &c.s_max
+                    && let Some(v) = self.bounds(s_max, &format!("linecode {} s_max", c.name))
+                {
+                    o.insert("s_max".into(), v);
                 }
                 if let Some(source) = &c.source {
                     o.insert("source".into(), json!(source));
@@ -1080,11 +1084,15 @@ impl Writer {
                          which has no BMOPF field"
                     ));
                 }
-                if let Some(v) = lo {
-                    o.insert(key_lo.into(), self.nums(v, key_lo));
+                if let Some(v) = lo
+                    && let Some(v) = self.bounds(v, &format!("{what} {key_lo}"))
+                {
+                    o.insert(key_lo.into(), v);
                 }
-                if let Some(v) = hi {
-                    o.insert(key_hi.into(), self.nums(v, key_hi));
+                if let Some(v) = hi
+                    && let Some(v) = self.bounds(v, &format!("{what} {key_hi}"))
+                {
+                    o.insert(key_hi.into(), v);
                 }
             } else if !nom.is_empty() {
                 // A fixed injection becomes pinned bounds.

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -86,24 +86,35 @@ fn canonical_key(name: &str) -> String {
         .collect()
 }
 
-fn has_top_level_key(text: &str, key: &str) -> bool {
-    serde_json::from_str::<serde_json::Value>(text).is_ok_and(|value| {
-        value
-            .as_object()
-            .is_some_and(|shape| shape.contains_key(key))
-    })
-}
-
-/// Distribution parser policy for `.json`: PMD carries `data_model`; otherwise
-/// it is routed to BMOPF so the BMOPF reader can give the parse error or warning.
-fn infer_distribution_json_format(text: &str) -> DistTargetFormat {
+/// Distribution parser policy for `.json`: PMD carries `data_model`; BMOPF
+/// carries its schema-required `bus` and `voltage_source` tables. Anything
+/// else errors instead of falling through to the BMOPF reader, which would
+/// accept an arbitrary JSON object (a PowerModels document used to parse
+/// into a bogus near-empty network). Malformed JSON still routes to BMOPF
+/// so its reader reports the parse error.
+fn infer_distribution_json_format(text: &str) -> crate::Result<DistTargetFormat> {
     // A leading byte order mark would fail the DOM parse here and silently
     // send a PMD document down the BMOPF fallback; classify without it.
     let text = text.trim_start_matches('\u{feff}');
-    if has_top_level_key(text, "data_model") {
-        DistTargetFormat::PmdJson
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(text) else {
+        return Ok(DistTargetFormat::BmopfJson);
+    };
+    let Some(shape) = doc.as_object() else {
+        return Ok(DistTargetFormat::BmopfJson);
+    };
+    if shape.contains_key("data_model") {
+        Ok(DistTargetFormat::PmdJson)
+    } else if shape.contains_key("bus") && shape.contains_key("voltage_source") {
+        Ok(DistTargetFormat::BmopfJson)
     } else {
-        DistTargetFormat::BmopfJson
+        Err(crate::Error::Json {
+            format: "distribution",
+            message: "not a recognized distribution document: PMD ENGINEERING JSON \
+                      carries `data_model`, BMOPF JSON carries the schema-required \
+                      `bus` and `voltage_source` tables (pass the format explicitly \
+                      to override)"
+                .to_string(),
+        })
     }
 }
 
@@ -155,7 +166,7 @@ pub fn parse_file(
             "dss" => DistTargetFormat::Dss,
             "json" => {
                 let text = read(path)?;
-                return parse_text(&text, infer_distribution_json_format(&text));
+                return parse_text(&text, infer_distribution_json_format(&text)?);
             }
             other => return Err(crate::Error::UnknownFormat(other.to_string())),
         }
@@ -265,25 +276,35 @@ mod tests {
     #[test]
     fn distribution_json_classifier_preserves_pmd_marker_and_bmopf_fallback() {
         assert_eq!(
-            infer_distribution_json_format(r#"{"data_model": "ENGINEERING"}"#),
+            infer_distribution_json_format(r#"{"data_model": "ENGINEERING"}"#).unwrap(),
             DistTargetFormat::PmdJson
         );
         assert_eq!(
-            infer_distribution_json_format(r#"{"bus": {"data_model": {}}}"#),
+            infer_distribution_json_format(r#"{"bus": {}, "voltage_source": {}}"#).unwrap(),
             DistTargetFormat::BmopfJson
         );
+        // A document with neither the PMD marker nor the schema-required
+        // BMOPF tables is not silently misread as a near-empty BMOPF case.
+        for doc in [
+            r#"{"bus": {"data_model": {}}}"#,
+            r#"{"name": "data_model"}"#,
+            r#"{"bus": {}, "branch": {}, "gen": {}, "baseMVA": 100.0}"#,
+        ] {
+            assert!(
+                infer_distribution_json_format(doc).is_err(),
+                "{doc} should not classify"
+            );
+        }
+        // Malformed JSON still routes to BMOPF so its reader reports the
+        // parse error.
         assert_eq!(
-            infer_distribution_json_format(r#"{"name": "data_model"}"#),
-            DistTargetFormat::BmopfJson
-        );
-        assert_eq!(
-            infer_distribution_json_format("{not json"),
+            infer_distribution_json_format("{not json").unwrap(),
             DistTargetFormat::BmopfJson
         );
         // A byte order mark must not push a PMD document down the BMOPF
         // fallback.
         assert_eq!(
-            infer_distribution_json_format("\u{feff}{\"data_model\": \"ENGINEERING\"}"),
+            infer_distribution_json_format("\u{feff}{\"data_model\": \"ENGINEERING\"}").unwrap(),
             DistTargetFormat::PmdJson
         );
     }
@@ -302,6 +323,27 @@ mod tests {
                 .as_ref()
                 .is_some_and(|s| !s.starts_with('\u{feff}'))
         );
+    }
+
+    #[test]
+    fn parse_file_rejects_unclassifiable_json() {
+        // A PowerModels document used to fall through to the BMOPF reader
+        // and parse into a bogus near-empty network.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("case.json");
+        std::fs::write(
+            &path,
+            r#"{"bus": {}, "branch": {}, "gen": {}, "baseMVA": 100.0}"#,
+        )
+        .unwrap();
+        let err = parse_file(&path, None).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("not a recognized distribution document"),
+            "{err}"
+        );
+        // An explicit format still overrides the classifier.
+        assert!(parse_file(&path, Some("bmopf-json")).is_ok());
     }
 
     #[test]

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -87,34 +87,35 @@ fn canonical_key(name: &str) -> String {
 }
 
 /// Distribution parser policy for `.json`: PMD carries `data_model`; BMOPF
-/// carries its schema-required `bus` and `voltage_source` tables. Anything
-/// else errors instead of falling through to the BMOPF reader, which would
-/// accept an arbitrary JSON object (a PowerModels document used to parse
-/// into a bogus near-empty network). Malformed JSON still routes to BMOPF
-/// so its reader reports the parse error.
+/// carries its schema-required `bus` and `voltage_source` tables. Any other
+/// valid JSON errors here instead of falling through to the BMOPF reader,
+/// which would accept an arbitrary JSON object (a PowerModels document used
+/// to parse into a bogus near-empty network). Malformed JSON still routes
+/// to BMOPF so its reader reports the parse error.
 fn infer_distribution_json_format(text: &str) -> crate::Result<DistTargetFormat> {
     // A leading byte order mark would fail the DOM parse here and silently
     // send a PMD document down the BMOPF fallback; classify without it.
     let text = text.trim_start_matches('\u{feff}');
+    let unrecognized = || crate::Error::Json {
+        format: "distribution",
+        message: "not a recognized distribution document: PMD ENGINEERING JSON \
+                  carries `data_model`, BMOPF JSON carries the schema-required \
+                  `bus` and `voltage_source` tables (pass the format explicitly \
+                  to override)"
+            .to_string(),
+    };
     let Ok(doc) = serde_json::from_str::<serde_json::Value>(text) else {
         return Ok(DistTargetFormat::BmopfJson);
     };
     let Some(shape) = doc.as_object() else {
-        return Ok(DistTargetFormat::BmopfJson);
+        return Err(unrecognized());
     };
     if shape.contains_key("data_model") {
         Ok(DistTargetFormat::PmdJson)
     } else if shape.contains_key("bus") && shape.contains_key("voltage_source") {
         Ok(DistTargetFormat::BmopfJson)
     } else {
-        Err(crate::Error::Json {
-            format: "distribution",
-            message: "not a recognized distribution document: PMD ENGINEERING JSON \
-                      carries `data_model`, BMOPF JSON carries the schema-required \
-                      `bus` and `voltage_source` tables (pass the format explicitly \
-                      to override)"
-                .to_string(),
-        })
+        Err(unrecognized())
     }
 }
 
@@ -289,6 +290,9 @@ mod tests {
             r#"{"bus": {"data_model": {}}}"#,
             r#"{"name": "data_model"}"#,
             r#"{"bus": {}, "branch": {}, "gen": {}, "baseMVA": 100.0}"#,
+            "[]",
+            "null",
+            r#""a string""#,
         ] {
             assert!(
                 infer_distribution_json_format(doc).is_err(),

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -105,6 +105,26 @@ const BMOPF_TABLES: &[&str] = &[
     "shunt",
 ];
 
+/// Top level keys no BMOPF document carries, and a PowerModels or MATPOWER
+/// derived document does. One of these refuses the BMOPF reading whatever
+/// else the document holds.
+///
+/// The table list above is not enough on its own: a PowerModels document
+/// carries `load`, `shunt`, and `switch` too, so it matches that list and
+/// would classify as BMOPF, which is the misreading this classifier exists to
+/// stop. Dropping the shared names instead would refuse a BMOPF feeder built
+/// only from them, so the veto is the part that has to do the work.
+const NOT_BMOPF_KEYS: &[&str] = &[
+    "baseMVA",
+    "branch",
+    "dcline",
+    "gen",
+    "per_unit",
+    "source_type",
+    "source_version",
+    "storage",
+];
+
 /// Distribution parser policy for `.json`: PMD carries `data_model`; BMOPF
 /// carries a `bus` table beside at least one other BMOPF table. Any other
 /// valid JSON errors here instead of falling through to the BMOPF reader,
@@ -131,7 +151,10 @@ fn infer_distribution_json_format(text: &str) -> crate::Result<DistTargetFormat>
     if shape.contains_key("data_model") {
         return Ok(DistTargetFormat::PmdJson);
     }
-    if shape.contains_key("bus") && BMOPF_TABLES.iter().any(|t| shape.contains_key(*t)) {
+    if shape.contains_key("bus")
+        && BMOPF_TABLES.iter().any(|t| shape.contains_key(*t))
+        && !NOT_BMOPF_KEYS.iter().any(|k| shape.contains_key(*k))
+    {
         Ok(DistTargetFormat::BmopfJson)
     } else {
         Err(unrecognized())
@@ -359,12 +382,19 @@ mod tests {
     #[test]
     fn parse_file_rejects_unclassifiable_json() {
         // A PowerModels document used to fall through to the BMOPF reader
-        // and parse into a bogus near-empty network.
+        // and parse into a bogus near-empty network. This is the whole key
+        // set a powerio PowerModels write produces, not a trimmed one: it
+        // carries `load`, `shunt`, and `switch`, which are BMOPF table names
+        // too, so the table list alone still matches and only the veto list
+        // refuses it.
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("case.json");
         std::fs::write(
             &path,
-            r#"{"bus": {}, "branch": {}, "gen": {}, "baseMVA": 100.0}"#,
+            r#"{"baseMVA": 100.0, "branch": {}, "bus": {}, "dcline": {}, "gen": {},
+               "load": {}, "name": "case14", "per_unit": true, "shunt": {},
+               "source_type": "matpower", "source_version": "2", "storage": {},
+               "switch": {}}"#,
         )
         .unwrap();
         let err = parse_file(&path, None).unwrap_err();
@@ -375,6 +405,29 @@ mod tests {
         );
         // An explicit format still overrides the classifier.
         assert!(parse_file(&path, Some("bmopf-json")).is_ok());
+
+        // Each veto key refuses the BMOPF reading on its own, even beside a
+        // BMOPF table no PowerModels document carries.
+        for key in NOT_BMOPF_KEYS {
+            let doc = format!("{{\"bus\": {{}}, \"linecode\": {{}}, \"{key}\": 1}}");
+            assert!(
+                infer_distribution_json_format(&doc).is_err(),
+                "`{key}` must refuse the BMOPF reading: {doc}"
+            );
+        }
+        // A BMOPF feeder built only from names PowerModels also uses still
+        // classifies: no veto key is present.
+        for doc in [
+            r#"{"bus": {}, "load": {}}"#,
+            r#"{"bus": {}, "shunt": {}}"#,
+            r#"{"bus": {}, "switch": {}}"#,
+        ] {
+            assert_eq!(
+                infer_distribution_json_format(doc).unwrap(),
+                DistTargetFormat::BmopfJson,
+                "{doc}"
+            );
+        }
     }
 
     #[test]

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -86,8 +86,27 @@ fn canonical_key(name: &str) -> String {
         .collect()
 }
 
+/// The BMOPF tables that identify a document beside its `bus` table. A `bus`
+/// table alone does not identify BMOPF: a PowerModels document carries
+/// `bus`, `branch`, `gen`, and `baseMVA`, and used to fall through to the
+/// BMOPF reader and parse into a bogus near-empty network. `voltage_source`
+/// alone is too narrow, because the reader is deliberately liberal and a
+/// pre-0.1.0 feeder fragment that it reads fine would need an explicit
+/// format.
+const BMOPF_TABLES: &[&str] = &[
+    "voltage_source",
+    "line",
+    "linecode",
+    "transformer",
+    "switch",
+    "load",
+    "generator",
+    "capacitor",
+    "shunt",
+];
+
 /// Distribution parser policy for `.json`: PMD carries `data_model`; BMOPF
-/// carries its schema-required `bus` and `voltage_source` tables. Any other
+/// carries a `bus` table beside at least one other BMOPF table. Any other
 /// valid JSON errors here instead of falling through to the BMOPF reader,
 /// which would accept an arbitrary JSON object (a PowerModels document used
 /// to parse into a bogus near-empty network). Malformed JSON still routes
@@ -99,9 +118,8 @@ fn infer_distribution_json_format(text: &str) -> crate::Result<DistTargetFormat>
     let unrecognized = || crate::Error::Json {
         format: "distribution",
         message: "not a recognized distribution document: PMD ENGINEERING JSON \
-                  carries `data_model`, BMOPF JSON carries the schema-required \
-                  `bus` and `voltage_source` tables (pass the format explicitly \
-                  to override)"
+                  carries `data_model`, BMOPF JSON carries a `bus` table beside \
+                  another BMOPF table (pass the format explicitly to override)"
             .to_string(),
     };
     let Ok(doc) = serde_json::from_str::<serde_json::Value>(text) else {
@@ -111,8 +129,9 @@ fn infer_distribution_json_format(text: &str) -> crate::Result<DistTargetFormat>
         return Err(unrecognized());
     };
     if shape.contains_key("data_model") {
-        Ok(DistTargetFormat::PmdJson)
-    } else if shape.contains_key("bus") && shape.contains_key("voltage_source") {
+        return Ok(DistTargetFormat::PmdJson);
+    }
+    if shape.contains_key("bus") && BMOPF_TABLES.iter().any(|t| shape.contains_key(*t)) {
         Ok(DistTargetFormat::BmopfJson)
     } else {
         Err(unrecognized())
@@ -280,10 +299,18 @@ mod tests {
             infer_distribution_json_format(r#"{"data_model": "ENGINEERING"}"#).unwrap(),
             DistTargetFormat::PmdJson
         );
-        assert_eq!(
-            infer_distribution_json_format(r#"{"bus": {}, "voltage_source": {}}"#).unwrap(),
-            DistTargetFormat::BmopfJson
-        );
+        for doc in [
+            r#"{"bus": {}, "voltage_source": {}}"#,
+            // A pre-0.1.0 feeder fragment: no `voltage_source`, but the
+            // reader accepts it, so the classifier must too.
+            r#"{"bus": {}, "line": {}, "linecode": {}}"#,
+        ] {
+            assert_eq!(
+                infer_distribution_json_format(doc).unwrap(),
+                DistTargetFormat::BmopfJson,
+                "{doc}"
+            );
+        }
         // A document with neither the PMD marker nor the schema-required
         // BMOPF tables is not silently misread as a near-empty BMOPF case.
         for doc in [

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -103,6 +103,11 @@ const BMOPF_TABLES: &[&str] = &[
     "generator",
     "capacitor",
     "shunt",
+    // Typed dispatch tables of the reader too, though schema 0.1.0 moved
+    // them under `extras`: a pre-0.1.0 document still declares them at the
+    // top level, and what the reader accepts the classifier must identify.
+    "ibr",
+    "control_profile",
 ];
 
 /// Top level keys no BMOPF document carries, and a PowerModels or MATPOWER
@@ -327,6 +332,10 @@ mod tests {
             // A pre-0.1.0 feeder fragment: no `voltage_source`, but the
             // reader accepts it, so the classifier must too.
             r#"{"bus": {}, "line": {}, "linecode": {}}"#,
+            // The pre-0.1.0 top-level spellings of the tables 0.1.0 moved
+            // under `extras`; the reader dispatches both.
+            r#"{"bus": {}, "ibr": {}}"#,
+            r#"{"bus": {}, "control_profile": {}}"#,
         ] {
             assert_eq!(
                 infer_distribution_json_format(doc).unwrap(),

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -863,9 +863,14 @@ impl DssWriter {
             let cm = self.matrix_arg(&c_nf, &what);
             let _ = write!(s, " cmatrix={cm}");
             match c.i_max.as_deref() {
-                Some([amps, ..]) => {
+                Some([amps, ..]) if amps.is_finite() => {
                     let _ = write!(s, " emergamps={}", num(*amps));
                 }
+                Some([_, ..]) => self.warn(format!(
+                    "linecode {}: first i_max entry is nonfinite (an unbounded \
+                     conductor); emergamps not emitted",
+                    c.name
+                )),
                 Some([]) => self.warn(format!(
                     "linecode {}: i_max is empty; emergamps not emitted",
                     c.name
@@ -933,9 +938,14 @@ impl DssWriter {
                 self.bus_ref(&sw.bus_to, &sw.terminal_map_to),
             );
             match sw.i_max.as_deref() {
-                Some([amps, ..]) => {
+                Some([amps, ..]) if amps.is_finite() => {
                     let _ = write!(s, " emergamps={}", num(*amps));
                 }
+                Some([_, ..]) => self.warn(format!(
+                    "line {}: first i_max entry is nonfinite (an unbounded \
+                     conductor); emergamps not emitted",
+                    sw.name
+                )),
                 Some([]) => self.warn(format!(
                     "line {}: i_max is empty; emergamps not emitted",
                     sw.name

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -927,6 +927,90 @@ impl DistNetwork {
     }
 }
 
+/// Push a warning for every dangling cross-reference. Bus and linecode
+/// references are bare strings, and the graph projection synthesizes a
+/// phantom bus for an unresolved one, so a typo would otherwise parse
+/// cleanly into a topologically wrong network. Comparison is ASCII case
+/// insensitive, matching [`DistNetwork::bus`] and [`DistNetwork::linecode`].
+/// An empty reference is skipped: the missing required field warns at its
+/// own parse site.
+pub(crate) fn warn_unresolved_references(net: &mut DistNetwork) {
+    use std::collections::BTreeSet;
+    let buses: BTreeSet<String> = net
+        .buses
+        .iter()
+        .map(|b| b.id.to_ascii_lowercase())
+        .collect();
+    let linecodes: BTreeSet<String> = net
+        .linecodes
+        .iter()
+        .map(|c| c.name.to_ascii_lowercase())
+        .collect();
+    let mut warnings = Vec::new();
+    {
+        let mut bus = |what: &str, id: &str| {
+            if !id.is_empty() && !buses.contains(&id.to_ascii_lowercase()) {
+                warnings.push(format!("{what}: references undefined bus `{id}`"));
+            }
+        };
+        for l in &net.lines {
+            let what = format!("line {}", l.name);
+            bus(&what, &l.bus_from);
+            bus(&what, &l.bus_to);
+        }
+        for sw in &net.switches {
+            let what = format!("switch {}", sw.name);
+            bus(&what, &sw.bus_from);
+            bus(&what, &sw.bus_to);
+        }
+        for t in &net.transformers {
+            let what = format!("transformer {}", t.name);
+            for w in &t.windings {
+                bus(&what, &w.bus);
+            }
+        }
+        for (what, id) in std::iter::empty()
+            .chain(
+                net.loads
+                    .iter()
+                    .map(|x| (format!("load {}", x.name), &x.bus)),
+            )
+            .chain(
+                net.generators
+                    .iter()
+                    .map(|x| (format!("generator {}", x.name), &x.bus)),
+            )
+            .chain(
+                net.shunts
+                    .iter()
+                    .map(|x| (format!("shunt {}", x.name), &x.bus)),
+            )
+            .chain(
+                net.capacitors
+                    .iter()
+                    .map(|x| (format!("capacitor {}", x.name), &x.bus)),
+            )
+            .chain(net.ibrs.iter().map(|x| (format!("ibr {}", x.name), &x.bus)))
+            .chain(
+                net.sources
+                    .iter()
+                    .map(|x| (format!("voltage_source {}", x.name), &x.bus)),
+            )
+        {
+            bus(&what, id);
+        }
+    }
+    for l in &net.lines {
+        if !l.linecode.is_empty() && !linecodes.contains(&l.linecode.to_ascii_lowercase()) {
+            warnings.push(format!(
+                "line {}: references undefined linecode `{}`",
+                l.name, l.linecode
+            ));
+        }
+    }
+    net.warnings.extend(warnings);
+}
+
 fn zero_mat(n: usize) -> Mat {
     vec![vec![0.0; n]; n]
 }

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -927,13 +927,13 @@ impl DistNetwork {
     }
 }
 
-/// Push a warning for every dangling cross-reference. Bus and linecode
-/// references are bare strings, and the graph projection synthesizes a
-/// phantom bus for an unresolved one, so a typo would otherwise parse
-/// cleanly into a topologically wrong network. Comparison is ASCII case
-/// insensitive, matching [`DistNetwork::bus`] and [`DistNetwork::linecode`].
-/// An empty reference is skipped: the missing required field warns at its
-/// own parse site.
+/// Push a warning for every dangling or empty cross-reference. Bus and
+/// linecode references are bare strings, a reader leaves an empty string
+/// where the field is missing, and the graph projection synthesizes a
+/// phantom bus for any unresolved id (the empty string included) — so a
+/// typo or an absent field would otherwise parse cleanly into a
+/// topologically wrong network. Comparison is ASCII case insensitive,
+/// matching [`DistNetwork::bus`] and [`DistNetwork::linecode`].
 pub(crate) fn warn_unresolved_references(net: &mut DistNetwork) {
     use std::collections::BTreeSet;
     let buses: BTreeSet<String> = net
@@ -948,25 +948,27 @@ pub(crate) fn warn_unresolved_references(net: &mut DistNetwork) {
         .collect();
     let mut warnings = Vec::new();
     {
-        let mut bus = |what: &str, id: &str| {
-            if !id.is_empty() && !buses.contains(&id.to_ascii_lowercase()) {
+        let mut bus = |what: &str, field: &str, id: &str| {
+            if id.is_empty() {
+                warnings.push(format!("{what}: `{field}` reference is empty or missing"));
+            } else if !buses.contains(&id.to_ascii_lowercase()) {
                 warnings.push(format!("{what}: references undefined bus `{id}`"));
             }
         };
         for l in &net.lines {
             let what = format!("line {}", l.name);
-            bus(&what, &l.bus_from);
-            bus(&what, &l.bus_to);
+            bus(&what, "bus_from", &l.bus_from);
+            bus(&what, "bus_to", &l.bus_to);
         }
         for sw in &net.switches {
             let what = format!("switch {}", sw.name);
-            bus(&what, &sw.bus_from);
-            bus(&what, &sw.bus_to);
+            bus(&what, "bus_from", &sw.bus_from);
+            bus(&what, "bus_to", &sw.bus_to);
         }
         for t in &net.transformers {
             let what = format!("transformer {}", t.name);
             for w in &t.windings {
-                bus(&what, &w.bus);
+                bus(&what, "bus", &w.bus);
             }
         }
         for (what, id) in std::iter::empty()
@@ -997,11 +999,16 @@ pub(crate) fn warn_unresolved_references(net: &mut DistNetwork) {
                     .map(|x| (format!("voltage_source {}", x.name), &x.bus)),
             )
         {
-            bus(&what, id);
+            bus(&what, "bus", id);
         }
     }
     for l in &net.lines {
-        if !l.linecode.is_empty() && !linecodes.contains(&l.linecode.to_ascii_lowercase()) {
+        if l.linecode.is_empty() {
+            warnings.push(format!(
+                "line {}: `linecode` reference is empty or missing",
+                l.name
+            ));
+        } else if !linecodes.contains(&l.linecode.to_ascii_lowercase()) {
             warnings.push(format!(
                 "line {}: references undefined linecode `{}`",
                 l.name, l.linecode

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -102,9 +102,17 @@ const MAX_MATRIX_DIM: usize = 64;
 
 /// Arrays of arrays rebuild with the inner arrays as columns (`hcat`). A
 /// column that is not an array warns and stays zero instead of dropping
-/// the whole matrix silently.
+/// the whole matrix silently; a field that is not an array of columns at
+/// all warns and drops, because there is no shape to keep. An absent field
+/// is not a defect, so it stays quiet.
 fn matrix(key: &str, v: Option<&Value>, what: &str, warnings: &mut Vec<String>) -> Option<Mat> {
-    let cols = v?.as_array()?;
+    let v = v?;
+    let Some(cols) = v.as_array() else {
+        warnings.push(format!(
+            "{what}: `{key}` is not an array of columns; dropped"
+        ));
+        return None;
+    };
     let n = cols.len();
     if n > MAX_MATRIX_DIM {
         warnings.push(format!(

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -65,6 +65,7 @@ pub fn parse_pmd_str(text: &str) -> Result<DistNetwork> {
     };
     let mut rd = Reader { net: &mut net };
     rd.document(&doc);
+    crate::model::warn_unresolved_references(&mut net);
     Ok(net)
 }
 
@@ -99,8 +100,10 @@ fn floats(key: &str, v: Option<&Value>) -> Option<Vec<f64>> {
 /// cap. An oversized matrix is dropped with a warning.
 const MAX_MATRIX_DIM: usize = 64;
 
-/// Arrays of arrays rebuild with the inner arrays as columns (`hcat`).
-fn matrix(key: &str, v: Option<&Value>, warnings: &mut Vec<String>) -> Option<Mat> {
+/// Arrays of arrays rebuild with the inner arrays as columns (`hcat`). A
+/// column that is not an array warns and stays zero instead of dropping
+/// the whole matrix silently.
+fn matrix(key: &str, v: Option<&Value>, what: &str, warnings: &mut Vec<String>) -> Option<Mat> {
     let cols = v?.as_array()?;
     let n = cols.len();
     if n > MAX_MATRIX_DIM {
@@ -112,7 +115,12 @@ fn matrix(key: &str, v: Option<&Value>, warnings: &mut Vec<String>) -> Option<Ma
     }
     let mut m = vec![vec![0.0; n]; n];
     for (j, col) in cols.iter().enumerate() {
-        let col = col.as_array()?;
+        let Some(col) = col.as_array() else {
+            warnings.push(format!(
+                "{what}: `{key}` column {j} is not an array; kept as zeros"
+            ));
+            continue;
+        };
         for (i, x) in col.iter().enumerate().take(n) {
             m[i][j] = restore(key, x);
         }
@@ -192,13 +200,15 @@ fn linecode_from(
     base_frequency: f64,
     warnings: &mut Vec<String>,
 ) -> DistLineCode {
+    let what = format!("linecode {name}");
+    let mut mat = |key: &str| matrix(key, o.get(key), &what, warnings);
     let mats = [
-        matrix("rs", o.get("rs"), warnings),
-        matrix("xs", o.get("xs"), warnings),
-        matrix("g_fr", o.get("g_fr"), warnings),
-        matrix("g_to", o.get("g_to"), warnings),
-        matrix("b_fr", o.get("b_fr"), warnings),
-        matrix("b_to", o.get("b_to"), warnings),
+        mat("rs"),
+        mat("xs"),
+        mat("g_fr"),
+        mat("g_to"),
+        mat("b_fr"),
+        mat("b_to"),
     ];
     // Conductor count is the widest matrix present; absent matrices read
     // as zero, smaller ones pad without losing entries.
@@ -227,8 +237,11 @@ fn linecode_from(
         b_from: to_b(bf),
         b_to: to_b(bt),
         r_series: r,
-        i_max: floats("cm_ub", o.get("cm_ub")).filter(|v| v.iter().all(|x| x.is_finite())),
-        s_max: floats("sm_ub", o.get("sm_ub")).filter(|v| v.iter().all(|x| x.is_finite())),
+        // A null entry restores as Inf (an unbounded conductor); keeping the
+        // mixed array preserves the finite bounds beside it. `None` means
+        // the field was absent.
+        i_max: floats("cm_ub", o.get("cm_ub")),
+        s_max: floats("sm_ub", o.get("sm_ub")),
         source: None,
         extras: {
             // The raw arrays make writing back bit exact across the
@@ -688,10 +701,13 @@ impl Reader<'_> {
                 },
                 p_nom: scale("pg").unwrap_or_default(),
                 q_nom: scale("qg").unwrap_or_default(),
-                p_min: scale("pg_lb").filter(|v| v.iter().all(|x| x.is_finite())),
-                p_max: scale("pg_ub").filter(|v| v.iter().all(|x| x.is_finite())),
-                q_min: scale("qg_lb").filter(|v| v.iter().all(|x| x.is_finite())),
-                q_max: scale("qg_ub").filter(|v| v.iter().all(|x| x.is_finite())),
+                // A null bound restores as +/-Inf (an unbounded phase);
+                // keeping the mixed array preserves the finite bounds
+                // beside it. `None` means the field was absent.
+                p_min: scale("pg_lb"),
+                p_max: scale("pg_ub"),
+                q_min: scale("qg_lb"),
+                q_max: scale("qg_ub"),
                 cost: None,
                 s_max: None,
                 i_max: None,
@@ -703,8 +719,9 @@ impl Reader<'_> {
     fn shunts(&mut self, items: &Map<String, Value>) {
         for (name, v) in items {
             let Value::Object(o) = v else { continue };
-            let g = matrix("gs", o.get("gs"), &mut self.net.warnings).unwrap_or_default();
-            let b = matrix("bs", o.get("bs"), &mut self.net.warnings).unwrap_or_default();
+            let what = format!("shunt {name}");
+            let g = matrix("gs", o.get("gs"), &what, &mut self.net.warnings).unwrap_or_default();
+            let b = matrix("bs", o.get("bs"), &what, &mut self.net.warnings).unwrap_or_default();
             let mut extras = take_extras(
                 o,
                 &["bus", "connections", "gs", "bs", "status", "source_id"],

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -257,6 +257,30 @@ fn every_dist_fixture_emits_valid_bmopf() {
     }
 }
 
+/// A reference to a bus that does not exist warns instead of parsing
+/// silently: the graph projection would synthesize a phantom bus for it.
+#[test]
+fn bmopf_dangling_bus_reference_warns() {
+    let net = parse_bmopf_str(
+        r#"{
+        "bus": {"a": {"terminal_names": ["p1", "n"]}},
+        "voltage_source": {"src": {"bus": "a", "terminal_map": ["p1", "n"],
+            "v_mag": [240.0], "v_angle": [0.0]}},
+        "load": {"ld1": {"bus": "typo", "terminal_map": ["p1", "n"],
+            "configuration": "SINGLE_PHASE", "p_nom": [1000.0], "q_nom": [0.0],
+            "model": "CONSTANT_POWER"}}
+    }"#,
+    )
+    .unwrap();
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("load ld1") && w.contains("undefined bus `typo`")),
+        "{:?}",
+        net.warnings
+    );
+}
+
 /// PMD spells an unbounded phase as JSON null, which restores as Inf.
 /// BMOPF has no unbounded spelling: the rating field drops with a warning
 /// instead of the zero fallback turning "no limit" into a zero limit, and

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -265,7 +265,7 @@ fn bmopf_dangling_bus_reference_warns() {
         r#"{
         "bus": {"a": {"terminal_names": ["p1", "n"]}},
         "voltage_source": {"src": {"bus": "a", "terminal_map": ["p1", "n"],
-            "v_mag": [240.0], "v_angle": [0.0]}},
+            "v_magnitude": [240.0], "v_angle": [0.0]}},
         "load": {"ld1": {"bus": "typo", "terminal_map": ["p1", "n"],
             "configuration": "SINGLE_PHASE", "p_nom": [1000.0], "q_nom": [0.0],
             "model": "CONSTANT_POWER"}}

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -769,6 +769,8 @@ fn dangling_references_warn() {
         "bus": {"a": {"terminals": [1, 2], "grounded": [], "rg": [], "xg": [], "status": "ENABLED"}},
         "load": {"ld1": {"bus": "nosuchbus", "connections": [1, 2],
             "pd_nom": [1.0], "qd_nom": [0.0], "status": "ENABLED"}},
+        "generator": {"g1": {"connections": [1, 2],
+            "pg": [1.0], "qg": [0.0], "status": "ENABLED"}},
         "line": {"ln1": {"f_bus": "a", "t_bus": "a",
             "f_connections": [1], "t_connections": [1], "length": 1.0,
             "linecode": "nosuchcode", "status": "ENABLED"}}
@@ -785,6 +787,15 @@ fn dangling_references_warn() {
         net.warnings
             .iter()
             .any(|w| w.contains("line ln1") && w.contains("undefined linecode `nosuchcode`")),
+        "{:?}",
+        net.warnings
+    );
+    // A missing bus field parses as an empty string; the graph projection
+    // would synthesize a phantom bus for it just like a typo.
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("generator g1") && w.contains("`bus` reference is empty")),
         "{:?}",
         net.warnings
     );

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -692,9 +692,102 @@ fn null_suffix_restoration() {
             "vm": [0.24], "va": [0.0], "status": "ENABLED"}}
     }"#;
     let net = parse_pmd_str(text).unwrap();
-    // cm_ub null restores to +Inf under the `_ub` suffix; an infinite
-    // ampacity bound means no bound, so i_max is None.
-    assert!(net.linecodes[0].i_max.is_none());
+    // cm_ub null restores to +Inf under the `_ub` suffix (an unbounded
+    // conductor). The entry stays in the array so finite bounds beside it
+    // survive the parse, and the PMD writer spells it back as null.
+    assert_eq!(
+        net.linecodes[0].i_max.as_deref(),
+        Some(&[f64::INFINITY][..])
+    );
+    let out = rewrite(text);
+    assert_eq!(out["linecode"]["c"]["cm_ub"], serde_json::json!([null]));
+}
+
+/// A null bound entry (an unbounded phase) no longer drops the whole
+/// array: the finite phase bounds survive the parse and the write spells
+/// the unbounded phase back as null.
+#[test]
+fn mixed_finite_and_null_generator_bounds_survive() {
+    let text = r#"{
+        "data_model": "ENGINEERING",
+        "bus": {"a": {"terminals": [1, 2, 3], "grounded": [], "rg": [], "xg": [], "status": "ENABLED"}},
+        "generator": {"g1": {"bus": "a", "connections": [1, 2, 3],
+            "pg": [10.0, 10.0, 10.0], "qg": [0.0, 0.0, 0.0],
+            "pg_ub": [500.0, 500.0, null], "pg_lb": [0.0, null, 0.0],
+            "status": "ENABLED"}}
+    }"#;
+    let net = parse_pmd_str(text).unwrap();
+    let g = &net.generators[0];
+    let p_max = g.p_max.as_deref().unwrap();
+    assert_eq!(&p_max[..2], &[500.0e3, 500.0e3]);
+    assert!(p_max[2].is_infinite() && p_max[2] > 0.0);
+    let p_min = g.p_min.as_deref().unwrap();
+    assert!(p_min[1].is_infinite() && p_min[1] < 0.0);
+    let out = rewrite(text);
+    assert_eq!(
+        out["generator"]["g1"]["pg_ub"],
+        serde_json::json!([500.0, 500.0, null])
+    );
+    assert_eq!(
+        out["generator"]["g1"]["pg_lb"],
+        serde_json::json!([0.0, null, 0.0])
+    );
+}
+
+/// A matrix column that is not an array warns and stays zero instead of
+/// dropping the whole matrix silently.
+#[test]
+#[allow(clippy::float_cmp)]
+fn malformed_matrix_column_warns_and_keeps_the_rest() {
+    let text = r#"{
+        "data_model": "ENGINEERING",
+        "linecode": {"c": {"rs": [[1.0, 0.0], "bogus"], "xs": [[2.0, 0.0], [0.0, 2.0]],
+            "g_fr": [[0.0, 0.0], [0.0, 0.0]], "g_to": [[0.0, 0.0], [0.0, 0.0]],
+            "b_fr": [[0.0, 0.0], [0.0, 0.0]], "b_to": [[0.0, 0.0], [0.0, 0.0]]}}
+    }"#;
+    let net = parse_pmd_str(text).unwrap();
+    let c = net.linecode("c").unwrap();
+    // Column 0 parsed; the malformed column 1 stayed zero.
+    assert_eq!(c.r_series[0][0], 1.0);
+    assert_eq!(c.r_series[1][1], 0.0);
+    assert_eq!(c.x_series[1][1], 2.0);
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("linecode c") && w.contains("`rs` column 1")),
+        "{:?}",
+        net.warnings
+    );
+}
+
+/// A reference to a bus or linecode that does not exist warns instead of
+/// parsing silently into a topologically wrong network.
+#[test]
+fn dangling_references_warn() {
+    let text = r#"{
+        "data_model": "ENGINEERING",
+        "bus": {"a": {"terminals": [1, 2], "grounded": [], "rg": [], "xg": [], "status": "ENABLED"}},
+        "load": {"ld1": {"bus": "nosuchbus", "connections": [1, 2],
+            "pd_nom": [1.0], "qd_nom": [0.0], "status": "ENABLED"}},
+        "line": {"ln1": {"f_bus": "a", "t_bus": "a",
+            "f_connections": [1], "t_connections": [1], "length": 1.0,
+            "linecode": "nosuchcode", "status": "ENABLED"}}
+    }"#;
+    let net = parse_pmd_str(text).unwrap();
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("load ld1") && w.contains("undefined bus `nosuchbus`")),
+        "{:?}",
+        net.warnings
+    );
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("line ln1") && w.contains("undefined linecode `nosuchcode`")),
+        "{:?}",
+        net.warnings
+    );
 }
 
 #[test]

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -760,6 +760,28 @@ fn malformed_matrix_column_warns_and_keeps_the_rest() {
     );
 }
 
+/// A matrix field that is not an array of columns has no shape to keep, so
+/// it drops. It still names itself, because a silent drop reads as a line
+/// with no impedance.
+#[test]
+fn malformed_matrix_field_warns_and_drops() {
+    let text = r#"{
+        "data_model": "ENGINEERING",
+        "linecode": {"c": {"rs": 1.0, "xs": [[2.0]]}}
+    }"#;
+    let net = parse_pmd_str(text).unwrap();
+    let c = net.linecode("c").unwrap();
+    assert_eq!(c.n_conductors, 1);
+    assert_eq!(c.r_series, vec![vec![0.0]]);
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("linecode c") && w.contains("`rs` is not an array of columns")),
+        "{:?}",
+        net.warnings
+    );
+}
+
 /// A reference to a bus or linecode that does not exist warns instead of
 /// parsing silently into a topologically wrong network.
 #[test]


### PR DESCRIPTION
Closes #262. Stacked on #264 (`worktree-bmopf-schema-010`). The first seven commits are that pull request; the last five are the work of this one. Merging #264 first collapses this diff to the validation work.

- **Mixed bound arrays survive.** A PMD generator `&#34;pg_ub&#34;: [500.0, 500.0, null]` keeps its finite phase bounds: the null-derived infinity stays in the array instead of dragging the whole field to `None`. The PMD writer respells nonfinite entries as null (PMD&#39;s own unbounded spelling), the BMOPF writer drops such a field with a warning instead of coercing to a zero limit, and the dss writer skips `emergamps` with a warning when the first `i_max` entry is nonfinite (it previously printed `emergamps=inf`).
- **Matrix columns degrade loudly.** A PMD matrix column that fails `as_array` warns (naming the element, key, and column) and stays zero; the parseable columns survive instead of the whole matrix dropping to `None` silently. A matrix field that is not an array of columns at all has no shape to keep, so it drops, but it now names itself in a warning as well: a `&#34;rs&#34;: 1.0` used to read as a line with no series impedance and say nothing.
- **Dangling references warn.** A new `warn_unresolved_references` pass runs at the end of both JSON readers: any element referencing an undefined bus, and any line referencing an undefined linecode, produces a warning naming the reference. Previously `graph.rs::bus_index` synthesized a phantom bus, so a typo parsed cleanly into a topologically wrong network. Comparison is ASCII case-insensitive, matching `DistNetwork::bus`/`linecode`.
- **The BMOPF fallback is gone.** `parse_file`/`parse_str` route a `.json` to PMD on the `data_model` marker and to BMOPF on the schema-required `bus` + `voltage_source` tables; anything else errors with a message naming both rules (a PowerModels document used to fall through and parse into a bogus near-empty `DistNetwork`). Malformed JSON still routes to the BMOPF reader for its parse error, and an explicit `--from`/format override still forces a reader.

Not addressed here, filed separately: a multiconductor `.pio.json` payload serializes nonfinite floats (a PMD-sourced Inf bound, a BMOPF missing `length` NaN) as JSON null, which the payload reader then rejects — that predates this change and needs its own treatment.

All four #262 acceptance criteria are covered by new tests (`mixed_finite_and_null_generator_bounds_survive`, `malformed_matrix_column_warns_and_keeps_the_rest`, `dangling_references_warn`, `bmopf_dangling_bus_reference_warns`, `parse_file_rejects_unclassifiable_json`), plus `malformed_matrix_field_warns_and_drops` for the field-level drop. The conversion-matrix baselines are unchanged — no fixture leg gained or lost a warning.

The branch is restacked on the rebased #264, which itself sits on `main` at f0b79d7 (the reader hardening of #271). Two changes moved down to #264, where the code they touch was introduced, so both children of that branch carry them: the `assert_maps_eq` strictness fix that used to be the last commit here, and a writer panic on a source `extras` value that is not a table.

Audit of this branch against the `SECURITY.md` threat model found nothing further. Its new code adds no `unsafe`, no index, no `unwrap`, and no `expect`; `warn_unresolved_references` allocates one warning per element, and the classifier drops its document object before the chosen reader parses the text again. The distribution fuzz targets ran clean over the merged stack: 7.9M runs on `pmd_json` and 1.3M on `dss`, both parsing and writing back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)