### PR TITLE
ci: cancel a superseded run on a pull request branch

### DIFF
--- a/.github/workflows/conversion-matrix.yml
+++ b/.github/workflows/conversion-matrix.yml
@@ -6,11 +6,18 @@ on:
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
 # passes, and it emails every watcher a second time for a commit nobody is
-# reviewing. `main` is exempt, because each commit there is a release
-# candidate whose result must stand on its own.
+# reviewing.
+#
+# Only a pull request run is ever superseded, so only a pull request run is
+# cancelled. A push to `main` is a release candidate whose result must stand
+# on its own, and a release run is the release itself: `python.yml` publishes
+# wheels to PyPI from one, behind an environment whose reviewer gate can hold
+# it for a long time. Keying the switch on the ref instead would make every
+# tag run cancellable, and a re-published release or a re-run of the same tag
+# would then cancel a publish in flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   actions: read

--- a/.github/workflows/conversion-matrix.yml
+++ b/.github/workflows/conversion-matrix.yml
@@ -3,6 +3,15 @@ name: Conversion Matrix
 on:
   pull_request:
 
+# One run per workflow per branch. A force push to a stacked pull request
+# otherwise leaves the superseded run going: it finishes, it fails or it
+# passes, and it emails every watcher a second time for a commit nobody is
+# reviewing. `main` is exempt, because each commit there is a release
+# candidate whose result must stand on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,13 +19,14 @@ permissions:
   pages: write
   id-token: write
 
-# Serialize per ref, queueing rather than cancelling: a cancelled in-flight
+# Serialize per ref. On main, queue rather than cancel: a cancelled in-flight
 # Pages deployment can leave the backend rejecting the next deployment
 # ("Deployment failed, try again later"), so successive main pushes must each
-# deploy in order. A PR's doc build still can't touch main's deploy.
+# deploy in order. A pull request run never deploys (see the `deploy` gate),
+# so a superseded one is cancelled like the other pull request workflows.
 concurrency:
   group: pages-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -27,11 +27,18 @@ on:
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
 # passes, and it emails every watcher a second time for a commit nobody is
-# reviewing. `main` is exempt, because each commit there is a release
-# candidate whose result must stand on its own.
+# reviewing.
+#
+# Only a pull request run is ever superseded, so only a pull request run is
+# cancelled. A push to `main` is a release candidate whose result must stand
+# on its own, and a release run is the release itself: `python.yml` publishes
+# wheels to PyPI from one, behind an environment whose reviewer gate can hold
+# it for a long time. Keying the switch on the ref instead would make every
+# tag run cancellable, and a re-published release or a re-run of the same tag
+# would then cancel a publish in flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -24,6 +24,15 @@ on:
   pull_request:
     paths: [ "powerio/**", "powerio-capi/**", "powerio-matrix/**", "powerio-dist/**", "powerio-pkg/**", "powerio-prob/**", ".github/workflows/julia-binding.yml" ]
 
+# One run per workflow per branch. A force push to a stacked pull request
+# otherwise leaves the superseded run going: it finishes, it fails or it
+# passes, and it emails every watcher a second time for a commit nobody is
+# reviewing. `main` is exempt, because each commit there is a release
+# candidate whose result must stand on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,11 +12,18 @@ on:
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
 # passes, and it emails every watcher a second time for a commit nobody is
-# reviewing. `main` is exempt, because each commit there is a release
-# candidate whose result must stand on its own.
+# reviewing.
+#
+# Only a pull request run is ever superseded, so only a pull request run is
+# cancelled. A push to `main` is a release candidate whose result must stand
+# on its own, and a release run is the release itself: `python.yml` publishes
+# wheels to PyPI from one, behind an environment whose reviewer gate can hold
+# it for a long time. Keying the switch on the ref instead would make every
+# tag run cancellable, and a re-published release or a re-run of the same tag
+# would then cancel a publish in flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,15 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+# One run per workflow per branch. A force push to a stacked pull request
+# otherwise leaves the superseded run going: it finishes, it fails or it
+# passes, and it emails every watcher a second time for a commit nobody is
+# reviewing. `main` is exempt, because each commit there is a release
+# candidate whose result must stand on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,11 +11,18 @@ on:
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
 # passes, and it emails every watcher a second time for a commit nobody is
-# reviewing. `main` is exempt, because each commit there is a release
-# candidate whose result must stand on its own.
+# reviewing.
+#
+# Only a pull request run is ever superseded, so only a pull request run is
+# cancelled. A push to `main` is a release candidate whose result must stand
+# on its own, and a release run is the release itself: `python.yml` publishes
+# wheels to PyPI from one, behind an environment whose reviewer gate can hold
+# it for a long time. Keying the switch on the ref instead would make every
+# tag run cancellable, and a re-published release or a re-run of the same tag
+# would then cancel a publish in flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,15 @@ on:
   # never re-triggers filtered workflows. Run on every PR instead.
   pull_request:
 
+# One run per workflow per branch. A force push to a stacked pull request
+# otherwise leaves the superseded run going: it finishes, it fails or it
+# passes, and it emails every watcher a second time for a commit nobody is
+# reviewing. `main` is exempt, because each commit there is a release
+# candidate whose result must stand on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -27,11 +27,18 @@ on:
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
 # passes, and it emails every watcher a second time for a commit nobody is
-# reviewing. `main` is exempt, because each commit there is a release
-# candidate whose result must stand on its own.
+# reviewing.
+#
+# Only a pull request run is ever superseded, so only a pull request run is
+# cancelled. A push to `main` is a release candidate whose result must stand
+# on its own, and a release run is the release itself: `python.yml` publishes
+# wheels to PyPI from one, behind an environment whose reviewer gate can hold
+# it for a long time. Keying the switch on the ref instead would make every
+# tag run cancellable, and a re-published release or a re-run of the same tag
+# would then cancel a publish in flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -24,6 +24,15 @@ on:
       - "powerio-dist/examples/**"
       - ".github/workflows/validation.yml"
 
+# One run per workflow per branch. A force push to a stacked pull request
+# otherwise leaves the superseded run going: it finishes, it fails or it
+# passes, and it emails every watcher a second time for a commit nobody is
+# reviewing. `main` is exempt, because each commit there is a release
+# candidate whose result must stand on its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Each push to a pull request branch starts a full matrix and leaves the previous run going. Both then finish, and both email every watcher, for a commit nobody is reviewing. A stacked pull request makes this worse: restacking force pushes several branches at once, so one restack starts five matrices and leaves five going. Today that produced more than ten failure emails from a single sequence of pushes.

The six workflows that run on a pull request now keep one run per workflow per branch and cancel the superseded one:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Only a pull request run is ever superseded, so only a pull request run is cancelled. A push to `main` is a release candidate whose result must stand on its own, and a release run is the release itself: `python.yml` publishes wheels to PyPI from one, behind an environment whose reviewer gate can hold it for a long time. Keying the switch on the ref instead would make every tag run cancellable, and a re-published release or a re-run of the same tag would then cancel a publish in flight.

`docs.yml` keeps its existing `pages-${{ github.ref }}` group and its queue on `main` (a cancelled in-flight Pages deployment can poison the next one); it gains the same cancel switch for pull request runs, which never reach the deploy job.

Not touched: `crates.yml`, `release-binaries.yml`, and `notify-powerio-jl.yml` run on a tag or a published release, where a cancelled run would leave assets missing. `claude.yml` and `claude-code-review.yml` are invoked on demand, so no run of theirs is ever superseded.

Each edited file was parsed as YAML to confirm the block sits at the top level and the workflow still loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016PxpxFiN9nBAs8GLF1C7i6)_
