### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.8.0
+
+BMOPF schema 0.1.0 alignment, one version number for `.pio.json`, and distribution JSON reader validation. Two migration notes: `.pio.json` files written by 0.7.x and earlier are rejected with an error that says to regenerate them from their source case (convert with a 0.7.x install to migrate an orphaned file), and the BMOPF writer targets the published schema 0.1.0 `$id`, so consumers that key on the old `$schema` URI should update their accepted list.
 
 - `.pio.json` carries one version number. `schema_version` (now `0.2.0`)
   covers the whole document, model JSON included: while the major is 0 an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "arrow",
  "powerio",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "approx",
  "arrow",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-prob"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -39,11 +39,11 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.7.3" }
-powerio-matrix = { path = "powerio-matrix", version = "0.7.3" }
-powerio-prob = { path = "powerio-prob", version = "0.7.3" }
-powerio-dist = { path = "powerio-dist", version = "0.7.3" }
-powerio-pkg = { path = "powerio-pkg", version = "0.7.3" }
+powerio = { path = "powerio", version = "0.8.0" }
+powerio-matrix = { path = "powerio-matrix", version = "0.8.0" }
+powerio-prob = { path = "powerio-prob", version = "0.8.0" }
+powerio-dist = { path = "powerio-dist", version = "0.8.0" }
+powerio-pkg = { path = "powerio-pkg", version = "0.8.0" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }


### PR DESCRIPTION
Version 0.8.0 across the workspace and the changelog section for the release. The section headline carries the two migration notes: `.pio.json` files written by 0.7.x and earlier are rejected with the regenerate error (convert with a 0.7.x install to migrate an orphaned file), and the BMOPF writer stamps the published schema 0.1.0 `$id`, so consumers keying on the old `$schema` URI should update their accepted list.

After the squash merge and green main CI: tag `v0.8.0` on the merge commit, publish the draft release, and the PowerIO.jl side releases itself (repin, version, changelog, register — no ABI bump in this release, so nothing parks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
