### PR TITLE
Report source-row provenance from the normalize pass

### DIFF
--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -77,7 +77,9 @@ pub use network::{
     SolverParams, SourceFormat, Storage, Switch, SwitchedShuntControl, SwitchedShuntMode,
     Transformer3W, TransformerControl, TransformerControlMode, Winding,
 };
-pub use normalize::{NormalizeOptions, NormalizedNetwork, POWER_MODELS_ANGLE_BOUND_PAD};
+pub use normalize::{
+    NormalizeOptions, NormalizeSourceRows, NormalizedNetwork, POWER_MODELS_ANGLE_BOUND_PAD,
+};
 pub use operations::Selector;
 pub use solver_tables::{
     NORMALIZED_SOLVER_TABLES_PASS, NormalizedSolverTables, SolverArcRow, SolverArcTerminal,

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -1510,6 +1510,17 @@ fn repair_vg(vg: f64) -> Option<f64> {
     (!vg.is_finite() || vg <= 0.0).then_some(1.0)
 }
 
+/// The three element counts the star lowering changes, from
+/// [`Network::lowered_lengths`]. Every other family keeps its length, since the
+/// lowering only appends a star bus, its winding branches, and a magnetizing
+/// shunt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LoweredLengths {
+    pub(crate) buses: usize,
+    pub(crate) branches: usize,
+    pub(crate) shunts: usize,
+}
+
 impl Network {
     #[must_use]
     pub fn new(name: impl Into<String>, base_mva: f64) -> Network {
@@ -2057,6 +2068,27 @@ impl Network {
         findings
     }
 
+    /// The element counts [`Self::expand_transformers_3w`] would produce, read off
+    /// the transformer records instead of building the lowering. A caller that
+    /// only needs the lowered lengths — sizing a per-row map, say — would
+    /// otherwise pay a whole `Network` clone for three `len()` calls.
+    /// `lowered_lengths_match_the_expansion` pins the two against each other.
+    pub(crate) fn lowered_lengths(&self) -> LoweredLengths {
+        let mut lengths = LoweredLengths {
+            buses: self.buses.len(),
+            branches: self.branches.len(),
+            shunts: self.shunts.len(),
+        };
+        for t in self.transformers_3w.iter().filter(|t| t.in_service) {
+            lengths.buses += 1;
+            lengths.branches += 3;
+            if t.mag_g != 0.0 || t.mag_b != 0.0 {
+                lengths.shunts += 1;
+            }
+        }
+        lengths
+    }
+
     /// A bus-branch lowering of the network for analysis: each in-service
     /// 3-winding transformer becomes a synthetic star bus, its three winding
     /// branches, and (when present) its magnetizing shunt, so the matrix builders
@@ -2370,6 +2402,37 @@ mod tests {
         assert_eq!(back.transformers_3w.len(), 1);
         close(back.transformers_3w[0].z[1].x, 0.20);
         assert_eq!(back.transformers_3w[0].windings[2].bus, BusId(3));
+    }
+
+    #[test]
+    fn lowered_lengths_match_the_expansion() {
+        // `lowered_lengths` counts what `expand_transformers_3w` would append
+        // instead of building it. The two must agree on every mix: an
+        // out-of-service unit appends nothing, and only a unit with magnetizing
+        // admittance appends a shunt.
+        let mut magnetizing = transformer_3w();
+        magnetizing.mag_b = 0.02;
+        let mut out_of_service = transformer_3w();
+        out_of_service.in_service = false;
+        out_of_service.mag_g = 0.01;
+
+        for units in [
+            vec![],
+            vec![transformer_3w()],
+            vec![magnetizing.clone()],
+            vec![out_of_service.clone()],
+            vec![transformer_3w(), magnetizing, out_of_service],
+        ] {
+            let mut net = Network::in_memory("t", 100.0, vec![bus(1), bus(2), bus(3)], Vec::new());
+            net.shunts.push(Shunt::new(BusId(1), 0.0, 0.5));
+            net.transformers_3w = units;
+
+            let counted = net.lowered_lengths();
+            let built = net.expand_transformers_3w();
+            assert_eq!(counted.buses, built.buses.len());
+            assert_eq!(counted.branches, built.branches.len());
+            assert_eq!(counted.shunts, built.shunts.len());
+        }
     }
 
     #[test]

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -64,28 +64,54 @@ pub struct NormalizedNetwork {
     pub warnings: Vec<String>,
 }
 
-/// Row provenance for one normalize pass: for each element position in the
-/// normalized network, the row of the same element family in the source
-/// network. The pass filters rows and never reorders or merges them, so
-/// `buses[i]` is the source row of normalized bus `i`, and the same holds
-/// for every family.
+/// Row provenance for one normalize pass: for each dense position in the
+/// [`IndexedNetwork`](crate::IndexedNetwork) view of the normalized network,
+/// the row of the same element family in the source network. `None` marks an
+/// element the pipeline synthesized, which has no source row.
 ///
-/// `IndexedNetwork` dense indices over a normalized network are positional,
-/// so `rows.buses[dense_index]` resolves a matrix row back to its source
-/// element without re-deriving the filter rules — the map is produced by the
-/// same pass that filters, so the two cannot drift.
+/// Every field is positional over that view, so `buses[dense_index]` resolves
+/// a matrix row back to its source element. Each length equals the matching
+/// element table of the view: `buses` equals `view.n()`, `branches` equals
+/// `view.branches().len()`.
+///
+/// The star lowering that the view applies to a 3-winding transformer appends
+/// one bus, its star branches, and a magnetizing shunt. Those entries are
+/// `None`. The lowering also consumes the transformer itself, so the view
+/// holds none; `transformers_3w` therefore stays positional over the
+/// normalized network's own list.
+///
+/// The map is valid only for the [`NormalizedNetwork`] returned beside it. A
+/// later mutation of that network ([`Network::merge_bus`],
+/// [`Network::reduce_zero_impedance`], [`Network::reduce_passthrough_buses`],
+/// [`Network::subset`], or a hand edit) invalidates every entry; run the pass
+/// again instead of patching the map.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct NormalizeSourceRows {
-    pub buses: Vec<usize>,
-    pub loads: Vec<usize>,
-    pub shunts: Vec<usize>,
-    pub branches: Vec<usize>,
-    pub switches: Vec<usize>,
-    pub generators: Vec<usize>,
-    pub storage: Vec<usize>,
-    pub hvdc: Vec<usize>,
-    pub transformers_3w: Vec<usize>,
+    pub buses: Vec<Option<usize>>,
+    pub loads: Vec<Option<usize>>,
+    pub shunts: Vec<Option<usize>>,
+    pub branches: Vec<Option<usize>>,
+    pub switches: Vec<Option<usize>>,
+    pub generators: Vec<Option<usize>>,
+    pub storage: Vec<Option<usize>>,
+    pub hvdc: Vec<Option<usize>>,
+    pub transformers_3w: Vec<Option<usize>>,
+}
+
+impl NormalizeSourceRows {
+    /// Grow the families the star lowering appends to so each length matches
+    /// `lowered`. The appended entries have no source row.
+    fn pad_to(&mut self, lowered: &Network) {
+        self.buses.resize(lowered.buses.len(), None);
+        self.branches.resize(lowered.branches.len(), None);
+        self.shunts.resize(lowered.shunts.len(), None);
+    }
+
+    /// Pad against the star-lowered form of `net`.
+    pub(crate) fn pad_to_lowered(&mut self, net: &Network) {
+        self.pad_to(&net.expand_transformers_3w());
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -586,16 +612,24 @@ impl Network {
         &self,
         options: &NormalizeOptions,
     ) -> Result<NormalizedNetwork> {
-        Ok(self.to_normalized_with_source_rows(options)?.0)
+        Ok(self.normalize_inner(options)?.0)
     }
 
     /// Like [`Network::to_normalized_with_options`], also returning the
-    /// [`NormalizeSourceRows`] row provenance for every retained element.
-    ///
-    /// The map comes from the same pass that filters, so a consumer resolving
-    /// normalized positions (or `IndexedNetwork` dense indices) back to source
-    /// rows does not re-derive the filter rules.
+    /// [`NormalizeSourceRows`] row provenance.
     pub fn to_normalized_with_source_rows(
+        &self,
+        options: &NormalizeOptions,
+    ) -> Result<(NormalizedNetwork, NormalizeSourceRows)> {
+        let (normalized, mut rows) = self.normalize_inner(options)?;
+        rows.pad_to(&normalized.network.expand_transformers_3w());
+        Ok((normalized, rows))
+    }
+
+    /// The pass itself. The rows it gives cover the normalized network before
+    /// the star lowering, so only [`Self::to_normalized_with_source_rows`] pays
+    /// for the lowered lengths.
+    fn normalize_inner(
         &self,
         options: &NormalizeOptions,
     ) -> Result<(NormalizedNetwork, NormalizeSourceRows)> {
@@ -632,16 +666,17 @@ impl Network {
         let (hvdc, hvdc_rows) = norm_hvdc(&self.hvdc, base, &id_map);
         let (transformers_3w, transformer_3w_rows) =
             norm_transformers_3w(&self.transformers_3w, base, &id_map);
+        let some = |rows: Vec<usize>| rows.into_iter().map(Some).collect();
         let source_rows = NormalizeSourceRows {
-            buses: bus_rows,
-            loads: load_rows,
-            shunts: shunt_rows,
-            branches: branch_rows,
-            switches: switch_rows,
-            generators: generator_rows,
-            storage: storage_rows,
-            hvdc: hvdc_rows,
-            transformers_3w: transformer_3w_rows,
+            buses: some(bus_rows),
+            loads: some(load_rows),
+            shunts: some(shunt_rows),
+            branches: some(branch_rows),
+            switches: some(switch_rows),
+            generators: some(generator_rows),
+            storage: some(storage_rows),
+            hvdc: some(hvdc_rows),
+            transformers_3w: some(transformer_3w_rows),
         };
 
         // Bus types: a bus hosting an in-service generator keeps `Ref` if the

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -85,7 +85,7 @@ pub struct NormalizedNetwork {
 /// [`Network::reduce_zero_impedance`], [`Network::reduce_passthrough_buses`],
 /// [`Network::subset`], or a hand edit) invalidates every entry; run the pass
 /// again instead of patching the map.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct NormalizeSourceRows {
     pub buses: Vec<Option<usize>>,
@@ -100,17 +100,33 @@ pub struct NormalizeSourceRows {
 }
 
 impl NormalizeSourceRows {
-    /// Grow the families the star lowering appends to so each length matches
-    /// `lowered`. The appended entries have no source row.
-    fn pad_to(&mut self, lowered: &Network) {
-        self.buses.resize(lowered.buses.len(), None);
-        self.branches.resize(lowered.branches.len(), None);
-        self.shunts.resize(lowered.shunts.len(), None);
+    /// The map for a network that is already normalized: it is its own source,
+    /// so every element maps to its own row. Positional over `net` itself —
+    /// [`Self::pad_to_lowered`] extends it to the star-lowered view.
+    pub(crate) fn identity(net: &Network) -> Self {
+        let ident = |n: usize| (0..n).map(Some).collect();
+        Self {
+            buses: ident(net.buses.len()),
+            loads: ident(net.loads.len()),
+            shunts: ident(net.shunts.len()),
+            branches: ident(net.branches.len()),
+            switches: ident(net.switches.len()),
+            generators: ident(net.generators.len()),
+            storage: ident(net.storage.len()),
+            hvdc: ident(net.hvdc.len()),
+            transformers_3w: ident(net.transformers_3w.len()),
+        }
     }
 
-    /// Pad against the star-lowered form of `net`.
+    /// Grow the families the star lowering appends to so each length matches the
+    /// lowered form of `net`. The appended entries have no source row. The
+    /// lengths come from [`Network::lowered_lengths`], which counts them off the
+    /// transformer records, so padding never builds the lowering itself.
     pub(crate) fn pad_to_lowered(&mut self, net: &Network) {
-        self.pad_to(&net.expand_transformers_3w());
+        let lengths = net.lowered_lengths();
+        self.buses.resize(lengths.buses, None);
+        self.branches.resize(lengths.branches, None);
+        self.shunts.resize(lengths.shunts, None);
     }
 }
 
@@ -199,7 +215,11 @@ fn remap(map: &HashMap<BusId, BusId>, id: BusId) -> Option<BusId> {
     map.get(&id).copied()
 }
 
-fn norm_loads(loads: &[Load], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Load>, Vec<usize>) {
+fn norm_loads(
+    loads: &[Load],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Load>, Vec<Option<usize>>) {
     loads
         .iter()
         .enumerate()
@@ -216,7 +236,7 @@ fn norm_loads(loads: &[Load], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Lo
                         .map(|m| norm_load_voltage_model(m, base)),
                     ..l.clone()
                 },
-                row,
+                Some(row),
             ))
         })
         .unzip()
@@ -266,7 +286,7 @@ fn norm_shunts(
     shunts: &[Shunt],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Shunt>, Vec<usize>) {
+) -> (Vec<Shunt>, Vec<Option<usize>>) {
     shunts
         .iter()
         .enumerate()
@@ -285,7 +305,7 @@ fn norm_shunts(
                     }),
                     ..s.clone()
                 },
-                row,
+                Some(row),
             ))
         })
         .unzip()
@@ -295,7 +315,7 @@ fn norm_branches(
     branches: &[Branch],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Branch>, Vec<usize>) {
+) -> (Vec<Branch>, Vec<Option<usize>>) {
     branches
         .iter()
         .enumerate()
@@ -334,7 +354,7 @@ fn norm_branches(
                 }),
                 ..br.clone()
             };
-            Some((branch, row))
+            Some((branch, Some(row)))
         })
         .unzip()
 }
@@ -396,7 +416,7 @@ fn norm_gens(
     gens: &[Generator],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Generator>, Vec<usize>) {
+) -> (Vec<Generator>, Vec<Option<usize>>) {
     gens.iter()
         .enumerate()
         .filter(|(_, g)| g.in_service)
@@ -428,7 +448,7 @@ fn norm_gens(
                 regulated_bus: g.regulated_bus.and_then(|b| remap(map, b)),
                 ..g.clone()
             };
-            Some((generator, row))
+            Some((generator, Some(row)))
         })
         .unzip()
 }
@@ -437,7 +457,7 @@ fn norm_switches(
     switches: &[Switch],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Switch>, Vec<usize>) {
+) -> (Vec<Switch>, Vec<Option<usize>>) {
     switches
         .iter()
         .enumerate()
@@ -452,7 +472,7 @@ fn norm_switches(
                 qt: s.qt.map(|v| v / base),
                 ..s.clone()
             };
-            Some((switch, row))
+            Some((switch, Some(row)))
         })
         .unzip()
 }
@@ -461,7 +481,7 @@ fn norm_storage(
     storage: &[Storage],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Storage>, Vec<usize>) {
+) -> (Vec<Storage>, Vec<Option<usize>>) {
     storage
         .iter()
         .enumerate()
@@ -482,12 +502,16 @@ fn norm_storage(
                 q_loss: s.q_loss / base,
                 ..s.clone()
             };
-            Some((unit, row))
+            Some((unit, Some(row)))
         })
         .unzip()
 }
 
-fn norm_hvdc(hvdc: &[Hvdc], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Hvdc>, Vec<usize>) {
+fn norm_hvdc(
+    hvdc: &[Hvdc],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Hvdc>, Vec<Option<usize>>) {
     hvdc.iter()
         .enumerate()
         .filter(|(_, d)| d.in_service)
@@ -513,7 +537,7 @@ fn norm_hvdc(hvdc: &[Hvdc], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Hvdc
                 }),
                 ..d.clone()
             };
-            Some((link, row))
+            Some((link, Some(row)))
         })
         .unzip()
 }
@@ -522,7 +546,7 @@ fn norm_transformers_3w(
     xfmrs: &[Transformer3W],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> (Vec<Transformer3W>, Vec<usize>) {
+) -> (Vec<Transformer3W>, Vec<Option<usize>>) {
     xfmrs
         .iter()
         .enumerate()
@@ -546,7 +570,7 @@ fn norm_transformers_3w(
                     star_va: t.star_va * DEG_TO_RAD,
                     ..t.clone()
                 },
-                row,
+                Some(row),
             ))
         })
         .unzip()
@@ -617,12 +641,34 @@ impl Network {
 
     /// Like [`Network::to_normalized_with_options`], also returning the
     /// [`NormalizeSourceRows`] row provenance.
+    ///
+    /// The rows are positional over the
+    /// [`IndexedNetwork`](crate::IndexedNetwork) view of the returned network,
+    /// which is the index space a matrix row or a solver table row lives in.
+    /// That view star-lowers a 3-winding transformer, so it holds more buses,
+    /// branches, and shunts than the returned [`NormalizedNetwork`] does;
+    /// indexing the returned network by a row position is out of bounds on any
+    /// case that carries one. Resolve a row through the view:
+    ///
+    /// ```
+    /// # use powerio::{IndexedNetwork, Network, NormalizeOptions};
+    /// # fn f(raw: &Network) -> powerio::Result<()> {
+    /// let (normalized, rows) = raw.to_normalized_with_source_rows(&NormalizeOptions::default())?;
+    /// let view = IndexedNetwork::new(&normalized.network);
+    /// for (dense, source) in rows.buses.iter().enumerate() {
+    ///     let bus = &view.network().buses[dense];
+    ///     // `source` is `None` for the synthetic star bus the view appended.
+    ///     let _ = (bus, source);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn to_normalized_with_source_rows(
         &self,
         options: &NormalizeOptions,
     ) -> Result<(NormalizedNetwork, NormalizeSourceRows)> {
         let (normalized, mut rows) = self.normalize_inner(options)?;
-        rows.pad_to(&normalized.network.expand_transformers_3w());
+        rows.pad_to_lowered(&normalized.network);
         Ok((normalized, rows))
     }
 
@@ -641,7 +687,10 @@ impl Network {
         // reads it) and their source ids. Isolated buses are dropped.
         let mut id_map: HashMap<BusId, BusId> = HashMap::with_capacity(self.buses.len());
         let mut buses: Vec<Bus> = Vec::with_capacity(self.buses.len());
-        let mut bus_rows: Vec<usize> = Vec::with_capacity(self.buses.len());
+        // The pass keeps only elements that came from a source row, so each row
+        // here is `Some`; the `None` entries appear later, when
+        // `pad_to_lowered` extends the map over what the star lowering appends.
+        let mut bus_rows: Vec<Option<usize>> = Vec::with_capacity(self.buses.len());
         for (row, b) in self.buses.iter().enumerate() {
             if b.kind == BusType::Isolated {
                 continue;
@@ -651,7 +700,7 @@ impl Network {
                 va: b.va * DEG_TO_RAD,
                 ..b.clone()
             });
-            bus_rows.push(row);
+            bus_rows.push(Some(row));
         }
         let (loads, load_rows) = norm_loads(&self.loads, base, &id_map);
         let (shunts, shunt_rows) = norm_shunts(&self.shunts, base, &id_map);
@@ -666,17 +715,16 @@ impl Network {
         let (hvdc, hvdc_rows) = norm_hvdc(&self.hvdc, base, &id_map);
         let (transformers_3w, transformer_3w_rows) =
             norm_transformers_3w(&self.transformers_3w, base, &id_map);
-        let some = |rows: Vec<usize>| rows.into_iter().map(Some).collect();
         let source_rows = NormalizeSourceRows {
-            buses: some(bus_rows),
-            loads: some(load_rows),
-            shunts: some(shunt_rows),
-            branches: some(branch_rows),
-            switches: some(switch_rows),
-            generators: some(generator_rows),
-            storage: some(storage_rows),
-            hvdc: some(hvdc_rows),
-            transformers_3w: some(transformer_3w_rows),
+            buses: bus_rows,
+            loads: load_rows,
+            shunts: shunt_rows,
+            branches: branch_rows,
+            switches: switch_rows,
+            generators: generator_rows,
+            storage: storage_rows,
+            hvdc: hvdc_rows,
+            transformers_3w: transformer_3w_rows,
         };
 
         // Bus types: a bus hosting an in-service generator keeps `Ref` if the

--- a/powerio/src/normalize.rs
+++ b/powerio/src/normalize.rs
@@ -64,6 +64,30 @@ pub struct NormalizedNetwork {
     pub warnings: Vec<String>,
 }
 
+/// Row provenance for one normalize pass: for each element position in the
+/// normalized network, the row of the same element family in the source
+/// network. The pass filters rows and never reorders or merges them, so
+/// `buses[i]` is the source row of normalized bus `i`, and the same holds
+/// for every family.
+///
+/// `IndexedNetwork` dense indices over a normalized network are positional,
+/// so `rows.buses[dense_index]` resolves a matrix row back to its source
+/// element without re-deriving the filter rules — the map is produced by the
+/// same pass that filters, so the two cannot drift.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct NormalizeSourceRows {
+    pub buses: Vec<usize>,
+    pub loads: Vec<usize>,
+    pub shunts: Vec<usize>,
+    pub branches: Vec<usize>,
+    pub switches: Vec<usize>,
+    pub generators: Vec<usize>,
+    pub storage: Vec<usize>,
+    pub hvdc: Vec<usize>,
+    pub transformers_3w: Vec<usize>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum CostModel {
     Piecewise,
@@ -149,23 +173,27 @@ fn remap(map: &HashMap<BusId, BusId>, id: BusId) -> Option<BusId> {
     map.get(&id).copied()
 }
 
-fn norm_loads(loads: &[Load], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Load> {
+fn norm_loads(loads: &[Load], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Load>, Vec<usize>) {
     loads
         .iter()
-        .filter(|l| l.in_service)
-        .filter_map(|l| {
-            Some(Load {
-                bus: remap(map, l.bus)?,
-                p: l.p / base,
-                q: l.q / base,
-                voltage_model: l
-                    .voltage_model
-                    .as_ref()
-                    .map(|m| norm_load_voltage_model(m, base)),
-                ..l.clone()
-            })
+        .enumerate()
+        .filter(|(_, l)| l.in_service)
+        .filter_map(|(row, l)| {
+            Some((
+                Load {
+                    bus: remap(map, l.bus)?,
+                    p: l.p / base,
+                    q: l.q / base,
+                    voltage_model: l
+                        .voltage_model
+                        .as_ref()
+                        .map(|m| norm_load_voltage_model(m, base)),
+                    ..l.clone()
+                },
+                row,
+            ))
         })
-        .collect()
+        .unzip()
 }
 
 fn norm_load_voltage_model(model: &LoadVoltageModel, base: f64) -> LoadVoltageModel {
@@ -208,33 +236,46 @@ fn norm_load_voltage_model(model: &LoadVoltageModel, base: f64) -> LoadVoltageMo
     }
 }
 
-fn norm_shunts(shunts: &[Shunt], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Shunt> {
+fn norm_shunts(
+    shunts: &[Shunt],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Shunt>, Vec<usize>) {
     shunts
         .iter()
-        .filter(|s| s.in_service)
-        .filter_map(|s| {
-            Some(Shunt {
-                bus: remap(map, s.bus)?,
-                g: s.g / base,
-                b: s.b / base,
-                // Remap the switched-shunt control bus and drop it if its target was
-                // filtered out, so the normalized network has no dangling reference.
-                control: s.control.clone().map(|mut c| {
-                    c.control_bus = c.control_bus.and_then(|b| remap(map, b));
-                    c
-                }),
-                ..s.clone()
-            })
+        .enumerate()
+        .filter(|(_, s)| s.in_service)
+        .filter_map(|(row, s)| {
+            Some((
+                Shunt {
+                    bus: remap(map, s.bus)?,
+                    g: s.g / base,
+                    b: s.b / base,
+                    // Remap the switched-shunt control bus and drop it if its target was
+                    // filtered out, so the normalized network has no dangling reference.
+                    control: s.control.clone().map(|mut c| {
+                        c.control_bus = c.control_bus.and_then(|b| remap(map, b));
+                        c
+                    }),
+                    ..s.clone()
+                },
+                row,
+            ))
         })
-        .collect()
+        .unzip()
 }
 
-fn norm_branches(branches: &[Branch], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Branch> {
+fn norm_branches(
+    branches: &[Branch],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Branch>, Vec<usize>) {
     branches
         .iter()
-        .filter(|br| br.in_service)
-        .filter_map(|br| {
-            Some(Branch {
+        .enumerate()
+        .filter(|(_, br)| br.in_service)
+        .filter_map(|(row, br)| {
+            let branch = Branch {
                 from: remap(map, br.from)?,
                 to: remap(map, br.to)?,
                 rate_a: br.rate_a / base,
@@ -266,9 +307,10 @@ fn norm_branches(branches: &[Branch], base: f64, map: &HashMap<BusId, BusId>) ->
                     c
                 }),
                 ..br.clone()
-            })
+            };
+            Some((branch, row))
         })
-        .collect()
+        .unzip()
 }
 
 fn validate_normalize_options(options: &NormalizeOptions) -> Result<()> {
@@ -324,10 +366,15 @@ fn clamp_angle_bounds(branches: &mut [Branch], pad: f64, warnings: &mut Vec<Stri
     }
 }
 
-fn norm_gens(gens: &[Generator], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Generator> {
+fn norm_gens(
+    gens: &[Generator],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Generator>, Vec<usize>) {
     gens.iter()
-        .filter(|g| g.in_service)
-        .filter_map(|g| {
+        .enumerate()
+        .filter(|(_, g)| g.in_service)
+        .filter_map(|(row, g)| {
             let bus = remap(map, g.bus)?;
             let mut caps = g.caps;
             for (i, key) in GEN_EXTRA_KEYS.iter().enumerate() {
@@ -337,7 +384,7 @@ fn norm_gens(gens: &[Generator], base: f64, map: &HashMap<BusId, BusId>) -> Vec<
                     }
                 }
             }
-            Some(Generator {
+            let generator = Generator {
                 bus,
                 pg: g.pg / base,
                 qg: g.qg / base,
@@ -354,16 +401,22 @@ fn norm_gens(gens: &[Generator], base: f64, map: &HashMap<BusId, BusId>) -> Vec<
                 // target was filtered out so the normalized form stays consistent.
                 regulated_bus: g.regulated_bus.and_then(|b| remap(map, b)),
                 ..g.clone()
-            })
+            };
+            Some((generator, row))
         })
-        .collect()
+        .unzip()
 }
 
-fn norm_switches(switches: &[Switch], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Switch> {
+fn norm_switches(
+    switches: &[Switch],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Switch>, Vec<usize>) {
     switches
         .iter()
-        .filter_map(|s| {
-            Some(Switch {
+        .enumerate()
+        .filter_map(|(row, s)| {
+            let switch = Switch {
                 from: remap(map, s.from)?,
                 to: remap(map, s.to)?,
                 thermal_rating: s.thermal_rating.map(|v| v / base),
@@ -372,19 +425,25 @@ fn norm_switches(switches: &[Switch], base: f64, map: &HashMap<BusId, BusId>) ->
                 pt: s.pt.map(|v| v / base),
                 qt: s.qt.map(|v| v / base),
                 ..s.clone()
-            })
+            };
+            Some((switch, row))
         })
-        .collect()
+        .unzip()
 }
 
-fn norm_storage(storage: &[Storage], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Storage> {
+fn norm_storage(
+    storage: &[Storage],
+    base: f64,
+    map: &HashMap<BusId, BusId>,
+) -> (Vec<Storage>, Vec<usize>) {
     storage
         .iter()
-        .filter(|s| s.in_service)
-        .filter_map(|s| {
+        .enumerate()
+        .filter(|(_, s)| s.in_service)
+        .filter_map(|(row, s)| {
             // ps/qs stay raw (PowerModels' make_per_unit! leaves the dispatch
             // setpoint alone); the energy, ratings, limits, and losses scale.
-            Some(Storage {
+            let unit = Storage {
                 bus: remap(map, s.bus)?,
                 energy: s.energy / base,
                 energy_rating: s.energy_rating / base,
@@ -396,19 +455,21 @@ fn norm_storage(storage: &[Storage], base: f64, map: &HashMap<BusId, BusId>) -> 
                 p_loss: s.p_loss / base,
                 q_loss: s.q_loss / base,
                 ..s.clone()
-            })
+            };
+            Some((unit, row))
         })
-        .collect()
+        .unzip()
 }
 
-fn norm_hvdc(hvdc: &[Hvdc], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Hvdc> {
+fn norm_hvdc(hvdc: &[Hvdc], base: f64, map: &HashMap<BusId, BusId>) -> (Vec<Hvdc>, Vec<usize>) {
     hvdc.iter()
-        .filter(|d| d.in_service)
-        .filter_map(|d| {
+        .enumerate()
+        .filter(|(_, d)| d.in_service)
+        .filter_map(|(row, d)| {
             // No sign flip: the writer's Pt/Qf/Qt negation is a PowerModels output
             // convention, not part of per-unit normalization. The aggregate
             // pmin/pmax stay raw, matching make_per_unit!.
-            Some(Hvdc {
+            let link = Hvdc {
                 from: remap(map, d.from)?,
                 to: remap(map, d.to)?,
                 pf: d.pf / base,
@@ -425,20 +486,22 @@ fn norm_hvdc(hvdc: &[Hvdc], base: f64, map: &HashMap<BusId, BusId>) -> Vec<Hvdc>
                     ..c.clone()
                 }),
                 ..d.clone()
-            })
+            };
+            Some((link, row))
         })
-        .collect()
+        .unzip()
 }
 
 fn norm_transformers_3w(
     xfmrs: &[Transformer3W],
     base: f64,
     map: &HashMap<BusId, BusId>,
-) -> Vec<Transformer3W> {
+) -> (Vec<Transformer3W>, Vec<usize>) {
     xfmrs
         .iter()
-        .filter(|t| t.in_service)
-        .filter_map(|t| {
+        .enumerate()
+        .filter(|(_, t)| t.in_service)
+        .filter_map(|(row, t)| {
             // Remap each winding terminal and drop the whole unit if any was filtered
             // out (a 3-winding transformer can't keep a dangling winding). Phase
             // shifts and the star angle go to radians; winding ratings go per unit;
@@ -451,13 +514,16 @@ fn norm_transformers_3w(
                 w.rate_b /= base;
                 w.rate_c /= base;
             }
-            Some(Transformer3W {
-                windings,
-                star_va: t.star_va * DEG_TO_RAD,
-                ..t.clone()
-            })
+            Some((
+                Transformer3W {
+                    windings,
+                    star_va: t.star_va * DEG_TO_RAD,
+                    ..t.clone()
+                },
+                row,
+            ))
         })
-        .collect()
+        .unzip()
 }
 
 impl Network {
@@ -520,6 +586,19 @@ impl Network {
         &self,
         options: &NormalizeOptions,
     ) -> Result<NormalizedNetwork> {
+        Ok(self.to_normalized_with_source_rows(options)?.0)
+    }
+
+    /// Like [`Network::to_normalized_with_options`], also returning the
+    /// [`NormalizeSourceRows`] row provenance for every retained element.
+    ///
+    /// The map comes from the same pass that filters, so a consumer resolving
+    /// normalized positions (or `IndexedNetwork` dense indices) back to source
+    /// rows does not re-derive the filter rules.
+    pub fn to_normalized_with_source_rows(
+        &self,
+        options: &NormalizeOptions,
+    ) -> Result<(NormalizedNetwork, NormalizeSourceRows)> {
         validate_normalize_options(options)?;
         self.check_base_mva()?;
         let base = self.base_mva;
@@ -528,7 +607,8 @@ impl Network {
         // reads it) and their source ids. Isolated buses are dropped.
         let mut id_map: HashMap<BusId, BusId> = HashMap::with_capacity(self.buses.len());
         let mut buses: Vec<Bus> = Vec::with_capacity(self.buses.len());
-        for b in &self.buses {
+        let mut bus_rows: Vec<usize> = Vec::with_capacity(self.buses.len());
+        for (row, b) in self.buses.iter().enumerate() {
             if b.kind == BusType::Isolated {
                 continue;
             }
@@ -537,19 +617,32 @@ impl Network {
                 va: b.va * DEG_TO_RAD,
                 ..b.clone()
             });
+            bus_rows.push(row);
         }
-        let loads = norm_loads(&self.loads, base, &id_map);
-        let shunts = norm_shunts(&self.shunts, base, &id_map);
-        let mut branches = norm_branches(&self.branches, base, &id_map);
+        let (loads, load_rows) = norm_loads(&self.loads, base, &id_map);
+        let (shunts, shunt_rows) = norm_shunts(&self.shunts, base, &id_map);
+        let (mut branches, branch_rows) = norm_branches(&self.branches, base, &id_map);
         let mut warnings = Vec::new();
         if options.clamp_angle_bounds {
             clamp_angle_bounds(&mut branches, options.angle_bound_pad, &mut warnings);
         }
-        let switches = norm_switches(&self.switches, base, &id_map);
-        let generators = norm_gens(&self.generators, base, &id_map);
-        let storage = norm_storage(&self.storage, base, &id_map);
-        let hvdc = norm_hvdc(&self.hvdc, base, &id_map);
-        let transformers_3w = norm_transformers_3w(&self.transformers_3w, base, &id_map);
+        let (switches, switch_rows) = norm_switches(&self.switches, base, &id_map);
+        let (generators, generator_rows) = norm_gens(&self.generators, base, &id_map);
+        let (storage, storage_rows) = norm_storage(&self.storage, base, &id_map);
+        let (hvdc, hvdc_rows) = norm_hvdc(&self.hvdc, base, &id_map);
+        let (transformers_3w, transformer_3w_rows) =
+            norm_transformers_3w(&self.transformers_3w, base, &id_map);
+        let source_rows = NormalizeSourceRows {
+            buses: bus_rows,
+            loads: load_rows,
+            shunts: shunt_rows,
+            branches: branch_rows,
+            switches: switch_rows,
+            generators: generator_rows,
+            storage: storage_rows,
+            hvdc: hvdc_rows,
+            transformers_3w: transformer_3w_rows,
+        };
 
         // Bus types: a bus hosting an in-service generator keeps `Ref` if the
         // file marked it `Ref`, else becomes `Pv`; a gen-less bus is `Pq`.
@@ -610,10 +703,13 @@ impl Network {
             net.validate().is_ok(),
             "to_normalized produced a dangling reference"
         );
-        Ok(NormalizedNetwork {
-            network: net,
-            warnings,
-        })
+        Ok((
+            NormalizedNetwork {
+                network: net,
+                warnings,
+            },
+            source_rows,
+        ))
     }
 }
 

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -5,14 +5,13 @@
 //! provenance to map lowered data back to the source case. This module provides
 //! that table layout without changing the lossless `Network` representation.
 
-use std::collections::{HashMap, HashSet};
-
 use serde::{Deserialize, Serialize};
 
 use crate::network::{
     BranchCurrentRatings, BranchRatingSet, BusId, BusType, GenCaps, GenCost, Hvdc,
     LoadVoltageModel, Network,
 };
+use crate::normalize::{NormalizeOptions, NormalizeSourceRows};
 use crate::{Error, IndexedNetwork, Result};
 
 /// Stable pass name for the balanced normalized solver table lowering.
@@ -313,10 +312,9 @@ impl Network {
 
 impl NormalizedSolverTables {
     pub fn from_network(source: &Network) -> Result<Self> {
-        let normalized = normalized_for_solver(source)?;
+        let (normalized, provenance) = normalized_for_solver(source)?;
         let view = IndexedNetwork::new(&normalized);
         let net = view.network();
-        let provenance = SourceRows::new(source, net);
 
         let branch_arcs = branch_and_arc_rows(&view, &provenance)?;
         let buses = bus_rows(&view, &provenance);
@@ -339,12 +337,12 @@ impl NormalizedSolverTables {
                 component_labels: view.connected_component_labels(),
                 branch_from_arc_indices: branch_arcs.branch_from_arc_indices,
                 branch_to_arc_indices: branch_arcs.branch_to_arc_indices,
-                bus_source_rows: provenance.bus,
-                load_source_rows: provenance.load,
-                shunt_source_rows: provenance.shunt,
-                branch_source_rows: provenance.branch,
-                switch_source_rows: provenance.switch,
-                generator_source_rows: provenance.generator,
+                bus_source_rows: provenance.buses,
+                load_source_rows: provenance.loads,
+                shunt_source_rows: provenance.shunts,
+                branch_source_rows: provenance.branches,
+                switch_source_rows: provenance.switches,
+                generator_source_rows: provenance.generators,
                 storage_source_rows: provenance.storage,
                 hvdc_source_rows: provenance.hvdc,
             },
@@ -361,15 +359,34 @@ impl NormalizedSolverTables {
     }
 }
 
-fn normalized_for_solver(source: &Network) -> Result<Network> {
+/// The normalized network and the row provenance for its star-lowered view.
+/// A network that is already normalized is its own source, so every element
+/// maps to its own row.
+fn normalized_for_solver(source: &Network) -> Result<(Network, NormalizeSourceRows)> {
     if source.is_normalized() {
-        Ok(source.clone())
+        let net = source.clone();
+        let ident = |n: usize| (0..n).map(Some).collect();
+        let mut rows = NormalizeSourceRows {
+            buses: ident(net.buses.len()),
+            loads: ident(net.loads.len()),
+            shunts: ident(net.shunts.len()),
+            branches: ident(net.branches.len()),
+            switches: ident(net.switches.len()),
+            generators: ident(net.generators.len()),
+            storage: ident(net.storage.len()),
+            hvdc: ident(net.hvdc.len()),
+            transformers_3w: ident(net.transformers_3w.len()),
+        };
+        rows.pad_to_lowered(&net);
+        Ok((net, rows))
     } else {
-        source.to_normalized()
+        let (normalized, rows) =
+            source.to_normalized_with_source_rows(&NormalizeOptions::default())?;
+        Ok((normalized.network, rows))
     }
 }
 
-fn bus_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Vec<SolverBusRow> {
+fn bus_rows(view: &IndexedNetwork<'_>, provenance: &NormalizeSourceRows) -> Vec<SolverBusRow> {
     view.network()
         .buses
         .iter()
@@ -377,7 +394,7 @@ fn bus_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Vec<SolverBus
         .map(|(i, bus)| SolverBusRow {
             index: i,
             bus_id: bus.id,
-            source_row: provenance.bus[i],
+            source_row: provenance.buses[i],
             kind: bus.kind,
             vm: bus.vm,
             va: bus.va,
@@ -396,7 +413,10 @@ fn bus_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Vec<SolverBus
         .collect()
 }
 
-fn load_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<SolverLoadRow>> {
+fn load_rows(
+    view: &IndexedNetwork<'_>,
+    provenance: &NormalizeSourceRows,
+) -> Result<Vec<SolverLoadRow>> {
     view.network()
         .loads
         .iter()
@@ -404,7 +424,7 @@ fn load_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<S
         .map(|(i, load)| {
             Ok(SolverLoadRow {
                 index: i,
-                source_row: provenance.load[i],
+                source_row: provenance.loads[i],
                 bus_index: dense_bus(view, load.bus, i)?,
                 p: load.p,
                 q: load.q,
@@ -414,7 +434,10 @@ fn load_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<S
         .collect()
 }
 
-fn shunt_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<SolverShuntRow>> {
+fn shunt_rows(
+    view: &IndexedNetwork<'_>,
+    provenance: &NormalizeSourceRows,
+) -> Result<Vec<SolverShuntRow>> {
     view.network()
         .shunts
         .iter()
@@ -422,7 +445,7 @@ fn shunt_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<
         .map(|(i, shunt)| {
             Ok(SolverShuntRow {
                 index: i,
-                source_row: provenance.shunt[i],
+                source_row: provenance.shunts[i],
                 bus_index: dense_bus(view, shunt.bus, i)?,
                 g: shunt.g,
                 b: shunt.b,
@@ -440,7 +463,7 @@ struct BranchArcRows {
 
 fn branch_and_arc_rows(
     view: &IndexedNetwork<'_>,
-    provenance: &SourceRows,
+    provenance: &NormalizeSourceRows,
 ) -> Result<BranchArcRows> {
     let net = view.network();
     let mut branch_from_arc_indices = Vec::with_capacity(net.branches.len());
@@ -485,7 +508,7 @@ fn branch_and_arc_rows(
 
             Ok(SolverBranchRow {
                 index: i,
-                source_row: provenance.branch[i],
+                source_row: provenance.branches[i],
                 from_bus_index,
                 to_bus_index,
                 r: branch.r,
@@ -516,7 +539,10 @@ fn branch_and_arc_rows(
     })
 }
 
-fn switch_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<SolverSwitchRow>> {
+fn switch_rows(
+    view: &IndexedNetwork<'_>,
+    provenance: &NormalizeSourceRows,
+) -> Result<Vec<SolverSwitchRow>> {
     view.network()
         .switches
         .iter()
@@ -524,7 +550,7 @@ fn switch_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec
         .map(|(i, switch)| {
             Ok(SolverSwitchRow {
                 index: i,
-                source_row: provenance.switch[i],
+                source_row: provenance.switches[i],
                 from_bus_index: dense_bus(view, switch.from, i)?,
                 to_bus_index: dense_bus(view, switch.to, i)?,
                 closed: switch.closed,
@@ -541,7 +567,7 @@ fn switch_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec
 
 fn generator_rows(
     view: &IndexedNetwork<'_>,
-    provenance: &SourceRows,
+    provenance: &NormalizeSourceRows,
 ) -> Result<Vec<SolverGeneratorRow>> {
     view.network()
         .generators
@@ -550,7 +576,7 @@ fn generator_rows(
         .map(|(i, generator)| {
             Ok(SolverGeneratorRow {
                 index: i,
-                source_row: provenance.generator[i],
+                source_row: provenance.generators[i],
                 bus_index: dense_bus(view, generator.bus, i)?,
                 pg: generator.pg,
                 qg: generator.qg,
@@ -573,7 +599,7 @@ fn generator_rows(
 
 fn storage_rows(
     view: &IndexedNetwork<'_>,
-    provenance: &SourceRows,
+    provenance: &NormalizeSourceRows,
 ) -> Result<Vec<SolverStorageRow>> {
     let base_mva = view.network().base_mva;
     view.network()
@@ -606,7 +632,10 @@ fn storage_rows(
         .collect()
 }
 
-fn hvdc_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<SolverHvdcRow>> {
+fn hvdc_rows(
+    view: &IndexedNetwork<'_>,
+    provenance: &NormalizeSourceRows,
+) -> Result<Vec<SolverHvdcRow>> {
     view.network()
         .hvdc
         .iter()
@@ -617,7 +646,7 @@ fn hvdc_rows(view: &IndexedNetwork<'_>, provenance: &SourceRows) -> Result<Vec<S
 
 fn hvdc_row(
     view: &IndexedNetwork<'_>,
-    provenance: &SourceRows,
+    provenance: &NormalizeSourceRows,
     i: usize,
     hvdc: &Hvdc,
 ) -> Result<SolverHvdcRow> {
@@ -650,117 +679,6 @@ fn dense_bus(view: &IndexedNetwork<'_>, bus_id: BusId, element_index: usize) -> 
         bus_id,
         element_index,
     })
-}
-
-#[derive(Debug)]
-struct SourceRows {
-    bus: Vec<Option<usize>>,
-    load: Vec<Option<usize>>,
-    shunt: Vec<Option<usize>>,
-    branch: Vec<Option<usize>>,
-    switch: Vec<Option<usize>>,
-    generator: Vec<Option<usize>>,
-    storage: Vec<Option<usize>>,
-    hvdc: Vec<Option<usize>>,
-}
-
-impl SourceRows {
-    fn new(source: &Network, lowered: &Network) -> Self {
-        let kept_buses: HashSet<BusId> = source
-            .buses
-            .iter()
-            .filter(|b| b.kind != BusType::Isolated)
-            .map(|b| b.id)
-            .collect();
-        let bus_source: HashMap<BusId, usize> = source
-            .buses
-            .iter()
-            .enumerate()
-            .filter(|(_, b)| b.kind != BusType::Isolated)
-            .map(|(i, b)| (b.id, i))
-            .collect();
-        let bus = lowered
-            .buses
-            .iter()
-            .map(|b| bus_source.get(&b.id).copied())
-            .collect();
-
-        Self {
-            bus,
-            load: resize_sources(
-                lowered.loads.len(),
-                source.loads.iter().enumerate().filter_map(|(i, load)| {
-                    (load.in_service && kept_buses.contains(&load.bus)).then_some(i)
-                }),
-            ),
-            shunt: resize_sources(
-                lowered.shunts.len(),
-                source.shunts.iter().enumerate().filter_map(|(i, shunt)| {
-                    (shunt.in_service && kept_buses.contains(&shunt.bus)).then_some(i)
-                }),
-            ),
-            branch: resize_sources(
-                lowered.branches.len(),
-                source
-                    .branches
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, branch)| {
-                        (branch.in_service
-                            && kept_buses.contains(&branch.from)
-                            && kept_buses.contains(&branch.to))
-                        .then_some(i)
-                    }),
-            ),
-            switch: resize_sources(
-                lowered.switches.len(),
-                source
-                    .switches
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, switch)| {
-                        (kept_buses.contains(&switch.from) && kept_buses.contains(&switch.to))
-                            .then_some(i)
-                    }),
-            ),
-            generator: resize_sources(
-                lowered.generators.len(),
-                source
-                    .generators
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, generator)| {
-                        (generator.in_service && kept_buses.contains(&generator.bus)).then_some(i)
-                    }),
-            ),
-            storage: resize_sources(
-                lowered.storage.len(),
-                source
-                    .storage
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, storage)| {
-                        (storage.in_service && kept_buses.contains(&storage.bus)).then_some(i)
-                    }),
-            ),
-            hvdc: resize_sources(
-                lowered.hvdc.len(),
-                source.hvdc.iter().enumerate().filter_map(|(i, hvdc)| {
-                    (hvdc.in_service
-                        && kept_buses.contains(&hvdc.from)
-                        && kept_buses.contains(&hvdc.to))
-                    .then_some(i)
-                }),
-            ),
-        }
-    }
-}
-
-fn resize_sources(len: usize, rows: impl Iterator<Item = usize>) -> Vec<Option<usize>> {
-    let mut out: Vec<Option<usize>> = rows.map(Some).collect();
-    out.resize(len, None);
-    out.truncate(len);
-    out
 }
 
 #[cfg(test)]

--- a/powerio/src/solver_tables.rs
+++ b/powerio/src/solver_tables.rs
@@ -365,18 +365,7 @@ impl NormalizedSolverTables {
 fn normalized_for_solver(source: &Network) -> Result<(Network, NormalizeSourceRows)> {
     if source.is_normalized() {
         let net = source.clone();
-        let ident = |n: usize| (0..n).map(Some).collect();
-        let mut rows = NormalizeSourceRows {
-            buses: ident(net.buses.len()),
-            loads: ident(net.loads.len()),
-            shunts: ident(net.shunts.len()),
-            branches: ident(net.branches.len()),
-            switches: ident(net.switches.len()),
-            generators: ident(net.generators.len()),
-            storage: ident(net.storage.len()),
-            hvdc: ident(net.hvdc.len()),
-            transformers_3w: ident(net.transformers_3w.len()),
-        };
+        let mut rows = NormalizeSourceRows::identity(&net);
         rows.pad_to_lowered(&net);
         Ok((net, rows))
     } else {
@@ -830,6 +819,57 @@ mod tests {
         assert!(approx(tables.branches[0].rate_a, 1.0));
         assert!(approx(tables.branches[0].tap, 1.0));
         assert!(approx(tables.branches[0].shift, 30.0_f64.to_radians()));
+    }
+
+    #[test]
+    fn solver_tables_map_an_already_normalized_network_to_its_own_rows() {
+        // An already-normalized network skips the pass, so nothing is filtered
+        // and every table row names the row it sits at. The out-of-service load
+        // and generator and the isolated bus are the cases that separate this
+        // from the filtered path: they survive here, so the map stays the
+        // identity across every family instead of shifting positions.
+        let mut net = Network::in_memory(
+            "identity",
+            100.0,
+            vec![
+                bus(1, BusType::Ref),
+                bus(2, BusType::Pq),
+                bus(3, BusType::Pq),
+                bus(4, BusType::Isolated),
+            ],
+            vec![branch(1, 2, true), branch(1, 3, false)],
+        );
+        net.loads.push(Load {
+            bus: BusId(2),
+            p: 0.1,
+            q: 0.05,
+            voltage_model: None,
+            in_service: false,
+            uid: None,
+            extras: Extras::new(),
+        });
+        net.loads.push(Load {
+            bus: BusId(3),
+            p: 0.2,
+            q: 0.1,
+            voltage_model: None,
+            in_service: true,
+            uid: None,
+            extras: Extras::new(),
+        });
+        net.generators.push(generator(1, false));
+        net.generators.push(generator(2, true));
+        net.source_format = SourceFormat::Normalized;
+
+        let tables = net.to_normalized_solver_tables().unwrap();
+
+        assert_eq!(
+            tables.index.bus_source_rows,
+            vec![Some(0), Some(1), Some(2), Some(3)]
+        );
+        assert_eq!(tables.index.branch_source_rows, vec![Some(0), Some(1)]);
+        assert_eq!(tables.index.load_source_rows, vec![Some(0), Some(1)]);
+        assert_eq!(tables.index.generator_source_rows, vec![Some(0), Some(1)]);
     }
 
     #[test]

--- a/powerio/tests/normalize.rs
+++ b/powerio/tests/normalize.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use powerio::{
-    BusId, BusType, Error, IndexedNetwork, SourceFormat, Storage, TargetFormat, parse_file,
-    parse_matpower_file, parse_str, write_as,
+    BusId, BusType, Error, IndexedNetwork, NormalizeOptions, SourceFormat, Storage, TargetFormat,
+    parse_file, parse_matpower_file, parse_str, write_as,
 };
 
 const DEG_TO_RAD: f64 = std::f64::consts::PI / 180.0;
@@ -212,6 +212,69 @@ mpc.branch = [
     assert_eq!(n.loads[0].bus.0, 3, "load keeps the source id");
     assert_eq!(n.buses[0].kind, BusType::Ref);
     assert_eq!(n.buses[1].kind, BusType::Pq);
+}
+
+#[test]
+fn source_rows_map_normalized_positions_to_raw_rows() {
+    // Bus 2 is isolated; branch row 1 (2-3) dies with it; branch row 2 is out
+    // of service; gen row 1 is out of service; the load on bus 2 dies with the
+    // bus. Each surviving family position must name its raw row.
+    let src = "\
+function mpc = rows
+mpc.version = '2';
+mpc.baseMVA = 100;
+mpc.bus = [
+\t1\t3\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t2\t4\t0\t0\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t3\t1\t50\t10\t0\t0\t1\t1\t0\t230\t1\t1.1\t0.9;
+\t4\t1\t20\t5\t3\t7\t1\t1\t0\t230\t1\t1.1\t0.9;
+];
+mpc.gen = [
+\t1\t0\t0\t100\t-100\t1\t100\t1\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+\t3\t0\t0\t100\t-100\t1\t100\t0\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+\t4\t0\t0\t100\t-100\t1\t100\t1\t200\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0;
+];
+mpc.branch = [
+\t1\t3\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t2\t3\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+\t3\t4\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t0\t-360\t360;
+\t1\t4\t0.01\t0.1\t0\t0\t0\t0\t0\t0\t1\t-360\t360;
+];
+";
+    let raw = parse_str(src, "matpower").unwrap().network;
+    let (n, rows) = raw
+        .to_normalized_with_source_rows(&NormalizeOptions::default())
+        .unwrap();
+
+    // Buses: raw rows 0, 2, 3 survive (row 1 is isolated).
+    assert_eq!(rows.buses, [0, 2, 3]);
+    // Branches: row 1 references the dropped bus, row 2 is out of service.
+    assert_eq!(rows.branches, [0, 3]);
+    // Generators: row 1 is out of service.
+    assert_eq!(rows.generators, [0, 2]);
+    // The MATPOWER bus PD/QD columns become one load per demand-carrying bus,
+    // in bus order; the load on dropped bus 2 never exists as a raw load here,
+    // so both raw loads (buses 3 and 4) survive.
+    assert_eq!(rows.loads, [0, 1]);
+    assert_eq!(rows.shunts, [0]);
+
+    // The maps agree with the elements the normalized network holds, and the
+    // options wrapper returns the identical network.
+    for (pos, &row) in rows.buses.iter().enumerate() {
+        assert_eq!(n.network.buses[pos].id, raw.buses[row].id);
+    }
+    for (pos, &row) in rows.branches.iter().enumerate() {
+        assert_eq!(n.network.branches[pos].from, raw.branches[row].from);
+        assert_eq!(n.network.branches[pos].to, raw.branches[row].to);
+    }
+    for (pos, &row) in rows.generators.iter().enumerate() {
+        assert_eq!(n.network.generators[pos].bus, raw.generators[row].bus);
+    }
+    let plain = raw
+        .to_normalized_with_options(&NormalizeOptions::default())
+        .unwrap();
+    assert_eq!(plain.network.buses.len(), n.network.buses.len());
+    assert_eq!(plain.network.branches.len(), n.network.branches.len());
 }
 
 #[test]

--- a/powerio/tests/normalize.rs
+++ b/powerio/tests/normalize.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use powerio::{
-    BusId, BusType, Error, Generator, IndexedNetwork, NormalizeOptions, SourceFormat, Storage,
-    TargetFormat, parse_file, parse_matpower_file, parse_str, write_as,
+    BusId, BusType, Error, Generator, IndexedNetwork, NormalizeOptions, Shunt, SourceFormat,
+    Storage, TargetFormat, parse_file, parse_matpower_file, parse_str, write_as,
 };
 
 const DEG_TO_RAD: f64 = std::f64::consts::PI / 180.0;
@@ -677,6 +677,43 @@ fn source_rows_cover_the_star_lowered_view() {
     assert_eq!(rows.buses[..3], [Some(0), Some(1), Some(2)]);
     assert_eq!(*rows.buses.last().unwrap(), None);
     assert!(rows.branches.iter().all(Option::is_none));
+}
+
+#[test]
+fn source_rows_cover_the_magnetizing_shunt_the_lowering_appends() {
+    // `source_rows_cover_the_star_lowered_view` runs on a transformer with no
+    // magnetizing admittance, so its shunt assertion compares an empty map to an
+    // empty table. Give the transformer a magnetizing branch and the lowering
+    // appends a shunt after the real one: the map has to grow with it, or
+    // reading provenance for that tail position is out of bounds.
+    let mut raw = parse_str(EPC_3W, "pslf").unwrap().network;
+    raw.buses[0].kind = BusType::Ref;
+    let mut g = Generator::new(BusId(1));
+    g.pmax = 100.0;
+    raw.generators.push(g);
+    raw.shunts.push(Shunt::new(BusId(2), 0.0, 5.0));
+    raw.transformers_3w[0].mag_b = 0.01;
+
+    let (n, rows) = raw
+        .to_normalized_with_source_rows(&NormalizeOptions::default())
+        .unwrap();
+    let view = IndexedNetwork::new(&n.network);
+
+    assert_eq!(
+        view.network().shunts.len(),
+        2,
+        "real shunt, then magnetizing"
+    );
+    assert_eq!(rows.shunts.len(), view.network().shunts.len());
+    // The real shunt keeps its raw row; the appended magnetizing shunt has none.
+    assert_eq!(rows.shunts, [Some(0), None]);
+    assert_eq!(rows.buses.len(), view.n());
+    assert_eq!(rows.branches.len(), view.branches().len());
+
+    // The tables read provenance by position across the lowered view, so the
+    // padding has to hold for them too.
+    let tables = raw.to_normalized_solver_tables().unwrap();
+    assert_eq!(tables.index.shunt_source_rows, [Some(0), None]);
 }
 
 const EPC_3W: &str = r#"title

--- a/powerio/tests/normalize.rs
+++ b/powerio/tests/normalize.rs
@@ -4,8 +4,8 @@
 use std::path::{Path, PathBuf};
 
 use powerio::{
-    BusId, BusType, Error, IndexedNetwork, NormalizeOptions, SourceFormat, Storage, TargetFormat,
-    parse_file, parse_matpower_file, parse_str, write_as,
+    BusId, BusType, Error, Generator, IndexedNetwork, NormalizeOptions, SourceFormat, Storage,
+    TargetFormat, parse_file, parse_matpower_file, parse_str, write_as,
 };
 
 const DEG_TO_RAD: f64 = std::f64::consts::PI / 180.0;
@@ -246,28 +246,26 @@ mpc.branch = [
         .to_normalized_with_source_rows(&NormalizeOptions::default())
         .unwrap();
 
-    // Buses: raw rows 0, 2, 3 survive (row 1 is isolated).
-    assert_eq!(rows.buses, [0, 2, 3]);
-    // Branches: row 1 references the dropped bus, row 2 is out of service.
-    assert_eq!(rows.branches, [0, 3]);
-    // Generators: row 1 is out of service.
-    assert_eq!(rows.generators, [0, 2]);
+    assert_eq!(rows.buses, [Some(0), Some(2), Some(3)]);
+    assert_eq!(rows.branches, [Some(0), Some(3)]);
+    assert_eq!(rows.generators, [Some(0), Some(2)]);
     // The MATPOWER bus PD/QD columns become one load per demand-carrying bus,
-    // in bus order; the load on dropped bus 2 never exists as a raw load here,
-    // so both raw loads (buses 3 and 4) survive.
-    assert_eq!(rows.loads, [0, 1]);
-    assert_eq!(rows.shunts, [0]);
+    // in bus order. The load on dropped bus 2 is not a raw load here, so both
+    // raw loads (buses 3 and 4) survive.
+    assert_eq!(rows.loads, [Some(0), Some(1)]);
+    assert_eq!(rows.shunts, [Some(0)]);
 
-    // The maps agree with the elements the normalized network holds, and the
-    // options wrapper returns the identical network.
-    for (pos, &row) in rows.buses.iter().enumerate() {
+    for (pos, row) in rows.buses.iter().enumerate() {
+        let row = row.expect("no star lowering in this case");
         assert_eq!(n.network.buses[pos].id, raw.buses[row].id);
     }
-    for (pos, &row) in rows.branches.iter().enumerate() {
+    for (pos, row) in rows.branches.iter().enumerate() {
+        let row = row.expect("no star lowering in this case");
         assert_eq!(n.network.branches[pos].from, raw.branches[row].from);
         assert_eq!(n.network.branches[pos].to, raw.branches[row].to);
     }
-    for (pos, &row) in rows.generators.iter().enumerate() {
+    for (pos, row) in rows.generators.iter().enumerate() {
+        let row = row.expect("no star lowering in this case");
         assert_eq!(n.network.generators[pos].bus, raw.generators[row].bus);
     }
     let plain = raw
@@ -654,3 +652,45 @@ mpc.branch = [
     assert!(approx(s.ps, 5.0), "ps stays raw: {}", s.ps);
     assert!(approx(s.qs, 3.0), "qs stays raw: {}", s.qs);
 }
+
+#[test]
+fn source_rows_cover_the_star_lowered_view() {
+    // `IndexedNetwork` star-lowers an in-service 3-winding transformer, which
+    // appends a bus, its star branches, and a magnetizing shunt. Those have no
+    // source row, so the map must still be positional over the lowered view.
+    let mut raw = parse_str(EPC_3W, "pslf").unwrap().network;
+    raw.buses[0].kind = BusType::Ref;
+    let mut g = Generator::new(BusId(1));
+    g.pmax = 100.0;
+    raw.generators.push(g);
+
+    let (n, rows) = raw
+        .to_normalized_with_source_rows(&NormalizeOptions::default())
+        .unwrap();
+    let view = IndexedNetwork::new(&n.network);
+
+    assert_eq!(rows.buses.len(), view.n());
+    assert_eq!(rows.branches.len(), view.branches().len());
+    assert_eq!(rows.shunts.len(), view.network().shunts.len());
+
+    // The star bus and its branches are the appended tail.
+    assert_eq!(rows.buses[..3], [Some(0), Some(1), Some(2)]);
+    assert_eq!(*rows.buses.last().unwrap(), None);
+    assert!(rows.branches.iter().all(Option::is_none));
+}
+
+const EPC_3W: &str = r#"title
+t3w
+!
+solution parameters
+sbase 100.0000
+!
+bus data  [3] ty vsched volt angle ar zone vmax vmin
+1 "B1          " 230.0000 : 0 1.0 1.0 0.0 1 1 1.1 0.9
+2 "B2          " 138.0000 : 1 1.0 1.0 0.0 1 1 1.1 0.9
+3 "B3          " 13.8000 : 1 1.0 1.0 0.0 1 1 1.1 0.9
+transformer data  [1]
+1 "B1          " 230.00 2 "B2          " 138.00 "1 " 1 "xf3" : 1 0 0 0 0 0 0 0 0 3 0 0 0 0 100 0.01 0.06 0.02 0.07 0.03 0.08 /
+0 0 0 0 0 0 100 90 80 0 0.0 0 0 0 0 0 1.05
+end
+"#;


### PR DESCRIPTION
## What this PR does

Adds `Network::to_normalized_with_source_rows(options)`. It returns the
normalized network together with a `NormalizeSourceRows` map: for each element
family, position `i` names the source row of the element at dense position `i`
in the `IndexedNetwork` view of that network. `None` marks an element the
pipeline synthesized, which has no source row. The map comes from the same pass
that filters, so the map and the filter rules cannot drift. The struct is
`non_exhaustive`, so later families stay additive. `to_normalized_with_options`
behavior does not change.

## Why

A consumer that resolves dense indices back to source elements had to
re-implement the filter rules. tellegen does exactly that today
(`reconstruct_ids`), with a runtime count assertion as the only guard against
drift. With this map, that function and its two error paths become a lookup.

## The star lowering

`IndexedNetwork` star-lowers every in-service 3-winding transformer, appending a
bus, the star branches, and a magnetizing shunt. A first version of this PR
returned `Vec<usize>` sized to the network *before* that lowering, so
`rows.buses[dense_index]` ran past the end of the vector for any case with a 3W
transformer — which PSS/E `.raw` and PSLF `.epc` both produce routinely. On the
PSLF 3W fixture the map held 3 buses against a view of 4, and 0 branches against
a view of 3.

The fields are now `Vec<Option<usize>>`, each as long as the matching table of
the lowered view, with `None` for the appended elements. `transformers_3w` stays
positional over the normalized network, because the lowering consumes the
transformers themselves. `powerio/tests/normalize.rs` carries a regression test
that asserts the lengths against the view; it fails on the first version.

## One implementation, not two

`solver_tables.rs` held a second copy of the filter rules in a private
`SourceRows`, used to populate `SolverTableIndex::*_source_rows`. That type is
deleted. `SolverTableIndex` now reads the map from the pass, so the rules exist
one time in the crate. Its field types and wire form are unchanged — they were
already `Vec<Option<usize>>` over the lowered view.

`to_normalized_with_options` calls the pass directly, so only the caller that
asks for the map pays for the lowered lengths.

## Notes

- No C ABI or Python mirror in this PR. tellegen consumes the Rust crate
  directly. Bindings can follow when a consumer needs them.
- In the v0.9.0 window, we can fold the map into `NormalizedNetwork` as a field.
  That is a breaking struct change, so it waits for the breaking release.

## Checks

`cargo test --workspace` (52 test binaries, 0 failures — the pre-existing
`solver_tables` tests assert exact source-row vectors, so they are the evidence
the unified map reproduces the old provenance), `cargo fmt --check`,
`scripts/ci-clippy.sh`, `scripts/capi-header-parity.sh`, and the conversion
matrix baseline, all clean.

## Release sequencing

Target release: **v0.8.2**. Sequence: v0.8.1 (fixes) → v0.8.2 (consumer
features) → v0.9.0 (breaking changes with deprecation shims) → v1.0.0 (clean
break, stability policy).