### PR TITLE
mcp: port the server to the mcp 2.0 SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ gridfm = ["polars>=1"]
 pandas = ["pandas>=2; python_version >= '3.10'", "pyarrow>=23.0.1; python_version >= '3.10'"]
 # The MCP server exposes the powerio.mcp tool surface. The official `mcp` SDK
 # requires Python >=3.10; the env marker keeps this extra empty on 3.9.
-# `mcp` 2.0 (2026-07) removed `mcp.server.fastmcp`, which the server imports;
-# stay on 1.x until the server migrates to the 2.0 API.
-mcp = ["mcp>=1.2,<2; python_version >= '3.10'"]
+# The server targets the 2.0 API (`mcp.server.mcpserver.MCPServer`); 1.x
+# shipped the decorator server as `mcp.server.fastmcp`, which 2.0 removed.
+mcp = ["mcp>=2,<3; python_version >= '3.10'"]
 
 [project.scripts]
 # Serves the powerio.mcp tool surface over stdio. Needs the `mcp` extra.

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server for powerio.
+"""MCP server for powerio.
 
 The advertised MCP surface is semantic and format neutral:
 
@@ -23,9 +23,9 @@ from urllib.parse import unquote, urlparse
 
 import powerio
 from powerio import dist
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("powerio")
+mcp = MCPServer("powerio")
 
 _DIST_FORMATS = frozenset(
     {

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -39,19 +39,22 @@ def test_tool_surface_is_semantic():
         "display",
     }
     for name in ("parse", "summary", "normalize", "matrix", "display"):
-        props = tools[name].inputSchema["properties"]
+        props = tools[name].input_schema["properties"]
         assert "from_format" in props
         assert "format" not in props
-    convert_props = tools["convert"].inputSchema["properties"]
+    convert_props = tools["convert"].input_schema["properties"]
     assert "to_format" in convert_props and "from_format" in convert_props
     assert "to" not in convert_props and "format" not in convert_props
-    save_schema = tools["save"].inputSchema
+    save_schema = tools["save"].input_schema
     assert save_schema["required"] == ["out_path"]
     save_props = save_schema["properties"]
     assert "to_format" in save_props and "from_format" in save_props
     assert "to" not in save_props and "format" not in save_props
     assert "package_json" in save_props
-    assert "transport" in tools["parse"].inputSchema["properties"]
+    assert "transport" in tools["parse"].input_schema["properties"]
+    # The SDK 2.0 model field is snake_case `input_schema`; the wire format is
+    # still the protocol's camelCase `inputSchema`.
+    assert "inputSchema" in tools["save"].model_dump(by_alias=True)
 
 
 def test_summary_transmission_schema():


### PR DESCRIPTION
## What this PR does

mcp 2.0 removed `mcp.server.fastmcp`, which the server imported; #271 pinned the extra to `<2` as a stopgap. This PR ports the server to the 2.0 API (`mcp.server.mcpserver.MCPServer`) and moves the pin to `mcp>=2,<3`.

The port is three lines of server code: the import, the constructor, and a docstring word. The tool decorator, the stdio `run()` default, the eight-tool surface, the input schemas, the response payloads, the `_SCHEMA_VERSION` envelopes, and the allowed-roots sandboxing are unchanged — verified over a stdio client round trip (initialize, `list_tools`, `summary`, `matrix`, and an error case). PowerMCP re-binds the module names verbatim, and every name it binds is identical.

The one observable SDK change: the 2.0 `types.Tool` model renamed the Python attribute `inputSchema` to `input_schema` while keeping the camelCase wire alias. The tool-surface test follows the rename and now also pins the wire alias.

Closes #272.

## Release sequencing

Target release: **v0.8.2**. Sequence: v0.8.1 (fixes) → v0.8.2 (consumer features) → v0.9.0 (breaking changes with deprecation shims) → v1.0.0 (clean break, stability policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_