### PR TITLE
format: capture unknown JSON fields; warn on discarded taps; single read

### DIFF
--- a/powerio-cli/src/cases.rs
+++ b/powerio-cli/src/cases.rs
@@ -39,20 +39,48 @@ pub fn infer_input_family(input: &Path) -> anyhow::Result<Option<bool>> {
     if DISTRIBUTION_EXTENSIONS.contains(&ext) {
         return Ok(Some(true));
     }
-    if ext != JSON_EXTENSION {
+    Ok(classified_json(input)?.map(|case| case.is_distribution()))
+}
+
+/// A `.json` case read and classified in one pass. The text rides along so the
+/// typed parse reuses it instead of reading the file a second time.
+pub struct ClassifiedCase {
+    pub text: String,
+    pub format: DetectedFormat,
+}
+
+impl ClassifiedCase {
+    pub fn is_distribution(&self) -> bool {
+        matches!(self.format, DetectedFormat::Distribution(_))
+    }
+}
+
+/// Read and classify `input` when it is a `.json` file; `Ok(None)` for every
+/// other extension, whose family (if any) is named without touching the file.
+/// The single-file routes hand the returned text straight to the typed parser
+/// — the read-once rule #260 established for `batch` and the TUI.
+pub fn classified_json(input: &Path) -> anyhow::Result<Option<ClassifiedCase>> {
+    let ext = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    if ext.as_deref() != Some(JSON_EXTENSION) {
         return Ok(None);
     }
     let text = std::fs::read_to_string(input)
         .with_context(|| format!("reading JSON format markers from {}", input.display()))?;
-    match classify_case_json(&text, input)? {
-        DetectedFormat::Distribution(_) => Ok(Some(true)),
-        DetectedFormat::Transmission(_) => Ok(Some(false)),
-        other => anyhow::bail!(
+    let format = classify_case_json(&text, input)?;
+    if !matches!(
+        format,
+        DetectedFormat::Transmission(_) | DetectedFormat::Distribution(_)
+    ) {
+        anyhow::bail!(
             "unrecognized JSON format family `{}` in {}; pass --from to choose a format",
-            other.name(),
+            format.name(),
             input.display()
-        ),
+        );
     }
+    Ok(Some(ClassifiedCase { text, format }))
 }
 
 /// Classify `.json` case text to its detected format, turning the non-case

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -22,7 +22,8 @@ use serde_json::json;
 mod cases;
 mod tui;
 
-use cases::{infer_input_family, looks_like_distribution_input};
+use cases::infer_input_family;
+use powerio_matrix::format::routing::SourceFormat as DetectedFormat;
 
 const SUMMARY_SCHEMA_VERSION: &str = "0.1";
 
@@ -1106,16 +1107,13 @@ fn run_summary(input: &Path, from: Option<FormatArg>, scenario: i64) -> anyhow::
             let read = powerio_matrix::read_gridfm_dataset(input, scenario)
                 .with_context(|| format!("reading gridfm dataset {}", input.display()))?;
             transmission_summary_json(&read.network, &read.warnings)
-        } else if from.is_some_and(|f| f.distribution().is_some())
-            || (from.is_none() && looks_like_distribution_input(input)?)
-        {
-            let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
-                .with_context(|| format!("reading {}", input.display()))?;
-            distribution_summary_json(&net)
         } else {
-            let parsed = powerio_matrix::parse_file(input, from.map(FormatArg::name))
-                .with_context(|| format!("reading {}", input.display()))?;
-            transmission_summary_json(&parsed.network, &parsed.warnings)
+            match parse_family_case(input, from)? {
+                FamilyCase::Distribution(net) => distribution_summary_json(&net),
+                FamilyCase::Transmission(parsed) => {
+                    transmission_summary_json(&parsed.network, &parsed.warnings)
+                }
+            }
         };
     println!("{}", serde_json::to_string_pretty(&value)?);
     Ok(())
@@ -1152,10 +1150,6 @@ fn build_package(
     from: Option<FormatArg>,
     scenario: i64,
 ) -> anyhow::Result<NetworkPackage> {
-    if from == Some(FormatArg::PowerioJson) {
-        warn_deprecated_powerio_json();
-    }
-
     if from == Some(FormatArg::Gridfm) || (from.is_none() && looks_like_gridfm_dir(input)) {
         let read = powerio_matrix::read_gridfm_dataset(input, scenario)
             .with_context(|| format!("reading gridfm dataset {}", input.display()))?;
@@ -1169,34 +1163,30 @@ fn build_package(
         return Ok(pkg);
     }
 
-    if from.is_some_and(|f| f.distribution().is_some())
-        || (from.is_none() && looks_like_distribution_input(input)?)
-    {
-        let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
-            .with_context(|| format!("reading {}", input.display()))?;
-        let format = net
-            .source_format
-            .map(powerio_dist::DistSourceFormat::name)
-            .or_else(|| from.map(FormatArg::name))
-            .unwrap_or("unknown");
-        let retained_source = net.source.is_some();
-        let mut pkg = NetworkPackage::from_multiconductor(net);
-        set_package_source(
-            &mut pkg,
-            input,
-            package_source_kind(input, format),
-            format,
-            retained_source,
-        );
-        pkg.run_sane_validation();
-        return Ok(pkg);
-    }
-
-    let parsed = powerio_matrix::parse_file(input, from.map(FormatArg::name))
-        .with_context(|| format!("reading {}", input.display()))?;
-    let format = parsed.network.source_format.name();
-    let retained_source = parsed.network.source.is_some();
-    let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
+    let (mut pkg, format, retained_source) = match parse_family_case(input, from)? {
+        FamilyCase::Distribution(net) => {
+            let format = net
+                .source_format
+                .map(powerio_dist::DistSourceFormat::name)
+                .or_else(|| from.map(FormatArg::name))
+                .unwrap_or("unknown");
+            let retained_source = net.source.is_some();
+            (
+                NetworkPackage::from_multiconductor(net),
+                format,
+                retained_source,
+            )
+        }
+        FamilyCase::Transmission(parsed) => {
+            let format = parsed.network.source_format.name();
+            let retained_source = parsed.network.source.is_some();
+            (
+                NetworkPackage::from_parsed_balanced(parsed),
+                format,
+                retained_source,
+            )
+        }
+    };
     set_package_source(
         &mut pkg,
         input,
@@ -1378,12 +1368,21 @@ fn run_convert(
     if to == FormatArg::PypsaCsv {
         return convert_to_pypsa_folder(input, output, from, scenario, gen_cost_options);
     }
+    // A `.json` with no --from is read and DOM-classified once here; the
+    // family check below uses the verdict and the typed parse reuses the text.
+    let classified = if from.is_none() {
+        cases::classified_json(input)?
+    } else {
+        None
+    };
     // The two families share no conversion path; say so directly instead of
     // letting the wrong family's reader produce a confusing format error. The
     // input family comes from --from (gridfm reads into the transmission
     // model), from a clear extension, or from the shared JSON classifier.
     let input_is_dist = if let Some(f) = from {
         Some(f.distribution().is_some())
+    } else if let Some(case) = &classified {
+        Some(case.is_distribution())
     } else {
         infer_input_family(input)?
     };
@@ -1410,6 +1409,18 @@ fn run_convert(
                 eprintln!("fidelity: {w}");
             }
             read.network
+        } else if let Some(case) = &classified {
+            match parse_classified_case(case, input)? {
+                FamilyCase::Transmission(parsed) => {
+                    for w in &parsed.warnings {
+                        eprintln!("fidelity: {w}");
+                    }
+                    parsed.network
+                }
+                FamilyCase::Distribution(_) => {
+                    unreachable!("the family check routed a distribution input here")
+                }
+            }
         } else {
             read_network(input, from)?
         };
@@ -1417,8 +1428,17 @@ fn run_convert(
             .with_context(|| format!("serializing to {target}"))?;
         (conv.text, Vec::new(), conv.warnings)
     } else {
-        let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
-            .with_context(|| format!("reading {}", input.display()))?;
+        let net = if let Some(case) = &classified {
+            match parse_classified_case(case, input)? {
+                FamilyCase::Distribution(net) => net,
+                FamilyCase::Transmission(_) => {
+                    unreachable!("the family check routed a transmission input here")
+                }
+            }
+        } else {
+            powerio_dist::parse_file(input, from.map(FormatArg::name))
+                .with_context(|| format!("reading {}", input.display()))?
+        };
         for w in &net.warnings {
             eprintln!("parse: {w}");
         }
@@ -1492,15 +1512,6 @@ fn is_relative_component_path(path: &str) -> bool {
             .all(|c| matches!(c, std::path::Component::Normal(_)))
 }
 
-/// Whether the geo command's case input is a distribution case: `--from`
-/// decides when given, else the extension and JSON markers.
-fn geo_input_is_dist(input: &std::path::Path, from: Option<FormatArg>) -> anyhow::Result<bool> {
-    if let Some(f) = from {
-        return Ok(f.distribution().is_some());
-    }
-    looks_like_distribution_input(input)
-}
-
 fn run_geo_extract(
     input: &std::path::Path,
     output: Option<&std::path::Path>,
@@ -1525,15 +1536,19 @@ fn run_geo_extract(
         }
         return write_conversion_output(&layer.to_geojson(), &[], output);
     }
-    let layer = if geo_input_is_dist(input, from)? {
-        let net = powerio_dist::parse_file(input, from.map(FormatArg::name))
-            .with_context(|| format!("reading {}", input.display()))?;
-        for w in &net.warnings {
-            eprintln!("parse: {w}");
+    let layer = match parse_family_case(input, from)? {
+        FamilyCase::Distribution(net) => {
+            for w in &net.warnings {
+                eprintln!("parse: {w}");
+            }
+            powerio_pkg::dist_geo_layer(&net)
         }
-        powerio_pkg::dist_geo_layer(&net)
-    } else {
-        read_network(input, from)?.geo_layer()
+        FamilyCase::Transmission(parsed) => {
+            for w in &parsed.warnings {
+                eprintln!("fidelity: {w}");
+            }
+            parsed.network.geo_layer()
+        }
     };
     if layer.features.is_empty() {
         anyhow::bail!("{} carries no coordinates to extract", input.display());
@@ -1562,54 +1577,62 @@ fn run_geo_apply(
     for w in &parsed.warnings {
         eprintln!("layer: {w}");
     }
-    let (text, sidecars, warnings) = if geo_input_is_dist(input, from)? {
-        let mut net = powerio_dist::parse_file(input, from.map(FormatArg::name))
-            .with_context(|| format!("reading {}", input.display()))?;
-        for w in &net.warnings {
-            eprintln!("parse: {w}");
-        }
-        report_geo_apply(&powerio_pkg::apply_dist_geo_layer(&mut net, &parsed.layer));
-        net.source = None;
-        let target = match to {
-            Some(f) => f.distribution().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "`{}` is not a distribution text target; a distribution case writes \
-                     back to dss, pmd-json, or bmopf-json",
-                    f.name()
-                )
-            })?,
-            None => net
-                .source_format
-                .map(|f| f.name().parse())
-                .transpose()?
-                .ok_or_else(|| anyhow::anyhow!("the input carries no source format; pass --to"))?,
-        };
-        let conv = net.to_format(target);
-        (conv.text, conv.sidecars, conv.warnings)
-    } else {
-        let mut net = read_network(input, from)?;
-        report_geo_apply(&net.apply_geo_layer(&parsed.layer));
-        net.source = None;
-        let target = match to {
-            Some(f) => f.transmission().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "`{}` is not a transmission text target here; apply writes a single \
-                     case file (use `convert` for pypsa-csv and gridfm outputs)",
-                    f.name()
-                )
-            })?,
-            None => powerio_matrix::target_format_from_name(&format!("{:?}", net.source_format))
-                .ok_or_else(|| {
+    let (text, sidecars, warnings) = match parse_family_case(input, from)? {
+        FamilyCase::Distribution(mut net) => {
+            for w in &net.warnings {
+                eprintln!("parse: {w}");
+            }
+            report_geo_apply(&powerio_pkg::apply_dist_geo_layer(&mut net, &parsed.layer));
+            net.source = None;
+            let target = match to {
+                Some(f) => f.distribution().ok_or_else(|| {
                     anyhow::anyhow!(
-                        "`{:?}` has no write target; pass --to to choose one",
-                        net.source_format
+                        "`{}` is not a distribution text target; a distribution case writes \
+                         back to dss, pmd-json, or bmopf-json",
+                        f.name()
                     )
                 })?,
-        };
-        let conv = net
-            .to_format(target)
-            .with_context(|| format!("serializing to {target}"))?;
-        (conv.text, Vec::new(), conv.warnings)
+                None => net
+                    .source_format
+                    .map(|f| f.name().parse())
+                    .transpose()?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("the input carries no source format; pass --to")
+                    })?,
+            };
+            let conv = net.to_format(target);
+            (conv.text, conv.sidecars, conv.warnings)
+        }
+        FamilyCase::Transmission(case) => {
+            for w in &case.warnings {
+                eprintln!("fidelity: {w}");
+            }
+            let mut net = case.network;
+            report_geo_apply(&net.apply_geo_layer(&parsed.layer));
+            net.source = None;
+            let target = match to {
+                Some(f) => f.transmission().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "`{}` is not a transmission text target here; apply writes a single \
+                         case file (use `convert` for pypsa-csv and gridfm outputs)",
+                        f.name()
+                    )
+                })?,
+                None => {
+                    powerio_matrix::target_format_from_name(&format!("{:?}", net.source_format))
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "`{:?}` has no write target; pass --to to choose one",
+                                net.source_format
+                            )
+                        })?
+                }
+            };
+            let conv = net
+                .to_format(target)
+                .with_context(|| format!("serializing to {target}"))?;
+            (conv.text, Vec::new(), conv.warnings)
+        }
     };
     for w in &warnings {
         eprintln!("fidelity: {w}");
@@ -1692,6 +1715,73 @@ fn convert_to_pypsa_folder(
     Ok(())
 }
 
+/// A single-file case input parsed to its own family model.
+enum FamilyCase {
+    Transmission(powerio_matrix::Parsed),
+    Distribution(powerio_dist::DistNetwork),
+}
+
+/// Parse a single-file case to whichever family model it belongs to. With no
+/// `--from`, a `.json` is read and DOM-classified once and the same text feeds
+/// the typed parser — the read-once rule #260 established for `batch` and the
+/// TUI, extended here to the single-file routes. Warnings stay on the returned
+/// value: the callers differ in where they surface them (summary JSON, package
+/// diagnostics, stderr).
+fn parse_family_case(input: &Path, from: Option<FormatArg>) -> anyhow::Result<FamilyCase> {
+    if let Some(f) = from {
+        if f == FormatArg::PowerioJson {
+            warn_deprecated_powerio_json();
+        }
+        if f == FormatArg::Gridfm {
+            anyhow::bail!(
+                "gridfm datasets are read by `convert --from gridfm` or the `gridfm` \
+                 subcommand, not this command"
+            );
+        }
+        return if f.distribution().is_some() {
+            let net = powerio_dist::parse_file(input, Some(f.name()))
+                .with_context(|| format!("reading {}", input.display()))?;
+            Ok(FamilyCase::Distribution(net))
+        } else {
+            let parsed = powerio_matrix::parse_file(input, Some(f.name()))
+                .with_context(|| format!("reading {}", input.display()))?;
+            Ok(FamilyCase::Transmission(parsed))
+        };
+    }
+    if let Some(case) = cases::classified_json(input)? {
+        return parse_classified_case(&case, input);
+    }
+    if cases::looks_like_distribution_input(input)? {
+        let net = powerio_dist::parse_file(input, None)
+            .with_context(|| format!("reading {}", input.display()))?;
+        Ok(FamilyCase::Distribution(net))
+    } else {
+        let parsed = powerio_matrix::parse_file(input, None)
+            .with_context(|| format!("reading {}", input.display()))?;
+        Ok(FamilyCase::Transmission(parsed))
+    }
+}
+
+/// Parse already-classified `.json` text through its family's string parser,
+/// keeping the file stem as the name hint the path-based parsers would use.
+fn parse_classified_case(case: &cases::ClassifiedCase, input: &Path) -> anyhow::Result<FamilyCase> {
+    match case.format {
+        DetectedFormat::Distribution(format) => {
+            let net = powerio_dist::parse_str(&case.text, format.name())
+                .with_context(|| format!("reading {}", input.display()))?;
+            Ok(FamilyCase::Distribution(net))
+        }
+        DetectedFormat::Transmission(format) => {
+            let stem = input.file_stem().and_then(|s| s.to_str());
+            let parsed =
+                powerio_matrix::format::parse_str_with_name(&case.text, format.name(), stem)
+                    .with_context(|| format!("reading {}", input.display()))?;
+            Ok(FamilyCase::Transmission(parsed))
+        }
+        _ => unreachable!("classified_json returns transmission or distribution formats only"),
+    }
+}
+
 /// Read `input` into the neutral [`powerio_matrix::Network`] through the shared
 /// format hub, which picks the reader from `from` or the extension (sniffing a
 /// `.json` with the shared top level shape classifier). The distribution
@@ -1730,10 +1820,11 @@ fn read_network(
 
 #[cfg(test)]
 mod tests {
+    use super::cases::looks_like_distribution_input;
     use super::{
-        Cli, Command, FormatArg, GenCostCliOptions, build_package, distribution_summary_json,
-        infer_input_family, looks_like_distribution_input, package_text, run_convert, run_package,
-        transmission_summary_json,
+        Cli, Command, FamilyCase, FormatArg, GenCostCliOptions, build_package,
+        distribution_summary_json, infer_input_family, package_text, parse_family_case,
+        run_convert, run_package, transmission_summary_json,
     };
     use clap::Parser;
     use powerio_pkg::{MappingKind, NetworkPackage, Origin, ValidationStatus};
@@ -1819,6 +1910,43 @@ mod tests {
         .unwrap();
         assert!(!looks_like_distribution_input(&tmp).unwrap());
         let _ = std::fs::remove_file(tmp);
+    }
+
+    #[test]
+    fn family_case_routes_json_by_classifier_without_from() {
+        // The single-file routes' one-read path: the classifier's verdict on
+        // the text picks the family and format, and the stem still names a
+        // nameless transmission case as the path-based parser would.
+        let dir = std::env::temp_dir().join(format!(
+            "powerio-family-case-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let egret = dir.join("myegret.json");
+        std::fs::write(
+            &egret,
+            std::fs::read_to_string(data("egret/case9.json")).unwrap(),
+        )
+        .unwrap();
+        match parse_family_case(&egret, None).unwrap() {
+            FamilyCase::Transmission(parsed) => {
+                assert_eq!(parsed.network.buses.len(), 9);
+                assert_eq!(parsed.network.name, "myegret");
+            }
+            FamilyCase::Distribution(_) => panic!("egret JSON classified as distribution"),
+        }
+
+        let dist = dir.join("feeder.json");
+        std::fs::write(&dist, r#"{"bus":{"a":{"terminal_names":["1"]}}}"#).unwrap();
+        match parse_family_case(&dist, None).unwrap() {
+            FamilyCase::Distribution(net) => assert_eq!(net.buses.len(), 1),
+            FamilyCase::Transmission(_) => panic!("BMOPF JSON classified as transmission"),
+        }
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1914,9 +1914,8 @@ mod tests {
 
     #[test]
     fn family_case_routes_json_by_classifier_without_from() {
-        // The single-file routes' one-read path: the classifier's verdict on
-        // the text picks the family and format, and the stem still names a
-        // nameless transmission case as the path-based parser would.
+        // The classifier's verdict picks the family and format from one
+        // read. The stem still names a nameless transmission case.
         let dir = std::env::temp_dir().join(format!(
             "powerio-family-case-{}",
             SystemTime::now()

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1766,7 +1766,13 @@ fn parse_family_case(input: &Path, from: Option<FormatArg>) -> anyhow::Result<Fa
 /// keeping the file stem as the name hint the path-based parsers would use.
 fn parse_classified_case(case: &cases::ClassifiedCase, input: &Path) -> anyhow::Result<FamilyCase> {
     match case.format {
-        DetectedFormat::Distribution(format) => {
+        DetectedFormat::Distribution(_) => {
+            // The shared classifier routes the family; the dist crate owns
+            // which documents are cases at all, and its rule is stricter
+            // (a BMOPF document needs a `bus` table). Apply it to the text
+            // already read, as `powerio_dist::parse_file` does.
+            let format = powerio_dist::classify_distribution_json(&case.text)
+                .with_context(|| format!("reading {}", input.display()))?;
             let net = powerio_dist::parse_str(&case.text, format.name())
                 .with_context(|| format!("reading {}", input.display()))?;
             Ok(FamilyCase::Distribution(net))
@@ -1916,14 +1922,8 @@ mod tests {
     fn family_case_routes_json_by_classifier_without_from() {
         // The classifier's verdict picks the family and format from one
         // read. The stem still names a nameless transmission case.
-        let dir = std::env::temp_dir().join(format!(
-            "powerio-family-case-{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
         let egret = dir.join("myegret.json");
         std::fs::write(
             &egret,
@@ -1939,13 +1939,34 @@ mod tests {
         }
 
         let dist = dir.join("feeder.json");
-        std::fs::write(&dist, r#"{"bus":{"a":{"terminal_names":["1"]}}}"#).unwrap();
+        std::fs::write(
+            &dist,
+            r#"{"bus":{"a":{"terminal_names":["1"]}},"meta":{"version":"0.1.0"}}"#,
+        )
+        .unwrap();
         match parse_family_case(&dist, None).unwrap() {
             FamilyCase::Distribution(net) => assert_eq!(net.buses.len(), 1),
             FamilyCase::Transmission(_) => panic!("BMOPF JSON classified as transmission"),
         }
+    }
 
-        let _ = std::fs::remove_dir_all(dir);
+    #[test]
+    fn family_case_applies_the_distribution_readers_own_refusal() {
+        // The shared classifier calls any document with a `linecode` table
+        // distribution, but a BMOPF case needs a `bus` table too. The read
+        // once path must apply that rule, not parse a bogus empty network.
+        let tmp = tempfile::tempdir().unwrap();
+        let orphan = tmp.path().join("orphan.json");
+        std::fs::write(&orphan, r#"{"linecode":{"lc1":{"nphases":1}}}"#).unwrap();
+
+        let text = match parse_family_case(&orphan, None) {
+            Err(err) => format!("{err:#}"),
+            Ok(_) => panic!("a linecode-only document parsed as a distribution case"),
+        };
+        assert!(
+            text.contains("not a recognized distribution document"),
+            "{text}"
+        );
     }
 
     #[test]

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -105,9 +105,8 @@ fn summary_outputs_machine_readable_json() {
 
 #[test]
 fn summary_routes_json_inputs_through_the_classifier() {
-    // The single-file `.json` routes read the file once: the classifier's
-    // verdict on the text names the family and format, and the same text
-    // feeds the typed parser. Both families must come out the right door.
+    // The `.json` routes read the file once; the classifier's verdict
+    // routes each family to its parser.
     let case = repo_file("tests/data/egret/case9.json");
     let out = run(&["summary", case.to_str().unwrap()]);
     assert_success(&out);

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -104,6 +104,43 @@ fn summary_outputs_machine_readable_json() {
 }
 
 #[test]
+fn summary_routes_json_inputs_through_the_classifier() {
+    // The single-file `.json` routes read the file once: the classifier's
+    // verdict on the text names the family and format, and the same text
+    // feeds the typed parser. Both families must come out the right door.
+    let case = repo_file("tests/data/egret/case9.json");
+    let out = run(&["summary", case.to_str().unwrap()]);
+    assert_success(&out);
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(value["domain"], "transmission");
+    assert_eq!(value["source_format"], "EgretJson");
+    assert_eq!(value["elements"]["buses"], 9);
+
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dist_json = std::env::temp_dir().join(format!("powerio-cli-summary-{stamp}.json"));
+    let dss = repo_file("tests/data/dist/micro/xfmr_single_phase.dss");
+    let out = run(&[
+        "convert",
+        dss.to_str().unwrap(),
+        "--to",
+        "bmopf-json",
+        "-o",
+        dist_json.to_str().unwrap(),
+    ]);
+    assert_success(&out);
+    let out = run(&["summary", dist_json.to_str().unwrap()]);
+    assert_success(&out);
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(value["domain"], "distribution");
+    assert_eq!(value["elements"]["buses"], 2);
+
+    let _ = std::fs::remove_file(dist_json);
+}
+
+#[test]
 fn package_overwrites_existing_output_file() {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -943,9 +943,10 @@ pub fn ensure_payload_uids(net: &mut BalancedNetwork) {
     fill!(transformers_3w);
 }
 
-const SANE_VALIDATION_CODES: [&str; 9] = [
+const SANE_VALIDATION_CODES: [&str; 10] = [
     "VALIDATE.BALANCED.STRUCTURE",
     "VALIDATE.BALANCED.VALUE_DOMAIN",
+    "VALIDATE.BALANCED.PAYLOAD_IDENTITY",
     "VALIDATE.MULTI.STRUCTURE",
     "VALIDATE.MULTI.TERMINAL_MAP",
     "VALIDATE.MULTI.UNTYPED_OBJECT",
@@ -1095,12 +1096,69 @@ fn sane_validate_balanced(
         value_domain.push(d);
     }
 
+    // Duplicate payload uids are diagnosed here, at build/validation time:
+    // operating point and study references resolve by uid, and
+    // `ensure_payload_uids` can mint a `{table}:{row}` value that collides
+    // with a source-supplied one — an ambiguity that would otherwise surface
+    // only once a series update fails to resolve against it.
+    let mut identity = Vec::new();
+    macro_rules! check_uids {
+        ($table:ident) => {
+            table_uid_duplicates(
+                stringify!($table),
+                net.$table.iter().map(|e| e.uid.as_deref()),
+                &mut identity,
+            )
+        };
+    }
+    check_uids!(buses);
+    check_uids!(loads);
+    check_uids!(shunts);
+    check_uids!(branches);
+    check_uids!(switches);
+    check_uids!(generators);
+    check_uids!(storage);
+    check_uids!(hvdc);
+    check_uids!(transformers_3w);
+
     let passes = vec![
         ValidationPass::new("balanced.structure", validation_status(&structure)),
         ValidationPass::new("balanced.value_domain", validation_status(&value_domain)),
+        ValidationPass::new("balanced.payload_identity", validation_status(&identity)),
     ];
     structure.extend(value_domain);
+    structure.extend(identity);
     (structure, passes)
+}
+
+/// One Error diagnostic per row that repeats an earlier row's uid in `table`.
+/// A repeated uid makes every identity-based reference to it ambiguous (the
+/// same condition `resolve_update_row` rejects during application).
+fn table_uid_duplicates<'a>(
+    table: &str,
+    uids: impl Iterator<Item = Option<&'a str>>,
+    diagnostics: &mut Vec<StructuredDiagnostic>,
+) {
+    let mut first_row: HashMap<&str, usize> = HashMap::new();
+    for (row, uid) in uids.enumerate() {
+        let Some(uid) = uid else { continue };
+        if let Some(&first) = first_row.get(uid) {
+            diagnostics.push(
+                StructuredDiagnostic::new(
+                    "VALIDATE.BALANCED.PAYLOAD_IDENTITY",
+                    DiagnosticSeverity::Error,
+                    DiagnosticStage::Validate,
+                    format!(
+                        "payload table `{table}` carries uid `{uid}` on rows {first} and {row}; \
+                         identity resolution is ambiguous"
+                    ),
+                )
+                .with_element_path(format!("/model/balanced_network/{table}/{row}/uid")),
+            );
+        } else {
+            first_row.insert(uid, row);
+        }
+    }
 }
 
 fn attach_source_refs(diagnostics: &mut [StructuredDiagnostic], source_maps: &[SourceMapEntry]) {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -1096,11 +1096,9 @@ fn sane_validate_balanced(
         value_domain.push(d);
     }
 
-    // Duplicate payload uids are diagnosed here, at build/validation time:
-    // operating point and study references resolve by uid, and
-    // `ensure_payload_uids` can mint a `{table}:{row}` value that collides
-    // with a source-supplied one — an ambiguity that would otherwise surface
-    // only once a series update fails to resolve against it.
+    // References resolve by uid, and `ensure_payload_uids` can mint a
+    // `{table}:{row}` value that collides with a source-supplied one.
+    // Diagnose the collision here, at validation time.
     let mut identity = Vec::new();
     macro_rules! check_uids {
         ($table:ident) => {

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -1796,6 +1796,59 @@ fn package_synthesizes_row_identity() {
 }
 
 #[test]
+fn duplicate_payload_uid_is_diagnosed_without_operating_points() {
+    // A source-supplied uid equal to the `{table}:{row}` value
+    // ensure_payload_uids mints for a uid-less sibling collides at build;
+    // validation must surface the ambiguity even when nothing (no operating
+    // points, no study) references it yet.
+    let mut net = powerio::parse_str(MATPOWER_SRC, "matpower")
+        .unwrap()
+        .network;
+    net.buses[1].uid = Some("buses:0".to_owned());
+    let mut pkg = NetworkPackage::from_balanced(net);
+    pkg.run_sane_validation();
+
+    assert!(pkg.operating_points().is_none());
+    assert!(
+        pkg.diagnostics.iter().any(|d| {
+            d.code == DiagnosticCode::new("VALIDATE.BALANCED.PAYLOAD_IDENTITY")
+                && d.message.contains("`buses:0`")
+                && d.element_path.as_deref() == Some("/model/balanced_network/buses/1/uid")
+        }),
+        "expected duplicate uid diagnostic: {:?}",
+        pkg.diagnostics
+    );
+    assert_eq!(pkg.validation.status, ValidationStatus::Error);
+    assert!(
+        pkg.validation
+            .passes
+            .iter()
+            .any(|p| p.name == "balanced.payload_identity" && p.status == ValidationStatus::Error),
+        "missing payload identity pass: {:?}",
+        pkg.validation.passes
+    );
+    assert_json_roundtrips(&pkg);
+
+    // Unique uids leave the pass green, so the check itself is visible in the
+    // validation summary of every balanced package.
+    let mut clean = NetworkPackage::from_balanced(
+        powerio::parse_str(MATPOWER_SRC, "matpower")
+            .unwrap()
+            .network,
+    );
+    clean.run_sane_validation();
+    assert!(
+        clean
+            .validation
+            .passes
+            .iter()
+            .any(|p| p.name == "balanced.payload_identity" && p.status == ValidationStatus::Ok),
+        "missing payload identity pass: {:?}",
+        clean.validation.passes
+    );
+}
+
+#[test]
 fn geo_types_share_the_same_json_shape() {
     let balanced_location = powerio::Location {
         x: -80.0,

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -904,10 +904,9 @@ mod tests {
 
     #[test]
     fn unrecognized_element_fields_are_preserved_as_extras() {
-        // The fidelity policy: a field the neutral model has no slot for must
-        // survive the read as extras, not vanish. The consumed fields and the
-        // writer's own `shunt_type` stamp must stay out of extras, or every
-        // egret round trip would double-carry them.
+        // A field with no model slot must survive the read as extras.
+        // Consumed fields and the writer's own `shunt_type` stamp must
+        // stay out of extras.
         let doc = r#"{"elements":{
             "bus":{"1":{"matpower_bustype":"ref","vm":1.0,"vendor_ext":42},
                    "2":{"matpower_bustype":"PQ"}},

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -513,6 +513,20 @@ fn bustype_from_str(s: &str) -> BusType {
     }
 }
 
+/// Element keys the neutral model names directly are dropped here; whatever's
+/// left is preserved as extras for round trips and cross format conversion
+/// (the PowerModels reader's stance). `known` also carries the fixed stamps
+/// this module's writer emits with no model slot behind them (`shunt_type`),
+/// so a powerio-written file reads back extras-free.
+fn extras_excluding(v: &Value, known: &[&str]) -> Extras {
+    v.as_object().map_or_else(Default::default, |obj| {
+        obj.iter()
+            .filter(|(k, _)| !known.contains(&k.as_str()))
+            .map(|(k, val)| (k.clone(), val.clone()))
+            .collect()
+    })
+}
+
 fn read_bus(key: &str, v: &Value) -> Result<Bus> {
     let id = key
         .trim()
@@ -537,7 +551,20 @@ fn read_bus(key: &str, v: &Value) -> Result<Bus> {
         name: v.get("name").and_then(Value::as_str).map(str::to_string),
         uid: None,
         location: None,
-        extras: Extras::new(),
+        extras: extras_excluding(
+            v,
+            &[
+                "matpower_bustype",
+                "vm",
+                "va",
+                "base_kv",
+                "v_max",
+                "v_min",
+                "area",
+                "zone",
+                "name",
+            ],
+        ),
     })
 }
 
@@ -549,7 +576,7 @@ fn read_load(v: &Value) -> Result<Load> {
         voltage_model: None,
         in_service: flag(v, "in_service", true)?,
         uid: None,
-        extras: Extras::new(),
+        extras: extras_excluding(v, &["bus", "p_load", "q_load", "in_service"]),
     })
 }
 
@@ -561,7 +588,7 @@ fn read_shunt(v: &Value) -> Result<Shunt> {
         in_service: flag(v, "in_service", true)?,
         control: None,
         uid: None,
-        extras: Extras::new(),
+        extras: extras_excluding(v, &["bus", "gs", "bs", "in_service", "shunt_type"]),
     })
 }
 
@@ -592,7 +619,25 @@ fn read_branch(v: &Value) -> Result<Branch> {
         solution: None,
         uid: None,
         route: None,
-        extras: Extras::new(),
+        extras: extras_excluding(
+            v,
+            &[
+                "from_bus",
+                "to_bus",
+                "resistance",
+                "reactance",
+                "charging_susceptance",
+                "rating_long_term",
+                "rating_short_term",
+                "rating_emergency",
+                "branch_type",
+                "transformer_tap_ratio",
+                "transformer_phase_shift",
+                "in_service",
+                "angle_diff_min",
+                "angle_diff_max",
+            ],
+        ),
     })
 }
 
@@ -647,7 +692,28 @@ fn read_dc_branch(v: &Value) -> Result<Hvdc> {
         loss1: f_or(v, "loss_factor", 0.0)?,
         cost: None,
         uid: None,
-        extras: Extras::new(),
+        extras: extras_excluding(
+            v,
+            &[
+                "from_bus",
+                "to_bus",
+                "in_service",
+                "pf",
+                "pt",
+                "qf",
+                "qt",
+                "vf",
+                "vt",
+                "pmin",
+                "pmax",
+                "qminf",
+                "qmaxf",
+                "qmint",
+                "qmaxt",
+                "loss0",
+                "loss_factor",
+            ],
+        ),
     })
 }
 
@@ -834,6 +900,42 @@ mod tests {
         assert_eq!((h.pmin, h.pmax), (-50.0, 60.0));
         assert_eq!((h.qminf, h.qmaxf, h.qmint, h.qmaxt), (-5.0, 5.0, -4.0, 4.5));
         assert_eq!((h.loss0, h.loss1), (0.2, 0.03));
+    }
+
+    #[test]
+    fn unrecognized_element_fields_are_preserved_as_extras() {
+        // The fidelity policy: a field the neutral model has no slot for must
+        // survive the read as extras, not vanish. The consumed fields and the
+        // writer's own `shunt_type` stamp must stay out of extras, or every
+        // egret round trip would double-carry them.
+        let doc = r#"{"elements":{
+            "bus":{"1":{"matpower_bustype":"ref","vm":1.0,"vendor_ext":42},
+                   "2":{"matpower_bustype":"PQ"}},
+            "load":{"load_1":{"bus":"1","p_load":1.0,"q_load":0.5,"owner":"co-op"}},
+            "shunt":{"shunt_1":{"bus":"1","gs":0.0,"bs":5.0,"shunt_type":"fixed"}},
+            "branch":{"1":{"from_bus":"1","to_bus":"2","reactance":0.1,"pf":12.5}},
+            "dc_branch":{"1":{"from_bus":"1","to_bus":"2","rating_long_term":30.0}}},
+            "system":{"baseMVA":100.0,"reference_bus":"1"}}"#;
+        let net = parse_egret_json(doc).unwrap();
+        assert_eq!(
+            net.buses[0].extras.get("vendor_ext"),
+            Some(&Value::from(42))
+        );
+        assert!(!net.buses[0].extras.contains_key("vm"));
+        assert_eq!(
+            net.loads[0].extras.get("owner"),
+            Some(&Value::String("co-op".into()))
+        );
+        assert!(
+            net.shunts[0].extras.is_empty(),
+            "{:?}",
+            net.shunts[0].extras
+        );
+        assert_eq!(net.branches[0].extras.get("pf"), Some(&Value::from(12.5)));
+        assert_eq!(
+            net.hvdc[0].extras.get("rating_long_term"),
+            Some(&Value::from(30.0))
+        );
     }
 
     #[test]

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -122,7 +122,16 @@ pub(crate) fn parse_pandapower_source(
             name: row.string("name"),
             uid: None,
             location: read_bus_geo(row.get("geo")),
-            extras: Extras::default(),
+            extras: row.extras_excluding(&[
+                "name",
+                "vn_kv",
+                "type",
+                "zone",
+                "in_service",
+                "geo",
+                "min_vm_pu",
+                "max_vm_pu",
+            ]),
         });
     }
     let bus_pos: HashMap<BusId, usize> = buses.iter().enumerate().map(|(i, b)| (b.id, i)).collect();
@@ -190,7 +199,22 @@ pub(crate) fn parse_pandapower_source(
                 voltage_model,
                 in_service: row.bool_or("in_service", true),
                 uid: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "name",
+                    "bus",
+                    "p_mw",
+                    "q_mvar",
+                    "const_z_percent",
+                    "const_i_percent",
+                    "const_z_p_percent",
+                    "const_i_p_percent",
+                    "const_z_q_percent",
+                    "const_i_q_percent",
+                    "sn_mva",
+                    "scaling",
+                    "in_service",
+                    "type",
+                ]),
             });
         }
         let _ = zip_rows;
@@ -218,7 +242,16 @@ pub(crate) fn parse_pandapower_source(
                 in_service: row.bool_or("in_service", true),
                 control: None,
                 uid: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "bus",
+                    "name",
+                    "q_mvar",
+                    "p_mw",
+                    "vn_kv",
+                    "step",
+                    "max_step",
+                    "in_service",
+                ]),
             });
         }
     }
@@ -360,7 +393,23 @@ pub(crate) fn parse_pandapower_source(
                 solution: None,
                 uid: None,
                 route: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "name",
+                    "std_type",
+                    "from_bus",
+                    "to_bus",
+                    "length_km",
+                    "r_ohm_per_km",
+                    "x_ohm_per_km",
+                    "c_nf_per_km",
+                    "g_us_per_km",
+                    "max_i_ka",
+                    "df",
+                    "parallel",
+                    "type",
+                    "in_service",
+                    "geo",
+                ]),
             });
         }
     }
@@ -502,7 +551,31 @@ pub(crate) fn parse_pandapower_source(
                 solution: None,
                 uid: None,
                 route: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "name",
+                    "std_type",
+                    "hv_bus",
+                    "lv_bus",
+                    "sn_mva",
+                    "vn_hv_kv",
+                    "vn_lv_kv",
+                    "vk_percent",
+                    "vkr_percent",
+                    "pfe_kw",
+                    "i0_percent",
+                    "shift_degree",
+                    "tap_side",
+                    "tap_neutral",
+                    "tap_step_percent",
+                    "tap_step_degree",
+                    "tap_pos",
+                    "tap_changer_type",
+                    "tap_phase_shifter",
+                    "tap_dependency_table",
+                    "parallel",
+                    "df",
+                    "in_service",
+                ]),
             });
         }
         if tabular_rows > 0 {
@@ -546,7 +619,21 @@ pub(crate) fn parse_pandapower_source(
                 q_loss: 0.0,
                 in_service: row.bool_or("in_service", true),
                 uid: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "bus",
+                    "p_mw",
+                    "q_mvar",
+                    "scaling",
+                    "min_e_mwh",
+                    "max_e_mwh",
+                    "soc_percent",
+                    "max_p_mw",
+                    "min_p_mw",
+                    "sn_mva",
+                    "min_q_mvar",
+                    "max_q_mvar",
+                    "in_service",
+                ]),
             });
         }
     }
@@ -580,7 +667,21 @@ pub(crate) fn parse_pandapower_source(
                 loss1: loss_percent / 100.0,
                 cost: None,
                 uid: None,
-                extras: Extras::default(),
+                extras: row.extras_excluding(&[
+                    "from_bus",
+                    "to_bus",
+                    "p_mw",
+                    "loss_mw",
+                    "loss_percent",
+                    "vm_from_pu",
+                    "vm_to_pu",
+                    "max_p_mw",
+                    "min_q_from_mvar",
+                    "max_q_from_mvar",
+                    "min_q_to_mvar",
+                    "max_q_to_mvar",
+                    "in_service",
+                ]),
             });
         }
     }
@@ -1606,6 +1707,25 @@ impl Row<'_> {
             .filter(|s| !s.is_empty())
             .map(str::to_string)
     }
+    /// Cells in columns outside `known`, preserved as element extras for round
+    /// trips and cross format conversion (the PowerModels reader's stance, per
+    /// column instead of per key). `known` carries the columns the reader
+    /// consumes plus the ones powerio's own writer emits with no model slot
+    /// behind them (`type`, `std_type`, `df`, ...), so a powerio-written file
+    /// reads back extras-free. A null cell is pandas' "unset" marker, not
+    /// source data, and is skipped.
+    fn extras_excluding(&self, known: &[&str]) -> Extras {
+        self.frame
+            .columns
+            .iter()
+            .enumerate()
+            .filter(|(_, column)| !known.contains(&column.as_str()))
+            .filter_map(|(ci, column)| {
+                let cell = self.frame.data.get(self.i).and_then(|r| r.get(ci))?;
+                (!cell.is_null()).then(|| (column.clone(), cell.clone()))
+            })
+            .collect()
+    }
 }
 
 /// The written `geo` cell: pandapower 3 stores a GeoJSON Point string per
@@ -2005,6 +2125,47 @@ mod tests {
         let parsed = parse_pandapower_json(&pp_net(vec![bus_table(json!([0, 1, 2]))])).unwrap();
         let ids: Vec<usize> = parsed.network.buses.iter().map(|b| b.id.0).collect();
         assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn unrecognized_columns_are_preserved_as_extras() {
+        // The fidelity policy for handled tables: a column the reader has no
+        // model slot for must survive as element extras. Consumed columns and
+        // the writer's own slot-less columns (`type`) stay out, and a null
+        // cell (pandas' "unset") is not captured.
+        let net = pp_net(vec![
+            (
+                "bus",
+                pp_frame(
+                    &["name", "vn_kv", "in_service", "type", "vendor_ext", "empty"],
+                    json!([0, 1]),
+                    json!([
+                        [null, 110.0, true, "b", 42.0, null],
+                        [null, 110.0, true, "b", null, null]
+                    ]),
+                ),
+            ),
+            (
+                "trafo",
+                pp_frame(
+                    &["hv_bus", "lv_bus", "sn_mva", "vk_percent", "vector_group"],
+                    json!([0]),
+                    json!([[0, 1, 25.0, 12.0, "Dyn"]]),
+                ),
+            ),
+        ]);
+        let parsed = parse_pandapower_json(&net).unwrap();
+        assert_eq!(
+            parsed.network.buses[0].extras.get("vendor_ext"),
+            Some(&json!(42.0))
+        );
+        assert!(!parsed.network.buses[0].extras.contains_key("type"));
+        assert!(!parsed.network.buses[0].extras.contains_key("empty"));
+        assert!(parsed.network.buses[1].extras.is_empty());
+        assert_eq!(
+            parsed.network.branches[0].extras.get("vector_group"),
+            Some(&json!("Dyn"))
+        );
     }
 
     #[test]

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -651,9 +651,8 @@ fn read_shunt(v: &Value, pscale: f64) -> Shunt {
     }
 }
 
-// `raw != 1.0` is exact on purpose: only the literal 1.0 (a line's tap as
-// PowerModels serializes it) carries no information; an epsilon compare would
-// silence the warning for real near-unit taps.
+// Exact compare on purpose: only the literal 1.0 carries no information.
+// An epsilon compare would silence the warning for real near-unit taps.
 #[allow(clippy::float_cmp)]
 fn read_branch(v: &Value, pscale: f64, ascale: f64, warnings: &mut Vec<String>) -> Branch {
     // PowerModels stores the effective tap (1.0 for a line); the `transformer`
@@ -666,10 +665,9 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64, warnings: &mut Vec<String>) 
     let tap = if transformer {
         f_or(v, "tap", 1.0)
     } else {
-        // The flag, not the tap, decides the type, so a non-unit tap on an
-        // untagged branch is real electrical data this rule throws away; say
-        // so instead of zeroing it silently. Taps of 1 and 0 both mean "no
-        // off-nominal ratio" and stay quiet.
+        // The `transformer` flag decides the type, so this rule drops a
+        // non-unit tap on an untagged branch. Warn about the drop. Taps of
+        // 1 and 0 both mean no off-nominal ratio and stay quiet.
         if let Some(raw) = v.get("tap").and_then(Value::as_f64) {
             if raw != 0.0 && raw != 1.0 {
                 warnings.push(format!(

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -498,10 +498,7 @@ pub(crate) fn parse_powermodels_json_source(
             .iter()
             .map(|v| read_shunt(v, pscale))
             .collect(),
-        branches: sorted(root, "branch", "index")
-            .iter()
-            .map(|v| read_branch(v, pscale, ascale, warnings))
-            .collect(),
+        branches: read_branches(root, pscale, ascale, warnings),
         switches: sorted(root, "switch", "index")
             .iter()
             .map(|v| read_switch(v, pscale))
@@ -531,11 +528,25 @@ pub(crate) fn parse_powermodels_json_source(
 /// Elements of a top-level section, ordered by their integer `idx_key` so a
 /// re-emitted file assigns the same running keys.
 fn sorted<'a>(root: &'a Map<String, Value>, section: &str, idx_key: &str) -> Vec<&'a Value> {
+    sorted_keyed(root, section, idx_key)
+        .into_iter()
+        .map(|(_, v)| v)
+        .collect()
+}
+
+/// [`sorted`] keeping each entry's map key. Only PowerModels.jl written files
+/// repeat the key in an inner `index`, so the key is the identity a
+/// diagnostic can always name.
+fn sorted_keyed<'a>(
+    root: &'a Map<String, Value>,
+    section: &str,
+    idx_key: &str,
+) -> Vec<(&'a str, &'a Value)> {
     let Some(obj) = root.get(section).and_then(Value::as_object) else {
         return Vec::new();
     };
-    let mut items: Vec<&Value> = obj.values().collect();
-    items.sort_by_key(|v| v.get(idx_key).and_then(Value::as_i64).unwrap_or(0));
+    let mut items: Vec<(&str, &Value)> = obj.iter().map(|(k, v)| (k.as_str(), v)).collect();
+    items.sort_by_key(|(_, v)| v.get(idx_key).and_then(Value::as_i64).unwrap_or(0));
     items
 }
 
@@ -651,10 +662,54 @@ fn read_shunt(v: &Value, pscale: f64) -> Shunt {
     }
 }
 
+/// Read the branch table, reporting the taps the `transformer` flag makes
+/// this reader discard. One aggregated warning names the first few branches
+/// and the total: a producer that never sets the flag would otherwise emit
+/// one line per transformer.
+fn read_branches(
+    root: &Map<String, Value>,
+    pscale: f64,
+    ascale: f64,
+    warnings: &mut Vec<String>,
+) -> Vec<Branch> {
+    const NAMED: usize = 3;
+    let mut discarded: Vec<String> = Vec::new();
+    let branches = sorted_keyed(root, "branch", "index")
+        .iter()
+        .map(|(key, v)| read_branch(v, pscale, ascale, key, &mut discarded))
+        .collect();
+    if !discarded.is_empty() {
+        let head = discarded
+            .iter()
+            .take(NAMED)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let rest = discarded.len().saturating_sub(NAMED);
+        let tail = if rest > 0 {
+            format!(" and {rest} more")
+        } else {
+            String::new()
+        };
+        warnings.push(format!(
+            "{} branch(es) carry an off-nominal `tap` without `transformer: true`, \
+             so the tap is discarded and the branch reads as a line: {head}{tail}",
+            discarded.len()
+        ));
+    }
+    branches
+}
+
 // Exact compare on purpose: only the literal 1.0 carries no information.
 // An epsilon compare would silence the warning for real near-unit taps.
 #[allow(clippy::float_cmp)]
-fn read_branch(v: &Value, pscale: f64, ascale: f64, warnings: &mut Vec<String>) -> Branch {
+fn read_branch(
+    v: &Value,
+    pscale: f64,
+    ascale: f64,
+    key: &str,
+    discarded: &mut Vec<String>,
+) -> Branch {
     // PowerModels stores the effective tap (1.0 for a line); the `transformer`
     // flag disambiguates an explicit-tap transformer from a line, which is what
     // the neutral raw-tap convention (0 = line) needs.
@@ -670,10 +725,8 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64, warnings: &mut Vec<String>) 
         // 1 and 0 both mean no off-nominal ratio and stay quiet.
         if let Some(raw) = v.get("tap").and_then(Value::as_f64) {
             if raw != 0.0 && raw != 1.0 {
-                warnings.push(format!(
-                    "branch {} ({} -> {}): tap {raw} discarded: no `transformer: true` flag, \
-                     so the branch reads as a line",
-                    uid(v, "index"),
+                discarded.push(format!(
+                    "`{key}` ({} -> {}) tap {raw}",
                     uid(v, "f_bus"),
                     uid(v, "t_bus"),
                 ));
@@ -1049,9 +1102,11 @@ mod tests {
         assert_eq!(net.branches[0].tap, 0.0);
         assert_eq!(net.branches[1].tap, 0.0);
         assert_eq!(net.branches[2].tap, 1.05);
+        // One aggregated warning naming the offending branch by its map key,
+        // which is the identity a file without an inner `index` still has.
         assert_eq!(warnings.len(), 1, "{warnings:?}");
         assert!(
-            warnings[0].contains("branch 1 (1 -> 2)") && warnings[0].contains("tap 1.05"),
+            warnings[0].contains("1 branch(es)") && warnings[0].contains("`1` (1 -> 2) tap 1.05"),
             "{warnings:?}"
         );
     }

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -500,7 +500,7 @@ pub(crate) fn parse_powermodels_json_source(
             .collect(),
         branches: sorted(root, "branch", "index")
             .iter()
-            .map(|v| read_branch(v, pscale, ascale))
+            .map(|v| read_branch(v, pscale, ascale, warnings))
             .collect(),
         switches: sorted(root, "switch", "index")
             .iter()
@@ -651,7 +651,11 @@ fn read_shunt(v: &Value, pscale: f64) -> Shunt {
     }
 }
 
-fn read_branch(v: &Value, pscale: f64, ascale: f64) -> Branch {
+// `raw != 1.0` is exact on purpose: only the literal 1.0 (a line's tap as
+// PowerModels serializes it) carries no information; an epsilon compare would
+// silence the warning for real near-unit taps.
+#[allow(clippy::float_cmp)]
+fn read_branch(v: &Value, pscale: f64, ascale: f64, warnings: &mut Vec<String>) -> Branch {
     // PowerModels stores the effective tap (1.0 for a line); the `transformer`
     // flag disambiguates an explicit-tap transformer from a line, which is what
     // the neutral raw-tap convention (0 = line) needs.
@@ -662,6 +666,21 @@ fn read_branch(v: &Value, pscale: f64, ascale: f64) -> Branch {
     let tap = if transformer {
         f_or(v, "tap", 1.0)
     } else {
+        // The flag, not the tap, decides the type, so a non-unit tap on an
+        // untagged branch is real electrical data this rule throws away; say
+        // so instead of zeroing it silently. Taps of 1 and 0 both mean "no
+        // off-nominal ratio" and stay quiet.
+        if let Some(raw) = v.get("tap").and_then(Value::as_f64) {
+            if raw != 0.0 && raw != 1.0 {
+                warnings.push(format!(
+                    "branch {} ({} -> {}): tap {raw} discarded: no `transformer: true` flag, \
+                     so the branch reads as a line",
+                    uid(v, "index"),
+                    uid(v, "f_bus"),
+                    uid(v, "t_bus"),
+                ));
+            }
+        }
         0.0
     };
     Branch {
@@ -1011,6 +1030,31 @@ mod tests {
         assert!(
             !net.generators[0].in_service,
             "gen_status: false must read out of service"
+        );
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)] // exact values pass straight through the reader
+    fn nonunit_tap_without_transformer_flag_warns_and_stays_a_line() {
+        let doc = r#"{"baseMVA":100.0,"per_unit":true,
+            "bus":{"1":{"bus_i":1,"bus_type":3,"vm":1.0,"va":0.0,"base_kv":345.0},
+                   "2":{"bus_i":2,"bus_type":1,"vm":1.0,"va":0.0,"base_kv":345.0}},
+            "branch":{"1":{"index":1,"f_bus":1,"t_bus":2,"br_r":0.01,"br_x":0.1,"tap":1.05},
+                      "2":{"index":2,"f_bus":1,"t_bus":2,"br_r":0.01,"br_x":0.1,"tap":1.0},
+                      "3":{"index":3,"f_bus":1,"t_bus":2,"br_r":0.01,"br_x":0.1,
+                           "tap":1.05,"transformer":true}}}"#;
+        let mut warnings = Vec::new();
+        let net =
+            parse_powermodels_json_source(Arc::new(doc.to_owned()), None, &mut warnings).unwrap();
+        // The inference rule is unchanged: without the flag the tap is dropped
+        // (raw 0 = line); only the drop of a non-unit value is reported.
+        assert_eq!(net.branches[0].tap, 0.0);
+        assert_eq!(net.branches[1].tap, 0.0);
+        assert_eq!(net.branches[2].tap, 1.05);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(
+            warnings[0].contains("branch 1 (1 -> 2)") && warnings[0].contains("tap 1.05"),
+            "{warnings:?}"
         );
     }
 


### PR DESCRIPTION
## What this PR does

Implements the direct items of #263 (JSON reader fidelity follow-ups from the 0.7.2 review):

- **egret + pandapower unknown-key capture.** Both readers built every element with empty `extras`, so a vendor extension field vanished with no warning, against the fidelity policy. They now capture unrecognized fields the way the PowerModels reader's `extras_excluding` does. The known sets include the fields powerio's own writers emit without a model slot, so a powerio-written file still reads back extras-free — that is why the conversion-matrix baselines did not move.
- **PowerModels tap warning.** A branch with `"tap": 1.05` and no `transformer: true` flag zeroed the tap silently. The inference rule is unchanged; the reader now warns with the branch identity and the discarded value.
- **Duplicate payload uid diagnostic.** A generated `table:row` uid can collide with a source-supplied one, and the ambiguity surfaced only when an operating point failed to resolve. `.pio.json` validation now diagnoses it directly (`VALIDATE.BALANCED.PAYLOAD_IDENTITY`, new always-present `balanced.payload_identity` pass), with no operating points required.
- **CLI single read.** `summary`, `package`, `convert` without `--from`, and `geo extract|apply` read and DOM-classified a `.json` twice. They now share one read and one classification, the same way #260 fixed `batch` and the TUI.

Deferred on the issue, per its own scoping: the pandapower `read_frame` clone elimination and the powerio-pkg unknown-field-preservation/perf items.

Closes #263.

## Release sequencing

Target release: **v0.8.1**, after #280. Sequence: v0.8.1 (fixes) → v0.8.2 (consumer features) → v0.9.0 (breaking changes with deprecation shims) → v1.0.0 (clean break, stability policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_