### PR TITLE
pkg: accept null for nonfinite floats in the multiconductor payload

### DIFF
--- a/docs/schema/pio-package/0.2/schema.json
+++ b/docs/schema/pio-package/0.2/schema.json
@@ -747,7 +747,10 @@
         "q_rated": {
           "description": "Nameplate rated reactive power of the whole bank, vars.",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "terminal_map": {
           "items": {
@@ -758,7 +761,10 @@
         "v_nom": {
           "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         }
       },
       "required": [
@@ -766,8 +772,6 @@
         "bus",
         "terminal_map",
         "configuration",
-        "q_rated",
-        "v_nom",
         "extras"
       ],
       "type": "object"
@@ -973,7 +977,10 @@
           "description": "Per conductor current limits, amperes.",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -994,7 +1001,10 @@
         "p_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1004,7 +1014,10 @@
         "p_min": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1017,7 +1030,10 @@
         "q_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1027,7 +1043,10 @@
         "q_min": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1038,7 +1057,10 @@
           "description": "Per phase apparent power nameplate ratings, volt amperes.",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": "array"
         },
@@ -4838,12 +4860,18 @@
         "r_pct": {
           "description": "Winding resistance, percent of the winding base.",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "s_rating": {
           "description": "Volt amperes.",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "tap": {
           "format": "double",
@@ -4858,7 +4886,10 @@
         "v_ref": {
           "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "x_neutral": {
           "format": "double",
@@ -4872,9 +4903,6 @@
         "bus",
         "terminal_map",
         "conn",
-        "v_ref",
-        "s_rating",
-        "r_pct",
         "tap"
       ],
       "type": "object"

--- a/docs/schema/pio-package/0.2/schema.json
+++ b/docs/schema/pio-package/0.2/schema.json
@@ -772,6 +772,8 @@
         "bus",
         "terminal_map",
         "configuration",
+        "q_rated",
+        "v_nom",
         "extras"
       ],
       "type": "object"
@@ -859,6 +861,7 @@
           "type": "string"
         },
         "p_max": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -872,6 +875,7 @@
           ]
         },
         "p_min": {
+          "default": null,
           "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
           "items": {
             "format": "double",
@@ -894,6 +898,7 @@
           "type": "array"
         },
         "q_max": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -907,6 +912,7 @@
           ]
         },
         "q_min": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -974,6 +980,7 @@
           "type": "object"
         },
         "i_max": {
+          "default": null,
           "description": "Per conductor current limits, amperes.",
           "items": {
             "format": "double",
@@ -999,6 +1006,7 @@
           ]
         },
         "p_max": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -1012,6 +1020,7 @@
           ]
         },
         "p_min": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -1028,6 +1037,7 @@
           "$ref": "#/$defs/IbrPrimeMover"
         },
         "q_max": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -1041,6 +1051,7 @@
           ]
         },
         "q_min": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -1178,6 +1189,7 @@
         "terminal_map_from",
         "terminal_map_to",
         "linecode",
+        "length",
         "extras"
       ],
       "type": "object"
@@ -1230,6 +1242,7 @@
           "type": "array"
         },
         "i_max": {
+          "default": null,
           "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
             "format": "double",
@@ -1263,6 +1276,7 @@
           "type": "array"
         },
         "s_max": {
+          "default": null,
           "items": {
             "format": "double",
             "type": [
@@ -1780,6 +1794,7 @@
           "type": "object"
         },
         "i_max": {
+          "default": null,
           "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
             "format": "double",
@@ -4903,6 +4918,9 @@
         "bus",
         "terminal_map",
         "conn",
+        "v_ref",
+        "s_rating",
+        "r_pct",
         "tap"
       ],
       "type": "object"

--- a/docs/schema/pio-package/0.2/schema.json
+++ b/docs/schema/pio-package/0.2/schema.json
@@ -841,7 +841,10 @@
         "i_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -854,7 +857,10 @@
         "p_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -862,9 +868,13 @@
           ]
         },
         "p_min": {
+          "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -882,7 +892,10 @@
         "q_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -892,7 +905,10 @@
         "q_min": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -910,7 +926,10 @@
           "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1067,10 +1086,13 @@
           "type": "object"
         },
         "i_max": {
-          "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).",
+          "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1078,9 +1100,12 @@
           ]
         },
         "length": {
-          "description": "Meters.",
+          "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
           "format": "double",
-          "type": "number"
+          "type": [
+            "number",
+            "null"
+          ]
         },
         "linecode": {
           "type": "string"
@@ -1101,7 +1126,10 @@
         "s_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1128,7 +1156,6 @@
         "terminal_map_from",
         "terminal_map_to",
         "linecode",
-        "length",
         "extras"
       ],
       "type": "object"
@@ -1181,10 +1208,13 @@
           "type": "array"
         },
         "i_max": {
-          "description": "Ampacity per conductor.",
+          "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1213,7 +1243,10 @@
         "s_max": {
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",
@@ -1725,9 +1758,13 @@
           "type": "object"
         },
         "i_max": {
+          "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
             "format": "double",
-            "type": "number"
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "type": [
             "array",

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -45,7 +45,7 @@ ABI v4 continues to accept `powerio-json` in `pio_parse_str` and
 ## Versioning: `pio-package/0.2` {#pio-package}
 
 One version number covers the whole document, model JSON included:
-`schema_version`, semver, currently `0.2.0`. A `.pio.json` file is a
+`schema_version`, semver, currently `0.2.1`. A `.pio.json` file is a
 regenerable snapshot, so the reader's only versioning job is telling the caller
 when a file needs regenerating.
 
@@ -272,7 +272,7 @@ bindings, or MCP operations.
 
 ```json
 {
-  "schema_version": "0.2.0",
+  "schema_version": "0.2.1",
   "producer": { "tool": "powerio", "version": "0.8.0" },
   "model_kind": "multiconductor",
   "model": {

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -47,6 +47,7 @@ pub mod error;
 pub mod geo;
 pub mod graph;
 pub mod model;
+pub(crate) mod nonfinite;
 pub mod pmd;
 
 pub use bmopf::{

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -122,8 +122,12 @@ pub struct DistLineCode {
     pub b_from: Mat,
     pub g_to: Mat,
     pub b_to: Mat,
-    /// Ampacity per conductor.
+    /// Ampacity per conductor. A `null` element reads as +Inf (#268).
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
     /// Provenance of the impedance matrices (BMOPF `source`, e.g. "fem",
     /// "datasheet", "import").
@@ -163,7 +167,9 @@ pub struct DistLine {
     pub terminal_map_from: Vec<String>,
     pub terminal_map_to: Vec<String>,
     pub linecode: String,
-    /// Meters.
+    /// Meters. A `null` reads as NaN: a BMOPF line without a length (#268).
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub length: f64,
     /// Polyline route in the network's coordinate space (`DistNetwork.geo`),
     /// present only when a source provides intermediate geometry.
@@ -173,9 +179,14 @@ pub struct DistLine {
     pub route: Option<Vec<Location>>,
     /// Per-conductor ampacity and apparent power limits, amps and VA
     /// (BMOPF schema 0.1.0 line fields, alongside the linecode's own).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// A `null` element reads as +Inf (#268).
+    #[serde(default, skip_serializing_if = "Option::is_none",
+            with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none",
+            with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
     pub extras: Extras,
 }
@@ -260,6 +271,9 @@ pub struct DistSwitch {
     pub terminal_map_from: Vec<String>,
     pub terminal_map_to: Vec<String>,
     pub open: bool,
+    /// Ampacity per conductor. A `null` element reads as +Inf (#268).
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     pub extras: Extras,
 }
@@ -399,17 +413,31 @@ pub struct DistGenerator {
     /// Setpoint, watts per phase.
     pub p_nom: Vec<f64>,
     pub q_nom: Vec<f64>,
+    /// Bounds per phase. A `null` element reads as -Inf in a lower bound
+    /// and +Inf in an upper bound: the PMD unbounded spelling (#268).
+    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_min: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_max: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_min: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_max: Option<Vec<f64>>,
     /// $/kWh; no OpenDSS equivalent, so it is None until a format supplies it.
     pub cost: Option<f64>,
     /// Per-conductor apparent power and current limits, VA and amps (BMOPF
     /// generator fields, alongside the p/q bounds).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none",
+            with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none",
+            with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     pub extras: Extras,
 }

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -238,9 +238,13 @@ pub struct DistCapacitor {
     pub terminal_map: Vec<String>,
     pub configuration: Configuration,
     /// Nameplate rated reactive power of the whole bank, vars.
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub q_rated: f64,
     /// Nameplate nominal voltage, volts: line to line for the three phase
     /// configurations, across the terminals for SINGLE_PHASE.
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub v_nom: f64,
     pub extras: Extras,
 }
@@ -524,14 +528,26 @@ pub struct DistIbr {
     pub topology: IbrTopology,
     pub prime_mover: IbrPrimeMover,
     /// Per phase apparent power nameplate ratings, volt amperes.
+    #[serde(with = "crate::nonfinite::upper_limits")]
+    #[cfg_attr(feature = "schema", schemars(with = "Vec<Option<f64>>"))]
     pub s_max: Vec<f64>,
     /// Per conductor current limits, amperes.
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     /// Available active power, watts.
     pub p_avail: Option<f64>,
+    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_min: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_max: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_min: Option<Vec<f64>>,
+    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_max: Option<Vec<f64>>,
     pub control_profile: Option<String>,
     pub voltage_aggregation: Option<IbrVoltageAggregation>,
@@ -723,10 +739,16 @@ pub struct Winding {
     pub terminal_map: Vec<String>,
     pub conn: WindingConn,
     /// Rated winding voltage, volts (line to line for 2 and 3 phase).
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub v_ref: f64,
     /// Volt amperes.
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub s_rating: f64,
     /// Winding resistance, percent of the winding base.
+    #[serde(with = "crate::nonfinite::nan_scalar")]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
     pub r_pct: f64,
     pub tap: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -180,12 +180,18 @@ pub struct DistLine {
     /// Per-conductor ampacity and apparent power limits, amps and VA
     /// (BMOPF schema 0.1.0 line fields, alongside the linecode's own).
     /// A `null` element reads as +Inf (#268).
-    #[serde(default, skip_serializing_if = "Option::is_none",
-            with = "crate::nonfinite::upper_bounds")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::nonfinite::upper_bounds"
+    )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
-    #[serde(default, skip_serializing_if = "Option::is_none",
-            with = "crate::nonfinite::upper_bounds")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::nonfinite::upper_bounds"
+    )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
     pub extras: Extras,
@@ -431,12 +437,18 @@ pub struct DistGenerator {
     pub cost: Option<f64>,
     /// Per-conductor apparent power and current limits, VA and amps (BMOPF
     /// generator fields, alongside the p/q bounds).
-    #[serde(default, skip_serializing_if = "Option::is_none",
-            with = "crate::nonfinite::upper_bounds")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::nonfinite::upper_bounds"
+    )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
-    #[serde(default, skip_serializing_if = "Option::is_none",
-            with = "crate::nonfinite::upper_bounds")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "crate::nonfinite::upper_bounds"
+    )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     pub extras: Extras,

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -123,10 +123,10 @@ pub struct DistLineCode {
     pub g_to: Mat,
     pub b_to: Mat,
     /// Ampacity per conductor. A `null` element reads as +Inf (#268).
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub s_max: Option<Vec<f64>>,
     /// Provenance of the impedance matrices (BMOPF `source`, e.g. "fem",
@@ -169,7 +169,10 @@ pub struct DistLine {
     pub linecode: String,
     /// Meters. A `null` reads as NaN: a BMOPF line without a length (#268).
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub length: f64,
     /// Polyline route in the network's coordinate space (`DistNetwork.geo`),
     /// present only when a source provides intermediate geometry.
@@ -239,12 +242,18 @@ pub struct DistCapacitor {
     pub configuration: Configuration,
     /// Nameplate rated reactive power of the whole bank, vars.
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub q_rated: f64,
     /// Nameplate nominal voltage, volts: line to line for the three phase
     /// configurations, across the terminals for SINGLE_PHASE.
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub v_nom: f64,
     pub extras: Extras,
 }
@@ -282,7 +291,7 @@ pub struct DistSwitch {
     pub terminal_map_to: Vec<String>,
     pub open: bool,
     /// Ampacity per conductor. A `null` element reads as +Inf (#268).
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     pub extras: Extras,
@@ -425,16 +434,16 @@ pub struct DistGenerator {
     pub q_nom: Vec<f64>,
     /// Bounds per phase. A `null` element reads as -Inf in a lower bound
     /// and +Inf in an upper bound: the PMD unbounded spelling (#268).
-    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[serde(default, with = "crate::nonfinite::lower_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_min: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_max: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[serde(default, with = "crate::nonfinite::lower_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_min: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_max: Option<Vec<f64>>,
     /// $/kWh; no OpenDSS equivalent, so it is None until a format supplies it.
@@ -532,21 +541,21 @@ pub struct DistIbr {
     #[cfg_attr(feature = "schema", schemars(with = "Vec<Option<f64>>"))]
     pub s_max: Vec<f64>,
     /// Per conductor current limits, amperes.
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub i_max: Option<Vec<f64>>,
     /// Available active power, watts.
     pub p_avail: Option<f64>,
-    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[serde(default, with = "crate::nonfinite::lower_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_min: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub p_max: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::lower_bounds")]
+    #[serde(default, with = "crate::nonfinite::lower_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_min: Option<Vec<f64>>,
-    #[serde(with = "crate::nonfinite::upper_bounds")]
+    #[serde(default, with = "crate::nonfinite::upper_bounds")]
     #[cfg_attr(feature = "schema", schemars(with = "Option<Vec<Option<f64>>>"))]
     pub q_max: Option<Vec<f64>>,
     pub control_profile: Option<String>,
@@ -740,15 +749,24 @@ pub struct Winding {
     pub conn: WindingConn,
     /// Rated winding voltage, volts (line to line for 2 and 3 phase).
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub v_ref: f64,
     /// Volt amperes.
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub s_rating: f64,
     /// Winding resistance, percent of the winding base.
     #[serde(with = "crate::nonfinite::nan_scalar")]
-    #[cfg_attr(feature = "schema", schemars(with = "Option<f64>"))]
+    #[cfg_attr(
+        feature = "schema",
+        schemars(schema_with = "crate::nonfinite::nullable_number")
+    )]
     pub r_pct: f64,
     pub tap: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/powerio-dist/src/nonfinite.rs
+++ b/powerio-dist/src/nonfinite.rs
@@ -82,6 +82,22 @@ pub(crate) mod nan_scalar {
     }
 }
 
+/// The schema for a required field whose value may be `null`: the key must be
+/// present, and `null` is how a nonfinite value spells itself.
+///
+/// `schemars(with = "Option<f64>")` cannot say this. Naming an `Option` type
+/// there widens the type union *and* drops the field from the object's
+/// `required` list, which would publish a schema that accepts a document
+/// omitting the key — while [`nan_scalar`] still demands it, so the reader
+/// would reject a document the schema called valid.
+#[cfg(feature = "schema")]
+pub(crate) fn nullable_number(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": ["number", "null"],
+        "format": "double",
+    })
+}
+
 #[cfg(test)]
 mod tests {
     #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
@@ -123,5 +139,48 @@ mod tests {
         assert_eq!(back.lb, p.lb);
         assert!(back.len.is_nan());
         assert_eq!(text, serde_json::to_string(&back).unwrap());
+    }
+    /// `serde(with = ...)` drops the implicit "missing means `None`" handling
+    /// for an `Option` field, so every widened bound needs `default` beside it
+    /// or a document that omits the key stops parsing.
+    #[test]
+    fn an_omitted_bound_still_reads_as_absent() {
+        use crate::model::{DistLineCode, DistSwitch};
+
+        let code = DistLineCode::new("lc", vec![vec![0.1]], vec![vec![0.2]]);
+        let mut v = serde_json::to_value(&code).unwrap();
+        let obj = v.as_object_mut().unwrap();
+        obj.remove("i_max");
+        obj.remove("s_max");
+        let back: DistLineCode = serde_json::from_value(v).expect("omitted bounds must parse");
+        assert!(back.i_max.is_none() && back.s_max.is_none());
+
+        let sw = DistSwitch::new("sw", "a", "b", vec!["1".into()], vec!["1".into()], false);
+        let mut v = serde_json::to_value(&sw).unwrap();
+        v.as_object_mut().unwrap().remove("i_max");
+        let back: DistSwitch = serde_json::from_value(v).expect("omitted bound must parse");
+        assert!(back.i_max.is_none());
+    }
+
+    /// A required field spelled `null` for a nonfinite value is still required:
+    /// the schema must keep it in `required`, or it would accept a document the
+    /// reader rejects for a missing key.
+    #[cfg(feature = "schema")]
+    #[test]
+    fn a_nullable_scalar_stays_required_in_the_schema() {
+        let schema = schemars::schema_for!(crate::model::DistCapacitor);
+        let v = serde_json::to_value(&schema).unwrap();
+        let required: Vec<&str> = v["required"]
+            .as_array()
+            .expect("required list")
+            .iter()
+            .map(|x| x.as_str().unwrap())
+            .collect();
+        assert!(required.contains(&"q_rated"), "required: {required:?}");
+        assert!(required.contains(&"v_nom"), "required: {required:?}");
+        assert_eq!(
+            v["properties"]["q_rated"]["type"],
+            serde_json::json!(["number", "null"])
+        );
     }
 }

--- a/powerio-dist/src/nonfinite.rs
+++ b/powerio-dist/src/nonfinite.rs
@@ -5,6 +5,10 @@
 //! (#268). A `null` element in an upper bound means unbounded above
 //! (+Inf); in a lower bound, unbounded below (-Inf); in a length, not
 //! known (NaN). This is the PMD convention.
+//!
+//! serde `with` modules receive `&T`, so the serialize signatures take
+//! references the lints would otherwise refuse.
+#![allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/powerio-dist/src/nonfinite.rs
+++ b/powerio-dist/src/nonfinite.rs
@@ -1,0 +1,98 @@
+//! Payload spellings for nonfinite floats.
+//!
+//! serde_json writes a nonfinite `f64` as JSON `null`. These modules read
+//! that `null` back, so a payload the library wrote always reads back
+//! (#268). A `null` element in an upper bound means unbounded above
+//! (+Inf); in a lower bound, unbounded below (-Inf); in a length, not
+//! known (NaN). This is the PMD convention.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+fn restore(v: Option<Vec<Option<f64>>>, missing: f64) -> Option<Vec<f64>> {
+    v.map(|xs| xs.into_iter().map(|x| x.unwrap_or(missing)).collect())
+}
+
+/// `Option<Vec<f64>>` upper bounds: a `null` element reads as +Inf.
+pub(crate) mod upper_bounds {
+    use super::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<Vec<f64>>, s: S) -> Result<S::Ok, S::Error> {
+        v.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<f64>>, D::Error> {
+        let v = Option::<Vec<Option<f64>>>::deserialize(d)?;
+        Ok(super::restore(v, f64::INFINITY))
+    }
+}
+
+/// `Option<Vec<f64>>` lower bounds: a `null` element reads as -Inf.
+pub(crate) mod lower_bounds {
+    use super::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<Vec<f64>>, s: S) -> Result<S::Ok, S::Error> {
+        v.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<f64>>, D::Error> {
+        let v = Option::<Vec<Option<f64>>>::deserialize(d)?;
+        Ok(super::restore(v, f64::NEG_INFINITY))
+    }
+}
+
+/// Required `f64` with a not-known state: `null` reads as NaN.
+pub(crate) mod nan_scalar {
+    use super::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &f64, s: S) -> Result<S::Ok, S::Error> {
+        v.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+        Ok(Option::<f64>::deserialize(d)?.unwrap_or(f64::NAN))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq)]
+    struct Probe {
+        #[serde(with = "super::upper_bounds")]
+        ub: Option<Vec<f64>>,
+        #[serde(with = "super::lower_bounds")]
+        lb: Option<Vec<f64>>,
+        #[serde(with = "super::nan_scalar")]
+        len: f64,
+    }
+
+    #[test]
+    fn null_elements_read_as_signed_infinity_and_nan() {
+        let p: Probe =
+            serde_json::from_str(r#"{"ub":[1.0,null],"lb":[null,0.0],"len":null}"#).unwrap();
+        assert_eq!(p.ub, Some(vec![1.0, f64::INFINITY]));
+        assert_eq!(p.lb, Some(vec![f64::NEG_INFINITY, 0.0]));
+        assert!(p.len.is_nan());
+    }
+
+    #[test]
+    fn whole_null_bound_reads_as_absent() {
+        let p: Probe = serde_json::from_str(r#"{"ub":null,"lb":null,"len":3.0}"#).unwrap();
+        assert_eq!(p.ub, None);
+        assert_eq!(p.lb, None);
+    }
+
+    #[test]
+    fn write_read_write_is_stable() {
+        let p = Probe {
+            ub: Some(vec![500e3, f64::INFINITY]),
+            lb: Some(vec![f64::NEG_INFINITY]),
+            len: f64::NAN,
+        };
+        let text = serde_json::to_string(&p).unwrap();
+        let back: Probe = serde_json::from_str(&text).unwrap();
+        assert_eq!(back.ub, p.ub);
+        assert_eq!(back.lb, p.lb);
+        assert!(back.len.is_nan());
+        assert_eq!(text, serde_json::to_string(&back).unwrap());
+    }
+}

--- a/powerio-dist/src/nonfinite.rs
+++ b/powerio-dist/src/nonfinite.rs
@@ -8,12 +8,23 @@
 //!
 //! serde `with` modules receive `&T`, so the serialize signatures take
 //! references the lints would otherwise refuse.
-#![allow(clippy::ref_option, clippy::trivially_copy_pass_by_ref)]
+//!
+//! An `Option<f64>` field needs no module: a nonfinite writes as `null` and
+//! reads back as `None`, which is the same statement the bound made.
+#![allow(
+    clippy::ref_option,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::ptr_arg
+)]
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 fn restore(v: Option<Vec<Option<f64>>>, missing: f64) -> Option<Vec<f64>> {
     v.map(|xs| xs.into_iter().map(|x| x.unwrap_or(missing)).collect())
+}
+
+fn restore_all(v: Vec<Option<f64>>, missing: f64) -> Vec<f64> {
+    v.into_iter().map(|x| x.unwrap_or(missing)).collect()
 }
 
 /// `Option<Vec<f64>>` upper bounds: a `null` element reads as +Inf.
@@ -41,6 +52,20 @@ pub(crate) mod lower_bounds {
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<f64>>, D::Error> {
         let v = Option::<Vec<Option<f64>>>::deserialize(d)?;
         Ok(super::restore(v, f64::NEG_INFINITY))
+    }
+}
+
+/// Required `Vec<f64>` ratings: a `null` element reads as +Inf.
+pub(crate) mod upper_limits {
+    use super::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Vec<f64>, s: S) -> Result<S::Ok, S::Error> {
+        v.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<f64>, D::Error> {
+        let v = Vec::<Option<f64>>::deserialize(d)?;
+        Ok(super::restore_all(v, f64::INFINITY))
     }
 }
 

--- a/powerio-pkg/src/lowering.rs
+++ b/powerio-pkg/src/lowering.rs
@@ -666,6 +666,7 @@ impl<'a> LoweringState<'a> {
         neutral: &[usize],
         length: f64,
     ) -> Result<Complex64, MulticonductorToBalancedError> {
+        self.check_finite_length(line_idx, length)?;
         let matrix = complex_matrix(&code.r_series, &code.x_series, length);
         let reduced = kron_or_select(&matrix, active, neutral).map_err(|message| {
             self.matrix_error(line_idx, &code.name, "series impedance", &message)
@@ -721,6 +722,35 @@ impl<'a> LoweringState<'a> {
             self.record.diagnostics.push(diagnostic);
         }
         seq[1][1]
+    }
+
+    /// Refuse a line whose length is not a finite number. A BMOPF line without
+    /// a length reads back as `NaN` (the `null` spelling), and every impedance
+    /// and admittance below scales by it, so an unchecked value would reach the
+    /// solver as a `NaN` branch with nothing said about it.
+    fn check_finite_length(
+        &self,
+        line_idx: usize,
+        length: f64,
+    ) -> Result<(), MulticonductorToBalancedError> {
+        if length.is_finite() {
+            return Ok(());
+        }
+        let mut diagnostics = self.record.diagnostics.clone();
+        diagnostics.push(
+            StructuredDiagnostic::new(
+                "LOWER.MULTI_TO_BALANCED.NONFINITE_LINE_LENGTH",
+                DiagnosticSeverity::Error,
+                DiagnosticStage::Lower,
+                format!("line {line_idx} has no finite length ({length}), so its impedance cannot be scaled"),
+            )
+            .with_element_path(format!("/model/multiconductor_network/lines/{line_idx}/length"))
+            .with_suggested_action("give the line a length in meters, or drop it from the network"),
+        );
+        Err(MulticonductorToBalancedError::new(
+            self.options,
+            diagnostics,
+        ))
     }
 
     fn matrix_error(

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -39,7 +39,10 @@ use crate::validation::{ValidationPass, ValidationStatus, ValidationSummary};
 /// were removed, and the multiconductor bus `vsym_min`/`vsym_max` arrays
 /// became the per-sequence scalars `vpos_min`/`vpos_max`/`vneg_max`/
 /// `vzero_max`/`vn_max` (BMOPF schema 0.1.0).
-pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.2.0";
+///
+/// 0.2.1: multiconductor bounds, ratings, and line lengths accept `null`
+/// for a nonfinite value (#268). Same 0.2 lineage; the reader accepts both.
+pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.2.1";
 
 pub const READ_TRANSMISSION_PARSE_WARNING: &str = "READ.TRANSMISSION.PARSE_WARNING";
 pub const READ_GRIDFM_FIDELITY_WARNING: &str = "READ.GRIDFM.FIDELITY_WARNING";

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2439,3 +2439,45 @@ fn a_dropped_capacitor_bank_is_recorded_and_counted() {
         lowering.record.dropped_fields
     );
 }
+
+#[test]
+fn multiconductor_nonfinite_floats_roundtrip() {
+    // #268: serde_json writes a nonfinite f64 as `null`. The payload reader
+    // restores the bound's infinity and a length NaN, so a package the
+    // library wrote always reads back.
+    use powerio_dist::{Configuration, DistGenerator, DistSwitch};
+
+    let mut net = powerio_dist::parse_str("New Circuit.c1", "dss").expect("parse dss");
+    let mut generator = DistGenerator::new(
+        "g1",
+        "sourcebus",
+        vec!["1".into(), "2".into()],
+        Configuration::Wye,
+        vec![100e3, 100e3],
+        vec![0.0, 0.0],
+    );
+    generator.p_max = Some(vec![500e3, f64::INFINITY]);
+    generator.p_min = Some(vec![f64::NEG_INFINITY, 0.0]);
+    net.generators.push(generator);
+    let mut switch = DistSwitch::new(
+        "s1",
+        "sourcebus",
+        "sourcebus",
+        vec!["1".into()],
+        vec!["1".into()],
+        false,
+    );
+    switch.i_max = Some(vec![f64::INFINITY]);
+    net.switches.push(switch);
+
+    let pkg = NetworkPackage::from_multiconductor(net);
+    let text = pkg.to_json().expect("serialize");
+    let back = NetworkPackage::from_json(&text).expect("read back the package this wrote");
+
+    let payload = back.as_multiconductor().expect("multiconductor payload");
+    let generator = &payload.generators[payload.generators.len() - 1];
+    assert_eq!(generator.p_max, Some(vec![500e3, f64::INFINITY]));
+    assert_eq!(generator.p_min, Some(vec![f64::NEG_INFINITY, 0.0]));
+    let switch = &payload.switches[payload.switches.len() - 1];
+    assert_eq!(switch.i_max, Some(vec![f64::INFINITY]));
+}

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2481,3 +2481,46 @@ fn multiconductor_nonfinite_floats_roundtrip() {
     let switch = &payload.switches[payload.switches.len() - 1];
     assert_eq!(switch.i_max, Some(vec![f64::INFINITY]));
 }
+
+#[test]
+fn multiconductor_nonfinite_ratings_and_scalars_roundtrip() {
+    // #268: an inverter bound, a capacitor rating, and a transformer
+    // winding rating take the same `null` spelling as the generator bounds.
+    use powerio_dist::{Configuration, DistCapacitor, DistIbr, IbrPrimeMover, IbrTopology};
+
+    let mut net = powerio_dist::parse_str("New Circuit.c1", "dss").expect("parse dss");
+    let mut ibr = DistIbr::new(
+        "i1",
+        "sourcebus",
+        vec!["1".into()],
+        IbrTopology::ThreeLeg,
+        IbrPrimeMover::Pv,
+        vec![f64::INFINITY],
+    );
+    ibr.p_max = Some(vec![f64::INFINITY]);
+    ibr.p_min = Some(vec![f64::NEG_INFINITY]);
+    ibr.i_max = Some(vec![f64::INFINITY]);
+    net.ibrs.push(ibr);
+    net.capacitors.push(DistCapacitor::new(
+        "c1",
+        "sourcebus",
+        vec!["1".into()],
+        Configuration::Wye,
+        f64::NAN,
+        f64::NAN,
+    ));
+
+    let pkg = NetworkPackage::from_multiconductor(net);
+    let text = pkg.to_json().expect("serialize");
+    let back = NetworkPackage::from_json(&text).expect("read back the package this wrote");
+
+    let payload = back.as_multiconductor().expect("multiconductor payload");
+    let ibr = &payload.ibrs[payload.ibrs.len() - 1];
+    assert_eq!(ibr.s_max, vec![f64::INFINITY]);
+    assert_eq!(ibr.p_max, Some(vec![f64::INFINITY]));
+    assert_eq!(ibr.p_min, Some(vec![f64::NEG_INFINITY]));
+    assert_eq!(ibr.i_max, Some(vec![f64::INFINITY]));
+    let capacitor = &payload.capacitors[payload.capacitors.len() - 1];
+    assert!(capacitor.q_rated.is_nan());
+    assert!(capacitor.v_nom.is_nan());
+}

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -139,7 +139,8 @@ def test_package_transport_flows_through_summary_matrix_and_save(tmp_path):
     assert parsed["model"] == "balanced"
     assert "package_json" in parsed
     package = json.loads(parsed["package_json"])
-    assert package["schema_version"] == "0.2.0"
+    # The reader accepts the 0.2 lineage; do not pin the patch version.
+    assert package["schema_version"].startswith("0.2.")
     assert package["model_kind"] == "balanced"
     assert package["model"]["kind"] == "balanced"
 

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -194,7 +194,8 @@ def test_package_declares_schema_version_and_row_identity():
 
     pkg = pio.Package.from_file(DATA / "case9.m")
     doc = json.loads(pkg.to_json())
-    assert doc["schema_version"] == "0.2.0"
+    # The reader accepts the 0.2 lineage; do not pin the patch version.
+    assert doc["schema_version"].startswith("0.2.")
     assert "payload_schema" not in doc
     assert "payload_schema_version" not in doc
     # Every payload row carries an identity; case9 has no source uids, so they


### PR DESCRIPTION
Closes #268.

## What this PR does

serde_json writes a nonfinite `f64` as JSON `null`, so a package with an unbounded rating wrote a file the payload reader refused — the library could not read its own output (#268).

The multiconductor payload reader now restores `null` per field semantics, the PMD spelling:

- A `null` element in an upper bound (`i_max`, `s_max`, `p_max`, `q_max`) reads as +Inf.
- A `null` element in a lower bound (`p_min`, `q_min`) reads as -Inf.
- A `null` line `length` reads as NaN (a BMOPF line without a length).

The wire bytes do not change; only the reader widens. The generated schema items become `number | null`, and the document version moves to 0.2.1 in the same 0.2 lineage — the reader accepts both, and the PowerIO.jl pin gate compares by lineage, so 0.2.0 mirrors stay green.

This closes the acceptance case of #268: a `DistNetwork` whose generator carries `p_max = [500e3, Inf]` round-trips through package JSON. The deliberate writer spelling for the whole wire register lands in the v0.9.0 window; #268 stays open until then.

## Release sequencing

Target release: **v0.8.2**. Sequence: v0.8.1 (fixes) → v0.8.2 (consumer features) → v0.9.0 (breaking changes with deprecation shims) → v1.0.0 (clean break, stability policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_
