### PR TITLE
cli: exit nonzero on a refused DSS include

### DIFF
--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1125,7 +1125,7 @@ fn run_package(
     from: Option<FormatArg>,
     scenario: i64,
 ) -> anyhow::Result<()> {
-    let text = package_text(input, from, scenario)?;
+    let (text, parse_errors) = package_text(input, from, scenario)?;
     match output {
         Some(p) if p.as_os_str() != "-" => {
             std::fs::write(p, &text).with_context(|| format!("writing {}", p.display()))?;
@@ -1133,16 +1133,35 @@ fn run_package(
         }
         _ => print!("{text}"),
     }
-    Ok(())
+    // The package is written either way — it is the record of what the reader
+    // saw — but a refused include is an `Error` finding in its own envelope,
+    // so the exit code has to say so, as `convert` does.
+    fail_on_parse_errors(&parse_errors)
 }
 
-fn package_text(input: &Path, from: Option<FormatArg>, scenario: i64) -> anyhow::Result<String> {
+/// The package JSON and the `Error`-or-worse findings its envelope carries.
+fn package_text(
+    input: &Path,
+    from: Option<FormatArg>,
+    scenario: i64,
+) -> anyhow::Result<(String, Vec<String>)> {
     let pkg = build_package(input, from, scenario)?;
+    let errors = package_error_lines(&pkg.diagnostics);
     let text = pkg
         .to_json_pretty()
         .context("serializing .pio.json package")?;
     NetworkPackage::from_json(&text).context("validating .pio.json package readback")?;
-    Ok(text)
+    Ok((text, errors))
+}
+
+/// [`parse_error_lines`] for the package's own diagnostic type: the dist and
+/// package crates carry twin diagnostic shapes without depending on each other.
+fn package_error_lines(diagnostics: &[powerio_pkg::StructuredDiagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.severity >= powerio_pkg::DiagnosticSeverity::Error)
+        .map(|d| format!("{}: {}", d.code, d.message))
+        .collect()
 }
 
 fn build_package(
@@ -1446,11 +1465,16 @@ fn run_convert(
             .distribution()
             .expect("the family check routed a transmission target here");
         let conv = net.to_format(target);
+        // Both halves, as `convert.rs`'s own glue does: a writer emits its own
+        // structured findings, and an `Error` from either side has to reach
+        // the exit code.
+        let mut diagnostics = net.parse_diagnostics.clone();
+        diagnostics.extend(conv.diagnostics);
         (
             conv.text,
             conv.sidecars,
             conv.warnings,
-            parse_error_lines(&net.parse_diagnostics),
+            parse_error_lines(&diagnostics),
         )
     };
     for w in &warnings {
@@ -2009,7 +2033,7 @@ mod tests {
     #[test]
     fn package_text_matches_balanced_shape_and_provenance() {
         let input = data("case9.m");
-        let text = package_text(&input, None, 0).unwrap();
+        let (text, _) = package_text(&input, None, 0).unwrap();
         let pkg = NetworkPackage::from_json(&text).unwrap();
         assert_eq!(pkg.model_kind, powerio_pkg::ModelKind::Balanced);
         assert!(pkg.kind_is_consistent());
@@ -2067,7 +2091,7 @@ mod tests {
 
     #[test]
     fn package_helper_returns_stdout_text() {
-        let text = package_text(&data("case9.m"), None, 0).unwrap();
+        let (text, _) = package_text(&data("case9.m"), None, 0).unwrap();
         assert!(text.contains("\"schema_version\""));
         let pkg = NetworkPackage::from_json(&text).unwrap();
         assert_eq!(pkg.summary.elements["buses"], 9);
@@ -2075,7 +2099,7 @@ mod tests {
 
     #[test]
     fn package_text_includes_validation_passes() {
-        let text = package_text(&data("case9.m"), None, 0).unwrap();
+        let (text, _) = package_text(&data("case9.m"), None, 0).unwrap();
         let pkg = NetworkPackage::from_json(&text).unwrap();
         assert!(
             pkg.validation

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1397,7 +1397,7 @@ fn run_convert(
             to.name()
         );
     }
-    let (text, sidecars, warnings) = if let Some(target) = to.transmission() {
+    let (text, sidecars, warnings, parse_errors) = if let Some(target) = to.transmission() {
         let options = gen_cost_options.write_options()?;
         // gridfm reads a Parquet dataset directory (the parquet-free
         // `parse_file` can't), so it routes through powerio-matrix's reader,
@@ -1426,7 +1426,7 @@ fn run_convert(
         };
         let conv = powerio_matrix::write_as_with_options(&net, target, &options)
             .with_context(|| format!("serializing to {target}"))?;
-        (conv.text, Vec::new(), conv.warnings)
+        (conv.text, Vec::new(), conv.warnings, Vec::new())
     } else {
         let net = if let Some(case) = &classified {
             match parse_classified_case(case, input)? {
@@ -1446,12 +1446,43 @@ fn run_convert(
             .distribution()
             .expect("the family check routed a transmission target here");
         let conv = net.to_format(target);
-        (conv.text, conv.sidecars, conv.warnings)
+        (
+            conv.text,
+            conv.sidecars,
+            conv.warnings,
+            parse_error_lines(&net.parse_diagnostics),
+        )
     };
     for w in &warnings {
         eprintln!("fidelity: {w}");
     }
-    write_conversion_output(&text, &sidecars, output)
+    write_conversion_output(&text, &sidecars, output)?;
+    fail_on_parse_errors(&parse_errors)
+}
+
+/// The `Error`-or-worse parse findings, formatted for stderr.
+fn parse_error_lines(diagnostics: &[powerio_dist::StructuredDiagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.severity >= powerio_dist::DiagnosticSeverity::Error)
+        .map(|d| format!("{}: {}", d.code, d.message))
+        .collect()
+}
+
+/// Exit nonzero after the output is written: the file exists for
+/// inspection, but the parse was incomplete and scripts must not treat the
+/// run as clean (#275).
+fn fail_on_parse_errors(parse_errors: &[String]) -> anyhow::Result<()> {
+    if parse_errors.is_empty() {
+        return Ok(());
+    }
+    for e in parse_errors {
+        eprintln!("error: {e}");
+    }
+    anyhow::bail!(
+        "{} parse error(s); the output is incomplete (see the error lines above)",
+        parse_errors.len()
+    )
 }
 
 /// Write conversion `text` to `output` (stdout on `-` or `None`), placing any

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -508,3 +508,55 @@ fn convert_exits_nonzero_on_a_refused_include() {
 
     let _ = std::fs::remove_dir_all(dir);
 }
+
+#[cfg(unix)]
+#[test]
+fn convert_exits_nonzero_on_an_include_refused_through_a_symbolic_link() {
+    // The lexical check passes this include: the link sits in the case
+    // directory. Only the loader sees that it resolves out of it.
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("powerio-cli-symlink-{stamp}"));
+    let case_dir = dir.join("case");
+    std::fs::create_dir_all(&case_dir).unwrap();
+    std::fs::write(
+        dir.join("shared.dss"),
+        "New Linecode.lc1 nphases=3 r1=0.1 x1=0.2\n",
+    )
+    .unwrap();
+    std::os::unix::fs::symlink("../shared.dss", case_dir.join("link.dss")).unwrap();
+    let master = case_dir.join("master.dss");
+    std::fs::write(
+        &master,
+        "New Circuit.c1\nRedirect link.dss\nNew Line.l1 bus1=a bus2=b linecode=lc1\n",
+    )
+    .unwrap();
+    let out_path = dir.join("out.json");
+
+    let out = run(&[
+        "convert",
+        master.to_str().unwrap(),
+        "--to",
+        "bmopf",
+        "-o",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("READ.DSS.INCLUDE_REFUSED"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("symbolic link"),
+        "the refusal must name the route:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("references unknown linecode"),
+        "the linked file must stay unread:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -458,3 +458,53 @@ fn batch_scan_where_nothing_loads_fails() {
         "expected the zero-loaded error:\n{stderr}"
     );
 }
+
+#[test]
+fn convert_exits_nonzero_on_a_refused_include() {
+    // #275: the parse continues past a refused include and the output is
+    // still written, but the run must not exit 0.
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!("powerio-cli-refused-{stamp}"));
+    let case_dir = dir.join("case");
+    std::fs::create_dir_all(&case_dir).unwrap();
+    std::fs::write(
+        dir.join("shared.dss"),
+        "New Linecode.lc1 nphases=3 r1=0.1 x1=0.2\n",
+    )
+    .unwrap();
+    let master = case_dir.join("master.dss");
+    std::fs::write(
+        &master,
+        "New Circuit.c1\nRedirect ../shared.dss\nNew Line.l1 bus1=a bus2=b linecode=lc1\n",
+    )
+    .unwrap();
+    let out_path = dir.join("out.json");
+
+    let out = run(&[
+        "convert",
+        master.to_str().unwrap(),
+        "--to",
+        "bmopf",
+        "-o",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("READ.DSS.INCLUDE_REFUSED"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("the output is incomplete"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        out_path.is_file(),
+        "the output must still be written for inspection"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -463,11 +463,8 @@ fn batch_scan_where_nothing_loads_fails() {
 fn convert_exits_nonzero_on_a_refused_include() {
     // #275: the parse continues past a refused include and the output is
     // still written, but the run must not exit 0.
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("powerio-cli-refused-{stamp}"));
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
     let case_dir = dir.join("case");
     std::fs::create_dir_all(&case_dir).unwrap();
     std::fs::write(
@@ -505,8 +502,6 @@ fn convert_exits_nonzero_on_a_refused_include() {
         out_path.is_file(),
         "the output must still be written for inspection"
     );
-
-    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[cfg(unix)]
@@ -514,11 +509,8 @@ fn convert_exits_nonzero_on_a_refused_include() {
 fn convert_exits_nonzero_on_an_include_refused_through_a_symbolic_link() {
     // The lexical check passes this include: the link sits in the case
     // directory. Only the loader sees that it resolves out of it.
-    let stamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let dir = std::env::temp_dir().join(format!("powerio-cli-symlink-{stamp}"));
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
     let case_dir = dir.join("case");
     std::fs::create_dir_all(&case_dir).unwrap();
     std::fs::write(
@@ -557,6 +549,95 @@ fn convert_exits_nonzero_on_an_include_refused_through_a_symbolic_link() {
         stderr.contains("references unknown linecode"),
         "the linked file must stay unread:\n{stderr}"
     );
+}
 
-    let _ = std::fs::remove_dir_all(dir);
+#[test]
+fn package_exits_nonzero_on_a_refused_include() {
+    // The package envelope carries the same `Error` finding convert fails on,
+    // so the package subcommand has to fail with it too — otherwise a script
+    // gating on the exit code accepts a package built from a truncated network.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let case_dir = dir.join("case");
+    std::fs::create_dir_all(&case_dir).unwrap();
+    std::fs::write(
+        dir.join("shared.dss"),
+        "New Linecode.lc1 nphases=3 r1=0.1 x1=0.2\n",
+    )
+    .unwrap();
+    let master = case_dir.join("master.dss");
+    std::fs::write(
+        &master,
+        "New Circuit.c1\nRedirect ../shared.dss\nNew Line.l1 bus1=a bus2=b linecode=lc1\n",
+    )
+    .unwrap();
+    let out_path = dir.join("out.pio.json");
+
+    let out = run(&[
+        "package",
+        master.to_str().unwrap(),
+        "-o",
+        out_path.to_str().unwrap(),
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("READ.DSS.INCLUDE_REFUSED"),
+        "stderr:\n{stderr}"
+    );
+    assert!(
+        out_path.is_file(),
+        "the package must still be written for inspection"
+    );
+}
+
+#[test]
+fn an_unreadable_include_is_a_warning_not_a_containment_refusal() {
+    // A file the OS refuses to open raises the same `PermissionDenied` kind the
+    // loader uses for its own symlink-escape refusal. Only the loader's own
+    // refusal is a containment failure; an ordinary unreadable include inside
+    // the case directory stays a warning and the run still exits 0.
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    let unreadable = dir.join("shared.dss");
+    std::fs::write(&unreadable, "New Linecode.lc1 nphases=3 r1=0.1 x1=0.2\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).unwrap();
+    }
+    let master = dir.join("master.dss");
+    std::fs::write(
+        &master,
+        "New Circuit.c1\nRedirect shared.dss\nNew Line.l1 bus1=a bus2=b r1=0.1 x1=0.2\n",
+    )
+    .unwrap();
+    let out_path = dir.join("out.json");
+
+    let out = run(&[
+        "convert",
+        master.to_str().unwrap(),
+        "--to",
+        "bmopf",
+        "-o",
+        out_path.to_str().unwrap(),
+    ]);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    #[cfg(unix)]
+    if !nix_running_as_root() {
+        assert!(
+            out.status.success(),
+            "an unreadable include is not an escape attempt:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("READ.DSS.INCLUDE_REFUSED"),
+            "stderr:\n{stderr}"
+        );
+    }
+}
+
+/// Root reads a mode 000 file, so the permission case cannot be staged there.
+#[cfg(unix)]
+fn nix_running_as_root() -> bool {
+    std::fs::File::open("/proc/1/mem").is_ok() || std::env::var("USER").is_ok_and(|u| u == "root")
 }

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -366,18 +366,20 @@ pub fn parse_file(
     }
 }
 
-/// Prepend the reader's parse warnings to the writer's fidelity warnings: the
+/// Prepend the reader's parse warnings and diagnostics to the writer's: the
 /// one-shot converters return no handle to query, so this is the only place
 /// the loud half of the parse can surface.
 fn convert(net: &DistNetwork, target: DistTargetFormat) -> Conversion {
     let conv = net.to_format(target);
     let mut warnings = net.warnings.clone();
     warnings.extend(conv.warnings);
+    let mut diagnostics = net.parse_diagnostics.clone();
+    diagnostics.extend(conv.diagnostics);
     Conversion {
         text: conv.text,
         sidecars: conv.sidecars,
         warnings,
-        diagnostics: conv.diagnostics,
+        diagnostics,
     }
 }
 

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -71,6 +71,11 @@ pub enum DiagnosticStage {
     Partner,
 }
 
+/// A `Redirect`/`Compile`/`Buscoords` include the reader refused because it
+/// escapes the case directory. Severity `Error`: the parse continued, but
+/// the network is incomplete.
+pub const READ_DSS_INCLUDE_REFUSED: &str = "READ.DSS.INCLUDE_REFUSED";
+
 /// One structured conversion finding.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/powerio-dist/src/dss/raw.rs
+++ b/powerio-dist/src/dss/raw.rs
@@ -631,20 +631,45 @@ impl<L: Loader> Executor<'_, L> {
             let message = ctx(format!(
                 "{verb} {file_arg}: refused; include escapes the case directory"
             ));
-            self.raw.warn(message.clone());
-            self.raw.diagnostics.push(
-                crate::diagnostics::StructuredDiagnostic::new(
-                    crate::diagnostics::READ_DSS_INCLUDE_REFUSED,
-                    crate::diagnostics::DiagnosticSeverity::Error,
-                    crate::diagnostics::DiagnosticStage::Parse,
-                    message,
-                )
-                .with_suggested_action(
-                    "place included files inside the case directory, or merge them into the case",
-                ),
-            );
+            self.refuse(message);
         }
         resolved
+    }
+
+    /// Records a refused include: the warning line and the `Error` finding
+    /// that keeps the run from exiting 0.
+    fn refuse(&mut self, message: String) {
+        self.raw.warn(message.clone());
+        self.raw.diagnostics.push(
+            crate::diagnostics::StructuredDiagnostic::new(
+                crate::diagnostics::READ_DSS_INCLUDE_REFUSED,
+                crate::diagnostics::DiagnosticSeverity::Error,
+                crate::diagnostics::DiagnosticStage::Parse,
+                message,
+            )
+            .with_suggested_action(
+                "place included files inside the case directory, or merge them into the case",
+            ),
+        );
+    }
+
+    /// Records a failed include load. `PermissionDenied` is the loader's
+    /// containment refusal, which the lexical check cannot see: the path is
+    /// inside the case directory but resolves out of it through a symbolic
+    /// link. It carries the same code and severity as a lexical refusal.
+    fn warn_load_error(
+        &mut self,
+        verb: &str,
+        path: &Path,
+        e: &std::io::Error,
+        ctx: &dyn Fn(String) -> String,
+    ) {
+        let message = ctx(format!("{verb} {}: {e}", path.display()));
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            self.refuse(message);
+        } else {
+            self.raw.warn(message);
+        }
     }
 
     fn do_redirect(&mut self, scan: &mut Scanner, compile: bool, ctx: &dyn Fn(String) -> String) {
@@ -678,10 +703,7 @@ impl<L: Loader> Executor<'_, L> {
                     *top = dir;
                 }
             }
-            Err(e) => {
-                self.raw
-                    .warn(ctx(format!("{verb} {}: {e}", path.display())));
-            }
+            Err(e) => self.warn_load_error(verb, &path, &e, ctx),
         }
     }
 
@@ -717,9 +739,7 @@ impl<L: Loader> Executor<'_, L> {
                     }
                 }
             }
-            Err(e) => self
-                .raw
-                .warn(ctx(format!("buscoords {}: {e}", path.display()))),
+            Err(e) => self.warn_load_error("buscoords", &path, &e, ctx),
         }
     }
 

--- a/powerio-dist/src/dss/raw.rs
+++ b/powerio-dist/src/dss/raw.rs
@@ -653,10 +653,12 @@ impl<L: Loader> Executor<'_, L> {
         );
     }
 
-    /// Records a failed include load. `PermissionDenied` is the loader's
-    /// containment refusal, which the lexical check cannot see: the path is
-    /// inside the case directory but resolves out of it through a symbolic
-    /// link. It carries the same code and severity as a lexical refusal.
+    /// Records a failed include load. A containment refusal is the loader's
+    /// own, covering what the lexical check cannot see: the path is inside the
+    /// case directory but resolves out of it through a symbolic link. It
+    /// carries the same code and severity as a lexical refusal. Every other
+    /// load failure — including a `PermissionDenied` the filesystem raised on
+    /// an include that is where it claims to be — stays a warning.
     fn warn_load_error(
         &mut self,
         verb: &str,
@@ -665,7 +667,7 @@ impl<L: Loader> Executor<'_, L> {
         ctx: &dyn Fn(String) -> String,
     ) {
         let message = ctx(format!("{verb} {}: {e}", path.display()));
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
+        if Containment::refused_by_us(e) {
             self.refuse(message);
         } else {
             self.raw.warn(message);
@@ -961,20 +963,45 @@ pub(crate) fn confined_fs_read(
     path: &Path,
 ) -> std::io::Result<String> {
     let Some(root) = canonical_root else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
+        return Err(Containment::refused(
             "case directory cannot be resolved; includes are disabled",
         ));
     };
     let real = path.canonicalize()?;
     if !real.starts_with(root) {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
+        return Err(Containment::refused(
             "resolves outside the case directory through a symbolic link",
         ));
     }
     std::fs::read_to_string(&real)
 }
+
+/// The loader's own containment refusal, carried inside the `io::Error` so it
+/// stays distinguishable from a `PermissionDenied` the filesystem raised. A
+/// mode 000 file inside the case directory is an ordinary unreadable include,
+/// not an escape attempt, and must not be reported as one.
+#[derive(Debug)]
+pub(crate) struct Containment(&'static str);
+
+impl Containment {
+    fn refused(reason: &'static str) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, Containment(reason))
+    }
+
+    /// Whether `e` is a refusal this module raised.
+    pub(crate) fn refused_by_us(e: &std::io::Error) -> bool {
+        e.get_ref()
+            .is_some_and(<dyn std::error::Error + Send + Sync>::is::<Self>)
+    }
+}
+
+impl std::fmt::Display for Containment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+
+impl std::error::Error for Containment {}
 
 /// Like [`parse_raw_with`], but confines `Redirect`/`Compile`/`Buscoords`
 /// includes to the directory of `path`: an include that is absolute or climbs

--- a/powerio-dist/src/dss/raw.rs
+++ b/powerio-dist/src/dss/raw.rs
@@ -237,6 +237,9 @@ pub struct RawDss {
     pub buscoords: Vec<BusCoord>,
     pub vars: VarMap,
     pub warnings: Vec<String>,
+    /// Structured findings beside `warnings`; an `Error` entry marks an
+    /// incomplete parse the CLI must not exit 0 on.
+    pub diagnostics: Vec<crate::diagnostics::StructuredDiagnostic>,
     index: BTreeMap<(String, String), usize>,
     active: Option<usize>,
 }
@@ -625,9 +628,21 @@ impl<L: Loader> Executor<'_, L> {
     ) -> Option<PathBuf> {
         let resolved = self.resolve(file_arg);
         if resolved.is_none() {
-            self.raw.warn(ctx(format!(
+            let message = ctx(format!(
                 "{verb} {file_arg}: refused; include escapes the case directory"
-            )));
+            ));
+            self.raw.warn(message.clone());
+            self.raw.diagnostics.push(
+                crate::diagnostics::StructuredDiagnostic::new(
+                    crate::diagnostics::READ_DSS_INCLUDE_REFUSED,
+                    crate::diagnostics::DiagnosticSeverity::Error,
+                    crate::diagnostics::DiagnosticStage::Parse,
+                    message,
+                )
+                .with_suggested_action(
+                    "place included files inside the case directory, or merge them into the case",
+                ),
+            );
         }
         resolved
     }
@@ -1381,6 +1396,19 @@ mod tests {
                 .filter(|w| w.contains("escapes the case directory"))
                 .count(),
             3
+        );
+        // Each refusal is also an Error-severity finding (#275): the parse
+        // continued, but the network is incomplete.
+        let refused: Vec<_> = raw
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.as_str() == crate::diagnostics::READ_DSS_INCLUDE_REFUSED)
+            .collect();
+        assert_eq!(refused.len(), 3);
+        assert!(
+            refused
+                .iter()
+                .all(|d| d.severity == crate::diagnostics::DiagnosticSeverity::Error)
         );
     }
 

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -148,6 +148,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> DistNetwork {
             source: Some(source),
             source_format: Some(DistSourceFormat::Dss),
             warnings: raw.warnings.clone(),
+            parse_diagnostics: raw.diagnostics.clone(),
             ..DistNetwork::default()
         },
         buses: BTreeMap::new(),

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -934,6 +934,12 @@ pub struct DistNetwork {
     #[serde(skip)]
     pub defaulted: BTreeMap<String, Vec<&'static str>>,
     pub warnings: Vec<String>,
+    /// Structured findings from the parse session. An `Error` entry means
+    /// the network is incomplete (for example a refused include). Skipped
+    /// in the `.pio.json` payload: the wire spelling is a v0.9 register
+    /// decision, and package diagnostics live in the envelope.
+    #[serde(skip)]
+    pub parse_diagnostics: Vec<crate::diagnostics::StructuredDiagnostic>,
     /// Retained source text for the byte-exact echo tier. Skipped in the
     /// `.pio.json` payload (mirrors `powerio::Network::source`): keeping it out
     /// avoids serde's `rc` feature, and retained source is an envelope concern
@@ -973,6 +979,7 @@ impl Default for DistNetwork {
             options: Vec::new(),
             defaulted: BTreeMap::new(),
             warnings: Vec::new(),
+            parse_diagnostics: Vec::new(),
             source: None,
             source_format: None,
             extras: Extras::new(),

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -318,10 +318,6 @@ impl NetworkPackage {
         self.validation = ValidationSummary::from_diagnostics(&self.diagnostics);
     }
 
-    /// Wrap a multiconductor network. Parse `warnings` are lifted into structured
-    /// diagnostics, and `defaulted` fields are lifted into source maps with
-    /// `mapping_kind = defaulted`, so the package surfaces that provenance even
-    /// though those parser-side fields are not part of the IR payload.
     /// The dist crate mirrors the package diagnostic shape without a
     /// dependency on this crate; this maps between the twin types.
     fn lift_dist_diagnostic(d: &powerio_dist::StructuredDiagnostic) -> StructuredDiagnostic {
@@ -341,9 +337,9 @@ impl NetworkPackage {
             DG::Emit => DiagnosticStage::Emit,
             DG::Bind => DiagnosticStage::Bind,
             DG::Partner => DiagnosticStage::Partner,
-            // The dist stage enum is non_exhaustive; an unknown stage
-            // reads as the read stage.
-            DG::Read | _ => DiagnosticStage::Read,
+            // The dist stage enum is non_exhaustive; `Read` and any stage a
+            // newer dist crate adds read as the read stage.
+            _ => DiagnosticStage::Read,
         };
         StructuredDiagnostic {
             code: d.code.as_str().into(),
@@ -358,6 +354,10 @@ impl NetworkPackage {
         }
     }
 
+    /// Wrap a multiconductor network. Parse `warnings` are lifted into structured
+    /// diagnostics, and `defaulted` fields are lifted into source maps with
+    /// `mapping_kind = defaulted`, so the package surfaces that provenance even
+    /// though those parser-side fields are not part of the IR payload.
     pub fn from_multiconductor(net: MulticonductorNetwork) -> Self {
         let summary = multiconductor_summary(&net);
         let sources = multiconductor_sources(&net);

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -322,6 +322,39 @@ impl NetworkPackage {
     /// diagnostics, and `defaulted` fields are lifted into source maps with
     /// `mapping_kind = defaulted`, so the package surfaces that provenance even
     /// though those parser-side fields are not part of the IR payload.
+    /// The dist crate mirrors the package diagnostic shape without a
+    /// dependency on this crate; this maps between the twin types.
+    fn lift_dist_diagnostic(d: &powerio_dist::StructuredDiagnostic) -> StructuredDiagnostic {
+        use powerio_dist::{DiagnosticSeverity as DS, DiagnosticStage as DG};
+        let severity = match d.severity {
+            DS::Debug => DiagnosticSeverity::Debug,
+            DS::Info => DiagnosticSeverity::Info,
+            DS::Warning => DiagnosticSeverity::Warning,
+            DS::Error => DiagnosticSeverity::Error,
+            DS::Fatal => DiagnosticSeverity::Fatal,
+            // The dist enums are non_exhaustive. Map an unknown severity
+            // to Error: never downgrade a finding this crate cannot name.
+            _ => DiagnosticSeverity::Error,
+        };
+        let stage = match d.stage {
+            DG::Parse => DiagnosticStage::Parse,
+            DG::Read => DiagnosticStage::Read,
+            DG::Canonicalize => DiagnosticStage::Canonicalize,
+            DG::Validate => DiagnosticStage::Validate,
+            DG::Lower => DiagnosticStage::Lower,
+            DG::Emit => DiagnosticStage::Emit,
+            DG::Bind => DiagnosticStage::Bind,
+            DG::Partner => DiagnosticStage::Partner,
+            _ => DiagnosticStage::Read,
+        };
+        let mut out = StructuredDiagnostic::new(d.code.as_str(), severity, stage, d.message.clone());
+        out.element_path = d.element_path.clone();
+        out.details = d.details.clone();
+        out.suggested_action = d.suggested_action.clone();
+        out.safe_to_ignore = d.safe_to_ignore.clone();
+        out
+    }
+
     pub fn from_multiconductor(net: MulticonductorNetwork) -> Self {
         let summary = multiconductor_summary(&net);
         let sources = multiconductor_sources(&net);
@@ -329,18 +362,30 @@ impl NetworkPackage {
         let source_maps = multiconductor_source_maps(&net, source_id.as_deref());
         let origin = multiconductor_origin(&net);
 
-        let diagnostics: Vec<StructuredDiagnostic> = net
-            .warnings
+        // Typed parse findings keep their severity (a refused include is an
+        // `Error`); each remaining warning string lifts at `Warning`. A
+        // typed finding and its warning twin share one message, so the
+        // filter keeps the pair from appearing twice.
+        let mut diagnostics: Vec<StructuredDiagnostic> = net
+            .parse_diagnostics
             .iter()
-            .map(|w| {
-                StructuredDiagnostic::new(
-                    "READ.DIST.PARSE_WARNING",
-                    DiagnosticSeverity::Warning,
-                    DiagnosticStage::Read,
-                    w.clone(),
-                )
-            })
+            .map(Self::lift_dist_diagnostic)
             .collect();
+        let typed: std::collections::BTreeSet<String> =
+            diagnostics.iter().map(|d| d.message.clone()).collect();
+        diagnostics.extend(
+            net.warnings
+                .iter()
+                .filter(|w| !typed.contains(w.as_str()))
+                .map(|w| {
+                    StructuredDiagnostic::new(
+                        "READ.DIST.PARSE_WARNING",
+                        DiagnosticSeverity::Warning,
+                        DiagnosticStage::Read,
+                        w.clone(),
+                    )
+                }),
+        );
         let validation = ValidationSummary::from_diagnostics(&diagnostics);
 
         Self {

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -332,27 +332,30 @@ impl NetworkPackage {
             DS::Warning => DiagnosticSeverity::Warning,
             DS::Error => DiagnosticSeverity::Error,
             DS::Fatal => DiagnosticSeverity::Fatal,
-            // The dist enums are non_exhaustive. Map an unknown severity
-            // to Error: never downgrade a finding this crate cannot name.
-            _ => DiagnosticSeverity::Error,
         };
         let stage = match d.stage {
             DG::Parse => DiagnosticStage::Parse,
-            DG::Read => DiagnosticStage::Read,
             DG::Canonicalize => DiagnosticStage::Canonicalize,
             DG::Validate => DiagnosticStage::Validate,
             DG::Lower => DiagnosticStage::Lower,
             DG::Emit => DiagnosticStage::Emit,
             DG::Bind => DiagnosticStage::Bind,
             DG::Partner => DiagnosticStage::Partner,
-            _ => DiagnosticStage::Read,
+            // The dist stage enum is non_exhaustive; an unknown stage
+            // reads as the read stage.
+            DG::Read | _ => DiagnosticStage::Read,
         };
-        let mut out = StructuredDiagnostic::new(d.code.as_str(), severity, stage, d.message.clone());
-        out.element_path = d.element_path.clone();
-        out.details = d.details.clone();
-        out.suggested_action = d.suggested_action.clone();
-        out.safe_to_ignore = d.safe_to_ignore.clone();
-        out
+        StructuredDiagnostic {
+            code: d.code.as_str().into(),
+            severity,
+            stage,
+            message: d.message.clone(),
+            element_path: d.element_path.clone(),
+            source_ref: None,
+            details: d.details.clone(),
+            suggested_action: d.suggested_action.clone(),
+            safe_to_ignore: d.safe_to_ignore.clone(),
+        }
     }
 
     pub fn from_multiconductor(net: MulticonductorNetwork) -> Self {

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2534,12 +2534,13 @@ fn refused_include_lifts_as_an_error_diagnostic() {
     let mut net = powerio_dist::parse_str("New Circuit.c1", "dss").expect("parse dss");
     let message = "redirect ../shared.dss: refused; include escapes the case directory";
     net.warnings.push(message.to_owned());
-    net.parse_diagnostics.push(powerio_dist::StructuredDiagnostic::new(
-        powerio_dist::diagnostics::READ_DSS_INCLUDE_REFUSED,
-        powerio_dist::DiagnosticSeverity::Error,
-        powerio_dist::DiagnosticStage::Parse,
-        message,
-    ));
+    net.parse_diagnostics
+        .push(powerio_dist::StructuredDiagnostic::new(
+            powerio_dist::diagnostics::READ_DSS_INCLUDE_REFUSED,
+            powerio_dist::DiagnosticSeverity::Error,
+            powerio_dist::DiagnosticStage::Parse,
+            message,
+        ));
 
     let pkg = NetworkPackage::from_multiconductor(net);
     let carrying: Vec<_> = pkg

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2524,3 +2524,30 @@ fn multiconductor_nonfinite_ratings_and_scalars_roundtrip() {
     assert!(capacitor.q_rated.is_nan());
     assert!(capacitor.v_nom.is_nan());
 }
+
+#[test]
+fn refused_include_lifts_as_an_error_diagnostic() {
+    // #275: a typed parse finding keeps its severity in the envelope, and
+    // its warning twin does not appear a second time.
+    use powerio_pkg::{DiagnosticSeverity, ValidationStatus};
+
+    let mut net = powerio_dist::parse_str("New Circuit.c1", "dss").expect("parse dss");
+    let message = "redirect ../shared.dss: refused; include escapes the case directory";
+    net.warnings.push(message.to_owned());
+    net.parse_diagnostics.push(powerio_dist::StructuredDiagnostic::new(
+        powerio_dist::diagnostics::READ_DSS_INCLUDE_REFUSED,
+        powerio_dist::DiagnosticSeverity::Error,
+        powerio_dist::DiagnosticStage::Parse,
+        message,
+    ));
+
+    let pkg = NetworkPackage::from_multiconductor(net);
+    let carrying: Vec<_> = pkg
+        .diagnostics
+        .iter()
+        .filter(|d| d.message == message)
+        .collect();
+    assert_eq!(carrying.len(), 1, "the finding must appear exactly once");
+    assert_eq!(carrying[0].severity, DiagnosticSeverity::Error);
+    assert_eq!(pkg.validation.status, ValidationStatus::Error);
+}


### PR DESCRIPTION
## What this PR does

A refused `Redirect`/`Compile`/`Buscoords` include downgraded to a warning, and a conversion with an incomplete network exited 0 (#275).

- The reader emits a structured `READ.DSS.INCLUDE_REFUSED` finding at `Error` severity beside the existing warning string. The warning text does not change; consumers that match on it see what they saw before.
- `DistNetwork` carries the parse findings in a new `parse_diagnostics` field, outside the wire payload — the wire spelling is a v0.9 register decision.
- The one-shot converters merge parse findings into `Conversion.diagnostics`.
- The package envelope lifts typed findings with their true severity, deduplicated against their warning twins, so a package built from such a parse validates as `Error` instead of `Warning`.
- The CLI `convert` command still writes the output for inspection, then exits nonzero and names each finding:

```
parse: master.dss:3: redirect ../shared.dss: refused; include escapes the case directory
wrote out.json
error: READ.DSS.INCLUDE_REFUSED: redirect ../shared.dss: refused; ...
Error: 1 parse error(s); the output is incomplete (see the error lines above)
exit=1
```

Closes #275.

## Release sequencing

Target release: **v0.8.2**. Sequence: v0.8.1 (fixes) → v0.8.2 (consumer features) → v0.9.0 (breaking changes with deprecation shims) → v1.0.0 (clean break, stability policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_