### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## 0.8.1
+
+Text-writer hardening, JSON reader fidelity, a document-version report
+over the C ABI, and a release gate that tests the Julia binding before any
+binary ships. No breaking changes: every 0.8.0 API, format token, and wire
+version is unchanged.
+
+**Security.** The psse, pslf, powerworld, and OpenDSS writers replace a
+line terminator inside any quoted or free-text field. A name that held a
+`\n` or `\r` ended the record and made the rest of the text parse as new
+records, so a crafted case name, DC line label, circuit id, or bus name
+could forge whole records in the written file. Five such paths are now
+closed, each with a test that reads the written text back and counts the
+records. Upgrade if you write text formats from names you do not control.
+
+- The two C JSON report entry points, `pio_last_error_json` and
+  `pio_schema_versions_json`, now run inside the panic guard the other
+  entry points use. A panic in either one crossed the C boundary, which is
+  undefined behavior.
+- `build_ybus` refuses a case whose base MVA is zero or nonfinite. Such a
+  case wrote a matrix of `NaN` and the CLI exited 0.
+- The auto sensitivity solver reads the real matrix shape (branches by
+  buses) instead of the reduced dimension alone, and holds the dense path
+  to a 2 GiB memory budget. The dense threshold moves from 512 to 8192,
+  because a dense solve is faster than conjugate gradient well past 512
+  buses. Set `SensitivityOptions::auto_dense_threshold` to keep the old
+  value. PTDF and LODF results are unchanged: both paths were verified
+  bit-identical on case30.
+- The psse field splitter, the powerworld auxiliary token splitter, and
+  the pandapower split-frame reader reuse their buffers and move rows
+  instead of copying them. Reader output is unchanged.
+- New `pio_schema_versions_json` C entry point reports the schema version
+  of every document format the library speaks (`.pio.json`, Arrow, the
+  distribution capability document, and the BMOPF vintage). A key is
+  `null` when the owning feature is not compiled in. `PIO_ABI_VERSION`
+  does not cover document formats, so a binding that mirrors one of these
+  versions can now read it from the library and refuse a mismatch at load
+  or pin time instead of finding it downstream (#270, query half).
+- `release-binaries.yml` gates every tag on PowerIO.jl: the workflow
+  builds the tag, runs the binding's suite against it, and produces no
+  tarballs and no draft release on failure. A planned binding break
+  merges the paired PowerIO.jl change first, then re-runs the workflow.
+- The retired schema documents under `docs/schema/` are pinned by a test.
+  A `.pio.json` written before v0.8.0 declares those URLs, so they stay
+  published even though the reader no longer accepts that lineage.
+- The egret and pandapower readers keep unrecognized element fields as
+  `extras` instead of dropping them silently, matching the PowerModels
+  reader. A powerio-written file still reads back extras-free (#263).
+- The PowerModels reader reports the taps it discards: a branch with an
+  off-nominal `tap` but no `transformer: true` flag reads as a line, and
+  one aggregated warning now names the branches and the total. The
+  inference rule itself is unchanged.
+- `.pio.json` validation diagnoses duplicate payload uids directly
+  (`VALIDATE.BALANCED.PAYLOAD_IDENTITY`, a new always-present
+  `balanced.payload_identity` pass) instead of leaving the ambiguity to
+  surface later as a failed operating-point reference.
+- The text-only C conversion entry points warn when a distribution
+  writer produced a companion file they cannot return, naming the file:
+  an OpenDSS deck referencing a `Buscoords` CSV the caller never received
+  no longer fails to compile with nothing to explain why.
+- `summary`, `package`, `convert` without `--from`, and `geo
+  extract|apply` read and classify a `.json` once instead of twice. The
+  distribution reader's own document rule still applies on that path, so
+  a JSON that is not a distribution case is refused as before.
+- Python `Network.ptdf()` / `lodf()` route through the auto sensitivity
+  solver (dense below the reduced-dimension threshold, iterative
+  conjugate gradient above it), matching the CLI `sensitivities`
+  command. Both take `solver="auto"|"dense"|"iterative"`. On a case above
+  the threshold results move from exact-dense to iterative-CG at a 1e-10
+  relative residual (#273).
+
 ## 0.8.0
 
 BMOPF schema 0.1.0 alignment, one version number for `.pio.json`, and distribution JSON reader validation. Two migration notes: `.pio.json` files written by 0.7.x and earlier are rejected with an error that says to regenerate them from their source case (convert with a 0.7.x install to migrate an orphaned file), and the BMOPF writer targets the published schema 0.1.0 `$id`, so consumers that key on the old `$schema` URI should update their accepted list.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arrow",
  "powerio",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "approx",
  "arrow",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-prob"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -39,11 +39,11 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.8.0" }
-powerio-matrix = { path = "powerio-matrix", version = "0.8.0" }
-powerio-prob = { path = "powerio-prob", version = "0.8.0" }
-powerio-dist = { path = "powerio-dist", version = "0.8.0" }
-powerio-pkg = { path = "powerio-pkg", version = "0.8.0" }
+powerio = { path = "powerio", version = "0.8.1" }
+powerio-matrix = { path = "powerio-matrix", version = "0.8.1" }
+powerio-prob = { path = "powerio-prob", version = "0.8.1" }
+powerio-dist = { path = "powerio-dist", version = "0.8.1" }
+powerio-pkg = { path = "powerio-pkg", version = "0.8.1" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }


### PR DESCRIPTION
Release 0.8.1. The commit touches only `CHANGELOG.md`, `Cargo.toml`, and
`Cargo.lock`.

Rebased on main after #295 merged. The 0.8.1 changelog section now covers the
writer hardening as well.

## Contents

Merged since v0.8.0: #280 (schema version report over the C ABI, release gate),
#281 (Python auto sensitivity solver), #282 (docs), #287 (JSON reader
fidelity, single read), #295 (writer hardening, auto solver policy, reader
allocation churn).

The release is a security release as well as a fix release. The psse, pslf,
powerworld, and OpenDSS writers now replace a line terminator inside any
quoted or free-text field. A name that held a `\n` or `\r` ended the record
and made the rest of the text parse as new records, so a crafted case name, DC
line label, circuit id, or bus name could forge whole records in the written
file. Five such paths are closed, each with a test that reads the written text
back and counts the records.

No breaking changes: every 0.8.0 API, format token, and wire version is
unchanged. Two behavior changes are listed in the changelog: `build_ybus`
refuses a case whose base MVA is zero or nonfinite (it wrote a matrix of `NaN`
before), and the auto sensitivity solver moves its dense threshold from 512 to
8192 under a 2 GiB memory budget. PTDF and LODF results are unchanged; both
solver paths were verified bit-identical on case30.

## After the merge

I push the `v0.8.1` tag. `release-binaries.yml` then runs `binding-gate`
first: it builds the tag and runs the PowerIO.jl default-branch suite against
it. A failure produces no tarballs and no draft release. On success the
workflow attaches the five platform tarballs to a draft release, and the
repository dispatch tells PowerIO.jl to repin.

The PowerIO.jl repin is the reason this release matters beyond its contents.
PowerIO.jl main is at 0.8.0 but its `Artifacts.toml` still pins powerio
**v0.7.3** binaries, because v0.8.0 predates the `pio_schema_versions_json`
symbol its gate reads. v0.8.1 is the first tag that carries the symbol.

## Checks

The release body extracts from `CHANGELOG.md` with the workflow's own awk
command (70 lines). Locally green: `cargo fmt --check`, `scripts/ci-clippy.sh`,
`cargo test --workspace` (52 test binaries, 0 failures),
`scripts/capi-header-parity.sh`, the conversion matrix baseline, and `pytest
python/tests` (110 passed).