### PR TITLE
Close the record-injection seams; fix the auto solver policy and reader allocation churn

### DIFF
--- a/powerio-capi/README.md
+++ b/powerio-capi/README.md
@@ -217,8 +217,10 @@ Every entry point is hardened at the boundary:
   elements into each non-NULL buffer and return the total available, so a
   miscounted buffer reads short instead of overflowing, and `(NULL, 0)` sizes
   it. `pio_warnings` returns the byte length needed the same way.
-- A handle is immutable after construction: concurrent reads from any number
-  of threads are safe. `pio_network_free` is not; free exactly once.
+- A handle is immutable after construction unless a function takes it
+  non-`const` (`pio_package_validate`, `pio_package_set_operating_points`):
+  concurrent reads from any number of threads are safe, while those two and
+  `pio_*_free` need exclusive access. Free exactly once.
 
 Input size is not capped. Callers that accept untrusted input must impose their
 own byte and resource limits. The panic guards require the default

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -29,6 +29,13 @@
  * - Array extractors write up to `cap` values per output array and return the
  *   total available. NULL out or cap 0 is a count query. No extractor writes
  *   more than cap entries to an output array.
+ * - Size a per-bus buffer from the extractor's own count query, not from
+ *   pio_n_buses. A case with an in-service 3-winding transformer star-lowers
+ *   before the dense extractors run, so pio_bus_demand / pio_bus_shunt and
+ *   pio_n_islands see one added star bus per such transformer, while
+ *   pio_n_buses and pio_bus_ids report the unexpanded table. Sizing off
+ *   pio_n_buses reads short (never past cap); the trailing entries have no
+ *   pio_bus_ids id. Aligning the two is a v5 change.
  * - Bus ids are int64 in the range 1..2^63-1 (a v4 invariant). pio_bus_ids and
  *   every per-bus column keyed to its ordering are int64; a source whose ids are
  *   strings or exceed 2^63-1 has no representation in this API and is mapped
@@ -840,8 +847,8 @@ PioDistNetwork *pio_package_to_multiconductor_network(const PioPackage *pkg,
  * Unlike the read-only accessors, this rewrites the handle's `diagnostics` and
  * `validation` (the payload is untouched), so it takes the handle non-`const`
  * and needs exclusive access: no other call may touch the same handle
- * concurrently. This is the one exception to the header's blanket
- * concurrent-read guarantee.
+ * concurrently. [`pio_package_set_operating_points`] is the other such
+ * entry point; every other call takes the handle `const` and shares it.
  */
 int32_t pio_package_validate(PioPackage *pkg, char *errbuf, size_t errlen);
 #endif
@@ -876,6 +883,10 @@ char *pio_package_operating_points_json(const PioPackage *pkg, char *errbuf, siz
  * Replace the package's operating point series from `json`. `null` or an
  * empty series clears it. Validation is recomputed before this function
  * returns. Returns `0` on success and `-1` on error.
+ *
+ * This rewrites the handle, so it takes it non-`const` and needs exclusive
+ * access: no other call may touch the same handle concurrently. See
+ * [`pio_package_validate`], the other such entry point.
  */
 int32_t pio_package_set_operating_points(PioPackage *pkg,
                                          const char *json,

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -270,7 +270,14 @@ fn dist_capabilities_json() -> String {
 #[cfg(feature = "dist")]
 #[unsafe(no_mangle)]
 pub extern "C" fn pio_dist_capabilities_json() -> *mut c_char {
-    into_cstring(dist_capabilities_json()).unwrap_or(std::ptr::null_mut())
+    // Guarded like every other allocating entry point: `serde_json::json!`
+    // expands to `to_value(..).unwrap()`, so the panic-free property would
+    // otherwise rest on the current field types alone.
+    unsafe {
+        guard(std::ptr::null_mut(), || {
+            into_cstring(dist_capabilities_json()).unwrap_or(std::ptr::null_mut())
+        })
+    }
 }
 
 /// Report the schema version of each document format in this library, as
@@ -283,6 +290,11 @@ pub extern "C" fn pio_dist_capabilities_json() -> *mut c_char {
 /// this document's own shape.
 #[unsafe(no_mangle)]
 pub extern "C" fn pio_schema_versions_json() -> *mut c_char {
+    unsafe { guard(std::ptr::null_mut(), schema_versions_json_ptr) }
+}
+
+/// The body of [`pio_schema_versions_json`], called inside the panic guard.
+fn schema_versions_json_ptr() -> *mut c_char {
     // `None` serializes to `null`: the build cannot speak that format.
     #[cfg(feature = "pkg")]
     let package = Some(powerio_pkg::PIO_PACKAGE_SCHEMA_VERSION);
@@ -1719,8 +1731,8 @@ pub unsafe extern "C" fn pio_package_to_multiconductor_network(
 /// Unlike the read-only accessors, this rewrites the handle's `diagnostics` and
 /// `validation` (the payload is untouched), so it takes the handle non-`const`
 /// and needs exclusive access: no other call may touch the same handle
-/// concurrently. This is the one exception to the header's blanket
-/// concurrent-read guarantee.
+/// concurrently. [`pio_package_set_operating_points`] is the other such
+/// entry point; every other call takes the handle `const` and shares it.
 #[cfg(feature = "pkg")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_validate(
@@ -1814,6 +1826,10 @@ pub unsafe extern "C" fn pio_package_operating_points_json(
 /// Replace the package's operating point series from `json`. `null` or an
 /// empty series clears it. Validation is recomputed before this function
 /// returns. Returns `0` on success and `-1` on error.
+///
+/// This rewrites the handle, so it takes it non-`const` and needs exclusive
+/// access: no other call may touch the same handle concurrently. See
+/// [`pio_package_validate`], the other such entry point.
 #[cfg(feature = "pkg")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_package_set_operating_points(

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -291,9 +291,24 @@ fn zipv_cutoff(value: Option<&serde_json::Value>) -> Option<f64> {
 fn name_breaks_dss(name: &str, is_bus_id: bool) -> bool {
     name.contains("//")
         || name.chars().any(|c| {
+            // A line terminator does not shift a token, it ends the command
+            // and makes the rest of the name parse as a new dss object.
             matches!(
                 c,
-                ' ' | '\t' | ',' | '=' | '!' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'
+                ' ' | '\t'
+                    | '\n'
+                    | '\r'
+                    | ','
+                    | '='
+                    | '!'
+                    | '"'
+                    | '\''
+                    | '('
+                    | ')'
+                    | '['
+                    | ']'
+                    | '{'
+                    | '}'
             ) || (is_bus_id && c == '.')
         })
 }

--- a/powerio-matrix/src/matrix/laplacian.rs
+++ b/powerio-matrix/src/matrix/laplacian.rs
@@ -77,11 +77,22 @@ impl Grounding {
     /// Full index → reduced index, or `None` for a grounded index. The shift is
     /// `i − (number of grounds strictly below i)`.
     pub(crate) fn reduced(&self, i: usize) -> Option<usize> {
-        if self.grounds.binary_search(&i).is_ok() {
+        // One search, not two: `below` is the count of grounds under `i`, and
+        // the entry at that position is `i` itself exactly when `i` is
+        // grounded.
+        let below = self.grounds.partition_point(|&g| g < i);
+        if self.grounds.get(below) == Some(&i) {
             None
         } else {
-            Some(i - self.grounds.partition_point(|&g| g < i))
+            Some(i - below)
         }
+    }
+
+    /// Full indices of the surviving rows, reduced index order. Hoists
+    /// [`Self::reduced`] out of a loop that would otherwise call it per
+    /// column.
+    pub(crate) fn full_of_reduced(&self, n: usize) -> Vec<usize> {
+        (0..n).filter(|&i| self.reduced(i).is_some()).collect()
     }
 }
 

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -422,12 +422,17 @@ fn ptdf_dense_with_path(
     // into a PTDF row.
     let flow = build_flow_map(&inc.a, &inc.b); // m × n
     let mut ptdf = vec![0.0; m * n];
+    // Reduced → full column map, built once. The inner loop then walks the
+    // Rinv row contiguously and skips grounded columns instead of testing
+    // every one of them; reduced order is ascending full order, so the
+    // accumulation order is unchanged.
+    let full_of = g.full_of_reduced(n);
     for (&w, (l, c)) in flow.iter() {
         let Some(rc) = g.reduced(c) else { continue }; // Minv row at a slack is 0
-        for k in 0..n {
-            if let Some(rk) = g.reduced(k) {
-                ptdf[l * n + k] += w * rinv[rc * nr + rk];
-            }
+        let row = &rinv[rc * nr..rc * nr + nr];
+        let out = &mut ptdf[l * n..l * n + n];
+        for (rk, &k) in full_of.iter().enumerate() {
+            out[k] += w * row[rk];
         }
     }
     Ok((ptdf, m, n, solver_path))
@@ -604,19 +609,36 @@ fn dense_to_csr_with_drop(
     cols: usize,
     drop_tolerance: f64,
 ) -> (CsMat<f64>, usize) {
-    let mut coo = CooBuilder::with_capacity_rect(rows, cols, dense.len() / 2);
+    // The scan is row major and every coordinate is unique, so the CSR
+    // arrays fill directly. Routing it through a hash map bought a dedup
+    // that cannot fire, then copied the entries into a triplet matrix and
+    // sorted them: on a 10k-bus PTDF that was several GB of intermediates
+    // and an O(nnz log nnz) sort to emit an already-ordered matrix. One
+    // counting pass sizes the buffers exactly instead.
     let mut dropped = 0usize;
+    let mut nnz = 0usize;
+    for &v in dense {
+        if v.abs() > drop_tolerance {
+            nnz += 1;
+        } else if v != 0.0 {
+            dropped += 1;
+        }
+    }
+    let mut indptr = Vec::with_capacity(rows + 1);
+    let mut indices = Vec::with_capacity(nnz);
+    let mut data = Vec::with_capacity(nnz);
+    indptr.push(0usize);
     for i in 0..rows {
         for j in 0..cols {
             let v = dense[i * cols + j];
             if v.abs() > drop_tolerance {
-                coo.add(i, j, v);
-            } else if v != 0.0 {
-                dropped += 1;
+                indices.push(j);
+                data.push(v);
             }
         }
+        indptr.push(data.len());
     }
-    (coo.finish_csr(), dropped)
+    (CsMat::new((rows, cols), indptr, indices, data), dropped)
 }
 
 fn dense_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -29,7 +29,31 @@ use crate::{Error, Result};
 const PRUNE: f64 = 1e-12;
 const DEFAULT_CG_TOLERANCE: f64 = 1e-10;
 const DEFAULT_CG_MAX_ITERATIONS: usize = 20_000;
-const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 512;
+/// Reduced-dimension ceiling for the `Auto` dense path. The old value of 512
+/// was far below the real crossover: at nr = 600 the dense path is a ~7e7
+/// flop factorization while the iterative path runs ~1200 conjugate-gradient
+/// solves, so `Auto` picked the slower solver by one to three orders of
+/// magnitude across the whole range that holds the common published cases
+/// (1354, 2869, 3120, 6470 buses).
+const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 8192;
+
+/// Memory ceiling for the `Auto` dense path. The dimension alone does not
+/// bound the cost: the dense path also materializes an m x n PTDF and an
+/// m x m LODF, so a case with few buses and many parallel branches could ask
+/// for tens of GB while passing any nr test.
+const AUTO_DENSE_MEMORY_BUDGET: usize = 2 << 30;
+
+/// Peak bytes the dense path holds: the reduced Laplacian and its
+/// factorization and inverse (three nr x nr buffers alive together), plus the
+/// dense PTDF and the LODF built from it.
+fn dense_footprint_bytes(reduced_dimension: usize, branches: usize, buses: usize) -> usize {
+    let f = size_of::<f64>();
+    let sq = |a: usize, b: usize| a.saturating_mul(b).saturating_mul(f);
+    sq(reduced_dimension, reduced_dimension)
+        .saturating_mul(3)
+        .saturating_add(sq(branches, buses))
+        .saturating_add(sq(branches, branches))
+}
 const LODF_ISLAND_TOLERANCE: f64 = 1e-9;
 
 /// Solver selection for option based DC sensitivity builds.
@@ -125,16 +149,38 @@ impl SensitivityOptions {
         Ok(())
     }
 
-    /// Return the concrete solver selected for a reduced grounded dimension.
+    /// Return the concrete solver selected for a reduced grounded dimension,
+    /// assuming a square problem. Prefer
+    /// [`Self::selected_solver_for_shape`], which also sees the branch count
+    /// the dense PTDF and LODF are sized by.
     pub fn selected_solver_for_reduced_dimension(
         &self,
         reduced_dimension: usize,
     ) -> SensitivitySolver {
+        self.selected_solver_for_shape(reduced_dimension, reduced_dimension, reduced_dimension)
+    }
+
+    /// Return the concrete solver selected for a problem shape. `Auto` takes
+    /// the dense path while both the reduced dimension and the predicted
+    /// dense footprint stay within their ceilings, so a wide case (few buses,
+    /// many branches) no longer picks a path that would ask for tens of GB.
+    pub fn selected_solver_for_shape(
+        &self,
+        reduced_dimension: usize,
+        branches: usize,
+        buses: usize,
+    ) -> SensitivitySolver {
         match self.solver {
-            SensitivitySolver::Auto if reduced_dimension > self.auto_dense_threshold => {
-                SensitivitySolver::Iterative
+            SensitivitySolver::Auto => {
+                let fits = reduced_dimension <= self.auto_dense_threshold
+                    && dense_footprint_bytes(reduced_dimension, branches, buses)
+                        <= AUTO_DENSE_MEMORY_BUDGET;
+                if fits {
+                    SensitivitySolver::Dense
+                } else {
+                    SensitivitySolver::Iterative
+                }
             }
-            SensitivitySolver::Auto => SensitivitySolver::Dense,
             other => other,
         }
     }
@@ -225,7 +271,7 @@ pub fn build_ptdf_lodf_with_options(
     let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
 
     let (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped) = match options
-        .selected_solver_for_reduced_dimension(reduced_dimension)
+        .selected_solver_for_shape(reduced_dimension, inc.m(), inc.n())
     {
         SensitivitySolver::Dense => {
             let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
@@ -276,34 +322,34 @@ pub(crate) fn for_each_ptdf_lodf_entry(
     let inc = build_incidence(case, options.convention, &BuildOptions::default())?;
     let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
 
-    let (solver_path, ptdf, lodf) = match options
-        .selected_solver_for_reduced_dimension(reduced_dimension)
-    {
-        SensitivitySolver::Dense => {
-            let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
-            let (ptdf, ptdf_dropped) = dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
-            let (lodf, lodf_dropped) =
-                lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
-            let ptdf_meta = matrix_metadata(&ptdf, ptdf_dropped);
-            let lodf_meta = matrix_metadata(&lodf, lodf_dropped);
-            for (&v, (row, col)) in &ptdf {
-                ptdf_entry(row, col, v)?;
+    let (solver_path, ptdf, lodf) =
+        match options.selected_solver_for_shape(reduced_dimension, inc.m(), inc.n()) {
+            SensitivitySolver::Dense => {
+                let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
+                let (ptdf, ptdf_dropped) =
+                    dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
+                let (lodf, lodf_dropped) =
+                    lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
+                let ptdf_meta = matrix_metadata(&ptdf, ptdf_dropped);
+                let lodf_meta = matrix_metadata(&lodf, lodf_dropped);
+                for (&v, (row, col)) in &ptdf {
+                    ptdf_entry(row, col, v)?;
+                }
+                for (&v, (row, col)) in &lodf {
+                    lodf_entry(row, col, v)?;
+                }
+                (solver_path, ptdf_meta, lodf_meta)
             }
-            for (&v, (row, col)) in &lodf {
-                lodf_entry(row, col, v)?;
+            SensitivitySolver::Iterative => {
+                ensure_iterative_solver_eligible(&inc)?;
+                let (ptdf, lodf) =
+                    iterative_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
+                (SensitivitySolverPath::IterativeCg, ptdf, lodf)
             }
-            (solver_path, ptdf_meta, lodf_meta)
-        }
-        SensitivitySolver::Iterative => {
-            ensure_iterative_solver_eligible(&inc)?;
-            let (ptdf, lodf) =
-                iterative_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
-            (SensitivitySolverPath::IterativeCg, ptdf, lodf)
-        }
-        SensitivitySolver::Auto => {
-            unreachable!("selected_solver_for_reduced_dimension resolves Auto")
-        }
-    };
+            SensitivitySolver::Auto => {
+                unreachable!("selected_solver_for_reduced_dimension resolves Auto")
+            }
+        };
 
     Ok(sensitivity_metadata(
         options,
@@ -880,5 +926,63 @@ impl DenseCholesky {
             }
         }
         inv
+    }
+}
+
+#[cfg(test)]
+mod auto_policy_tests {
+    use super::{
+        AUTO_DENSE_MEMORY_BUDGET, SensitivityOptions, SensitivitySolver, dense_footprint_bytes,
+    };
+
+    #[test]
+    fn auto_takes_the_dense_path_for_a_mid_size_case() {
+        // 2869 buses is a common published case, far inside the dense path's
+        // real crossover; the old 512 ceiling sent it to the iterative
+        // solver, one to three orders of magnitude slower in this range.
+        let o = SensitivityOptions::default();
+        assert_eq!(
+            o.selected_solver_for_shape(2868, 4582, 2869),
+            SensitivitySolver::Dense
+        );
+    }
+
+    #[test]
+    fn auto_refuses_the_dense_path_for_a_wide_case() {
+        // Few buses, very many parallel branches: the reduced dimension is
+        // small but the dense LODF alone is m x m, so the footprint veto has
+        // to fire even though the dimension test passes.
+        let o = SensitivityOptions::default();
+        let (nr, m, n) = (400usize, 40_000usize, 401usize);
+        assert!(nr <= o.auto_dense_threshold);
+        assert!(dense_footprint_bytes(nr, m, n) > AUTO_DENSE_MEMORY_BUDGET);
+        assert_eq!(
+            o.selected_solver_for_shape(nr, m, n),
+            SensitivitySolver::Iterative
+        );
+    }
+
+    #[test]
+    fn an_explicit_solver_choice_ignores_both_ceilings() {
+        for solver in [SensitivitySolver::Dense, SensitivitySolver::Iterative] {
+            let o = SensitivityOptions {
+                solver,
+                ..SensitivityOptions::default()
+            };
+            assert_eq!(o.selected_solver_for_shape(1, 1, 1), solver);
+            assert_eq!(o.selected_solver_for_shape(99_999, 99_999, 99_999), solver);
+        }
+    }
+
+    #[test]
+    fn the_footprint_saturates_instead_of_overflowing() {
+        assert_eq!(
+            SensitivityOptions::default().selected_solver_for_shape(
+                usize::MAX,
+                usize::MAX,
+                usize::MAX
+            ),
+            SensitivitySolver::Iterative
+        );
     }
 }

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -71,6 +71,11 @@ pub fn build_ybus(case: &IndexedNetwork, opts: &super::BuildOptions) -> Result<Y
 // the standard makeYbus notation and the math reads worse spelled out.
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> Result<YbusParts> {
+    // The bus shunt block divides by `per_unit_base()`. A zero or non-finite
+    // base made that `0.0/0.0`, storing NaN on every diagonal — including
+    // shunt-free buses, since `CooBuilder::add` skips only exact zero — and
+    // the matrix shipped with no error.
+    case.network().check_base_mva()?;
     let n = case.n();
     let mut g_coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);
     let mut b_coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -448,7 +448,7 @@ fn auto_sensitivity_solver_switches_to_iterative_above_threshold() {
 }
 
 #[test]
-fn default_auto_writes_iterative_outputs_above_dense_threshold() {
+fn auto_writes_iterative_outputs_above_the_dense_threshold() {
     let n = 600;
     let mut buses = Vec::with_capacity(n);
     buses.push(bus(1, BusType::Ref));
@@ -462,16 +462,17 @@ fn default_auto_writes_iterative_outputs_above_dense_threshold() {
     let reduced_dimension = view.n() - view.reference_bus_indices().len();
     assert!(reduced_dimension > 512);
 
+    // Drive the routing through the knob rather than the default ceiling:
+    // 599 unknowns is far below the real dense/iterative crossover, so the
+    // default now (correctly) takes the dense path here.
+    let options = SensitivityOptions {
+        auto_dense_threshold: 512,
+        ..SensitivityOptions::default()
+    };
     let temp = tempfile::tempdir().unwrap();
     let ptdf_path = temp.path().join("ptdf.mtx");
     let lodf_path = temp.path().join("lodf.mtx");
-    let meta = write_sensitivity_mtx_with_options(
-        &view,
-        &SensitivityOptions::default(),
-        &ptdf_path,
-        &lodf_path,
-    )
-    .unwrap();
+    let meta = write_sensitivity_mtx_with_options(&view, &options, &ptdf_path, &lodf_path).unwrap();
     let ptdf = read_mtx(&ptdf_path).unwrap();
     let lodf = read_mtx(&lodf_path).unwrap();
 

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -1267,21 +1267,21 @@ pub(crate) fn bus_kv(buses: &[Bus], bus_pos: &HashMap<BusId, usize>, bus: BusId)
 /// name both interpolate a `Network` name straight into a quoted field, where an
 /// embedded quote (or, for PSS/E, the `/` inline-comment delimiter) would shift
 /// every later column of the record.
+/// A line terminator is always replaced, whatever `forbidden` holds: no text
+/// record format can carry one inside a field, so an embedded `\n` does not
+/// shift a column, it ends the record and makes everything after it parse as
+/// a new one. A crafted name could otherwise forge whole records in the
+/// written file.
 pub(crate) fn sanitize_quoted<'a>(
     value: &'a str,
     forbidden: &[char],
     replacement: char,
 ) -> std::borrow::Cow<'a, str> {
-    if value.contains(forbidden) {
+    let breaks = |c: char| c == '\n' || c == '\r' || forbidden.contains(&c);
+    if value.contains(breaks) {
         value
             .chars()
-            .map(|c| {
-                if forbidden.contains(&c) {
-                    replacement
-                } else {
-                    c
-                }
-            })
+            .map(|c| if breaks(c) { replacement } else { c })
             .collect::<String>()
             .into()
     } else {
@@ -1379,6 +1379,25 @@ fn collect_null_keys(value: &Value, out: &mut BTreeSet<String>) {
 mod tests {
     use super::*;
     use crate::network::SourceFormat;
+
+    #[test]
+    fn sanitize_quoted_always_replaces_line_terminators() {
+        // A terminator ends the record, so it is replaced whatever the
+        // caller's delimiter set holds: a name carrying one could otherwise
+        // forge whole records in a written .raw/.aux/.epc.
+        for forbidden in [&[][..], &['\''][..], &['"'][..]] {
+            let out = sanitize_quoted("A\n42, 'X'\r\nB", forbidden, ' ');
+            assert!(
+                !out.contains('\n') && !out.contains('\r'),
+                "terminator survived with forbidden={forbidden:?}: {out:?}"
+            );
+        }
+        // A clean value is still borrowed, not copied.
+        assert!(matches!(
+            sanitize_quoted("clean name", &['\''], ' '),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
 
     #[test]
     fn dss_extension_error_names_the_distribution_surface() {

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -1783,10 +1783,10 @@ fn read_frame(root: &Map<String, Value>, name: &str) -> Result<Option<DataFrame>
         .get("_object")
         .and_then(Value::as_str)
         .ok_or_else(|| bad(format!("`{name}` table missing string `_object`")))?;
-    let inner: Value =
+    let mut inner: Value =
         serde_json::from_str(raw).map_err(|e| bad(format!("`{name}` table: {e}")))?;
     let inner = inner
-        .as_object()
+        .as_object_mut()
         .ok_or_else(|| bad(format!("`{name}` split payload is not an object")))?;
     let columns = inner
         .get("columns")
@@ -1804,17 +1804,19 @@ fn read_frame(root: &Map<String, Value>, name: &str) -> Result<Option<DataFrame>
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default();
-    let raw_data = inner
-        .get("data")
-        .and_then(Value::as_array)
-        .ok_or_else(|| bad(format!("`{name}` split payload missing data")))?;
+    // Move the rows out of the inner document instead of cloning each one.
+    // The inner DOM is a local parsed from the table's escaped JSON string,
+    // so the clone made a third full copy of the largest table (outer DOM
+    // text, inner DOM, rows) live at once.
+    let Some(Value::Array(raw_data)) = inner.remove("data") else {
+        return Err(bad(format!("`{name}` split payload missing data")));
+    };
     let mut data = Vec::with_capacity(raw_data.len());
-    for (i, row) in raw_data.iter().enumerate() {
-        data.push(
-            row.as_array()
-                .cloned()
-                .ok_or_else(|| bad(format!("`{name}` table: row {i} is not an array")))?,
-        );
+    for (i, row) in raw_data.into_iter().enumerate() {
+        match row {
+            Value::Array(cells) => data.push(cells),
+            _ => return Err(bad(format!("`{name}` table: row {i} is not an array"))),
+        }
     }
     if index.len() != data.len() {
         return Err(bad(format!(

--- a/powerio/src/format/powerworld/auxiliary.rs
+++ b/powerio/src/format/powerworld/auxiliary.rs
@@ -508,7 +508,11 @@ fn split_values_into(line: &str, csv: bool, out: &mut Vec<String>) {
         }
         return;
     }
-    let mut cur = String::new();
+    // Keep `cur`'s capacity across tokens. Taking the buffer handed it away,
+    // so every token regrew from empty through the 8/16/32 realloc chain;
+    // cloning costs one exact-size allocation and leaves the scratch buffer
+    // sized for the next token.
+    let mut cur = String::with_capacity(32);
     let mut in_quote = false;
     let mut started = false; // a token has begun, including an empty quoted one
     for c in line.chars() {
@@ -519,7 +523,8 @@ fn split_values_into(line: &str, csv: bool, out: &mut Vec<String>) {
             }
             c if c.is_whitespace() && !in_quote => {
                 if started {
-                    out.push(std::mem::take(&mut cur));
+                    out.push(cur.clone());
+                    cur.clear();
                     started = false;
                 }
             }

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -678,10 +678,12 @@ pub fn write_powerworld(net: &Network) -> Conversion {
         }
     };
     let mut s = String::new();
+    // A `//` comment ends at the line break, so a terminator in the name
+    // would leave the rest of it uncommented as an aux DATA block.
     let _ = writeln!(
         s,
         "// PowerWorld auxiliary file — powerio export: {}",
-        net.name
+        sanitize_quoted(&net.name, NAME_FORBIDDEN, ' ')
     );
     let _ = writeln!(s, "// baseMVA {}", net.base_mva);
     let _ = writeln!(s);

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -1143,7 +1143,9 @@ pub fn write_pslf(net: &Network) -> Conversion {
 
     // ---- header blocks ----
     let _ = writeln!(s, "title");
-    let _ = writeln!(s, "{}", net.name);
+    // The title is one record; a terminator would end it and put the rest of
+    // the name where the parser expects the next block.
+    let _ = writeln!(s, "{}", sanitize_quoted(&net.name, NAME_FORBIDDEN, ' '));
     let _ = writeln!(s, "!");
     let _ = writeln!(s, "comments");
     let _ = writeln!(s, "powerio export");
@@ -1630,7 +1632,11 @@ fn circuit_tok(extras: &Extras) -> String {
         .get("pslf_circuit")
         .and_then(Value::as_str)
         .unwrap_or("1");
-    format!("\"{ck}\"")
+    // Sanitized like `device_id` and `name_tok`: an unfiltered quote or
+    // separator here shifts every later column of the branch record. `:`
+    // splits the EPC lhs/rhs, so it breaks the record too.
+    let clean = sanitize_quoted(ck, &['"', ':', ' ', '\t', '/'], '_');
+    format!("\"{clean}\"")
 }
 
 /// A numeric `pslf_*` extra, if present and finite. A non-finite value yields

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -196,15 +196,19 @@ pub fn write_psse_rev(net: &Network, rev: u32) -> Conversion {
         }
     };
 
+    // The case name reaches the header line and the title line. Both are
+    // single records, so an embedded terminator would make the rest of the
+    // name parse as bus data.
+    let case_name = sanitize_quoted(&net.name, NAME_FORBIDDEN, ' ');
     let _ = writeln!(
         s,
         "0, {}, {rev}, 0, {}, {}   / powerio export: {}",
         net.base_mva,
         i32::from(modern),
         num(net.base_frequency),
-        net.name
+        case_name
     );
-    let _ = writeln!(s, "{}", net.name);
+    let _ = writeln!(s, "{case_name}");
     let _ = writeln!(s);
     if modern {
         // v34+ system-wide block: emit the solver keyword lines (the fields that
@@ -2296,6 +2300,11 @@ fn dc_tail(extras: &Extras, key: &str, default: &str) -> String {
         Some(arr) if !arr.is_empty() => arr
             .iter()
             .filter_map(Value::as_str)
+            // These come from a source file's `extras` and are replayed into
+            // a record, so they go through the quoting seam like every other
+            // interpolated string: a terminator here would forge a whole DC
+            // record or a section end.
+            .map(|f| sanitize_quoted(f, NAME_FORBIDDEN, ' ').into_owned())
             .collect::<Vec<_>>()
             .join(", "),
         _ => default.to_string(),
@@ -3967,6 +3976,33 @@ Q
             "MATPOWER write must warn on the dropped emergency band, got {:?}",
             mpc.warnings
         );
+    }
+
+    #[test]
+    fn a_case_name_with_a_terminator_cannot_forge_a_bus_record() {
+        // The case name reaches the header and title lines verbatim. A
+        // terminator inside it used to end the record, so the rest parsed as
+        // bus data and the written file described a network the source never
+        // had.
+        let raw = r"0, 100.00, 33, 0, 0, 60.00 / x
+CASE
+COMMENT
+1,'B1          ', 230.0,3,1,1,1,1.0,0.0,1.1,0.9,1.1,0.9
+0 / END OF BUS DATA, BEGIN LOAD DATA
+0 / END OF LOAD DATA, BEGIN FIXED SHUNT DATA
+0 / END OF FIXED SHUNT DATA, BEGIN GENERATOR DATA
+0 / END OF GENERATOR DATA, BEGIN BRANCH DATA
+0 / END OF BRANCH DATA, BEGIN TRANSFORMER DATA
+0 / END OF TRANSFORMER DATA, BEGIN AREA DATA
+Q
+";
+        let mut net = parse_psse(raw).unwrap();
+        net.name =
+            "A\n42, 'INJECTED   ', 500.0, 2, 9, 9, 1, 1.0, 0.0, 1.1, 0.9, 1.1, 0.9".to_owned();
+        net.source = None; // force a real write, not the byte-exact echo
+        let text = write_psse(&net).text;
+        let back = parse_psse(&text).unwrap();
+        assert_eq!(back.buses.len(), 1, "forged bus record in:\n{text}");
     }
 
     #[test]

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -1483,25 +1483,36 @@ fn strip_inline_comment(line: &str) -> &str {
 /// no commas fall back to whitespace splitting.
 fn fields(line: &str) -> Vec<String> {
     let code = strip_inline_comment(line);
-    let mut out = Vec::new();
-    let mut cur = String::new();
-    let mut quoted = false;
     let comma_delimited = code.contains(',');
+    // Size both buffers up front and keep `cur`'s capacity across fields.
+    // Taking `cur` handed the buffer away, so every field regrew from empty
+    // and then paid a second allocation to trim: two allocations and a
+    // realloc chain per field, which dominated the cost of reading a `.raw`
+    // (~950 allocations per KB of input).
+    let mut out = Vec::with_capacity(if comma_delimited {
+        code.bytes().filter(|b| *b == b',').count() + 1
+    } else {
+        8
+    });
+    let mut cur = String::with_capacity(32);
+    let mut quoted = false;
     for c in code.chars() {
         match c {
             '\'' => quoted = !quoted,
             ',' if !quoted && comma_delimited => {
-                out.push(std::mem::take(&mut cur).trim().to_string());
+                out.push(cur.trim().to_owned());
+                cur.clear();
             }
             c if c.is_whitespace() && !quoted && !comma_delimited => {
                 if !cur.is_empty() {
-                    out.push(std::mem::take(&mut cur));
+                    out.push(cur.clone());
+                    cur.clear();
                 }
             }
             c => cur.push(c),
         }
     }
-    let last = cur.trim().to_string();
+    let last = cur.trim().to_owned();
     if comma_delimited || !last.is_empty() {
         out.push(last);
     }


### PR DESCRIPTION
A four-dimension audit of the whole tree (security, memory safety, memory efficiency, numerical performance), not just a diff. This is the non-breaking half; the rest is filed as #291–#294 against the v1.0.0 milestone.

## Security: five record-injection seams (HIGH)

A case file supplies free-form names and `extras` strings that the text writers interpolate into records. `sanitize_quoted` replaced each destination's quotes and delimiters but never a line terminator, and several seams bypassed it entirely. A terminator does not shift a column — it ends the record, so everything after it parses as new structure.

Verified by executing the writers before the fix, all silent (no warnings):

| payload in | written file reparsed as |
|---|---|
| PowerModels `name` with a newline | `.raw` → 2 buses instead of 1 |
| PowerModels bus `name` | `.raw` → 3 buses instead of 2 |
| same, to PowerWorld | `.aux` bus row rewritten: 230 kV → 765 kV, area 0 → 9 |
| `psse_dc_*_tail` extra | 2 HVDC lines instead of 1, second fully attacker-controlled |
| `pslf_circuit` extra | branch silently zero-impedance |
| BMOPF element name | `.dss` → 3 `Line` objects instead of 2 |

`sanitize_quoted` now always replaces `\r`/`\n` whatever the caller's set holds, and the seams that skipped it are routed through it: the case name in the PSS/E header and title, the PowerWorld `//` comment header, the PSLF title, the PSS/E `dc_tail` replay, and the PSLF `circuit_tok`. `name_breaks_dss` counts a terminator as breaking. Re-running the exploits: bus counts back to 1 and 2, the aux payload inert inside its quoted field with 230 kV preserved. Two regression tests added.

Clean on the rest: the OpenDSS include confinement (#271) holds against `..`, absolute paths, empty roots, UNC-ish input and symlinks; every other case-derived path join goes through `sanitize_stem` or `is_relative_component_path`; integer overflow and panic-on-malformed-input were probed with a 12,000-case mutation run with no hits; the MCP server has no shell or eval path.

## Memory safety

`unsafe` is confined to `powerio-capi/src/lib.rs`; the other seven crates and the Python bindings have none. The Arrow export is sound (every column is a fresh allocation borrowing nothing from `Network`, so an export cannot dangle past `pio_network_free`), handle lifecycle is single-constructor/single-free, and `Send`/`Sync` are compile-time asserted with no interior mutability in any handle.

- Two entry points allocated **outside the panic guard** that the other 78 use — including `pio_schema_versions_json`, new in 0.8.1. `serde_json::json!` expands to `to_value(..).unwrap()`, so their panic-free property rested on the current field types, on the two functions whose purpose is to grow new fields. A panic there unwinds across `extern "C"`. Both now run inside `guard`.
- The mutation contract named `pio_package_validate` as the only non-`const` entry point; `pio_package_set_operating_points` is another and documented none of it, while the README stated the concurrent-read guarantee with no exception at all. Both now document exclusive access.
- Documented (not changed, since aligning it needs an ABI bump): `pio_bus_demand`/`pio_bus_shunt`/`pio_n_islands` run on the 3-winding-star-lowered network while `pio_n_buses`/`pio_bus_ids` report the unexpanded table, so sizing a buffer from `pio_n_buses` reads short. Queued for the v5 pass.

## Performance

- **`Auto` solver policy.** Selected from the reduced dimension alone against a ceiling of 512 — far below the real crossover, so it chose the slower solver by one to three orders of magnitude across the range holding the common published cases (1354, 2869, 3120, 6470 buses). The dimension also does not bound cost, since the dense path materializes an m×n PTDF and an m×m LODF: a case with few buses and many parallel branches passed every dimension test and then asked for tens of GB. Now dense while both the dimension (8192) and a 2 GiB predicted-footprint veto allow it; an explicit choice still overrides both.
- **PSS/E and aux tokenizers** handed their scratch buffer away per token, so every field regrew from empty and then paid a second allocation to trim — 861k allocations to read a 905 KB `.raw`, against 539 for a comparable MATPOWER case. Both keep the buffer now. Output byte-identical (verified by hash).
- **pandapower** cloned every row out of the inner table document, holding a third full copy of the largest table; rows now move out.
- **Dense→CSR** fills the CSR arrays directly instead of a hash map + triplet copy + sort on data that is already row-major and unique (several GB of intermediates on a 10k-bus PTDF), and the **dense PTDF scatter** hoists the grounding lookup into a reduced-to-full map instead of two binary searches per column per flow nonzero (~2.5e8 of them). Both verified **bit-identical** on case30 PTDF/LODF by hash.
- **`build_ybus_with_flags` checks the base it divides by.** `baseMVA = 0` parsed, then wrote NaN onto every Ybus diagonal — including shunt-free buses, since the builder skips only exact zero — and shipped the matrix exit 0. Reproduced, now a clean error with nothing written.

## Verification

fmt, the repo clippy wall, **52 Rust test binaries green**, conversion-matrix baselines unmoved, 143 Python tests. Legitimate names carry no line terminators, so no writer baseline moves.

## Deferred

#291 sensitivity factorization · #292 degenerate numerical guards · #293 reader peak memory · #294 dense-path memory and cache order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_