### PR TITLE
dist: derive a missing winding kv, map line i_max to emergamps

### DIFF
--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -2627,7 +2627,10 @@ fn authored_terminal_conventions(net: &DistNetwork) -> Option<Value> {
             } else {
                 &mut phase
             };
-            if !labels.contains(&term) {
+            // Bucketing is case insensitive, so the dedup has to be too:
+            // `N` and `n` are one label, and emitting both would tell a
+            // consumer the network has two neutrals.
+            if !labels.iter().any(|l| l.eq_ignore_ascii_case(term)) {
                 labels.push(term);
             }
         }

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -307,6 +307,8 @@ impl Writer {
         doc.insert("meta".into(), meta);
         if let Some(Value::Object(tc)) = net.extras.get(BMOPF_TERMINAL_CONVENTIONS_STASH) {
             doc.insert("terminal_conventions".into(), Value::Object(tc.clone()));
+        } else if let Some(tc) = authored_terminal_conventions(net) {
+            doc.insert("terminal_conventions".into(), tc);
         }
         self.buses(net, &mut doc);
         self.linecodes(net, &mut doc);
@@ -2609,6 +2611,28 @@ fn bmopf_delta_roll(t: &DistTransformer, idx: usize, w: &Winding) -> Option<i64>
         .and_then(Value::as_i64)
         .filter(|roll| *roll == 1 || *roll == -1)
         .or(Some(-1))
+}
+
+/// The phase and neutral label lists, from the bus terminal names. The rule
+/// is the one the schema prescribes for an absent `terminal_conventions`
+/// block: an `n` or `N` label is neutral, every other label is a phase.
+/// Labels keep first-seen order. A network with no bus terminal gives `None`.
+fn authored_terminal_conventions(net: &DistNetwork) -> Option<Value> {
+    let mut phase: Vec<&String> = Vec::new();
+    let mut neutral: Vec<&String> = Vec::new();
+    for b in &net.buses {
+        for term in &b.terminals {
+            let labels = if term.eq_ignore_ascii_case("n") {
+                &mut neutral
+            } else {
+                &mut phase
+            };
+            if !labels.contains(&term) {
+                labels.push(term);
+            }
+        }
+    }
+    (!phase.is_empty() || !neutral.is_empty()).then(|| json!({"phase": phase, "neutral": neutral}))
 }
 
 fn no_load_voltage_base(from: &Winding) -> f64 {

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -925,7 +925,7 @@ impl Reader<'_> {
         // per line length unit, so the raw length preserves the Z·length
         // product.
         let mut malformed: Vec<(&'static str, String)> = Vec::new();
-        let (linecode, length_factor) = if let Some(code) = props.get("linecode") {
+        let (linecode, length_factor, synthesized) = if let Some(code) = props.get("linecode") {
             let lc_units_m = self
                 .linecode_units
                 .get(&code.text.to_ascii_lowercase())
@@ -936,15 +936,15 @@ impl Reader<'_> {
                 (Some(lcf), None) => lcf,
                 (None, _) => 1.0,
             };
-            (code.text.clone(), factor)
+            (code.text.clone(), factor, false)
         } else {
             let factor = line_units_m.unwrap_or(1.0);
             let (code, bad) = self.synthesize_linecode(&props, phases, factor, &obj.name);
             malformed = bad;
-            (code, factor)
+            (code, factor, true)
         };
 
-        let (i_max, raw_emergamps) = self.line_emergamps(&props, phases);
+        let (i_max, raw_emergamps) = self.line_rating(&props, phases, synthesized);
         let mut extras = extras_from_leftovers(&props);
         if let Some(u) = length_units {
             extras.insert("units".into(), u.into());
@@ -968,6 +968,25 @@ impl Reader<'_> {
             s_max: None,
             extras,
         });
+    }
+
+    /// The line's own `i_max`, and the raw `emergamps` token to keep in extras.
+    ///
+    /// A line with no `linecode=` gets a synthetic one holding its own
+    /// impedance, and `synthesize_linecode` already read `emergamps` into that
+    /// linecode's `i_max`. Repeating it on the line would state a per line
+    /// override of a shared default that does not exist: the synthetic
+    /// linecode belongs to this line alone.
+    fn line_rating(
+        &self,
+        props: &Props,
+        phases: usize,
+        synthesized_linecode: bool,
+    ) -> (Option<Vec<f64>>, Option<String>) {
+        if synthesized_linecode {
+            return (None, None);
+        }
+        self.line_emergamps(props, phases)
     }
 
     /// `emergamps` on a Line reads as that line's `i_max`, one entry for each

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -944,9 +944,13 @@ impl Reader<'_> {
             (code, factor)
         };
 
+        let (i_max, raw_emergamps) = self.line_emergamps(&props, phases);
         let mut extras = extras_from_leftovers(&props);
         if let Some(u) = length_units {
             extras.insert("units".into(), u.into());
+        }
+        if let Some(text) = raw_emergamps {
+            extras.insert("emergamps".into(), text.into());
         }
         for (key, text) in malformed {
             extras.insert(key.to_string(), text.into());
@@ -960,10 +964,23 @@ impl Reader<'_> {
             linecode,
             length: length * length_factor,
             route: None,
-            i_max: None,
+            i_max,
             s_max: None,
             extras,
         });
+    }
+
+    /// `emergamps` on a Line reads as that line's `i_max`, one entry for each
+    /// phase, the same mapping a linecode uses. An absent property leaves the
+    /// linecode rating in control. An unparsable token returns as text.
+    fn line_emergamps(&self, props: &Props, phases: usize) -> (Option<Vec<f64>>, Option<String>) {
+        let Some(v) = props.get("emergamps") else {
+            return (None, None);
+        };
+        match v.to_f64(Some(self.vars)) {
+            Ok(amps) => (Some(vec![amps; phases]), None),
+            Err(_) => (None, Some(v.text.clone())),
+        }
     }
 
     /// A line without `linecode=` carries inline or default impedance;

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -237,6 +237,28 @@ fn num(v: f64) -> String {
     format!("{v}")
 }
 
+/// Write one per-winding transformer property. The inline `(...)` form needs
+/// a token in every slot. A missing value thus moves the property to the
+/// per-winding `~ wdg=` edits, which can omit a winding.
+fn winding_array(
+    head: &mut String,
+    edits: &mut [String],
+    array_key: &str,
+    scalar_key: &str,
+    values: &[Option<f64>],
+) {
+    if values.iter().all(Option::is_some) {
+        let toks: Vec<String> = values.iter().map(|v| num(v.unwrap_or(0.0))).collect();
+        let _ = write!(head, " {array_key}=({})", toks.join(", "));
+    } else {
+        for (edit, v) in edits.iter_mut().zip(values) {
+            if let Some(v) = v {
+                let _ = write!(edit, " {scalar_key}={}", num(*v));
+            }
+        }
+    }
+}
+
 /// VSource.cpp's per phase magnitude divisor: the chord of the n-gon
 /// (1 for a single phase source, sqrt(3) at n = 3). Division by the
 /// 1 phase chord is exact, so one expression serves both reader branches.
@@ -924,18 +946,32 @@ impl DssWriter {
                 l.linecode,
                 num(l.length),
             );
-            // Line-level ratings await the normamps/emergamps mapping
-            // decision (#266); dropping them stays loud in the meantime.
-            for (key, present) in [("i_max", l.i_max.is_some()), ("s_max", l.s_max.is_some())] {
-                if present {
-                    self.warn(format!(
-                        "line {}: `{key}` has no dss Line field mapping yet; dropped",
-                        l.name
-                    ));
-                }
-            }
             let mut extras = l.extras.clone();
             extras.remove("units"); // canonical output is in meters
+            // `i_max` maps to `emergamps`, as it does on a linecode. The
+            // typed field wins over a token kept in extras.
+            match l.i_max.as_deref() {
+                Some([amps, ..]) if amps.is_finite() => {
+                    extras.remove("emergamps");
+                    let _ = write!(s, " emergamps={}", num(*amps));
+                }
+                Some([_, ..]) => self.warn(format!(
+                    "line {}: first i_max entry is nonfinite (an unbounded \
+                     conductor); emergamps not emitted",
+                    l.name
+                )),
+                Some([]) => self.warn(format!(
+                    "line {}: i_max is empty; emergamps not emitted",
+                    l.name
+                )),
+                None => {}
+            }
+            if l.s_max.is_some() {
+                self.warn(format!(
+                    "line {}: `s_max` has no dss Line field; dropped",
+                    l.name
+                ));
+            }
             s.push_str(&self.extras_tail("line", &l.name, &extras));
             self.line_out(&s);
         }
@@ -1014,21 +1050,43 @@ impl DssWriter {
                     WindingConn::Delta => "delta",
                 })
                 .collect();
-            let kvs: Vec<String> = t.windings.iter().map(|w| num(w.v_ref / 1e3)).collect();
-            let kvas: Vec<String> = t.windings.iter().map(|w| num(w.s_rating / 1e3)).collect();
+            let kvs: Vec<Option<f64>> = t
+                .windings
+                .iter()
+                .enumerate()
+                .map(|(idx, w)| self.winding_kv(t, idx, w))
+                .collect();
+            let kvas: Vec<Option<f64>> = t
+                .windings
+                .iter()
+                .enumerate()
+                .map(|(idx, w)| {
+                    if w.s_rating.is_finite() {
+                        Some(w.s_rating / 1e3)
+                    } else {
+                        self.warn(format!(
+                            "transformer {}: winding {} has no finite rating; kva not \
+                             emitted (the OpenDSS default applies)",
+                            t.name,
+                            idx + 1
+                        ));
+                        None
+                    }
+                })
+                .collect();
             let rs: Vec<String> = t.windings.iter().map(|w| num(w.r_pct)).collect();
             let taps: Vec<String> = t.windings.iter().map(|w| num(w.tap)).collect();
             let mut s = format!(
-                "New Transformer.{} phases={} windings={nw} buses=({}) conns=({}) kvs=({}) kvas=({}) %Rs=({}) taps=({})",
+                "New Transformer.{} phases={} windings={nw} buses=({}) conns=({})",
                 t.name,
                 t.phases,
                 buses.join(", "),
                 conns.join(", "),
-                kvs.join(", "),
-                kvas.join(", "),
-                rs.join(", "),
-                taps.join(", "),
             );
+            let mut edits: Vec<String> = vec![String::new(); nw];
+            winding_array(&mut s, &mut edits, "kvs", "kv", &kvs);
+            winding_array(&mut s, &mut edits, "kvas", "kva", &kvas);
+            let _ = write!(s, " %Rs=({}) taps=({})", rs.join(", "), taps.join(", "));
             if let Some(xhl) = t.xsc_pct.first() {
                 let _ = write!(s, " xhl={}", num(*xhl));
                 if t.xsc_pct.len() >= 3 {
@@ -1044,20 +1102,63 @@ impl DssWriter {
             s.push_str(&self.extras_tail("transformer", &t.name, &t.extras));
             self.line_out(&s);
             for (idx, w) in t.windings.iter().enumerate() {
-                if w.r_neutral.is_none() && w.x_neutral.is_none() {
-                    continue;
-                }
-                let mut edit = format!("~ wdg={}", idx + 1);
                 if let Some(r) = w.r_neutral {
-                    let _ = write!(edit, " rneut={}", num(r));
+                    let _ = write!(edits[idx], " rneut={}", num(r));
                 }
                 if let Some(x) = w.x_neutral {
-                    let _ = write!(edit, " xneut={}", num(x));
+                    let _ = write!(edits[idx], " xneut={}", num(x));
                 }
-                self.line_out(&edit);
+            }
+            for (idx, edit) in edits.iter().enumerate() {
+                if !edit.is_empty() {
+                    self.line_out(&format!("~ wdg={}{edit}", idx + 1));
+                }
             }
         }
         self.out.push('\n');
+    }
+
+    /// The winding `kv=` value in kV, or `None` if no value is available.
+    /// A BMOPF transformer without `v_nom_from`/`v_nom_to` reads as
+    /// `v_ref = NaN`, and OpenDSS refuses a deck that holds a `NaN` token.
+    /// The fallback is the bus voltage estimate, scaled to the voltage across
+    /// the two winding terminals: line to neutral for a single phase winding
+    /// on a grounded terminal, line to line in all other cases.
+    fn winding_kv(
+        &mut self,
+        t: &crate::model::DistTransformer,
+        idx: usize,
+        w: &Winding,
+    ) -> Option<f64> {
+        if w.v_ref.is_finite() && w.v_ref > 0.0 {
+            return Some(w.v_ref / 1e3);
+        }
+        let line_to_neutral = t.phases < 2
+            && self
+                .grounded
+                .get(&w.bus.to_ascii_lowercase())
+                .is_some_and(|g| w.terminal_map.iter().any(|tm| g.contains(tm)));
+        let scale = if line_to_neutral { 1.0 } else { 3f64.sqrt() };
+        let Some(v_pn) = self.kv_estimate.get(&w.bus.to_ascii_lowercase()).copied() else {
+            self.warn(format!(
+                "transformer {}: winding {} has no rated voltage and bus `{}` has \
+                 no voltage estimate; kv not emitted (the OpenDSS default applies)",
+                t.name,
+                idx + 1,
+                w.bus
+            ));
+            return None;
+        };
+        let kv = v_pn * scale / 1e3;
+        self.warn(format!(
+            "transformer {}: winding {} has no rated voltage; kv={} derived \
+             from the bus `{}` voltage estimate",
+            t.name,
+            idx + 1,
+            num(kv),
+            w.bus
+        ));
+        Some(kv)
     }
 
     fn loads(&mut self, net: &DistNetwork) {
@@ -2346,7 +2447,7 @@ mod tests {
     }
 
     #[test]
-    fn line_level_ratings_drop_with_a_warning() {
+    fn line_level_i_max_emits_emergamps_and_s_max_drops_with_a_warning() {
         let (b, vs) = three_phase_source(2400.0);
         let net = DistNetwork {
             base_frequency: 60.0,
@@ -2368,15 +2469,68 @@ mod tests {
             ..DistNetwork::default()
         };
         let out = write_dss(&net);
-        for key in ["i_max", "s_max"] {
-            assert!(
-                out.warnings
-                    .iter()
-                    .any(|w| w.contains("line l1") && w.contains(key) && w.contains("dropped")),
-                "{key}: {:?}",
-                out.warnings
-            );
-        }
+        let line = out.text.lines().find(|l| l.contains("Line.l1 ")).unwrap();
+        assert!(line.contains("emergamps=400"), "{line}");
+        assert!(
+            !out.warnings
+                .iter()
+                .any(|w| w.contains("line l1") && w.contains("i_max")),
+            "{:?}",
+            out.warnings
+        );
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("line l1") && w.contains("s_max") && w.contains("dropped")),
+            "{:?}",
+            out.warnings
+        );
+    }
+
+    #[test]
+    fn line_level_emergamps_round_trips_as_i_max() {
+        let src = "Clear\n\
+                   New Circuit.c1 basekv=12.47 pu=1 angle=0 phases=3 bus1=sb.1.2.3\n\
+                   New Linecode.lc nphases=3 r1=0.1 x1=0.2 emergamps=600\n\
+                   New Line.l1 bus1=sb.1.2.3 bus2=b2.1.2.3 phases=3 linecode=lc \
+                   length=10 units=m emergamps=250\n\
+                   New Line.l2 bus1=b2.1.2.3 bus2=b3.1.2.3 phases=3 linecode=lc \
+                   length=10 units=m\n";
+        let net = parse_dss_str(src);
+        let l1 = net.lines.iter().find(|l| l.name == "l1").unwrap();
+        assert_eq!(l1.i_max.as_deref(), Some(&[250.0, 250.0, 250.0][..]));
+        assert!(!l1.extras.contains_key("emergamps"), "{:?}", l1.extras);
+        // A line without its own rating defers to the linecode.
+        let l2 = net.lines.iter().find(|l| l.name == "l2").unwrap();
+        assert_eq!(l2.i_max, None);
+
+        let (first, second) = roundtrip(&net);
+        let line = first.lines().find(|l| l.contains("Line.l1 ")).unwrap();
+        assert!(line.contains("emergamps=250"), "{line}");
+        assert_eq!(line.matches("emergamps=").count(), 1, "{line}");
+        let line2 = first.lines().find(|l| l.contains("Line.l2 ")).unwrap();
+        assert!(!line2.contains("emergamps="), "{line2}");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn unparsable_line_emergamps_stays_in_extras_for_the_echo() {
+        let src = "Clear\n\
+                   New Circuit.c1 basekv=12.47 pu=1 angle=0 phases=3 bus1=sb.1.2.3\n\
+                   New Linecode.lc nphases=3 r1=0.1 x1=0.2\n\
+                   New Line.l1 bus1=sb.1.2.3 bus2=b2.1.2.3 phases=3 linecode=lc \
+                   length=10 units=m emergamps=@amps\n";
+        let net = parse_dss_str(src);
+        let l1 = net.lines.iter().find(|l| l.name == "l1").unwrap();
+        assert_eq!(l1.i_max, None);
+        assert_eq!(
+            l1.extras.get("emergamps").and_then(|v| v.as_str()),
+            Some("@amps")
+        );
+        let (first, second) = roundtrip(&net);
+        let line = first.lines().find(|l| l.contains("Line.l1 ")).unwrap();
+        assert!(line.contains("emergamps=@amps"), "{line}");
+        assert_eq!(first, second);
     }
 
     #[test]

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -951,7 +951,7 @@ impl DssWriter {
             // `i_max` maps to `emergamps`, as it does on a linecode. The
             // typed field wins over a token kept in extras.
             match l.i_max.as_deref() {
-                Some([amps, rest @ ..]) if amps.is_finite() => {
+                Some([amps, rest @ ..]) if amps.is_finite() && *amps > 0.0 => {
                     extras.remove("emergamps");
                     let _ = write!(s, " emergamps={}", num(*amps));
                     // The dss Line has one emergamps for all phases. Compare
@@ -1072,11 +1072,11 @@ impl DssWriter {
                 .iter()
                 .enumerate()
                 .map(|(idx, w)| {
-                    if w.s_rating.is_finite() {
+                    if w.s_rating.is_finite() && w.s_rating > 0.0 {
                         Some(w.s_rating / 1e3)
                     } else {
                         self.warn(format!(
-                            "transformer {}: winding {} has no finite rating; kva not \
+                            "transformer {}: winding {} has no usable rating; kva not \
                              emitted (the OpenDSS default applies)",
                             t.name,
                             idx + 1
@@ -1144,13 +1144,14 @@ impl DssWriter {
         if w.v_ref.is_finite() && w.v_ref > 0.0 {
             return Some(w.v_ref / 1e3);
         }
+        let bus = w.bus.to_ascii_lowercase();
         let line_to_neutral = t.phases < 2
             && self
                 .grounded
-                .get(&w.bus.to_ascii_lowercase())
+                .get(&bus)
                 .is_some_and(|g| w.terminal_map.iter().any(|tm| g.contains(tm)));
         let scale = if line_to_neutral { 1.0 } else { 3f64.sqrt() };
-        let Some(v_pn) = self.kv_estimate.get(&w.bus.to_ascii_lowercase()).copied() else {
+        let Some(v_pn) = self.kv_estimate.get(&bus).copied() else {
             self.warn(format!(
                 "transformer {}: winding {} has no rated voltage and bus `{}` has \
                  no voltage estimate; kv not emitted (the OpenDSS default applies)",

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -951,9 +951,20 @@ impl DssWriter {
             // `i_max` maps to `emergamps`, as it does on a linecode. The
             // typed field wins over a token kept in extras.
             match l.i_max.as_deref() {
-                Some([amps, ..]) if amps.is_finite() => {
+                Some([amps, rest @ ..]) if amps.is_finite() => {
                     extras.remove("emergamps");
                     let _ = write!(s, " emergamps={}", num(*amps));
+                    // The dss Line has one emergamps for all phases. Compare
+                    // exactly: any difference makes the token wrong for a phase.
+                    #[allow(clippy::float_cmp)]
+                    let uneven = rest.iter().any(|a| *a != *amps);
+                    if uneven {
+                        self.warn(format!(
+                            "line {}: i_max is not equal on all phases; emergamps \
+                             holds the first phase only",
+                            l.name
+                        ));
+                    }
                 }
                 Some([_, ..]) => self.warn(format!(
                     "line {}: first i_max entry is nonfinite (an unbounded \
@@ -2443,6 +2454,40 @@ mod tests {
                 .any(|w| w.contains("a=b") && w.contains("cannot represent")),
             "{:?}",
             out2.warnings
+        );
+    }
+
+    #[test]
+    fn unequal_per_phase_i_max_warns_that_emergamps_holds_one_phase() {
+        let (b, vs) = three_phase_source(2400.0);
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b, bus("b2", &["1", "2", "3"], &[])],
+            sources: vec![vs],
+            lines: vec![DistLine {
+                name: "l1".into(),
+                bus_from: "sb".into(),
+                bus_to: "b2".into(),
+                terminal_map_from: strings(&["1", "2", "3"]),
+                terminal_map_to: strings(&["1", "2", "3"]),
+                linecode: "lc".into(),
+                length: 1.0,
+                route: None,
+                i_max: Some(vec![400.0, 300.0, 200.0]),
+                s_max: None,
+                extras: Extras::new(),
+            }],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out.text.lines().find(|l| l.contains("Line.l1 ")).unwrap();
+        assert!(line.contains("emergamps=400"), "{line}");
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("line l1") && w.contains("not equal on all phases")),
+            "{:?}",
+            out.warnings
         );
     }
 

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -2841,3 +2841,159 @@ fn schema_fields_survive_a_round_trip_without_wrong_warnings() {
     let again = parse_bmopf_str(&out.text).unwrap();
     assert_eq!(write_bmopf_json(&again).text, out.text);
 }
+
+#[test]
+fn bmopf_transformer_without_v_nom_never_writes_nan_kv() {
+    let net = parse_bmopf_str(
+        r#"{
+          "bus": {
+            "hv": {"terminal_names": ["1", "2", "3"]},
+            "lv": {"terminal_names": ["1", "2", "3", "4"], "perfectly_grounded_terminals": ["4"]}
+          },
+          "voltage_source": {
+            "source": {"v_magnitude": [6350.9, 6350.9, 6350.9], "v_angle": [0.0, -2.0943951023931953, 2.0943951023931953], "bus": "hv", "terminal_map": ["1", "2", "3"]}
+          },
+          "transformer": {
+            "delta_wye": {
+              "t1": {
+                "bus_from": "hv", "bus_to": "lv",
+                "terminal_map_from": ["1", "2", "3"], "terminal_map_to": ["1", "2", "3", "4"],
+                "s_rating": 500000.0,
+                "r_series": 0.001, "x_series": 0.002
+              }
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+    let out = write_dss(&net);
+    assert!(!out.text.contains("NaN"), "{}", out.text);
+    let t = out
+        .text
+        .lines()
+        .find(|l| l.contains("Transformer.t1 "))
+        .unwrap();
+    assert!(!t.contains("kvs="), "{t}");
+    assert!(t.contains("kvas=(500, 500)"), "{t}");
+    // The hv winding derives from the source bus estimate. The lv bus has no
+    // estimate.
+    let expected_kv = 6350.9 * 3f64.sqrt() / 1e3;
+    let edit = out
+        .text
+        .lines()
+        .find(|l| l.starts_with("~ wdg=1 "))
+        .unwrap();
+    assert_eq!(edit, format!("~ wdg=1 kv={expected_kv}"));
+    assert!(!out.text.contains("wdg=2 kv="), "{}", out.text);
+    assert!(
+        out.warnings.iter().any(|w| w.contains("transformer t1")
+            && w.contains("winding 1")
+            && w.contains("derived")),
+        "{:?}",
+        out.warnings
+    );
+    assert!(
+        out.warnings.iter().any(|w| w.contains("transformer t1")
+            && w.contains("winding 2")
+            && w.contains("kv not emitted")),
+        "{:?}",
+        out.warnings
+    );
+    // The deck must read back, with the derived hv winding voltage.
+    let reparsed = parse_dss_str(&out.text);
+    let rt = &reparsed.transformers[0];
+    assert!((rt.windings[0].v_ref - expected_kv * 1e3).abs() < 1e-9);
+}
+
+#[test]
+fn bmopf_transformer_without_s_rating_never_writes_nan_kva() {
+    let net = parse_bmopf_str(
+        r#"{
+          "bus": {
+            "hv": {"terminal_names": ["1", "2", "3"]},
+            "lv": {"terminal_names": ["1", "2", "3", "4"], "perfectly_grounded_terminals": ["4"]}
+          },
+          "voltage_source": {
+            "source": {"v_magnitude": [6350.9, 6350.9, 6350.9], "v_angle": [0.0, -2.0943951023931953, 2.0943951023931953], "bus": "hv", "terminal_map": ["1", "2", "3"]}
+          },
+          "transformer": {
+            "delta_wye": {
+              "t1": {
+                "bus_from": "hv", "bus_to": "lv",
+                "terminal_map_from": ["1", "2", "3"], "terminal_map_to": ["1", "2", "3", "4"],
+                "v_nom_from": 11000.0, "v_nom_to": 415.0,
+                "r_series": 0.001, "x_series": 0.002
+              }
+            }
+          }
+        }"#,
+    )
+    .unwrap();
+    let out = write_dss(&net);
+    assert!(!out.text.contains("NaN"), "{}", out.text);
+    let t = out
+        .text
+        .lines()
+        .find(|l| l.contains("Transformer.t1 "))
+        .unwrap();
+    assert!(t.contains("kvs=(11, 0.415)"), "{t}");
+    assert!(!t.contains("kvas="), "{t}");
+    assert!(!out.text.contains("kva="), "{}", out.text);
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("transformer t1") && w.contains("kva not emitted")),
+        "{:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn dss_network_authors_terminal_conventions_from_its_naming() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.tc basekv=12.47 pu=1.0 phases=3 bus1=src.1.2.3\n\
+         New Line.l1 bus1=src.1.2.3 bus2=mid.1.2.3 phases=3 r1=0.1 x1=0.2 length=10 units=m\n",
+    );
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    // The dss reader makes the grounded neutral terminal `4` on the source
+    // bus. Every numeric label is a phase under the schema rule.
+    assert_eq!(
+        doc["terminal_conventions"],
+        serde_json::json!({"phase": ["1", "2", "3", "4"], "neutral": []})
+    );
+    assert!(
+        !out.warnings
+            .iter()
+            .any(|w| w.contains("terminal_conventions")),
+        "{:?}",
+        out.warnings
+    );
+    // The reader keeps the block, and the next write gives it again.
+    let again = parse_bmopf_str(&out.text).unwrap();
+    assert_eq!(write_bmopf_json(&again).text, out.text);
+}
+
+#[test]
+fn source_terminal_conventions_pass_through_verbatim() {
+    let net = parse_bmopf_str(
+        r#"{
+          "terminal_conventions": {"phase": ["a", "b", "c"], "neutral": ["n"]},
+          "bus": {"b": {"terminal_names": ["1"]}},
+          "voltage_source": {
+            "s": {"v_magnitude": [240.0], "v_angle": [0.0], "bus": "b", "terminal_map": ["1"]}
+          }
+        }"#,
+    )
+    .unwrap();
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    // The source block wins over the bus naming.
+    assert_eq!(
+        doc["terminal_conventions"],
+        serde_json::json!({"phase": ["a", "b", "c"], "neutral": ["n"]})
+    );
+}

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -2997,3 +2997,32 @@ fn source_terminal_conventions_pass_through_verbatim() {
         serde_json::json!({"phase": ["a", "b", "c"], "neutral": ["n"]})
     );
 }
+
+/// A line with no `linecode=` carries its rating on the linecode synthesized
+/// for it, not on both. Emitting it twice reads as a per line override of a
+/// shared default, and `_line_*` is a stand-in that belongs to this line alone.
+#[test]
+fn an_inline_line_rating_is_not_repeated_on_its_synthetic_linecode() {
+    let src = "New Circuit.c1\n\
+               New Line.l1 bus1=a bus2=b phases=3 r1=0.1 x1=0.2 length=10 units=m emergamps=250\n";
+    let net = powerio_dist::parse_dss_str(src);
+    let line = &net.lines[0];
+    let code = net
+        .linecodes
+        .iter()
+        .find(|c| c.name == line.linecode)
+        .expect("synthetic linecode");
+
+    assert_eq!(
+        code.i_max.as_deref(),
+        Some([250.0, 250.0, 250.0].as_slice())
+    );
+    assert!(
+        line.i_max.is_none(),
+        "the rating belongs to the linecode alone: {:?}",
+        line.i_max
+    );
+
+    let text = powerio_dist::write_dss(&net).text;
+    assert_eq!(text.matches("emergamps=250").count(), 1, "{text}");
+}


### PR DESCRIPTION
Target release: **0.8.2**. Size: M.

## The blocker

The dss writer wrote `kvs=(NaN, NaN)` for a transformer winding with no rated
voltage. OpenDSS refuses a deck that holds a `NaN` token, so no such deck
solved. A BMOPF net without `v_nom_from` / `v_nom_to` reads as `v_ref = NaN`.
The BMOPFTools OPF projection study named this its first blocker.

## The changes

**Winding kv and kva.** The writer derives a missing winding kv from the bus
voltage estimate, the same estimate the load and capacitor `kv` fields use. It
scales the estimate to the voltage across the two winding terminals: line to
neutral for a single phase winding on a grounded terminal, line to line in all
other cases. A winding with no estimate gets no `kv` value, and the writer
gives a warning. The inline `kvs=(...)` form needs a token in every slot, so a
property with a missing value moves to the per-winding `~ wdg=` edits. The
winding kva follows the same rule. No `NaN` token can reach the deck from this
path.

**Line ratings (#266 item 5).** Line-level `i_max` maps to the dss Line
`emergamps`, in both directions. This is the mapping the linecode already uses.
A written `emergamps` types as `i_max` instead of riding in extras. An
unparsable token stays in extras, for the verbatim echo. `s_max` still gives a
warning, because the dss Line has no apparent power field.

**Terminal conventions (#266 item 4).** The BMOPF writer authors
`terminal_conventions` from the bus terminal names if the source has no block.
The rule is the one the schema prescribes for an absent block: an `n` or `N`
label is neutral, and every other label is a phase. A source block passes
through unchanged.

**No-load losses.** These need no change. The schema 0.1.0 alignment already
exports `%noloadloss` and `%imag`.

## Tests

Four new tests in `powerio-dist/tests/bmopf.rs` and three in the dss writer
unit tests: the derived winding kv, the deck reads back, `emergamps` round
trips as `i_max`, an unparsable token echoes, and the authored block is stable
across a read and a write.

## Checks

`cargo fmt --check`, `scripts/ci-clippy.sh`, `cargo test --workspace` (0
failures), `scripts/capi-header-parity.sh`, the conversion matrix baseline
test (unchanged), and `pytest python/tests` (110 passed) all pass locally.

## Issue #266

This covers items 4 and 5. Items 1 and 2 (capacitor DSS conversion, per phase
load split in the dss writer) land in #298, which stacks on this branch. Item 3
landed in #276. The PMD leg of item 1 is still open, so #266 outlives both PRs
and no closing keyword appears here — the earlier wording spelled one out, and
GitHub reads the keyword whatever the sentence around it says.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtbRt5ZJRfiYe3kFvgHqUK)_
