### PR TITLE
chore: fold the duplication 0.8.2 left behind

### DIFF
--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -983,16 +983,13 @@ impl Reader<'_> {
         phases: usize,
         synthesized_linecode: bool,
     ) -> (Option<Vec<f64>>, Option<String>) {
+        // `emergamps` on a Line reads as that line's `i_max`, one entry for
+        // each phase, the same mapping a linecode uses. An absent property
+        // leaves the linecode rating in control; an unparsable token returns
+        // as text.
         if synthesized_linecode {
             return (None, None);
         }
-        self.line_emergamps(props, phases)
-    }
-
-    /// `emergamps` on a Line reads as that line's `i_max`, one entry for each
-    /// phase, the same mapping a linecode uses. An absent property leaves the
-    /// linecode rating in control. An unparsable token returns as text.
-    fn line_emergamps(&self, props: &Props, phases: usize) -> (Option<Vec<f64>>, Option<String>) {
         let Some(v) = props.get("emergamps") else {
             return (None, None);
         };

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -250,6 +250,15 @@ fn winding_is_line_to_neutral<'g>(
             .is_some_and(|g| w.terminal_map.iter().any(|tm| g.contains(tm)))
 }
 
+/// Whether a value states a usable magnitude: a rating, a voltage, or an
+/// ampacity a deck can carry. OpenDSS has no token for a nonfinite number, and
+/// a zero or negative one is not a nameplate. Every recovery differs — omit the
+/// property, derive from the bus estimate, drop the object — so this is the
+/// shared question, not the shared answer.
+fn is_positive_finite(v: f64) -> bool {
+    v.is_finite() && v > 0.0
+}
+
 /// The conductor count a dss element declares for `phases` on `conn`. A three
 /// phase delta has no neutral conductor; every other connection carries one.
 fn nconds_for(conn: &str, phases: usize) -> usize {
@@ -987,7 +996,7 @@ impl DssWriter {
             // `i_max` maps to `emergamps`, as it does on a linecode. The
             // typed field wins over a token kept in extras.
             match l.i_max.as_deref() {
-                Some([amps, rest @ ..]) if amps.is_finite() && *amps > 0.0 => {
+                Some([amps, rest @ ..]) if is_positive_finite(*amps) => {
                     extras.remove("emergamps");
                     let _ = write!(s, " emergamps={}", num(*amps));
                     // The dss Line has one emergamps for all phases. Compare
@@ -1108,7 +1117,7 @@ impl DssWriter {
                 .iter()
                 .enumerate()
                 .map(|(idx, w)| {
-                    if w.s_rating.is_finite() && w.s_rating > 0.0 {
+                    if is_positive_finite(w.s_rating) {
                         Some(w.s_rating / 1e3)
                     } else {
                         self.warn(format!(
@@ -1185,7 +1194,7 @@ impl DssWriter {
         idx: usize,
         w: &Winding,
     ) -> Option<f64> {
-        if w.v_ref.is_finite() && w.v_ref > 0.0 {
+        if is_positive_finite(w.v_ref) {
             return Some(w.v_ref / 1e3);
         }
         let bus = w.bus.to_ascii_lowercase();
@@ -1461,10 +1470,7 @@ impl DssWriter {
         name: &str,
     ) -> Option<f64> {
         let v_nom = model.v_nom();
-        let v_phase = v_nom
-            .first()
-            .copied()
-            .filter(|v| v.is_finite() && *v > 0.0)?;
+        let v_phase = v_nom.first().copied().filter(|v| is_positive_finite(*v))?;
         if v_nom
             .iter()
             .any(|v| (*v - v_phase).abs() > 1e-9 * v.abs().max(v_phase.abs()).max(1.0))
@@ -1684,7 +1690,7 @@ impl DssWriter {
     /// scalar rating cannot state.
     fn capacitors(&mut self, net: &DistNetwork) {
         for c in &net.capacitors {
-            if !(c.q_rated.is_finite() && c.q_rated > 0.0) {
+            if !is_positive_finite(c.q_rated) {
                 self.warn(format!(
                     "capacitor {}: rating {} is not a positive number; dropped from the output",
                     c.name, c.q_rated
@@ -1702,7 +1708,7 @@ impl DssWriter {
             let conn = self.element_conn(&c.extras, c.configuration, &c.bus, &c.terminal_map);
             let nconds = nconds_for(conn, phases);
             self.warn_short_map("capacitor", &c.name, c.terminal_map.len(), nconds);
-            let typed_kv = (c.v_nom.is_finite() && c.v_nom > 0.0).then(|| c.v_nom / 1e3);
+            let typed_kv = is_positive_finite(c.v_nom).then(|| c.v_nom / 1e3);
             if typed_kv.is_none() {
                 self.warn(format!(
                     "capacitor {}: nominal voltage {} is not a positive number; \

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -250,6 +250,24 @@ fn winding_is_line_to_neutral<'g>(
             .is_some_and(|g| w.terminal_map.iter().any(|tm| g.contains(tm)))
 }
 
+/// The conductor count a dss element declares for `phases` on `conn`. A three
+/// phase delta has no neutral conductor; every other connection carries one.
+fn nconds_for(conn: &str, phases: usize) -> usize {
+    if conn == "delta" && phases == 3 {
+        phases
+    } else {
+        phases + 1
+    }
+}
+
+/// Drop the extras the emitted record already states in its own tokens, so
+/// `extras_tail` cannot write a second, stale copy of one.
+fn strip_emitted_extras(extras: &mut Extras, keys: &[&str]) {
+    for key in keys {
+        extras.remove(*key);
+    }
+}
+
 fn num(v: f64) -> String {
     let v = if v == 0.0 { 0.0 } else { v };
     format!("{v}")
@@ -1282,11 +1300,7 @@ impl DssWriter {
         let conn = self.element_conn(&l.extras, l.configuration, &l.bus, &l.terminal_map);
         // The reader's nconds: a 3 phase delta has no neutral conductor,
         // every other connection carries phases + 1.
-        let nconds = if conn == "delta" && phases == 3 {
-            phases
-        } else {
-            phases + 1
-        };
+        let nconds = nconds_for(conn, phases);
         self.warn_short_map("load", &l.name, l.terminal_map.len(), nconds);
         let kw: f64 = l.p_nom.iter().sum::<f64>() / 1e3;
         let kvar: f64 = l.q_nom.iter().sum::<f64>() / 1e3;
@@ -1303,9 +1317,7 @@ impl DssWriter {
             },
         );
         let mut extras = l.extras.clone();
-        extras.remove("kv");
-        extras.remove("phases");
-        extras.remove("conn");
+        strip_emitted_extras(&mut extras, &["kv", "phases", "conn"]);
         let retained_model = extras.remove("model");
         let retained_zipv = extras.remove("zipv");
         // q that came from a power factor goes back as pf=, so the
@@ -1688,11 +1700,7 @@ impl DssWriter {
                 &c.name,
             );
             let conn = self.element_conn(&c.extras, c.configuration, &c.bus, &c.terminal_map);
-            let nconds = if conn == "delta" && phases == 3 {
-                phases
-            } else {
-                phases + 1
-            };
+            let nconds = nconds_for(conn, phases);
             self.warn_short_map("capacitor", &c.name, c.terminal_map.len(), nconds);
             let typed_kv = (c.v_nom.is_finite() && c.v_nom > 0.0).then(|| c.v_nom / 1e3);
             if typed_kv.is_none() {
@@ -1714,10 +1722,7 @@ impl DssWriter {
                 },
             );
             let mut extras = c.extras.clone();
-            extras.remove("kv");
-            extras.remove("phases");
-            extras.remove("conn");
-            extras.remove("kvar");
+            strip_emitted_extras(&mut extras, &["kv", "phases", "conn", "kvar"]);
             let mut line = format!(
                 "New Capacitor.{} bus1={} phases={phases} conn={conn} kv={} kvar={}",
                 c.name,
@@ -1758,11 +1763,7 @@ impl DssWriter {
                 &g.name,
             );
             let conn = self.element_conn(&g.extras, g.configuration, &g.bus, &g.terminal_map);
-            let nconds = if conn == "delta" && phases == 3 {
-                phases
-            } else {
-                phases + 1
-            };
+            let nconds = nconds_for(conn, phases);
             self.warn_short_map("generator", &g.name, g.terminal_map.len(), nconds);
             let kw: f64 = g.p_nom.iter().sum::<f64>() / 1e3;
             let kvar: f64 = g.q_nom.iter().sum::<f64>() / 1e3;
@@ -1808,9 +1809,7 @@ impl DssWriter {
                 }
             }
             let mut extras = g.extras.clone();
-            extras.remove("kv");
-            extras.remove("phases");
-            extras.remove("conn");
+            strip_emitted_extras(&mut extras, &["kv", "phases", "conn"]);
             s.push_str(&self.extras_tail("generator", &g.name, &extras));
             self.line_out(&s);
         }

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -360,23 +360,7 @@ class Network:
         branches = self._inner.branches
         generators = self._inner.generators
         bus_ids = np.asarray([b["id"] for b in buses], dtype=np.int64)
-        id_to_idx = {int(bus_id): idx for idx, bus_id in enumerate(bus_ids)}
-
-        pd = np.zeros(len(buses), dtype=float)
-        qd = np.zeros(len(buses), dtype=float)
-        for load in self._inner.loads:
-            idx = id_to_idx.get(load["bus"])
-            if idx is not None:
-                pd[idx] += load["p"]
-                qd[idx] += load["q"]
-
-        gs = np.zeros(len(buses), dtype=float)
-        bs = np.zeros(len(buses), dtype=float)
-        for shunt in self._inner.shunts:
-            idx = id_to_idx.get(shunt["bus"])
-            if idx is not None:
-                gs[idx] += shunt["g"]
-                bs[idx] += shunt["b"]
+        pd, qd, gs, bs = _bus_sums(np, buses, self._inner.loads, self._inner.shunts)
 
         branch = DenseBranch(
             from_id=np.asarray([br["from_id"] for br in branches], dtype=np.int64),
@@ -559,24 +543,20 @@ class Network:
         """
         np = _require("numpy", "matrix")
         buses = self._inner.buses
-        row_of = {b["id"]: i for i, b in enumerate(buses)}
-        bus = np.zeros((len(buses), 13))
-        for i, b in enumerate(buses):
-            bus[i, :] = (
-                b["id"], _PPC_BUS_TYPE.get(b["kind"], 1.0), 0.0, 0.0, 0.0, 0.0,
-                b["area"], b["vm"], b["va"], b["base_kv"], b["zone"],
-                b["vmax"], b["vmin"],
-            )
-        for load in self._inner.loads:
-            i = row_of.get(load["bus"])
-            if i is not None:
-                bus[i, 2] += load["p"]
-                bus[i, 3] += load["q"]
-        for shunt in self._inner.shunts:
-            i = row_of.get(shunt["bus"])
-            if i is not None:
-                bus[i, 4] += shunt["g"]
-                bus[i, 5] += shunt["b"]
+        bus = np.array(
+            [
+                (
+                    b["id"], _PPC_BUS_TYPE.get(b["kind"], 1.0), 0.0, 0.0, 0.0, 0.0,
+                    b["area"], b["vm"], b["va"], b["base_kv"], b["zone"],
+                    b["vmax"], b["vmin"],
+                )
+                for b in buses
+            ],
+            dtype=float,
+        ).reshape(len(buses), 13)
+        bus[:, 2], bus[:, 3], bus[:, 4], bus[:, 5] = _bus_sums(
+            np, buses, self._inner.loads, self._inner.shunts
+        )
 
         # The capability and ramp columns past PMIN are an OPF extension that a
         # source need not carry. Widen to the full 21 only when a generator
@@ -586,24 +566,31 @@ class Network:
         gens = self._inner.generators
         caps = [g["caps"] for g in gens]
         width = 21 if any(c is not None for row in caps for c in row) else 10
-        gen = np.zeros((len(gens), width))
-        for i, g in enumerate(gens):
-            gen[i, :10] = (
-                g["bus"], g["pg"], g["qg"], g["qmax"], g["qmin"], g["vg"],
-                g["mbase"], float(g["in_service"]), g["pmax"], g["pmin"],
-            )
-            if width == 21:
-                gen[i, 10:] = [0.0 if c is None else c for c in caps[i]]
+        gen = np.array(
+            [
+                [
+                    g["bus"], g["pg"], g["qg"], g["qmax"], g["qmin"], g["vg"],
+                    g["mbase"], float(g["in_service"]), g["pmax"], g["pmin"],
+                ]
+                + ([0.0 if c is None else c for c in row] if width == 21 else [])
+                for g, row in zip(gens, caps)
+            ],
+            dtype=float,
+        ).reshape(len(gens), width)
 
         branches = self._inner.branches
-        branch = np.zeros((len(branches), 13))
-        for i, br in enumerate(branches):
-            branch[i, :] = (
-                br["from_id"], br["to_id"], br["r"], br["x"], br["b"],
-                br["rate_a"], br["rate_b"], br["rate_c"], br["tap"],
-                br["shift"], float(br["in_service"]), br["angmin"],
-                br["angmax"],
-            )
+        branch = np.array(
+            [
+                (
+                    br["from_id"], br["to_id"], br["r"], br["x"], br["b"],
+                    br["rate_a"], br["rate_b"], br["rate_c"], br["tap"],
+                    br["shift"], float(br["in_service"]), br["angmin"],
+                    br["angmax"],
+                )
+                for br in branches
+            ],
+            dtype=float,
+        ).reshape(len(branches), 13)
 
         ppc = {
             "version": "2",
@@ -710,6 +697,28 @@ def from_json(text: str) -> Network:
 
 
 # powerio bus kind -> MATPOWER/PYPOWER BUS_TYPE code.
+def _bus_sums(np, buses, loads, shunts):
+    """Per bus `(pd, qd, gs, bs)` in bus order.
+
+    :meth:`Network.to_dense` and :meth:`Network.to_ppc` both fold the element
+    tables onto their bus the way the Rust indexed analysis view does. This is
+    that fold, once.
+    """
+    row_of = {b["id"]: i for i, b in enumerate(buses)}
+    pd, qd, gs, bs = (np.zeros(len(buses), dtype=float) for _ in range(4))
+    for load in loads:
+        i = row_of.get(load["bus"])
+        if i is not None:
+            pd[i] += load["p"]
+            qd[i] += load["q"]
+    for shunt in shunts:
+        i = row_of.get(shunt["bus"])
+        if i is not None:
+            gs[i] += shunt["g"]
+            bs[i] += shunt["b"]
+    return pd, qd, gs, bs
+
+
 _PPC_BUS_TYPE = {"PQ": 1.0, "PV": 2.0, "REF": 3.0, "ISOLATED": 4.0}
 
 # MATPOWER case-input table widths. PYPOWER result tables append columns


### PR DESCRIPTION
Quality only, no behavior change. A four angle cleanup pass over everything that landed since v0.8.1 (`git diff 16b804eb..main`), applying what survived review.

**dss writer.** The conductor count and the "drop the extras this record already states in its own tokens" step were each written out at three call sites, the third arriving with the capacitor writer in #298. Both are one helper now (`nconds_for`, `strip_emitted_extras`), so the next element type does not add a fourth copy.

**dss reader.** `line_rating` and `line_emergamps` were a single caller wrapping a single caller. They read as one function.

**ppc bridge.** `to_ppc` folded loads and shunts onto their bus with its own copy of the loop `to_dense` already had 200 lines above it; `_bus_sums` is that fold, once, and both call it. The three ppc tables are each built in one array construction rather than a row at a time, which also drops one `ndarray.__setitem__` per element on a large case.

## Deferred, deliberately

`normalize.rs` builds four element structs as `Struct { field: new, ..src.clone() }`, where the clone allocates the very field the literal overrides — `rating_sets` per branch, `coeffs` per gen cost and per HVDC link, `blocks` per switched shunt. That is real per element waste on a pass that runs before every solve, but it predates v0.8.1 (six sites, unchanged by this release) and rewriting them is not something to land between a release candidate and its tag. Worth its own PR after v0.8.2.

Also considered and left alone: extracting the shared iterator wrapper from the eight `norm_*` functions (the closure bodies genuinely differ, and the higher order form would hide which families filter on `in_service`), and the per field serde `with` modules in `nonfinite.rs` (the split earns its keep across ~15 fields).

`cargo test` passes for powerio, powerio-dist, powerio-pkg and powerio-cli; clippy is clean at `-D warnings`; ruff, mypy and the 89 python tests pass.