### PR TITLE
dist: split a center tapped load and repair a degenerate star

### DIFF
--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -52,7 +52,10 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
         base_frequency: 60.0,
         ..DistNetwork::default()
     };
-    let mut rd = Reader { net: &mut net };
+    let mut rd = Reader {
+        net: &mut net,
+        frequency_stated: false,
+    };
     rd.document(&doc);
     crate::model::warn_unresolved_references(&mut net);
     Ok(net)
@@ -60,6 +63,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
 
 struct Reader<'a> {
     net: &'a mut DistNetwork,
+    frequency_stated: bool,
 }
 
 const BMOPF_DELTA_ROLLS_EXTRA: &str = "bmopf_delta_rolls";
@@ -308,6 +312,7 @@ impl Reader<'_> {
             && frequency > 0.0
         {
             self.net.base_frequency = frequency;
+            self.frequency_stated = true;
         }
         // `serde_json::Map` iterates in key order, so the loop below reaches
         // `line` before `linecode`. A line with inline impedance synthesizes a
@@ -403,6 +408,9 @@ impl Reader<'_> {
             }
         }
         self.warn_orphan_transformer_overlay(doc);
+        if !self.frequency_stated {
+            crate::model::warn_defaulted_frequency(self.net, "frequency");
+        }
     }
 
     /// The `extras.transformer` overlay carries the transformer fields that
@@ -1304,6 +1312,18 @@ impl Reader<'_> {
             },
         ];
         expand_center_tap_windings(subtype, &mut windings, &self.net.buses);
+        if subtype == "center_tap"
+            && let Some(w) = windings.get(1)
+            && let Some(band) = phase_to_neutral_midpoint(w, &self.net.buses)
+            && (w.v_ref - band).abs() > (w.v_ref / 2.0 - band).abs() * 4.0
+        {
+            self.net.warnings.push(format!(
+                "transformer {name}: v_nom_to {} is about twice the {band} V the \
+                 secondary bus states phase to neutral, the value a full span \
+                 reading gives; the convention is the per leg voltage",
+                w.v_ref
+            ));
+        }
         let mut extras = take_extras(
             o,
             &known,
@@ -1450,6 +1470,18 @@ impl Reader<'_> {
             extras,
         }
     }
+}
+
+/// The middle of the secondary bus's phase to neutral band, when it states
+/// one. A center tapped winding's `v_nom_to` is the per leg voltage, so the
+/// two agree; a source that states the full span across both legs lands at
+/// twice this.
+fn phase_to_neutral_midpoint(w: &Winding, buses: &[DistBus]) -> Option<f64> {
+    let bus = buses.iter().find(|b| b.id == w.bus)?;
+    let lo = bus.vpn_min.as_ref()?.first()?;
+    let hi = bus.vpn_max.as_ref()?.first()?;
+    let mid = (lo + hi) / 2.0;
+    (mid.is_finite() && mid > 0.0 && w.v_ref.is_finite()).then_some(mid)
 }
 
 fn expand_center_tap_windings(subtype: &str, windings: &mut Vec<Winding>, buses: &[DistBus]) {

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -2485,6 +2485,14 @@ mod tests {
         }
     }
 
+    /// A source bus and a secondary spelled the way a center tapped service
+    /// is: two hot terminals with the grounded return between them.
+    fn center_tap_service(vln: f64) -> (DistBus, VoltageSource, DistBus) {
+        let (mut source, vs) = three_phase_source(vln);
+        source.id = "sb".into();
+        (source, vs, bus("lv", &["p1", "n", "p2"], &["n"]))
+    }
+
     fn three_phase_source(vln: f64) -> (DistBus, VoltageSource) {
         let third = 2.0 * std::f64::consts::FRAC_PI_3;
         (
@@ -3146,9 +3154,7 @@ mod tests {
         // dss reads a node list positionally, so one record over that map
         // states the wrong node pair and drops the conductors it cannot
         // address. The powers are equal, so the imbalance split never fires.
-        let (mut b, vs) = three_phase_source(11000.0);
-        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
-        b.id = "sb".into();
+        let (b, vs, lv) = center_tap_service(11000.0);
         let l = DistLoad {
             name: "ld".into(),
             bus: "lv".into(),
@@ -3192,9 +3198,7 @@ mod tests {
         // The balanced case cannot catch a swap. With the return conductor mid
         // map, taking the last terminal as the return pairs leg 1 with the
         // neutral and puts the second leg across both hots.
-        let (mut b, vs) = three_phase_source(11000.0);
-        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
-        b.id = "sb".into();
+        let (b, vs, lv) = center_tap_service(11000.0);
         let l = DistLoad::new(
             "ld",
             "lv",
@@ -3237,9 +3241,7 @@ mod tests {
     fn a_map_longer_than_the_record_says_what_dss_drops() {
         // The mirror of the short map warning. One power value over three
         // conductors cannot split, so the arity is all the writer can report.
-        let (mut b, vs) = three_phase_source(11000.0);
-        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
-        b.id = "sb".into();
+        let (b, vs, lv) = center_tap_service(11000.0);
         let mut l = DistLoad::new(
             "ld",
             "lv",
@@ -3277,9 +3279,7 @@ mod tests {
         // PowerIO.jl#79 bug 3. BMOPF puts the whole leakage on the primary
         // arm, so the star back solves to xlt=0, which dss converges on with
         // the secondary legs collapsed to about half voltage.
-        let (mut b, vs) = three_phase_source(11000.0);
-        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
-        b.id = "sb".into();
+        let (b, vs, lv) = center_tap_service(11000.0);
         let winding = |bus: &str, map: &[&str], v: f64| Winding {
             bus: bus.into(),
             terminal_map: strings(map),

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -19,9 +19,9 @@ use std::fmt::Write as _;
 use crate::convert::{Conversion, ConversionSidecar};
 use crate::model::{
     ActivePowerReference, Configuration, ControlVoltageReference, DistBus, DistControlProfile,
-    DistIbr, DistLoad, DistLoadVoltageModel, DistNetwork, Extras, IbrPrimeMover, IbrTopology,
-    IbrVoltageAggregation, Mat, ReactivePowerReference, VoltVarControl, VoltWattControl, Winding,
-    WindingConn,
+    DistIbr, DistLoad, DistLoadVoltageModel, DistNetwork, DistTransformer, Extras, IbrPrimeMover,
+    IbrTopology, IbrVoltageAggregation, Mat, ReactivePowerReference, VoltVarControl,
+    VoltWattControl, Winding, WindingConn,
 };
 
 use super::read::delta_edges;
@@ -461,14 +461,35 @@ impl DssWriter {
     /// ground for the rest — so a map shorter than the class's conductor
     /// count comes back from a reparse one grounded neutral longer. The
     /// first write of such a model is not a fixed point; the second is.
-    fn warn_short_map(&mut self, class: &str, name: &str, map_len: usize, nconds: usize) {
+    /// A map longer than the count is the more serious direction: dss reads
+    /// the node list positionally and drops what the record cannot address.
+    fn warn_map_arity(&mut self, class: &str, name: &str, map_len: usize, nconds: usize) {
         if map_len < nconds {
             self.warn(format!(
                 "{class} {name}: terminal map lists {map_len} of {nconds} conductors; \
                  dss materializes a grounded neutral terminal and the reparsed model \
                  gains one"
             ));
+        } else if map_len > nconds {
+            self.warn(format!(
+                "{class} {name}: terminal map lists {map_len} conductors but the record \
+                 addresses {nconds}; dss discards the last {} and the model loses them",
+                map_len - nconds
+            ));
         }
+    }
+
+    /// The position of the bus's grounded terminal in `map`, when the bus
+    /// grounds exactly one terminal the map lists. dss reads a node list
+    /// positionally, so this conductor belongs last.
+    fn return_terminal_index(&self, bus: &str, map: &[String]) -> Option<usize> {
+        let grounded = self.grounded.get(&bus.to_ascii_lowercase())?;
+        let mut found = map
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| grounded.contains(*t));
+        let (idx, _) = found.next()?;
+        found.next().is_none().then_some(idx)
     }
 
     /// A numeric source extra. A present token that does not parse warns;
@@ -874,7 +895,7 @@ impl DssWriter {
                     vs.name
                 ));
             }
-            self.warn_short_map("vsource", &vs.name, vs.terminal_map.len(), phases + 1);
+            self.warn_map_arity("vsource", &vs.name, vs.terminal_map.len(), phases + 1);
             let basekv = self
                 .source_extra_f64(vs, "basekv")
                 .unwrap_or_else(|| source_basekv(vs, phases));
@@ -1154,7 +1175,8 @@ impl DssWriter {
             if let Some(xhl) = t.xsc_pct.first() {
                 let _ = write!(s, " xhl={}", num(*xhl));
                 if t.xsc_pct.len() >= 3 {
-                    let _ = write!(s, " xht={} xlt={}", num(t.xsc_pct[1]), num(t.xsc_pct[2]));
+                    let xlt = self.star_xlt(t);
+                    let _ = write!(s, " xht={} xlt={}", num(t.xsc_pct[1]), num(xlt));
                 }
             } else {
                 self.warn(format!(
@@ -1180,6 +1202,41 @@ impl DssWriter {
             }
         }
         self.out.push('\n');
+    }
+
+    /// The `xlt=` value for a three winding record. dss cannot solve a star
+    /// whose third arm is zero: the two secondary legs collapse to about half
+    /// voltage and read unequal under balanced load, and the solution
+    /// converges without an error. A source that lumps the whole leakage on
+    /// the primary arm states exactly that, so the split from the OpenDSS
+    /// center tap example, `xlt = 2/3 xhl` at `xhl = xht`, substitutes.
+    fn star_xlt(&mut self, t: &DistTransformer) -> f64 {
+        let (xhl, xht, xlt) = (t.xsc_pct[0], t.xsc_pct[1], t.xsc_pct[2]);
+        if xlt > 0.0 && xlt.is_finite() {
+            return xlt;
+        }
+        #[allow(clippy::float_cmp)]
+        let lumped_on_primary = xhl == xht && xhl > 0.0 && xhl.is_finite();
+        if !lumped_on_primary {
+            self.warn(format!(
+                "transformer {}: xlt={} is not a reactance dss can solve, and the \
+                 other two arms do not determine a replacement; emitted as stated",
+                t.name,
+                num(xlt)
+            ));
+            return xlt;
+        }
+        let repaired = 2.0 / 3.0 * xhl;
+        self.warn(format!(
+            "transformer {}: the source puts the whole leakage on the primary arm, \
+             leaving xlt={}; dss solves that star as a collapsed secondary, so \
+             xlt={} went out instead, holding xhl={}",
+            t.name,
+            num(xlt),
+            num(repaired),
+            num(xhl)
+        ));
+        repaired
     }
 
     /// The winding `kv=` value in kV, or `None` if no value is available.
@@ -1244,7 +1301,15 @@ impl DssWriter {
         // imbalance is allowed to vanish.
         #[allow(clippy::float_cmp)]
         let uniform = |xs: &[f64]| xs.iter().all(|x| *x == xs[0]);
-        if n < 2 || l.q_nom.len() != n || (uniform(&l.p_nom) && uniform(&l.q_nom)) {
+        let stated_per_phase = n >= 2 && l.q_nom.len() == n;
+        let unbalanced = stated_per_phase && !(uniform(&l.p_nom) && uniform(&l.q_nom));
+        // dss reads the node list positionally: phase conductors first, the
+        // return last. A center tapped service maps as `[p1, n, p2]`, so one
+        // record over that map names a different node pair than the load sits
+        // on however its power divides.
+        let return_index = self.return_terminal_index(&l.bus, &l.terminal_map);
+        let misordered = return_index.is_some_and(|i| i + 1 != l.terminal_map.len());
+        if !unbalanced && !misordered {
             return vec![Cow::Borrowed(l)];
         }
         if l.configuration == Configuration::Delta {
@@ -1255,26 +1320,39 @@ impl DssWriter {
             ));
             return vec![Cow::Borrowed(l)];
         }
-        if l.terminal_map.len() < n {
+        // Without a grounded terminal the map states the return last, the
+        // shape the reader writes for a wye element.
+        let (hot_indices, return_terminal) = match return_index {
+            Some(i) => (
+                (0..l.terminal_map.len()).filter(|j| *j != i).collect(),
+                Some(l.terminal_map[i].clone()),
+            ),
+            None if l.terminal_map.len() > n => ((0..n).collect(), Some(l.terminal_map[n].clone())),
+            None => ((0..l.terminal_map.len()).collect::<Vec<_>>(), None),
+        };
+        if !stated_per_phase || hot_indices.len() != n {
             self.warn(format!(
-                "load {}: per phase power over {n} phases but only {} terminals; \
-                 emitted one balanced Load carrying the total",
+                "load {}: {} over a terminal map with {} phase conductors; \
+                 emitted one Load carrying the total",
                 l.name,
-                l.terminal_map.len()
+                if stated_per_phase {
+                    format!("per phase power over {n} phases")
+                } else {
+                    "one power value".to_string()
+                },
+                hot_indices.len()
             ));
             return vec![Cow::Borrowed(l)];
         }
-        // A wye map carries the return as its last conductor; each part keeps
-        // its own phase and that return, so `bus_ref` spells the same node pair
-        // the whole load sat on.
-        let return_terminal = (l.terminal_map.len() > n).then(|| l.terminal_map[n].clone());
-        (0..n)
-            .map(|i| {
+        hot_indices
+            .into_iter()
+            .enumerate()
+            .map(|(i, hot)| {
                 let mut part = l.clone();
-                part.name = format!("{}_{}", l.name, l.terminal_map[i]);
+                part.name = format!("{}_{}", l.name, l.terminal_map[hot]);
                 part.terminal_map = match &return_terminal {
-                    Some(r) => vec![l.terminal_map[i].clone(), r.clone()],
-                    None => vec![l.terminal_map[i].clone()],
+                    Some(r) => vec![l.terminal_map[hot].clone(), r.clone()],
+                    None => vec![l.terminal_map[hot].clone()],
                 };
                 part.configuration = Configuration::Wye;
                 part.p_nom = vec![l.p_nom[i]];
@@ -1310,7 +1388,7 @@ impl DssWriter {
         // The reader's nconds: a 3 phase delta has no neutral conductor,
         // every other connection carries phases + 1.
         let nconds = nconds_for(conn, phases);
-        self.warn_short_map("load", &l.name, l.terminal_map.len(), nconds);
+        self.warn_map_arity("load", &l.name, l.terminal_map.len(), nconds);
         let kw: f64 = l.p_nom.iter().sum::<f64>() / 1e3;
         let kvar: f64 = l.q_nom.iter().sum::<f64>() / 1e3;
         let typed_kv = self.load_nominal_kv(&l.voltage_model, phases, l.configuration, &l.name);
@@ -1707,7 +1785,7 @@ impl DssWriter {
             );
             let conn = self.element_conn(&c.extras, c.configuration, &c.bus, &c.terminal_map);
             let nconds = nconds_for(conn, phases);
-            self.warn_short_map("capacitor", &c.name, c.terminal_map.len(), nconds);
+            self.warn_map_arity("capacitor", &c.name, c.terminal_map.len(), nconds);
             let typed_kv = is_positive_finite(c.v_nom).then(|| c.v_nom / 1e3);
             if typed_kv.is_none() {
                 self.warn(format!(
@@ -1770,7 +1848,7 @@ impl DssWriter {
             );
             let conn = self.element_conn(&g.extras, g.configuration, &g.bus, &g.terminal_map);
             let nconds = nconds_for(conn, phases);
-            self.warn_short_map("generator", &g.name, g.terminal_map.len(), nconds);
+            self.warn_map_arity("generator", &g.name, g.terminal_map.len(), nconds);
             let kw: f64 = g.p_nom.iter().sum::<f64>() / 1e3;
             let kvar: f64 = g.q_nom.iter().sum::<f64>() / 1e3;
             let kv = self.element_kv(
@@ -3059,6 +3137,148 @@ mod tests {
             1,
             "a balanced load stays one object: {}",
             out.text
+        );
+    }
+
+    #[test]
+    fn a_center_tap_load_splits_onto_its_two_legs() {
+        // PowerIO.jl#79. A center tapped service maps as `[p1, n, p2]`, and
+        // dss reads a node list positionally, so one record over that map
+        // states the wrong node pair and drops the conductors it cannot
+        // address. The powers are equal, so the imbalance split never fires.
+        let (mut b, vs) = three_phase_source(11000.0);
+        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
+        b.id = "sb".into();
+        let l = DistLoad {
+            name: "ld".into(),
+            bus: "lv".into(),
+            terminal_map: strings(&["p1", "n", "p2"]),
+            configuration: Configuration::Wye,
+            p_nom: vec![1304.0, 1304.0],
+            q_nom: vec![978.0, 978.0],
+            voltage_model: DistLoadVoltageModel::ConstantImpedance { v_nom: Vec::new() },
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b, lv],
+            sources: vec![vs],
+            loads: vec![l],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let loads: Vec<&str> = out
+            .text
+            .lines()
+            .filter(|l| l.contains("New Load."))
+            .collect();
+        assert_eq!(loads.len(), 2, "{}", out.text);
+        // Each leg carries half the power over its own hot node and the
+        // grounded return, which dss spells as node 0.
+        for (name, node) in [("ld_p1", "lv.1.0"), ("ld_p2", "lv.3.0")] {
+            let line = loads
+                .iter()
+                .find(|l| l.contains(&format!("New Load.{name} ")))
+                .unwrap_or_else(|| panic!("no {name}: {}", out.text));
+            assert!(line.contains(&format!("bus1={node} ")), "{line}");
+            assert!(line.contains("phases=1"), "{line}");
+            assert!(line.contains("kw=1.304"), "{line}");
+            assert!(line.contains("kvar=0.978"), "{line}");
+        }
+    }
+
+    #[test]
+    fn a_map_longer_than_the_record_says_what_dss_drops() {
+        // The mirror of the short map warning. One power value over three
+        // conductors cannot split, so the arity is all the writer can report.
+        let (mut b, vs) = three_phase_source(11000.0);
+        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
+        b.id = "sb".into();
+        let mut l = DistLoad::new(
+            "ld",
+            "lv",
+            strings(&["p1", "n", "p2"]),
+            Configuration::Wye,
+            vec![2608.0],
+            vec![1956.0],
+        );
+        l.extras.insert("phases".into(), 1.into());
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b, lv],
+            sources: vec![vs],
+            loads: vec![l],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        assert_eq!(
+            out.text.lines().filter(|l| l.contains("New Load.")).count(),
+            1,
+            "{}",
+            out.text
+        );
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("addresses 2") && w.contains("loses them")),
+            "{:?}",
+            out.warnings
+        );
+    }
+
+    #[test]
+    fn a_star_with_no_secondary_leakage_goes_out_solvable() {
+        // PowerIO.jl#79 bug 3. BMOPF puts the whole leakage on the primary
+        // arm, so the star back solves to xlt=0, which dss converges on with
+        // the secondary legs collapsed to about half voltage.
+        let (mut b, vs) = three_phase_source(11000.0);
+        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
+        b.id = "sb".into();
+        let winding = |bus: &str, map: &[&str], v: f64| Winding {
+            bus: bus.into(),
+            terminal_map: strings(map),
+            conn: WindingConn::Wye,
+            v_ref: v,
+            s_rating: 25e3,
+            r_pct: 0.5,
+            tap: 1.0,
+            r_neutral: None,
+            x_neutral: None,
+        };
+        let t = DistTransformer {
+            name: "tx".into(),
+            phases: 1,
+            windings: vec![
+                winding("sb", &["1", "4"], 11000.0),
+                winding("lv", &["p1", "n"], 240.0),
+                winding("lv", &["n", "p2"], 240.0),
+            ],
+            xsc_pct: vec![2.5, 2.5, 0.0],
+            extras: Extras::new(),
+        };
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b, lv],
+            sources: vec![vs],
+            transformers: vec![t],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let line = out
+            .text
+            .lines()
+            .find(|l| l.contains("New Transformer.tx"))
+            .unwrap_or_else(|| panic!("no transformer: {}", out.text));
+        assert!(line.contains("xhl=2.5 xht=2.5 xlt=1.666"), "{line}");
+        // The reversed third winding is the dss center tap spelling, not a
+        // node order fault: the two halves are series additive.
+        assert!(line.contains("buses=(sb.1.0, lv.1.0, lv.0.3)"), "{line}");
+        assert!(
+            out.warnings
+                .iter()
+                .any(|w| w.contains("collapsed secondary")),
+            "{:?}",
+            out.warnings
         );
     }
 

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -3188,6 +3188,52 @@ mod tests {
     }
 
     #[test]
+    fn an_unbalanced_center_tap_load_keeps_each_leg_with_its_own_power() {
+        // The balanced case cannot catch a swap. With the return conductor mid
+        // map, taking the last terminal as the return pairs leg 1 with the
+        // neutral and puts the second leg across both hots.
+        let (mut b, vs) = three_phase_source(11000.0);
+        let lv = bus("lv", &["p1", "n", "p2"], &["n"]);
+        b.id = "sb".into();
+        let l = DistLoad::new(
+            "ld",
+            "lv",
+            strings(&["p1", "n", "p2"]),
+            Configuration::Wye,
+            vec![1000.0, 2000.0],
+            vec![100.0, 200.0],
+        );
+        let net = DistNetwork {
+            base_frequency: 60.0,
+            buses: vec![b, lv],
+            sources: vec![vs],
+            loads: vec![l],
+            ..DistNetwork::default()
+        };
+        let out = write_dss(&net);
+        let loads: Vec<&str> = out
+            .text
+            .lines()
+            .filter(|l| l.contains("New Load."))
+            .collect();
+        assert_eq!(loads.len(), 2, "{}", out.text);
+        for (name, node, kw, kvar) in [
+            ("ld_p1", "lv.1.0", "1", "0.1"),
+            ("ld_p2", "lv.3.0", "2", "0.2"),
+        ] {
+            let line = loads
+                .iter()
+                .find(|l| l.contains(&format!("New Load.{name} ")))
+                .unwrap_or_else(|| panic!("no {name}: {}", out.text));
+            assert!(line.contains(&format!("bus1={node} ")), "{line}");
+            assert!(line.contains(&format!("kw={kw} ")), "{line}");
+            assert!(line.contains(&format!("kvar={kvar}")), "{line}");
+        }
+        // No part lands on the neutral terminal or spans the two hot legs.
+        assert!(!out.text.contains("New Load.ld_n "), "{}", out.text);
+    }
+
+    #[test]
     fn a_map_longer_than_the_record_says_what_dss_drops() {
         // The mirror of the short map warning. One power value over three
         // conductors cannot split, so the arity is all the writer can report.

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -1014,6 +1014,27 @@ impl DistNetwork {
     }
 }
 
+/// Susceptance converts to a dss `cmatrix` at the network frequency, so a
+/// 50 Hz feeder read at the 60 Hz default loses a fifth of its line charging,
+/// and a stated 60 Hz is indistinguishable from a defaulted one downstream.
+/// Only a network carrying susceptance can lose anything, so a document that
+/// states no frequency and no charging stays quiet.
+pub(crate) fn warn_defaulted_frequency(net: &mut DistNetwork, field: &str) {
+    let charging = net.linecodes.iter().any(|c| {
+        [&c.b_from, &c.b_to]
+            .iter()
+            .flat_map(|m| m.iter())
+            .flatten()
+            .any(|v| v.is_finite() && v.abs() > 0.0)
+    });
+    if charging {
+        net.warnings.push(format!(
+            "document states no {field} and carries line susceptance; read at {} Hz",
+            net.base_frequency
+        ));
+    }
+}
+
 /// Push a warning for every dangling or empty cross-reference. Bus and
 /// linecode references are bare strings, a reader leaves an empty string
 /// where the field is missing, and the graph projection synthesizes a

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -372,10 +372,15 @@ impl Reader<'_> {
         if let Some(name) = doc.get("name").and_then(Value::as_str) {
             self.net.name = Some(name.to_string());
         }
+        let stated = doc
+            .get("settings")
+            .and_then(Value::as_object)
+            .and_then(|s| s.get("base_frequency"))
+            .and_then(Value::as_f64);
+        if let Some(f) = stated {
+            self.net.base_frequency = f;
+        }
         if let Some(settings) = doc.get("settings").and_then(Value::as_object) {
-            if let Some(f) = settings.get("base_frequency").and_then(Value::as_f64) {
-                self.net.base_frequency = f;
-            }
             self.net
                 .extras
                 .insert("pmd_settings".into(), Value::Object(settings.clone()));
@@ -420,6 +425,9 @@ impl Reader<'_> {
                     props: vec![(None, v.to_string())],
                 });
             }
+        }
+        if stated.is_none() {
+            crate::model::warn_defaulted_frequency(self.net, "settings.base_frequency");
         }
     }
 

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -2064,6 +2064,115 @@ fn bmopf_center_tap_canonical_order_rebuilds_dss_grounded_center() {
 }
 
 #[test]
+fn bmopf_center_tap_service_exports_solvable_dss() {
+    // PowerIO.jl#79, reduced to one consumer. The load is balanced across the
+    // two legs, so the imbalance split never fires; the star has no secondary
+    // leakage, so it back solves to xlt=0; and `v_nom_to` states the full
+    // span, which the bus's own phase to neutral band contradicts.
+    let text = r#"{
+        "meta": {"frequency": 50.0},
+        "bus": {
+            "hv": {"terminal_names": ["1", "2"], "perfectly_grounded_terminals": ["2"]},
+            "lv": {
+                "terminal_names": ["1", "2", "3"],
+                "perfectly_grounded_terminals": ["2"],
+                "vpn_min": [225.6, 225.6],
+                "vpn_max": [254.4, 254.4]
+            }
+        },
+        "voltage_source": {
+            "source": {
+                "v_magnitude": [19000.0, 0.0],
+                "v_angle": [0.0, 0.0],
+                "bus": "hv",
+                "terminal_map": ["1", "2"]
+            }
+        },
+        "transformer": {
+            "center_tap": {
+                "tx": {
+                    "bus_from": "hv",
+                    "bus_to": "lv",
+                    "terminal_map_from": ["1", "2"],
+                    "terminal_map_to": ["1", "2", "3"],
+                    "s_rating": 25000.0,
+                    "v_nom_from": 19000.0,
+                    "v_nom_to": 480.0,
+                    "r_series_from": 0.5,
+                    "x_series_from": 2.5
+                }
+            }
+        },
+        "load": {
+            "ld": {
+                "bus": "lv",
+                "terminal_map": ["1", "2", "3"],
+                "p_nom": [1304.0, 1304.0],
+                "q_nom": [978.0, 978.0],
+                "model": "constant_impedance"
+            }
+        }
+    }"#;
+    let net = parse_bmopf_str(text).unwrap();
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("v_nom_to 480") && w.contains("per leg")),
+        "{:?}",
+        net.warnings
+    );
+
+    let out = write_dss(&net);
+    // One Load per leg, each on its own hot node and the grounded return.
+    let loads: Vec<&str> = out
+        .text
+        .lines()
+        .filter(|l| l.contains("New Load."))
+        .collect();
+    assert_eq!(loads.len(), 2, "{}", out.text);
+    assert!(loads.iter().all(|l| l.contains("phases=1")), "{loads:?}");
+    assert!(loads.iter().all(|l| l.contains("kw=1.304")), "{loads:?}");
+    assert!(
+        loads.iter().any(|l| l.contains("bus1=lv.1.0 ")),
+        "{loads:?}"
+    );
+    assert!(
+        loads.iter().any(|l| l.contains("bus1=lv.3.0 ")),
+        "{loads:?}"
+    );
+
+    // A star dss can solve, and the warning names the substitution.
+    let tx = out
+        .text
+        .lines()
+        .find(|l| l.contains("New Transformer.tx"))
+        .unwrap_or_else(|| panic!("no transformer: {}", out.text));
+    let arm = |key: &str| -> f64 {
+        tx.split_whitespace()
+            .find_map(|t| t.strip_prefix(key))
+            .unwrap_or_else(|| panic!("no {key} in {tx}"))
+            .parse()
+            .unwrap()
+    };
+    let (xhl, xlt) = (arm("xhl="), arm("xlt="));
+    assert!(xhl > 0.0, "{tx}");
+    assert!((xlt - 2.0 / 3.0 * xhl).abs() < 1e-12 * xhl, "{tx}");
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("collapsed secondary")),
+        "{:?}",
+        out.warnings
+    );
+    // The stated frequency reaches the deck, so the charging conversion holds.
+    assert!(
+        out.text.contains("Set DefaultBaseFrequency=50"),
+        "{}",
+        out.text
+    );
+}
+
+#[test]
 fn bmopf_center_tap_neutral_grounding_rebuilds_once() {
     let text = r#"{
         "bus": {


### PR DESCRIPTION
Addresses the OpenDSS writer faults reported in eigenergy/PowerIO.jl#79, found across three 19 kV SWER feeders with 43 centre tapped consumers each. Every one converges to a physically wrong answer with no warning, so "it solves" does not catch any of them. That issue stays open until v0.8.3 ships, so the reporter can verify against a release.

## The load (the reporter's bug 1)

A dss node list is positional: the phase conductors come first and the return last. A centre tapped service maps as `[p1, n, p2]`, so one record over that map names a different node pair than the load sits on, and dss discards the conductor it cannot address. The split added in #298 fired only on unequal per phase power, which a centre tapped consumer does not have, and `warn_short_map` reported only the opposite arity, so nothing said anything.

Measured through OpenDSS on the reported network, reduced to one consumer:

| | 0.8.2 | this branch |
|---|---|---|
| `Load` records | 1, `NodeOrder=[1, 0]`, third node dropped | 2, one per leg |
| power drawn | 0.652 kW of the stated 2.608 | 2.6079 kW |
| second leg | 324.31 V (1.3513 pu), floating | 240.0 V (1.0 pu) |

Both converge. With the legs carrying *different* power the same deck does not converge at all.

The split now keys on the conductor count rather than on imbalance, and the return conductor is found from the bus grounding rather than from its position. The old rule took the last terminal, so an unbalanced centre tapped load split onto the wrong node pairs — a test pins that, and against the old rule it emits one load across both hot conductors at `kv=12.47`. A map longer than the record now warns the way a shorter one already did.

## The star (bug 3)

BMOPF lumps the leakage on the HV star branch, so `x_series_to` is absent and the reader back solves to `xlt = 0`. powerio's own BMOPF writer emits `x_series_to = 0.0`, so this is a closed loop inside this repository, not an artifact of the reporter's file. dss solves that star with the secondary legs collapsed to about half voltage and reading unequal under balanced load. The writer substitutes `xlt = 2/3 xhl`, the split from the OpenDSS centre tap example, and names the substitution.

## The frequency (bug 4)

The writer was never at fault here: it emits `Set DefaultBaseFrequency` from the network's own `base_frequency` and uses that same value for the susceptance to capacitance conversion. The default enters one step earlier, in the BMOPF and PMD readers, which seed 60 Hz and overwrite it only if the document states the field. A 50 Hz feeder that omits it loses about a fifth of its line charging. The readers now warn, and only when the network carries susceptance, so a document with nothing to lose stays quiet.

## The secondary voltage (bug 2)

Partly the source data, as the reporter says. `v_nom_to = 480` against a bus stating `[225.6, 254.4]` phase to neutral is internally inconsistent, and powerio passed it through in silence. A `center_tap` `v_nom_to` at about twice the secondary bus's own phase to neutral band now warns. The convention itself does not change.

## Not a bug

The reversed third winding, `buses=(hv.1.0, lv.1.0, lv.0.3)`, is the documented OpenDSS centre tap spelling: the two halves are series additive. Pinned in a test so it is not changed later.

## Scope

Only `Load` reorders the return conductor. Capacitors, generators, IBRs, and both line ends still pass their stored map straight through, so the same defect is reachable there; #307 tracks it. Lines are the awkward case, since their per conductor impedance matrices are positional too.

## Verification

`cargo fmt --check`, `scripts/ci-clippy.sh`, `cargo test --workspace`, `scripts/capi-header-parity.sh`, and the conversion matrix test all pass. Four unit tests and one end to end BMOPF to dss test cover the cases above. The measurements come from OpenDSSDirect 0.9.4 against the emitted decks.

Targets v0.8.3.

