### PR TITLE
dist: refuse a malformed BMOPF numeric instead of reading NaN

### DIFF
--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -160,51 +160,19 @@ fn is_numeric_field(key: &str) -> bool {
 /// `extras` is skipped, since it round trips arbitrary consumer JSON where
 /// these names carry no schema meaning.
 fn report_non_numeric_fields(doc: &Map<String, Value>, net: &mut DistNetwork) {
-    fn numeric(v: &Value) -> bool {
+    /// What the value holds, or `None` when the schema allows it.
+    fn not_numeric(v: &Value) -> Option<&'static str> {
         match v {
-            Value::Number(_) => true,
-            Value::Array(a) => a.iter().all(Value::is_number),
-            _ => false,
+            Value::Number(_) => None,
+            Value::Array(a) if a.iter().all(Value::is_number) => None,
+            Value::Null => Some("null"),
+            Value::Bool(_) => Some("a boolean"),
+            Value::String(_) => Some("a string"),
+            Value::Array(_) => Some("an array holding a value that is not a number"),
+            Value::Object(_) => Some("an object"),
         }
     }
-    fn kind(v: &Value) -> &'static str {
-        match v {
-            Value::Null => "null",
-            Value::Bool(_) => "a boolean",
-            Value::String(_) => "a string",
-            Value::Array(_) => "an array holding a value that is not a number",
-            Value::Object(_) => "an object",
-            Value::Number(_) => unreachable!("a number is not reported"),
-        }
-    }
-    fn walk(obj: &Map<String, Value>, path: &str, out: &mut Vec<(String, &'static str)>) {
-        for (key, value) in obj {
-            if key == "extras" {
-                continue;
-            }
-            let child = format!("{path}/{key}");
-            if is_numeric_field(key) {
-                if !numeric(value) {
-                    out.push((child, kind(value)));
-                }
-                continue;
-            }
-            match value {
-                Value::Object(o) => walk(o, &child, out),
-                Value::Array(a) => {
-                    for (i, e) in a.iter().enumerate() {
-                        if let Value::Object(o) = e {
-                            walk(o, &format!("{child}/{i}"), out);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-    let mut found = Vec::new();
-    walk(doc, "", &mut found);
-    for (pointer, what) in found {
+    fn report(net: &mut DistNetwork, pointer: String, what: &str) {
         let message = format!(
             "{pointer}: the schema types this field as a number and it holds {what}; \
              it reads as NaN and anything derived from it is undefined"
@@ -221,6 +189,33 @@ fn report_non_numeric_fields(doc: &Map<String, Value>, net: &mut DistNetwork) {
             .with_suggested_action("state a number, or omit the field"),
         );
     }
+    // A pointer costs an allocation, so it is built for a container the walk
+    // descends into and for a field it reports, never for a sound leaf.
+    fn walk(obj: &Map<String, Value>, path: &str, net: &mut DistNetwork) {
+        for (key, value) in obj {
+            if key == "extras" {
+                continue;
+            }
+            if is_numeric_field(key) {
+                if let Some(what) = not_numeric(value) {
+                    report(net, format!("{path}/{key}"), what);
+                }
+                continue;
+            }
+            match value {
+                Value::Object(o) => walk(o, &format!("{path}/{key}"), net),
+                Value::Array(a) => {
+                    for (i, e) in a.iter().enumerate() {
+                        if let Value::Object(o) = e {
+                            walk(o, &format!("{path}/{key}/{i}"), net);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    walk(doc, "", net);
 }
 
 struct Reader<'a> {

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -129,8 +129,10 @@ fn is_numeric_matrix_field(key: &str) -> bool {
         .any(|p| matrix_indices(key, p).is_some())
 }
 
+/// Runs for every key in the document, so the exact set is a binary search
+/// rather than a scan. `NUMERIC_FIELDS` is sorted, which a test holds.
 fn is_numeric_field(key: &str) -> bool {
-    NUMERIC_FIELDS.contains(&key) || is_numeric_matrix_field(key)
+    NUMERIC_FIELDS.binary_search(&key).is_ok() || is_numeric_matrix_field(key)
 }
 
 /// Report every schema-numeric field holding something that is not a number.
@@ -1840,5 +1842,10 @@ mod tests {
                 "`{name}` is not a schema number"
             );
         }
+        // `is_numeric_field` binary searches this list.
+        assert!(
+            super::NUMERIC_FIELDS.is_sorted(),
+            "NUMERIC_FIELDS must stay sorted"
+        );
     }
 }

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -40,7 +40,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
         format: "BMOPF",
         message: e.to_string(),
     })?;
-    let Value::Object(mut doc) = doc else {
+    let Value::Object(doc) = doc else {
         return Err(Error::Json {
             format: "BMOPF",
             message: "top level is not an object".into(),
@@ -52,7 +52,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
         base_frequency: 60.0,
         ..DistNetwork::default()
     };
-    drop_non_numeric_fields(&mut doc, &mut net);
+    report_non_numeric_fields(&doc, &mut net);
     let mut rd = Reader {
         net: &mut net,
         frequency_stated: false,
@@ -142,22 +142,24 @@ fn is_numeric_field(key: &str) -> bool {
     NUMERIC_FIELDS.contains(&key) || is_numeric_matrix_field(key)
 }
 
-/// Report every schema-numeric field holding something that is not a number,
-/// and remove it so the reader takes the field's own absent path.
+/// Report every schema-numeric field holding something that is not a number.
 ///
 /// Schema 0.1.0 spells no `null` anywhere and types the bounds and ratings as
-/// `nonnegative_number`, so every value this reaches is already invalid. Left
-/// in place each reads as `NaN`, which serializes on as `null` and restores
-/// as an unbounded limit — an explicit "no limit" the source never stated. A
-/// removed field states nothing, which is what the document did.
+/// `nonnegative_number`, so every value this reaches is already invalid. Each
+/// reads as `NaN`, which serializes on as `null` and restores as an unbounded
+/// limit — an explicit "no limit" the source never stated. The `Error`
+/// severity carries that to the CLI exit code.
 ///
-/// One unusable element condemns the whole array: the remaining entries are
-/// positional, and their phase correspondence is what the bad element
-/// destroyed.
+/// The field stays in the document. Removing it would read as absent, and
+/// absent is a third meaning the reader spells per field: `0.0` for an
+/// optional impedance, `NaN` for a rating, and for `R_series_1_1` the
+/// presence check that picks the inline branch of the line `oneOf` — so a
+/// removal there loses every other matrix entry on that line. Distinguishing
+/// absent from invalid per field needs the typed readers of #293.
 ///
 /// `extras` is skipped, since it round trips arbitrary consumer JSON where
 /// these names carry no schema meaning.
-fn drop_non_numeric_fields(doc: &mut Map<String, Value>, net: &mut DistNetwork) {
+fn report_non_numeric_fields(doc: &Map<String, Value>, net: &mut DistNetwork) {
     fn numeric(v: &Value) -> bool {
         match v {
             Value::Number(_) => true,
@@ -175,23 +177,22 @@ fn drop_non_numeric_fields(doc: &mut Map<String, Value>, net: &mut DistNetwork) 
             Value::Number(_) => unreachable!("a number is not reported"),
         }
     }
-    fn walk(obj: &mut Map<String, Value>, path: &str, out: &mut Vec<(String, &'static str)>) {
-        obj.retain(|key, value| {
+    fn walk(obj: &Map<String, Value>, path: &str, out: &mut Vec<(String, &'static str)>) {
+        for (key, value) in obj {
             if key == "extras" {
-                return true;
+                continue;
             }
             let child = format!("{path}/{key}");
             if is_numeric_field(key) {
-                if numeric(value) {
-                    return true;
+                if !numeric(value) {
+                    out.push((child, kind(value)));
                 }
-                out.push((child, kind(value)));
-                return false;
+                continue;
             }
             match value {
                 Value::Object(o) => walk(o, &child, out),
                 Value::Array(a) => {
-                    for (i, e) in a.iter_mut().enumerate() {
+                    for (i, e) in a.iter().enumerate() {
                         if let Value::Object(o) = e {
                             walk(o, &format!("{child}/{i}"), out);
                         }
@@ -199,15 +200,14 @@ fn drop_non_numeric_fields(doc: &mut Map<String, Value>, net: &mut DistNetwork) 
                 }
                 _ => {}
             }
-            true
-        });
+        }
     }
     let mut found = Vec::new();
     walk(doc, "", &mut found);
     for (pointer, what) in found {
         let message = format!(
             "{pointer}: the schema types this field as a number and it holds {what}; \
-             read as absent"
+             it reads as NaN and anything derived from it is undefined"
         );
         net.warnings.push(message.clone());
         net.parse_diagnostics.push(

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -40,7 +40,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
         format: "BMOPF",
         message: e.to_string(),
     })?;
-    let Value::Object(doc) = doc else {
+    let Value::Object(mut doc) = doc else {
         return Err(Error::Json {
             format: "BMOPF",
             message: "top level is not an object".into(),
@@ -52,6 +52,7 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
         base_frequency: 60.0,
         ..DistNetwork::default()
     };
+    drop_non_numeric_fields(&mut doc, &mut net);
     let mut rd = Reader {
         net: &mut net,
         frequency_stated: false,
@@ -59,6 +60,167 @@ pub fn parse_bmopf_str(text: &str) -> Result<DistNetwork> {
     rd.document(&doc);
     crate::model::warn_unresolved_references(&mut net);
     Ok(net)
+}
+
+/// Schema 0.1.0 field names typed `number` or an array of them. Derived from
+/// the vendored schema; `schema_numeric_fields_match_the_vendored_schema`
+/// holds the two together.
+const NUMERIC_FIELDS: &[&str] = &[
+    "alpha_i",
+    "alpha_p",
+    "alpha_z",
+    "beta_i",
+    "beta_p",
+    "beta_z",
+    "cost",
+    "frequency",
+    "gamma_p",
+    "gamma_q",
+    "i_max",
+    "i_max_from",
+    "i_max_to",
+    "length",
+    "p_max",
+    "p_min",
+    "p_nom",
+    "q_max",
+    "q_min",
+    "q_nom",
+    "q_rated",
+    "r_series",
+    "r_series_from",
+    "r_series_to",
+    "s_max",
+    "s_rating",
+    "v_angle",
+    "v_magnitude",
+    "v_max",
+    "v_min",
+    "v_nom",
+    "v_nom_from",
+    "v_nom_to",
+    "vn_max",
+    "vneg_max",
+    "vpn_max",
+    "vpn_min",
+    "vpos_max",
+    "vpos_min",
+    "vpp_max",
+    "vpp_min",
+    "vzero_max",
+    "x_series",
+    "x_series_from",
+    "x_series_to",
+];
+
+/// Prefixes of the schema's matrix element patterns, e.g. `R_series_0_1`.
+const NUMERIC_MATRIX_PREFIXES: &[&str] = &[
+    "B_from_",
+    "B_to_",
+    "B_",
+    "G_from_",
+    "G_to_",
+    "G_",
+    "R_series_",
+    "X_series_",
+];
+
+/// A `<prefix>_<row>_<col>` matrix element name.
+fn is_numeric_matrix_field(key: &str) -> bool {
+    NUMERIC_MATRIX_PREFIXES.iter().any(|p| {
+        key.strip_prefix(p).is_some_and(|rest| {
+            matches!(rest.split_once('_'), Some((row, col))
+                if !row.is_empty()
+                    && !col.is_empty()
+                    && row.bytes().all(|b| b.is_ascii_digit())
+                    && col.bytes().all(|b| b.is_ascii_digit()))
+        })
+    })
+}
+
+fn is_numeric_field(key: &str) -> bool {
+    NUMERIC_FIELDS.contains(&key) || is_numeric_matrix_field(key)
+}
+
+/// Report every schema-numeric field holding something that is not a number,
+/// and remove it so the reader takes the field's own absent path.
+///
+/// Schema 0.1.0 spells no `null` anywhere and types the bounds and ratings as
+/// `nonnegative_number`, so every value this reaches is already invalid. Left
+/// in place each reads as `NaN`, which serializes on as `null` and restores
+/// as an unbounded limit — an explicit "no limit" the source never stated. A
+/// removed field states nothing, which is what the document did.
+///
+/// One unusable element condemns the whole array: the remaining entries are
+/// positional, and their phase correspondence is what the bad element
+/// destroyed.
+///
+/// `extras` is skipped, since it round trips arbitrary consumer JSON where
+/// these names carry no schema meaning.
+fn drop_non_numeric_fields(doc: &mut Map<String, Value>, net: &mut DistNetwork) {
+    fn numeric(v: &Value) -> bool {
+        match v {
+            Value::Number(_) => true,
+            Value::Array(a) => a.iter().all(Value::is_number),
+            _ => false,
+        }
+    }
+    fn kind(v: &Value) -> &'static str {
+        match v {
+            Value::Null => "null",
+            Value::Bool(_) => "a boolean",
+            Value::String(_) => "a string",
+            Value::Array(_) => "an array holding a value that is not a number",
+            Value::Object(_) => "an object",
+            Value::Number(_) => unreachable!("a number is not reported"),
+        }
+    }
+    fn walk(obj: &mut Map<String, Value>, path: &str, out: &mut Vec<(String, &'static str)>) {
+        obj.retain(|key, value| {
+            if key == "extras" {
+                return true;
+            }
+            let child = format!("{path}/{key}");
+            if is_numeric_field(key) {
+                if numeric(value) {
+                    return true;
+                }
+                out.push((child, kind(value)));
+                return false;
+            }
+            match value {
+                Value::Object(o) => walk(o, &child, out),
+                Value::Array(a) => {
+                    for (i, e) in a.iter_mut().enumerate() {
+                        if let Value::Object(o) = e {
+                            walk(o, &format!("{child}/{i}"), out);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            true
+        });
+    }
+    let mut found = Vec::new();
+    walk(doc, "", &mut found);
+    for (pointer, what) in found {
+        let message = format!(
+            "{pointer}: the schema types this field as a number and it holds {what}; \
+             read as absent"
+        );
+        net.warnings.push(message.clone());
+        net.parse_diagnostics.push(
+            crate::diagnostics::StructuredDiagnostic::new(
+                crate::diagnostics::READ_BMOPF_FIELD_NOT_A_NUMBER,
+                crate::diagnostics::DiagnosticSeverity::Error,
+                crate::diagnostics::DiagnosticStage::Read,
+                message,
+            )
+            .with_element_path(pointer)
+            .with_suggested_action("state a number, or omit the field"),
+        );
+    }
 }
 
 struct Reader<'a> {
@@ -1580,4 +1742,82 @@ fn n_winding_base_from_internal(w: &Winding, s: f64) -> Option<f64> {
         n_winding_bmopf_v_nom_from_internal(w),
         s,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_numeric_field;
+    use serde_json::Value;
+
+    /// [`super::NUMERIC_FIELDS`] and [`super::NUMERIC_MATRIX_PREFIXES`] copy
+    /// what the schema types as a number. Derive the set again from the
+    /// vendored schema so the copy cannot drift when upstream moves.
+    #[test]
+    fn numeric_field_names_match_the_vendored_schema() {
+        fn number(v: &Value) -> bool {
+            v.get("type").and_then(Value::as_str) == Some("number")
+                || v.get("$ref")
+                    .and_then(Value::as_str)
+                    .is_some_and(|r| r.ends_with("nonnegative_number"))
+        }
+        fn is_numeric(v: &Value) -> bool {
+            number(v)
+                || (v.get("type").and_then(Value::as_str) == Some("array")
+                    && v.get("items").is_some_and(number))
+        }
+        fn walk(node: &Value, names: &mut Vec<String>, patterns: &mut Vec<String>) {
+            match node {
+                Value::Object(o) => {
+                    for (key, target) in
+                        [("properties", &mut *names), ("patternProperties", patterns)]
+                    {
+                        if let Some(Value::Object(props)) = o.get(key) {
+                            target.extend(
+                                props
+                                    .iter()
+                                    .filter(|(_, v)| is_numeric(v))
+                                    .map(|(k, _)| k.clone()),
+                            );
+                        }
+                    }
+                    o.values().for_each(|v| walk(v, names, patterns));
+                }
+                Value::Array(a) => a.iter().for_each(|v| walk(v, names, patterns)),
+                _ => {}
+            }
+        }
+
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data/dist/bmopf/draft_bmopf_schema.json");
+        let schema: Value = serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let (mut names, mut patterns) = (Vec::new(), Vec::new());
+        walk(&schema, &mut names, &mut patterns);
+        names.sort_unstable();
+        names.dedup();
+        patterns.sort_unstable();
+        patterns.dedup();
+        assert!(!names.is_empty() && !patterns.is_empty());
+
+        for name in &names {
+            assert!(is_numeric_field(name), "the reader does not know `{name}`");
+        }
+        // Each matrix pattern resolves through a `<prefix>_<row>_<col>` sample.
+        for pattern in &patterns {
+            let sample = pattern
+                .trim_start_matches('^')
+                .trim_end_matches('$')
+                .replace("\\d+", "7");
+            assert!(
+                is_numeric_field(&sample),
+                "the reader does not know `{sample}` (from `{pattern}`)"
+            );
+        }
+        // And nothing the reader claims is numeric is absent from the schema.
+        for name in super::NUMERIC_FIELDS {
+            assert!(
+                names.iter().any(|n| n == name),
+                "`{name}` is not a schema number"
+            );
+        }
+    }
 }

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -113,29 +113,20 @@ const NUMERIC_FIELDS: &[&str] = &[
     "x_series_to",
 ];
 
-/// Prefixes of the schema's matrix element patterns, e.g. `R_series_0_1`.
+/// Prefixes of the schema's matrix element patterns, e.g. `R_series_1_2`.
+/// The same spelling the readers pass to [`matrix_indices`] and
+/// [`flat_matrix`].
 const NUMERIC_MATRIX_PREFIXES: &[&str] = &[
-    "B_from_",
-    "B_to_",
-    "B_",
-    "G_from_",
-    "G_to_",
-    "G_",
-    "R_series_",
-    "X_series_",
+    "B_from", "B_to", "B", "G_from", "G_to", "G", "R_series", "X_series",
 ];
 
-/// A `<prefix>_<row>_<col>` matrix element name.
+/// A `<prefix>_<row>_<col>` matrix element name, by the rule that decides
+/// whether the reader assembles the cell. An index the reader rejects is
+/// outside the schema, so this must not claim it either.
 fn is_numeric_matrix_field(key: &str) -> bool {
-    NUMERIC_MATRIX_PREFIXES.iter().any(|p| {
-        key.strip_prefix(p).is_some_and(|rest| {
-            matches!(rest.split_once('_'), Some((row, col))
-                if !row.is_empty()
-                    && !col.is_empty()
-                    && row.bytes().all(|b| b.is_ascii_digit())
-                    && col.bytes().all(|b| b.is_ascii_digit()))
-        })
-    })
+    NUMERIC_MATRIX_PREFIXES
+        .iter()
+        .any(|p| matrix_indices(key, p).is_some())
 }
 
 fn is_numeric_field(key: &str) -> bool {
@@ -1741,8 +1732,43 @@ fn n_winding_base_from_internal(w: &Winding, s: f64) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_numeric_field;
+    use super::{MAX_MATRIX_INDEX, is_numeric_field, matrix_indices};
     use serde_json::Value;
+
+    /// A matrix key the reader will not assemble is outside the schema, and
+    /// the numeric check must not claim it. The two ran on separate rules
+    /// once, so an index past the bound was reported as a schema field while
+    /// the reader put it in extras.
+    #[test]
+    fn the_numeric_check_claims_exactly_the_matrix_keys_the_reader_assembles() {
+        let over = MAX_MATRIX_INDEX + 1;
+        for key in [
+            "R_series_1_1",
+            "X_series_2_3",
+            &format!("B_from_{MAX_MATRIX_INDEX}_{MAX_MATRIX_INDEX}"),
+            "G_to_1_2",
+            "B_1_1",
+        ] {
+            assert!(is_numeric_field(key), "{key} should be numeric");
+        }
+        for key in [
+            "R_series_0_1",
+            "R_series_1_0",
+            &format!("R_series_{over}_1"),
+            &format!("R_series_1_{over}"),
+            "R_series_1",
+            "R_series_a_b",
+            "R_series",
+        ] {
+            assert!(!is_numeric_field(key), "{key} should not be numeric");
+            assert!(
+                super::NUMERIC_MATRIX_PREFIXES
+                    .iter()
+                    .all(|p| matrix_indices(key, p).is_none()),
+                "{key} disagrees with the reader"
+            );
+        }
+    }
 
     /// [`super::NUMERIC_FIELDS`] and [`super::NUMERIC_MATRIX_PREFIXES`] copy
     /// what the schema types as a number. Derive the set again from the

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -76,6 +76,11 @@ pub enum DiagnosticStage {
 /// the network is incomplete.
 pub const READ_DSS_INCLUDE_REFUSED: &str = "READ.DSS.INCLUDE_REFUSED";
 
+/// A BMOPF field the schema types as a number holds something else. Severity
+/// `Error`: the field reads as `NaN`, which serializes on as an unbounded
+/// limit, so the parse states a fact the source never gave.
+pub const READ_BMOPF_FIELD_NOT_A_NUMBER: &str = "READ.BMOPF.FIELD_NOT_A_NUMBER";
+
 /// One structured conversion finding.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -3174,10 +3174,59 @@ fn a_non_numeric_bmopf_field_is_refused_rather_than_read_as_nan() {
             "{spelling}: {}",
             found[0].message
         );
-        // And the bound is absent rather than NaN. A NaN would serialize on
-        // as `null` and restore as +Inf, stating a limit the source did not.
-        assert_eq!(net.linecodes[0].i_max, None, "{spelling}");
     }
+}
+
+#[test]
+fn reporting_a_malformed_field_does_not_disturb_the_read() {
+    // The report used to remove the field. `R_series_1_1` is the presence
+    // check that picks the inline branch of the line `oneOt`, so removing it
+    // sent the whole line down the linecode branch and every other matrix
+    // entry landed in extras as "outside the schema".
+    let text = r#"{
+        "bus": {
+            "a": {"terminal_names": ["1", "2", "3"], "perfectly_grounded_terminals": []},
+            "b": {"terminal_names": ["1", "2", "3"], "perfectly_grounded_terminals": []}
+        },
+        "line": {
+            "ln1": {
+                "bus_from": "a", "bus_to": "b",
+                "terminal_map_from": ["1", "2", "3"], "terminal_map_to": ["1", "2", "3"],
+                "R_series_1_1": null,
+                "R_series_2_2": 0.3, "R_series_3_3": 0.3,
+                "X_series_1_1": 0.6, "X_series_2_2": 0.6, "X_series_3_3": 0.6
+            }
+        }
+    }"#;
+    let net = parse_bmopf_str(text).unwrap();
+    assert_eq!(
+        net.parse_diagnostics
+            .iter()
+            .filter(|d| d.code.as_str() == "READ.BMOPF.FIELD_NOT_A_NUMBER")
+            .count(),
+        1,
+        "{:?}",
+        net.parse_diagnostics
+    );
+    // The line keeps its inline matrices: one synthesized linecode, with the
+    // sound entries intact and only the malformed cell undefined.
+    assert_eq!(net.linecodes.len(), 1, "{:?}", net.warnings);
+    let lc = &net.linecodes[0];
+    assert!(lc.r_series[0][0].is_nan(), "{:?}", lc.r_series);
+    for (got, want) in [
+        (lc.r_series[1][1], 0.3),
+        (lc.r_series[2][2], 0.3),
+        (lc.x_series[0][0], 0.6),
+    ] {
+        assert!((got - want).abs() < 1e-12, "{got} != {want}");
+    }
+    assert!(
+        !net.warnings
+            .iter()
+            .any(|w| w.contains("outside the schema")),
+        "{:?}",
+        net.warnings
+    );
 }
 
 #[test]

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -3135,3 +3135,63 @@ fn an_inline_line_rating_is_not_repeated_on_its_synthetic_linecode() {
     let text = powerio_dist::write_dss(&net).text;
     assert_eq!(text.matches("emergamps=250").count(), 1, "{text}");
 }
+
+#[test]
+fn a_non_numeric_bmopf_field_is_refused_rather_than_read_as_nan() {
+    // #299: every one of these is schema invalid, and each used to read as
+    // NaN, which serializes on as `null` and restores as an unbounded limit.
+    for (spelling, what) in [
+        (r#""not a number""#, "a string"),
+        ("null", "null"),
+        ("{}", "an object"),
+        (
+            r#"[400.0, "x"]"#,
+            "an array holding a value that is not a number",
+        ),
+    ] {
+        let text = format!(
+            r#"{{
+                "bus": {{"b": {{"terminal_names": ["1"], "perfectly_grounded_terminals": []}}}},
+                "linecode": {{"lc": {{"i_max": {spelling}}}}}
+            }}"#
+        );
+        let net = parse_bmopf_str(&text).unwrap();
+        let found: Vec<_> = net
+            .parse_diagnostics
+            .iter()
+            .filter(|d| d.code.as_str() == "READ.BMOPF.FIELD_NOT_A_NUMBER")
+            .collect();
+        assert_eq!(found.len(), 1, "{spelling}: {:?}", net.parse_diagnostics);
+        assert_eq!(found[0].severity, DiagnosticSeverity::Error, "{spelling}");
+        assert_eq!(found[0].stage, DiagnosticStage::Read, "{spelling}");
+        assert_eq!(
+            found[0].element_path.as_deref(),
+            Some("/linecode/lc/i_max"),
+            "{spelling}"
+        );
+        assert!(
+            found[0].message.contains(what),
+            "{spelling}: {}",
+            found[0].message
+        );
+        // And the bound is absent rather than NaN. A NaN would serialize on
+        // as `null` and restore as +Inf, stating a limit the source did not.
+        assert_eq!(net.linecodes[0].i_max, None, "{spelling}");
+    }
+}
+
+#[test]
+fn consumer_extras_are_not_read_as_schema_fields() {
+    // `extras` round trips arbitrary consumer JSON, where a name like `cost`
+    // carries no schema meaning.
+    let text = r#"{
+        "bus": {"b": {"terminal_names": ["1"], "perfectly_grounded_terminals": []}},
+        "extras": {"anything": {"cost": "free", "v_nom": null}}
+    }"#;
+    let net = parse_bmopf_str(text).unwrap();
+    assert!(
+        net.parse_diagnostics.is_empty(),
+        "{:?}",
+        net.parse_diagnostics
+    );
+}


### PR DESCRIPTION
Closes #299.

`bmopf::read`'s `f()` was `as_f64().unwrap_or(f64::NAN)`, and `floats()` mapped every array element through it. A string, a null, an object, or an array holding one of those became `NaN` and the parse continued silently. Schema 0.1.0 spells no `null` anywhere and types the bounds and ratings as `nonnegative_number`, so every value that reached the `unwrap_or` was already invalid.

The consequence outlives the read. A `NaN` bound serializes into `.pio.json` as `null`, and the payload reader restores a null bound as ±Inf. A malformed entry therefore arrived downstream as an explicit "no limit" the source never stated. #288 made that round trip work; it did not decide what a malformed source should mean.

## What it does

The reader walks the document before reading it and reports each schema-numeric field holding a non-number as an `Error` finding carrying its JSON pointer. Through the machinery #289 added, `powerio convert` on such a file exits 1:

```
$ powerio convert --to pmd-json bad.json -o out.json
parse: /line/ln1/R_series_1_1: the schema types this field as a number and it holds null; it reads as NaN and anything derived from it is undefined
error: READ.BMOPF.FIELD_NOT_A_NUMBER: /line/ln1/R_series_1_1: ...
Error: 1 parse error(s); the output is incomplete (see the error lines above)
$ echo $?
1
```

`extras` is exempt: it round trips arbitrary consumer JSON, where names like `cost` or `v_nom` carry no schema meaning. Covered by a test.

## Reporting only, not repairing

The first version of this branch also **removed** the offending field, so the reader would take that field's absent path — option 3 in the issue. Review found that wrong, and the second commit reverts it.

Absent is a third meaning, and the reader spells it per field. `R_series_1_1` is the `contains_key` presence check that picks the inline branch of the line `oneOf` (`read.rs:976`), so removing it sent the whole line down the linecode branch and every other matrix entry — `R_series_2_2`, `R_series_3_3`, every `X_series_*` — landed in extras as "outside the schema". A line with one malformed cell lost its entire impedance matrix. Separately, at the twelve `map_or(0.0, f)` sites a malformed impedance became a plausible, physically meaningful `0.0` instead of a `NaN` that at least propagated visibly to a consumer.

So the read is now byte for byte what 0.8.2 did, plus the finding and the exit code. Telling absent from invalid per field is a real feature, and it wants the typed serde readers of #293 — where an `Option<f64>` distinguishes the two and serde rejects a malformed number in a typed field without any of this walking. A regression test pins the line-matrix case.

Option 1 from the issue — validate against the vendored schema and refuse the document — would change what `parse_bmopf_str` accepts, which is a 0.9.0-sized decision.

## Keeping the field set honest

The reader carries the schema's numeric field names as a constant, plus the `<prefix>_<row>_<col>` matrix patterns. A unit test re-derives both from the vendored `draft_bmopf_schema.json` and asserts they agree in both directions, so the copy cannot drift when upstream moves.

## Verification

`cargo fmt --check`, `scripts/ci-clippy.sh`, `cargo test --workspace`, `scripts/capi-header-parity.sh`, and the conversion matrix test all pass. No fixture in the corpus produces a new finding. The malformed corpus test covers a string, a null, an object, and an array with a bad element, each asserting one `Error` finding at stage `Read` with the right pointer.

## Stacked on #303

Both branches touch `powerio-dist/src/bmopf/read.rs` at the `Reader` construction, so this one is based on #303 rather than main and the diff above is only its own change. GitHub retargets this to main when #303 merges. Merge #303 first.
