### PR TITLE
py: bring the MCP server under the ruff and mypy gates

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,8 +63,10 @@ jobs:
         run: pip install ruff mypy
       - name: ruff
         run: ruff check --no-fix .
+      # The `mcp` extra: the server module is inside the type gate, so the SDK
+      # has to be importable or every symbol it names reads as `Any`.
       - name: Install powerio
-        run: pip install .
+        run: pip install '.[mcp]'
       - name: mypy
         run: python -m mypy python/powerio
       # stubtest runs from an empty directory: with the repo (or a venv) as

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -63,8 +63,8 @@ jobs:
         run: pip install ruff mypy
       - name: ruff
         run: ruff check --no-fix .
-      # The `mcp` extra: the server module is inside the type gate, so the SDK
-      # has to be importable or every symbol it names reads as `Any`.
+      # The `mcp` extra: the server module is inside the type gate, and mypy
+      # fails on an import it cannot resolve.
       - name: Install powerio
         run: pip install '.[mcp]'
       - name: mypy

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,9 +3,6 @@
 # them against the built extension in CI (python.yml), so a Rust-side rename
 # fails the gate instead of shipping a stale stub.
 #
-# python/powerio/mcp stays outside the gate. The mcp 2.0 SDK port (#272) does
-# not make it pass: 15 errors remain after it. #297 does that work and then
-# deletes the exclude line.
 # No `files` key: the mypy job passes the path on the command line
 # (`mypy python/powerio`), and stubtest reuses this config to compare the
 # stubs against the installed extension — a `files` key there would load the
@@ -14,7 +11,6 @@
 # python_version 3.10 is the oldest target modern mypy checks; the 3.9 wheel
 # floor is exercised by the test matrix, not by the type gate.
 [mypy]
-exclude = powerio/mcp/
 python_version = 3.10
 warn_unused_ignores = True
 no_implicit_optional = True

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -18,7 +18,7 @@ import json as jsonlib
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, overload
+from typing import Any, Dict, Optional
 from urllib.parse import unquote, urlparse
 
 from mcp.server.mcpserver import MCPServer
@@ -754,34 +754,21 @@ def _choose_from_format(
     return chosen
 
 
-@overload
-def _choose_to_format(
-    to_format: Optional[str] = ...,
-    *,
-    to: Optional[str] = ...,
-    required: Literal[True] = ...,
-) -> str: ...
-
-
-@overload
-def _choose_to_format(
-    to_format: Optional[str] = ...,
-    *,
-    to: Optional[str] = ...,
-    required: Literal[False],
-) -> Optional[str]: ...
-
-
 def _choose_to_format(
     to_format: Optional[str] = None,
     *,
     to: Optional[str] = None,
-    required: bool = True,
 ) -> Optional[str]:
+    """The target format from either spelling, or None when neither is set."""
     if to_format is not None and to is not None and _fmt(to_format) != _fmt(to):
         raise ValueError("`to_format` and `to` disagree")
-    target = to_format or to
-    if required and target is None:
+    return to_format or to
+
+
+def _require_to_format(to_format: Optional[str] = None, *, to: Optional[str] = None) -> str:
+    """[`_choose_to_format`] where the caller has no target to fall back on."""
+    target = _choose_to_format(to_format, to=to)
+    if target is None:
         raise ValueError("`to_format` is required")
     return target
 
@@ -1256,7 +1243,7 @@ def convert(
     from_: Optional[str] = None,
     package_json: Optional[str] = None,
 ) -> dict:
-    target = _choose_to_format(to_format, to=to)
+    target = _require_to_format(to_format, to=to)
     source = _choose_from_format(from_format, format=format, from_=from_)
     return _convert_impl(
         target,
@@ -1286,7 +1273,7 @@ def save(
     from_: Optional[str] = None,
     package_json: Optional[str] = None,
 ) -> dict:
-    target = _choose_to_format(to_format, to=to, required=False)
+    target = _choose_to_format(to_format, to=to)
     source = _choose_from_format(from_format, format=format, from_=from_)
     return _save_impl(
         out_path,

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -14,16 +14,17 @@ transport serializes either family through the ``.pio.json`` compiler package.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import json as jsonlib
 import os
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional, overload
 from urllib.parse import unquote, urlparse
+
+from mcp.server.mcpserver import MCPServer
 
 import powerio
 from powerio import dist
-from mcp.server.mcpserver import MCPServer
 
 mcp = MCPServer("powerio")
 
@@ -101,6 +102,18 @@ def _one_input(path: Optional[str], content: Optional[str]) -> None:
         raise ValueError("provide exactly one of `path` or `content`")
 
 
+def _required(value: Optional[str], name: str) -> str:
+    """Narrow an argument an earlier check already settled.
+
+    The input guards run at the top of each entry point, so a call site
+    reaches this with the value set. The raise states the invariant for a
+    type checker, which cannot see across the guard.
+    """
+    if value is None:
+        raise ValueError(f"`{name}` is not set")
+    return value
+
+
 def _one_network_input(
     path: Optional[str],
     content: Optional[str],
@@ -139,8 +152,8 @@ def _allowed_roots() -> tuple[Path, ...]:
     if not raw:
         return ()
     roots = []
-    for item in raw.split(os.pathsep):
-        item = item.strip()
+    for entry in raw.split(os.pathsep):
+        item = entry.strip()
         if item:
             roots.append(Path(item).expanduser().resolve(strict=False))
     return tuple(roots)
@@ -360,9 +373,14 @@ def _diagnostics_payload(package_json: str, verbose: bool = False) -> Dict[str, 
     if not verbose:
         keep = {"code", "severity", "stage", "message", "element_path"}
         diagnostics = [{k: v for k, v in item.items() if k in keep} for item in diagnostics]
-    validation = value.get("validation") if isinstance(value.get("validation"), dict) else {}
-    counts = validation.get("counts") if isinstance(validation.get("counts"), dict) else None
-    counts = dict(counts) if counts is not None else _severity_counts(diagnostics)
+    raw_validation = value.get("validation")
+    validation = raw_validation if isinstance(raw_validation, dict) else {}
+    raw_counts = validation.get("counts")
+    counts = (
+        dict(raw_counts)
+        if isinstance(raw_counts, dict)
+        else _severity_counts(diagnostics)
+    )
     status = validation.get("status") or (
         "fatal"
         if counts.get("fatal", 0)
@@ -453,12 +471,13 @@ def _package_json_from_input(
             return powerio.Package.from_file(
                 path, from_format, int(opts.get("scenario", 0))
             ).to_json()
-        if _looks_like_package_json(content):
-            powerio.Package.from_json(content)
-            return content
+        text = _required(content, "content")
+        if _looks_like_package_json(text):
+            powerio.Package.from_json(text)
+            return text
         if from_l in _PACKAGE_JSON_FORMATS:
             raise ValueError("content is not a .pio.json package envelope")
-        return powerio.Package.from_str(content, from_format).to_json()
+        return powerio.Package.from_str(text, from_format).to_json()
     except powerio.PowerIOError as exc:
         raise ValueError(f"parse failed: {exc}") from exc
     except FileNotFoundError as exc:
@@ -491,7 +510,9 @@ def _parse_transmission(
         if path is not None:
             net = powerio.parse_file(path, format)
         else:
-            net = powerio.parse_str(content, format or "matpower")
+            net = powerio.parse_str(
+                _required(content, "content"), format or "matpower"
+            )
     except powerio.PowerIOError as exc:
         raise ValueError(f"parse failed: {exc}") from exc
     except FileNotFoundError as exc:
@@ -518,7 +539,10 @@ def _parse_distribution(
         if path is not None:
             net = dist.parse_file(path, format)
         else:
-            net = dist.parse_str(content, format)
+            # The block above settles `format` whenever `content` is set.
+            net = dist.parse_str(
+                _required(content, "content"), _required(format, "from_format")
+            )
     except powerio.PowerIOError as exc:
         raise ValueError(f"parse failed: {exc}") from exc
     except FileNotFoundError as exc:
@@ -544,7 +568,7 @@ def _parse_any(
             except OSError as exc:
                 raise ValueError(f"cannot read input: {exc}") from exc
             return _load_package(text)
-        return _load_package(content)
+        return _load_package(_required(content, "content"))
     if _is_gridfm_format(format):
         return _parse_transmission(path, content, format, options)
     if _is_dist_format(format):
@@ -567,13 +591,15 @@ def _parse_any(
             if domain == "distribution":
                 return _parse_distribution(path, content, inferred)
             return _parse_transmission(path, content, inferred, options)
-    elif format is None and _jsonish(content):
-        if _looks_like_package_json(content):
-            return _load_package(content)
-        domain, inferred = _format_from_json_class(*_json_class(content))
-        if domain == "distribution":
-            return _parse_distribution(path, content, inferred)
-        return _parse_transmission(path, content, inferred, options)
+    else:
+        text = _required(content, "content")
+        if format is None and _jsonish(text):
+            if _looks_like_package_json(text):
+                return _load_package(text)
+            domain, inferred = _format_from_json_class(*_json_class(text))
+            if domain == "distribution":
+                return _parse_distribution(path, text, inferred)
+            return _parse_transmission(path, text, inferred, options)
     return _parse_transmission(path, content, format, options)
 
 
@@ -726,6 +752,24 @@ def _choose_from_format(
         if _fmt(value) != _fmt(chosen):
             raise ValueError(f"`{chosen_name}` and `{name}` disagree")
     return chosen
+
+
+@overload
+def _choose_to_format(
+    to_format: Optional[str] = ...,
+    *,
+    to: Optional[str] = ...,
+    required: Literal[True] = ...,
+) -> str: ...
+
+
+@overload
+def _choose_to_format(
+    to_format: Optional[str] = ...,
+    *,
+    to: Optional[str] = ...,
+    required: Literal[False],
+) -> Optional[str]: ...
 
 
 def _choose_to_format(

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -9,8 +9,9 @@ import pytest
 
 pytest.importorskip("mcp", reason="powerio[mcp] not installed (needs Python 3.10+)")
 
-import powerio  # noqa: E402
-from powerio.mcp import server  # noqa: E402
+from powerio.mcp import server
+
+import powerio
 
 DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
 DSS = DATA / "dist" / "micro" / "xfmr_single_phase.dss"

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,10 +6,6 @@
 # Style-modernization families (UP, PYI cosmetics) are deliberately absent:
 # the wheel targets Python 3.9, and annotation spelling is not a defect.
 include = ["python/**/*.py", "python/**/*.pyi"]
-# The MCP server and its test stay outside the gate. The mcp 2.0 port (#272)
-# does not make them pass: 5 findings here and 15 mypy errors remain after it.
-# #297 does that work and then deletes this line.
-exclude = ["python/powerio/mcp/**", "python/tests/test_mcp.py"]
 target-version = "py39"
 
 [lint]


### PR DESCRIPTION
Closes #297.

The `ruff.toml` and `mypy.ini` exclusions added in #285 both carry a comment saying they lift when the mcp 2.0 port (#272, PR #286) lands. Measured against the merged state of both, they do not: 5 ruff findings and 15 mypy errors remain, all in `server.py`.

## The mypy errors are narrowing gaps

Fourteen are a `str | None` reaching a parameter typed `str` — `parse_str`, `Package.from_json`, `_load_package`, `_convert_impl`. Each is guarded at runtime by `_one_input` at the top of the entry point, which raises unless exactly one of `path`/`content` is set; mypy cannot see that across the call boundary. `_required(value, name)` states the invariant where the value is used, so the check is the type checker's and the message names the argument if the invariant ever breaks.

Two more, at what were lines 364 and 366, call `value.get("validation")` twice around an `isinstance`, so the narrowing is lost between the two calls. The result binds once now.

The last is `_choose_to_format`, which returns a `str` when `required` is set and `Optional[str]` when it is not. Two overloads say that directly; both call sites already pass the flag as a literal.

## The ruff findings

Import order in `server.py` and `test_mcp.py`, two `# noqa: E402` directives that no longer suppress anything, and a `for` loop variable the body reassigned.

## CI

The mypy job installs `.[mcp]` rather than `.`. The server module is inside the gate now, and mypy fails on an import it cannot resolve, so without the SDK the job errors on `mcp.server.mcpserver` rather than checking the file.

## Verification

`ruff check --no-fix .` and `mypy python/powerio` both clean with the exclusions removed and the SDK installed. `pytest python/tests` is 147 passed, 6 skipped, with the MCP tests actually running (`mcp>=2,<3` plus polars and networkx installed) rather than the 110 that skipping produces — the control flow in `_parse_any` changed shape, so those tests are the check that matters.

Targets v0.8.3.