### PR TITLE
Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.8.3
+
+Correctness fixes for the OpenDSS writer and the BMOPF reader. No API, C ABI, or schema version changes: `PIO_ABI_VERSION` stays 4, `PIO_DIST_ABI_VERSION` stays 1, and `.pio.json` stays at schema 0.2.1. Two behaviors change in ways a consumer can observe, both below.
+
+**A center tapped service exports OpenDSS that solves to the right answer.** Reported in [eigenergy/PowerIO.jl#79](https://github.com/eigenergy/PowerIO.jl/issues/79) against three 19 kV SWER feeders. A dss node list is positional, the phase conductors first and the return last, and a center tapped service maps as `[p1, n, p2]`. The writer emitted one `Load` record over that map, so the engine discarded the conductor it could not address: on the reported network the load drew 0.652 kW of its stated 2.608 and the second leg floated to 1.35 pu, converged, with nothing in the warnings. Such a load now emits one single phase `Load` per leg. The split keys on the conductor count rather than on unequal per phase power, which a center tapped consumer does not have, and the return conductor is located from the bus grounding rather than assumed last. A terminal map longer than the record's conductor count now warns, the mirror of the short map warning that already existed.
+
+Three more silent paths from the same report: a three winding star whose third arm is zero cannot be solved by OpenDSS, which collapses the secondary legs to about half voltage instead, so the writer substitutes the split from the OpenDSS center tap example and says so; the BMOPF and PMD readers warn when a document states no frequency and carries line susceptance, since the 60 Hz default costs a 50 Hz feeder about a fifth of its line charging; and a `center_tap` `v_nom_to` at about twice the secondary bus's own phase to neutral band warns, that being the full span rather than the per leg voltage the convention asks for.
+
+**A malformed BMOPF numeric field is refused rather than read as `NaN`.** `bmopf::read` mapped every numeric field through `as_f64().unwrap_or(f64::NAN)`, so a string, a null, an object, or an array holding one of those became `NaN` and the parse continued silently. Schema 0.1.0 spells no `null` anywhere and types the bounds and ratings as `nonnegative_number`, so every value that reached it was already invalid — and a `NaN` bound serializes into `.pio.json` as `null`, which the payload reader restores as ±Inf, an explicit "no limit" the source never stated. Each such field is now an `Error` finding carrying its JSON pointer, so `powerio convert` and `powerio package` exit nonzero on a document that used to parse quietly. The value itself still reads as `NaN`: telling absent from invalid per field is a real feature and it waits for the typed readers of #293.
+
+**Python.** The MCP server is inside the ruff and mypy gates (#297); the exclusions #285 added are gone.
+
+**Repository.** The normalize pass no longer clones the element fields it immediately overwrites, on a pass that runs before every solve.
+
 ## 0.8.2
 
 Row provenance from the normalize pass, a PYPOWER bridge, `null` for a nonfinite float in the multiconductor payload, and distribution writer coverage for rated capacitor banks and unbalanced loads. No breaking API changes; two behaviors change in ways a consumer can observe, both below.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powerio"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "criterion",
  "lexical-core",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-capi"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "arrow",
  "powerio",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "jsonschema",
  "schemars",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "approx",
  "arrow",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-pkg"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2094,7 +2094,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-prob"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "num-complex",
  "powerio",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-py"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "powerio-dist",
  "powerio-matrix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ resolver = "2"
 # via `key.workspace = true`, so a release bump touches this version and the
 # workspace dependency pins below.
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"
@@ -39,11 +39,11 @@ homepage = "https://eigenergy.github.io/powerio/"
 [workspace.dependencies]
 # The intra-workspace deps carry the version pin `cargo publish` needs; keeping
 # them here means the pin moves with the [workspace.package] version.
-powerio = { path = "powerio", version = "0.8.2" }
-powerio-matrix = { path = "powerio-matrix", version = "0.8.2" }
-powerio-prob = { path = "powerio-prob", version = "0.8.2" }
-powerio-dist = { path = "powerio-dist", version = "0.8.2" }
-powerio-pkg = { path = "powerio-pkg", version = "0.8.2" }
+powerio = { path = "powerio", version = "0.8.3" }
+powerio-matrix = { path = "powerio-matrix", version = "0.8.3" }
+powerio-prob = { path = "powerio-prob", version = "0.8.3" }
+powerio-dist = { path = "powerio-dist", version = "0.8.3" }
+powerio-pkg = { path = "powerio-pkg", version = "0.8.3" }
 # Cross-crate type identity: `CsMat<f64>` (sprs) and the Arrow types cross crate
 # boundaries, so every crate must build against the same major.
 sprs = { version = "0.11", default-features = false }


### PR DESCRIPTION
Version bump and changelog for v0.8.3. Touches `CHANGELOG.md`, `Cargo.toml`, and `Cargo.lock` only.

**Merge this last**, after #303, #304, #305, and #306. It is based on main and touches no file any of them do, so it stays mergeable regardless of when they land — but the changelog describes their content, so tagging before they merge would ship a release note for code that is not in the tag.

## What ships

No API, C ABI, or schema version change. `PIO_ABI_VERSION` stays 4, `PIO_DIST_ABI_VERSION` stays 1, `.pio.json` stays 0.2.1 — so nothing parks waiting on a PowerIO.jl binding PR and the artifact repin runs on the normal path.

Two consumer-visible behavior changes, both in the changelog:

- The OpenDSS writer emits one `Load` per leg for a center tapped service where it emitted one record before, and substitutes a solvable `xlt` for a degenerate three winding star. A consumer diffing emitted decks will see both.
- A malformed BMOPF numeric field is an `Error` finding, so `powerio convert` and `powerio package` exit nonzero on a document that used to parse quietly. The modeled value is unchanged.

## After the tag

The automation takes it from here: the tag builds the five platform tarballs onto a draft release, publishing that release fires the dispatch to PowerIO.jl, and its `update-artifacts.yml` repins, versions, changelogs, tests, commits, and registers. Verify by observing the atomic release commit on PowerIO.jl main and the version in General.

Close eigenergy/PowerIO.jl#79 against the published release rather than against the merge, so the reporter can verify against a version they can install.