### PR TITLE
matrix: guard the degenerate numerical paths

### DIFF
--- a/powerio-matrix/src/io/mtx.rs
+++ b/powerio-matrix/src/io/mtx.rs
@@ -98,12 +98,9 @@ pub fn write_vector_mtx(values: &[f64], path: impl AsRef<Path>) -> Result<()> {
 /// Whether the `symmetric` header would round trip: every stored entry has a
 /// stored mirror holding the identical bits.
 ///
-/// The writer emits only the lower triangle under that header, so a reader
-/// reconstructs `a[j][i]` from `a[i][j]`. Deciding this on a tolerance meant a
-/// matrix that was merely close went out as symmetric and came back changed by
-/// up to the tolerance — a `Bp` built in BX mode with a small phase shifter is
-/// asymmetric by exactly `2 g sin(theta) / t`, which sat under the old 1e-12.
-/// Anything short of exact goes out as `general`, which stores both triangles.
+/// The writer emits only the lower triangle under that header, so deciding this
+/// on a tolerance sent a merely close matrix out as symmetric and read it back
+/// changed by up to the tolerance. Anything short of exact goes out `general`.
 fn is_exactly_symmetric(a: &CsMat<f64>) -> bool {
     if a.rows() != a.cols() {
         return false;
@@ -150,10 +147,9 @@ mod tests {
     #[test]
     fn a_matrix_asymmetric_below_the_old_tolerance_writes_general() {
         // #292. The pair differs by 1e-15 relative, which the old 1e-12
-        // tolerance called symmetric — so only the lower triangle went out and
-        // a reader mirrored 3.0 back over the 3.000000000000001 that was
-        // assembled. A `Bp` in BX mode with a small phase shifter is asymmetric
-        // by exactly this little.
+        // tolerance called symmetric, so a reader mirrored 3.0 back over the
+        // 3.000000000000001 that was assembled. A `Bp` in BX mode with a small
+        // phase shifter is asymmetric by exactly this little.
         let mut tri = TriMat::new((2, 2));
         tri.add_triplet(0, 0, 5.0);
         tri.add_triplet(0, 1, 3.000_000_000_000_001);

--- a/powerio-matrix/src/io/mtx.rs
+++ b/powerio-matrix/src/io/mtx.rs
@@ -15,7 +15,7 @@ use crate::{Error, Result};
 
 pub fn write_mtx(matrix: &CsMat<f64>, path: impl AsRef<Path>) -> Result<()> {
     let path = path.as_ref();
-    if is_numerically_symmetric(matrix) {
+    if is_exactly_symmetric(matrix) {
         write_symmetric_mtx(matrix, path)
     } else {
         sprs::io::write_matrix_market(path, matrix.view()).map_err(|e| Error::Mtx(e.to_string()))
@@ -95,16 +95,26 @@ pub fn write_vector_mtx(values: &[f64], path: impl AsRef<Path>) -> Result<()> {
     Ok(())
 }
 
-fn is_numerically_symmetric(a: &CsMat<f64>) -> bool {
+/// Whether the `symmetric` header would round trip: every stored entry has a
+/// stored mirror holding the identical bits.
+///
+/// The writer emits only the lower triangle under that header, so a reader
+/// reconstructs `a[j][i]` from `a[i][j]`. Deciding this on a tolerance meant a
+/// matrix that was merely close went out as symmetric and came back changed by
+/// up to the tolerance — a `Bp` built in BX mode with a small phase shifter is
+/// asymmetric by exactly `2 g sin(theta) / t`, which sat under the old 1e-12.
+/// Anything short of exact goes out as `general`, which stores both triangles.
+fn is_exactly_symmetric(a: &CsMat<f64>) -> bool {
     if a.rows() != a.cols() {
         return false;
     }
     for (i, row) in a.outer_iterator().enumerate() {
         for (j, &v) in row.iter() {
-            let mirror = a.get(j, i).copied().unwrap_or(0.0);
-            let scale = v.abs().max(mirror.abs()).max(1.0);
-            if (v - mirror).abs() > 1e-12 * scale {
-                return false;
+            // Bit equality, so a mirrored pair differing only in the sign of
+            // zero is `general` too: the symmetric form would not carry it.
+            match a.get(j, i) {
+                Some(&mirror) if mirror.to_bits() == v.to_bits() => {}
+                _ => return false,
             }
         }
     }
@@ -134,6 +144,72 @@ mod tests {
         assert!(
             text.lines().next().unwrap().ends_with("general"),
             "value-asymmetric matrices must not be written with a symmetric header"
+        );
+    }
+
+    #[test]
+    fn a_matrix_asymmetric_below_the_old_tolerance_writes_general() {
+        // #292. The pair differs by 1e-15 relative, which the old 1e-12
+        // tolerance called symmetric — so only the lower triangle went out and
+        // a reader mirrored 3.0 back over the 3.000000000000001 that was
+        // assembled. A `Bp` in BX mode with a small phase shifter is asymmetric
+        // by exactly this little.
+        let mut tri = TriMat::new((2, 2));
+        tri.add_triplet(0, 0, 5.0);
+        tri.add_triplet(0, 1, 3.000_000_000_000_001);
+        tri.add_triplet(1, 0, 3.0);
+        tri.add_triplet(1, 1, 5.0);
+        let matrix = tri.to_csr();
+
+        let path = temp_path("near-symmetric");
+        write_mtx(&matrix, &path).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            text.lines().next().unwrap().ends_with("general"),
+            "a matrix that is only nearly symmetric must carry both triangles:\n{text}"
+        );
+    }
+
+    #[test]
+    fn a_structurally_asymmetric_matrix_writes_general() {
+        // The mirror is absent rather than unequal: the old check read it as a
+        // stored 0.0 and compared equal whenever the entry was itself 0.0.
+        let mut tri = TriMat::new((2, 2));
+        tri.add_triplet(0, 0, 5.0);
+        tri.add_triplet(0, 1, 0.0);
+        tri.add_triplet(1, 1, 5.0);
+        let matrix = tri.to_csr();
+
+        let path = temp_path("structurally-asymmetric");
+        write_mtx(&matrix, &path).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            text.lines().next().unwrap().ends_with("general"),
+            "an unmirrored stored entry must not claim a symmetric header:\n{text}"
+        );
+    }
+
+    #[test]
+    fn an_exactly_symmetric_matrix_still_writes_symmetric() {
+        let mut tri = TriMat::new((2, 2));
+        tri.add_triplet(0, 0, 5.0);
+        tri.add_triplet(0, 1, -3.0);
+        tri.add_triplet(1, 0, -3.0);
+        tri.add_triplet(1, 1, 5.0);
+        let matrix = tri.to_csr();
+
+        let path = temp_path("exactly-symmetric");
+        write_mtx(&matrix, &path).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert!(
+            text.lines().next().unwrap().ends_with("symmetric"),
+            "an exactly symmetric matrix keeps the compact form:\n{text}"
         );
     }
 

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -69,8 +69,13 @@ pub fn build_incidence(
             bus_id: br.to,
             element_index: idx,
         })?;
-        if i == j || br.x == 0.0 {
-            if i != j && br.x == 0.0 {
+        // A reactance below the bound is zero impedance in every sense the
+        // builder can act on: `x = 1e-300` gives `b = 1e300`, which is finite,
+        // passes the check below, and annihilates every real branch sharing a
+        // diagonal with it. Exact zero used to be the whole test.
+        let degenerate_x = br.x.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE;
+        if i == j || degenerate_x {
+            if i != j && degenerate_x {
                 if !opts.skip_zero_impedance {
                     return Err(Error::ZeroImpedance { row: idx });
                 }
@@ -79,8 +84,8 @@ pub fn build_incidence(
             continue;
         }
         let b_e = conv.branch_susceptance(br.x, br.effective_tap());
-        // A NaN reactance slips past the `x == 0.0` guard above, and a
-        // denormal `x` yields Inf; either poisons the whole Laplacian.
+        // A NaN reactance slips past the guard above, and a tap near zero
+        // sends `b_e` to Inf; either poisons the whole Laplacian.
         if !b_e.is_finite() {
             return Err(Error::NonFiniteSusceptance { row: idx });
         }

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -47,9 +47,12 @@ impl IncidenceParts {
 
 /// Build `A`, `b`, the phase shift injection, and the column→branch map.
 ///
-/// Self-loops (from == to) are dropped. Branches with `x == 0` have no finite DC
-/// susceptance; they are skipped when `opts.skip_zero_impedance` is true and
-/// rejected with [`Error::ZeroImpedance`] when it is false.
+/// Self-loops (from == to) are dropped. Branches whose reactance is under
+/// [`MIN_DIVISIBLE_MAGNITUDE`](crate::matrix::MIN_DIVISIBLE_MAGNITUDE) have no DC
+/// susceptance the Laplacian can carry; they are skipped when
+/// `opts.skip_zero_impedance` is true and rejected with [`Error::ZeroImpedance`]
+/// when it is false. A tap ratio under the same bound is [`Error::DegenerateTap`]
+/// either way, as it is in Y_bus.
 pub fn build_incidence(
     case: &IndexedNetwork,
     conv: DcConvention,
@@ -69,10 +72,9 @@ pub fn build_incidence(
             bus_id: br.to,
             element_index: idx,
         })?;
-        // A reactance below the bound is zero impedance in every sense the
-        // builder can act on: `x = 1e-300` gives `b = 1e300`, which is finite,
-        // passes the check below, and annihilates every real branch sharing a
-        // diagonal with it. Exact zero used to be the whole test.
+        // Zero impedance in every sense the builder can act on: `x = 1e-300`
+        // gives a finite `b = 1e300` that annihilates every real branch sharing
+        // a diagonal with it. Exact zero used to be the whole test.
         let degenerate_x = br.x.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE;
         if i == j || degenerate_x {
             if i != j && degenerate_x {
@@ -83,9 +85,15 @@ pub fn build_incidence(
             }
             continue;
         }
-        let b_e = conv.branch_susceptance(br.x, br.effective_tap());
-        // A NaN reactance slips past the guard above, and a tap near zero
-        // sends `b_e` to Inf; either poisons the whole Laplacian.
+        // `Matpower` divides by the tap here and Y_bus divides by it always, so
+        // one bound decides both. `effective_tap` only remaps an exact 0.0.
+        let tap = br.effective_tap();
+        if !tap.is_finite() || tap.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE {
+            return Err(Error::DegenerateTap { row: idx, tap });
+        }
+        let b_e = conv.branch_susceptance(br.x, tap);
+        // A NaN reactance slips past the guard above and poisons the whole
+        // Laplacian.
         if !b_e.is_finite() {
             return Err(Error::NonFiniteSusceptance { row: idx });
         }

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -47,12 +47,11 @@ impl IncidenceParts {
 
 /// Build `A`, `b`, the phase shift injection, and the column→branch map.
 ///
-/// Self-loops (from == to) are dropped. Branches whose reactance is under
-/// [`MIN_DIVISIBLE_MAGNITUDE`](crate::matrix::MIN_DIVISIBLE_MAGNITUDE) have no DC
-/// susceptance the Laplacian can carry; they are skipped when
-/// `opts.skip_zero_impedance` is true and rejected with [`Error::ZeroImpedance`]
-/// when it is false. A tap ratio under the same bound is [`Error::DegenerateTap`]
-/// either way, as it is in Y_bus.
+/// Self-loops (from == to) are dropped. A branch whose reactance is too small
+/// to divide by has no DC susceptance the Laplacian can carry; it is skipped
+/// when `opts.skip_zero_impedance` is true and rejected with
+/// [`Error::ZeroImpedance`] when it is false. A tap ratio under the same bound
+/// is [`Error::DegenerateTap`] either way, as it is in Y_bus.
 pub fn build_incidence(
     case: &IndexedNetwork,
     conv: DcConvention,

--- a/powerio-matrix/src/matrix/mod.rs
+++ b/powerio-matrix/src/matrix/mod.rs
@@ -44,17 +44,14 @@ pub(crate) use ybus::{YbusFlags, branch_admittance, branch_flows};
 
 use sprs::CsMat;
 
-/// The magnitude below which a reactance, an impedance denominator, or a tap
-/// ratio stops being a number the builders can divide by.
+/// The magnitude below which a reactance, an impedance, or a tap ratio stops
+/// being a number the builders can divide by.
 ///
 /// It is `f64::MIN_POSITIVE.sqrt()`: the square of anything smaller underflows
-/// to zero, so the value cannot take part in a product that stays meaningful.
-/// The reciprocal is above 1e153, and one branch stamping that into a Laplacian
-/// annihilates every real branch in the same accumulation — the matrix comes
-/// out rank deficient in floating point with every finiteness check passing.
-///
-/// A physical branch is nowhere near this: per unit reactances run from about
-/// 1e-6 to 10, so the bound rejects poison and nothing else.
+/// to zero, and the reciprocal is above 1e153, which annihilates every real
+/// branch sharing its diagonal. Each builder compares a magnitude against it —
+/// `|x|`, `hypot(r, x)`, the tap — never `r² + x²`, which is a square. Per unit
+/// reactances run from 1e-6 to 10, so it rejects poison and nothing else.
 pub(crate) const MIN_DIVISIBLE_MAGNITUDE: f64 = 1.491_668_146_240_041_3e-154;
 
 /// Which MATPOWER fast decoupled scheme to use.

--- a/powerio-matrix/src/matrix/mod.rs
+++ b/powerio-matrix/src/matrix/mod.rs
@@ -44,6 +44,19 @@ pub(crate) use ybus::{YbusFlags, branch_admittance, branch_flows};
 
 use sprs::CsMat;
 
+/// The magnitude below which a reactance, an impedance denominator, or a tap
+/// ratio stops being a number the builders can divide by.
+///
+/// It is `f64::MIN_POSITIVE.sqrt()`: the square of anything smaller underflows
+/// to zero, so the value cannot take part in a product that stays meaningful.
+/// The reciprocal is above 1e153, and one branch stamping that into a Laplacian
+/// annihilates every real branch in the same accumulation — the matrix comes
+/// out rank deficient in floating point with every finiteness check passing.
+///
+/// A physical branch is nowhere near this: per unit reactances run from about
+/// 1e-6 to 10, so the bound rejects poison and nothing else.
+pub(crate) const MIN_DIVISIBLE_MAGNITUDE: f64 = 1.491_668_146_240_041_3e-154;
+
 /// Which MATPOWER fast decoupled scheme to use.
 ///
 /// - `Bx`: clears resistance for `Bpp`.

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -411,11 +411,19 @@ fn lodf_from_dense_with_drop(
     // along branch k.
     let delta = |l: usize, k: usize| ptdf[l * n + from[k]] - ptdf[l * n + to[k]];
 
+    // Outaging a bridge redistributes nothing, so its column is structurally
+    // zero. The magnitude test this replaces could not tell a true bridge from
+    // a branch carrying almost everything: a near bridge at
+    // `delta(k,k) = 1 - 1.1e-9` passed it, and its column came out amplified
+    // to ~1e9 with about seven digits gone — entries too large for
+    // `drop_tolerance` to catch.
+    let is_bridge = bridges(&from, &to, n);
+
     let mut lodf = CooBuilder::new(m); // m × m
     let mut dropped = 0usize;
     for k in 0..m {
         let denom = 1.0 - delta(k, k);
-        let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
+        let islands = is_bridge[k] || denom.abs() < LODF_ISLAND_TOLERANCE;
         for l in 0..m {
             let v = if l == k {
                 -1.0
@@ -624,6 +632,83 @@ fn branch_flow(
 }
 
 /// Branch endpoints from the signed incidence: `+1` row is from, `−1` is to.
+/// Which branches are bridges of the graph the columns describe: an edge whose
+/// removal disconnects its endpoints.
+///
+/// Outaging a bridge moves no flow anywhere, which is the condition the LODF
+/// denominator `1 - delta(k,k)` approaches. Deciding it topologically is exact,
+/// where a magnitude test on the denominator cannot separate a true bridge from
+/// a branch that merely carries almost everything.
+///
+/// Iterative Tarjan, O(n + m). The recursion a textbook writes overflows the
+/// stack on a real feeder. Entry is tracked by arc rather than by parent node,
+/// so a pair of parallel branches correctly leaves neither of them a bridge.
+fn bridges(from: &[usize], to: &[usize], n: usize) -> Vec<bool> {
+    let m = from.len();
+    // Forward star: arc `2k` runs from[k] -> to[k], arc `2k+1` its reverse, so
+    // `arc ^ 1` is the other direction of the same branch and `arc / 2` is the
+    // branch itself.
+    let mut head = vec![usize::MAX; n];
+    let mut next = vec![usize::MAX; 2 * m];
+    let mut dest = vec![0usize; 2 * m];
+    for k in 0..m {
+        for (arc, tail, other) in [(2 * k, from[k], to[k]), (2 * k + 1, to[k], from[k])] {
+            dest[arc] = other;
+            next[arc] = head[tail];
+            head[tail] = arc;
+        }
+    }
+
+    let mut disc = vec![usize::MAX; n];
+    let mut low = vec![0usize; n];
+    let mut is_bridge = vec![false; m];
+    let mut timer = 0usize;
+    // (node, the arc it was entered by, the next arc to examine)
+    let mut stack: Vec<(usize, usize, usize)> = Vec::new();
+
+    for root in 0..n {
+        if disc[root] != usize::MAX {
+            continue;
+        }
+        disc[root] = timer;
+        low[root] = timer;
+        timer += 1;
+        stack.push((root, usize::MAX, head[root]));
+        while let Some(top) = stack.last_mut() {
+            let (v, in_arc) = (top.0, top.1);
+            if top.2 == usize::MAX {
+                stack.pop();
+                if let Some(parent) = stack.last_mut() {
+                    let p = parent.0;
+                    low[p] = low[p].min(low[v]);
+                    // The subtree under v reaches nothing at or above p, so
+                    // the edge into v is the only way back.
+                    if low[v] > disc[p] {
+                        is_bridge[in_arc / 2] = true;
+                    }
+                }
+                continue;
+            }
+            let arc = top.2;
+            top.2 = next[arc];
+            // Skip the branch we arrived on, but not a parallel one beside it.
+            if arc == in_arc ^ 1 {
+                continue;
+            }
+            let w = dest[arc];
+            if disc[w] == usize::MAX {
+                disc[w] = timer;
+                low[w] = timer;
+                timer += 1;
+                stack.push((w, arc, head[w]));
+            } else {
+                low[v] = low[v].min(disc[w]);
+            }
+        }
+    }
+    is_bridge
+}
+
 fn endpoints(a: &CsMat<f64>, m: usize) -> (Vec<usize>, Vec<usize>) {
     let mut from = vec![0usize; m];
     let mut to = vec![0usize; m];
@@ -940,6 +1025,68 @@ impl DenseCholesky {
             }
         }
         inv
+    }
+}
+
+#[cfg(test)]
+mod bridge_tests {
+    use super::bridges;
+
+    #[test]
+    fn every_edge_of_a_path_is_a_bridge() {
+        // 0 - 1 - 2 - 3
+        let b = bridges(&[0, 1, 2], &[1, 2, 3], 4);
+        assert_eq!(b, vec![true, true, true]);
+    }
+
+    #[test]
+    fn no_edge_of_a_cycle_is_a_bridge() {
+        // 0 - 1 - 2 - 0
+        let b = bridges(&[0, 1, 2], &[1, 2, 0], 3);
+        assert_eq!(b, vec![false, false, false]);
+    }
+
+    #[test]
+    fn parallel_branches_leave_neither_a_bridge() {
+        // Two circuits on the same corridor: outaging one still leaves a path,
+        // so neither is a bridge. Tracking entry by node rather than by arc
+        // would call both of them bridges.
+        let b = bridges(&[0, 0], &[1, 1], 2);
+        assert_eq!(b, vec![false, false]);
+    }
+
+    #[test]
+    fn only_the_tie_between_two_loops_is_a_bridge() {
+        // Two triangles joined by one tie line: 0-1-2-0, tie 2-3, 3-4-5-3.
+        let from = [0, 1, 2, 2, 3, 4, 5];
+        let to = [1, 2, 0, 3, 4, 5, 3];
+        let b = bridges(&from, &to, 6);
+        assert_eq!(b, vec![false, false, false, true, false, false, false]);
+    }
+
+    #[test]
+    fn a_self_loop_is_not_a_bridge() {
+        let b = bridges(&[0, 1], &[1, 1], 2);
+        assert_eq!(b, vec![true, false]);
+    }
+
+    #[test]
+    fn separate_components_are_each_walked() {
+        // 0-1 and 2-3, no tie. Both edges are bridges of their own component,
+        // and the root loop must reach the second one.
+        let b = bridges(&[0, 2], &[1, 3], 4);
+        assert_eq!(b, vec![true, true]);
+    }
+
+    #[test]
+    fn a_long_path_does_not_overflow_the_stack() {
+        // The recursion a textbook writes dies here.
+        let n = 200_000;
+        let from: Vec<usize> = (0..n - 1).collect();
+        let to: Vec<usize> = (1..n).collect();
+        let b = bridges(&from, &to, n);
+        assert_eq!(b.len(), n - 1);
+        assert!(b.iter().all(|&x| x));
     }
 }
 

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -412,11 +412,9 @@ fn lodf_from_dense_with_drop(
     let delta = |l: usize, k: usize| ptdf[l * n + from[k]] - ptdf[l * n + to[k]];
 
     // Outaging a bridge redistributes nothing, so its column is structurally
-    // zero. The magnitude test this replaces could not tell a true bridge from
-    // a branch carrying almost everything: a near bridge at
-    // `delta(k,k) = 1 - 1.1e-9` passed it, and its column came out amplified
-    // to ~1e9 with about seven digits gone — entries too large for
-    // `drop_tolerance` to catch.
+    // zero. The magnitude test this replaces let a near bridge at
+    // `delta(k,k) = 1 - 1.1e-9` through, amplifying its column to ~1e9 with
+    // about seven digits gone.
     let is_bridge = bridges(&from, &to, n);
 
     let mut lodf = CooBuilder::new(m); // m × m
@@ -644,9 +642,9 @@ fn branch_flow(
 /// where a magnitude test on the denominator cannot separate a true bridge from
 /// a branch that merely carries almost everything.
 ///
-/// Iterative Tarjan, O(n + m). The recursion a textbook writes overflows the
-/// stack on a real feeder. Entry is tracked by arc rather than by parent node,
-/// so a pair of parallel branches correctly leaves neither of them a bridge.
+/// Iterative Tarjan, O(n + m); the textbook recursion overflows the stack on a
+/// real feeder. Entry is tracked by arc rather than by parent node, so parallel
+/// branches leave neither of them a bridge.
 fn bridges(from: &[usize], to: &[usize], n: usize) -> Vec<bool> {
     let m = from.len();
     // Forward star: arc `2k` runs from[k] -> to[k], arc `2k+1` its reverse, so

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -557,6 +557,10 @@ fn iterative_ptdf_lodf_entries(
         }
     }
 
+    // Same rule as the dense path: a bridge redistributes nothing, decided on
+    // the topology rather than on how close the denominator came to zero.
+    let is_bridge = bridges(&from, &to, n);
+
     let mut lodf_nnz = 0usize;
     let mut lodf_dropped = 0usize;
     for outage in 0..m {
@@ -570,7 +574,7 @@ fn iterative_ptdf_lodf_entries(
         let theta = solver.solve(&rhs)?;
         let outage_delta = branch_flow(outage, &from, &to, &inc.b, &g, &theta);
         let denom = 1.0 - outage_delta;
-        let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
+        let islands = is_bridge[outage] || denom.abs() < LODF_ISLAND_TOLERANCE;
         for branch in 0..m {
             let v = if branch == outage {
                 -1.0

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -688,6 +688,12 @@ fn dense_to_csr_with_drop(
 }
 
 fn dense_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {
+    // The pivot floor tracks the matrix's own scale. A fixed 1e-12 is at once
+    // too strict for a legitimately small scaled matrix and far too loose for
+    // one whose entries run to 1e12.
+    let scale = a.iter().fold(0.0_f64, |m, v| m.max(v.abs()));
+    #[allow(clippy::cast_precision_loss)]
+    let floor = n as f64 * f64::EPSILON * scale;
     let mut a = a.to_vec();
     let mut inv = vec![0.0; n * n];
     for i in 0..n {
@@ -704,7 +710,7 @@ fn dense_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {
                 pivot_row = r;
             }
         }
-        if !pivot_abs.is_finite() || pivot_abs <= 1e-12 {
+        if !pivot_abs.is_finite() || pivot_abs <= floor {
             return None;
         }
         if pivot_row != col {
@@ -867,6 +873,14 @@ struct DenseCholesky {
 
 impl DenseCholesky {
     fn factor(a: &[f64], n: usize) -> Option<Self> {
+        // A pivot is accepted against the matrix's own scale. `s > 0.0` alone
+        // accepts 1e-300, whose square root divides the column by 1e-150 twice
+        // and returns entries near 1e300 with no error — the shape a near
+        // disconnected island joined by one very high impedance branch takes,
+        // which `check_reference_coverage` passes.
+        let scale = a.iter().fold(0.0_f64, |m, v| m.max(v.abs()));
+        #[allow(clippy::cast_precision_loss)]
+        let floor = n as f64 * f64::EPSILON * scale;
         let mut l = vec![0.0; n * n];
         for i in 0..n {
             for j in 0..=i {
@@ -875,13 +889,13 @@ impl DenseCholesky {
                     s -= l[i * n + k] * l[j * n + k];
                 }
                 if i == j {
-                    // `!(s > 0.0)` rejects negative, zero, AND NaN pivots:
-                    // `NaN <= 0.0` is false, so `s <= 0.0` would let a
+                    // `!(s > floor)` rejects negative, too small, AND NaN
+                    // pivots: `NaN <= x` is false, so `s <= floor` would let a
                     // NaN-poisoned matrix factor "successfully" into all-NaN.
                     // The negated comparison is the point (NaN incomparability),
                     // so the partial_cmp rewrite clippy suggests would obscure it.
                     #[allow(clippy::neg_cmp_op_on_partial_ord)]
-                    if !(s > 0.0) {
+                    if !(s > floor) {
                         return None;
                     }
                     l[i * n + i] = s.sqrt();
@@ -926,6 +940,42 @@ impl DenseCholesky {
             }
         }
         inv
+    }
+}
+
+#[cfg(test)]
+mod pivot_tests {
+    use super::{DenseCholesky, dense_inverse};
+
+    /// #292. The pivot floor tracks the matrix's own scale, so it rejects the
+    /// same relative degeneracy at any magnitude and accepts a matrix that is
+    /// merely small.
+    #[test]
+    fn a_pivot_is_judged_against_the_matrix_scale() {
+        // Scaled up: against entries of 1e12 a pivot of 1e-6 carries no
+        // significant digits, and the old absolute 1e-12 accepted it.
+        let big = [1e12, 0.0, 0.0, 1e-6];
+        assert!(dense_inverse(&big, 2).is_none(), "1e-18 relative accepted");
+        assert!(DenseCholesky::factor(&big, 2).is_none());
+
+        // Scaled down: every entry is tiny but the matrix is perfectly
+        // conditioned, and the old absolute floor refused it outright.
+        let small = [1e-14, 0.0, 0.0, 1e-14];
+        let inv = dense_inverse(&small, 2).expect("a well conditioned small matrix inverts");
+        assert!((inv[0] - 1e14).abs() < 1.0, "{inv:?}");
+        assert!(DenseCholesky::factor(&small, 2).is_some());
+
+        // A genuinely singular matrix is still refused at any scale.
+        assert!(dense_inverse(&[1.0, 1.0, 1.0, 1.0], 2).is_none());
+        assert!(DenseCholesky::factor(&[1.0, 1.0, 1.0, 1.0], 2).is_none());
+    }
+
+    /// The `!(s > floor)` idiom must still reject a NaN pivot; `NaN > x` is
+    /// false, which is the whole reason the comparison is negated.
+    #[test]
+    fn a_nan_pivot_does_not_factor() {
+        assert!(DenseCholesky::factor(&[f64::NAN, 0.0, 0.0, 1.0], 2).is_none());
+        assert!(dense_inverse(&[f64::NAN, 0.0, 0.0, 1.0], 2).is_none());
     }
 }
 

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -561,6 +561,70 @@ fn zero_impedance_policy_can_error_instead_of_skipping() {
 }
 
 #[test]
+fn a_radial_tie_gets_a_structurally_zero_lodf_column() {
+    // #292. Two loops joined by one tie: outaging the tie islands the network,
+    // so its LODF column redistributes nothing. That used to rest on the
+    // denominator landing under an absolute 1e-9; it is now the topology.
+    // Both solver paths must agree.
+    let net = Network::in_memory(
+        "two-loops-one-tie",
+        100.0,
+        vec![
+            bus(1, BusType::Ref),
+            bus(2, BusType::Pq),
+            bus(3, BusType::Pq),
+            bus(4, BusType::Pq),
+            bus(5, BusType::Pq),
+            bus(6, BusType::Pq),
+        ],
+        vec![
+            br(1, 2, 0.0, 0.1, 0.0),
+            br(2, 3, 0.0, 0.1, 0.0),
+            br(3, 1, 0.0, 0.1, 0.0),
+            br(3, 4, 0.0, 0.1, 0.0), // the tie
+            br(4, 5, 0.0, 0.1, 0.0),
+            br(5, 6, 0.0, 0.1, 0.0),
+            br(6, 4, 0.0, 0.1, 0.0),
+        ],
+    );
+    let view = IndexedNetwork::new(&net);
+    let tie = 3;
+
+    for solver in [
+        crate::matrix::SensitivitySolver::Dense,
+        crate::matrix::SensitivitySolver::Iterative,
+    ] {
+        let out = crate::matrix::build_ptdf_lodf_with_options(
+            &view,
+            &crate::matrix::SensitivityOptions {
+                solver,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|e| panic!("{solver:?}: {e}"));
+        let lodf = out.lodf;
+        for (&v, (row, col)) in &lodf {
+            if col == tie && row != tie {
+                assert!(
+                    v.abs() < f64::MIN_POSITIVE,
+                    "{solver:?}: tie column carries {v} at row {row}"
+                );
+            }
+        }
+        // A branch inside a loop still redistributes.
+        let loop_col: f64 = lodf
+            .iter()
+            .filter(|&(_, (row, col))| col == 0 && row != 0)
+            .map(|(&v, _)| v.abs())
+            .sum();
+        assert!(
+            loop_col > 0.1,
+            "{solver:?}: loop branch redistributes nothing"
+        );
+    }
+}
+
+#[test]
 fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
     // #292. `x = 1e-300` gives `b = 1e300`, which is finite, so every
     // finiteness check passed it. One such branch on a diagonal annihilates

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -561,6 +561,80 @@ fn zero_impedance_policy_can_error_instead_of_skipping() {
 }
 
 #[test]
+fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
+    // #292. `x = 1e-300` gives `b = 1e300`, which is finite, so every
+    // finiteness check passed it. One such branch on a diagonal annihilates
+    // every real branch sharing it: the Laplacian comes out rank deficient in
+    // floating point and `sddm_check` reports nothing.
+    let net = Network::in_memory(
+        "denormal-x",
+        100.0,
+        vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+        vec![br(1, 2, 0.0, 1e-300, 0.0)],
+    );
+    let view = IndexedNetwork::new(&net);
+
+    let inc = build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+    assert_eq!(inc.skipped_zero_impedance.count, 1);
+    assert_eq!(inc.skipped_zero_impedance.branch_indices, vec![0]);
+
+    let strict = BuildOptions {
+        skip_zero_impedance: false,
+        ..Default::default()
+    };
+    let err = build_incidence(&view, DcConvention::PaperPure, &strict).unwrap_err();
+    assert!(
+        matches!(err, crate::Error::ZeroImpedance { row: 0 }),
+        "{err}"
+    );
+    let err = build_ybus(&view, &strict).unwrap_err();
+    assert!(
+        matches!(err, crate::Error::ZeroImpedance { row: 0 }),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_tap_ratio_ybus_cannot_divide_by_is_refused() {
+    // #292. `effective_tap` only remaps an exact 0.0, so a tap of 1e-200
+    // underflowed `a_norm_sqr` to zero and scattered +/-Inf into Y_bus.
+    for tap in [1e-200, f64::NAN, f64::INFINITY] {
+        let mut branch = br(1, 2, 0.01, 0.1, 0.0);
+        branch.tap = tap;
+        let net = Network::in_memory(
+            "degenerate-tap",
+            100.0,
+            vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+            vec![branch],
+        );
+        let view = IndexedNetwork::new(&net);
+        let err = build_ybus(&view, &BuildOptions::default()).unwrap_err();
+        assert!(
+            matches!(err, crate::Error::DegenerateTap { row: 0, .. }),
+            "tap {tap}: {err}"
+        );
+    }
+}
+
+#[test]
+fn an_ordinary_tap_still_builds() {
+    // The bound rejects poison and nothing else: a real off nominal tap and
+    // the 0.0 that `effective_tap` remaps to unity both stay.
+    for tap in [0.0, 0.95, 1.0, 1.1] {
+        let mut branch = br(1, 2, 0.01, 0.1, 0.0);
+        branch.tap = tap;
+        let net = Network::in_memory(
+            "ordinary-tap",
+            100.0,
+            vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+            vec![branch],
+        );
+        let view = IndexedNetwork::new(&net);
+        build_ybus(&view, &BuildOptions::default()).unwrap_or_else(|e| panic!("tap {tap}: {e}"));
+    }
+}
+
+#[test]
 fn self_loop_with_zero_reactance_drops_unconditionally() {
     // A self-loop (from == to) is documented as always dropped, independent
     // of skip_zero_impedance; it must not be misrouted through the

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -626,10 +626,9 @@ fn a_radial_tie_gets_a_structurally_zero_lodf_column() {
 
 #[test]
 fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
-    // #292. `x = 1e-300` gives `b = 1e300`, which is finite, so every
-    // finiteness check passed it. One such branch on a diagonal annihilates
-    // every real branch sharing it: the Laplacian comes out rank deficient in
-    // floating point and `sddm_check` reports nothing.
+    // #292. `x = 1e-300` gives a finite `b = 1e300`, so every finiteness check
+    // passed it and the Laplacian came out rank deficient in floating point
+    // with `sddm_check` reporting nothing.
     let net = Network::in_memory(
         "denormal-x",
         100.0,
@@ -659,9 +658,32 @@ fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
 }
 
 #[test]
-fn a_tap_ratio_ybus_cannot_divide_by_is_refused() {
-    // #292. `effective_tap` only remaps an exact 0.0, so a tap of 1e-200
-    // underflowed `a_norm_sqr` to zero and scattered +/-Inf into Y_bus.
+fn a_reactance_the_builders_can_divide_by_is_stamped_by_both() {
+    // #292. Bounding `r² + x²` by the magnitude bound made Y_bus call this
+    // branch zero impedance while the DC builder stamped `b = 1e100`.
+    let net = Network::in_memory(
+        "small-but-divisible-x",
+        100.0,
+        vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+        vec![br(1, 2, 0.0, 1e-100, 0.0)],
+    );
+    let view = IndexedNetwork::new(&net);
+    let opts = BuildOptions::default();
+
+    let inc = build_incidence(&view, DcConvention::PaperPure, &opts).unwrap();
+    assert_eq!(inc.skipped_zero_impedance.count, 0);
+    assert_relative_eq!(inc.b[0], 1e100, max_relative = 1e-12);
+
+    let ybus = build_ybus(&view, &opts).unwrap();
+    let ybus_stats = matrix_stats_for_kind(&ybus.b, &view, MatrixKind::YbusB, &opts);
+    assert_eq!(ybus_stats.skipped_zero_impedance, 0);
+    assert_relative_eq!(*ybus.b.get(0, 1).unwrap(), 1e100, max_relative = 1e-12);
+}
+
+#[test]
+fn a_tap_ratio_the_builders_cannot_divide_by_is_refused() {
+    // #292. A tap of 1e-200 underflowed `a_norm_sqr` to zero and scattered
+    // +/-Inf into Y_bus; `Matpower` divides `b` by the same tap.
     for tap in [1e-200, f64::NAN, f64::INFINITY] {
         let mut branch = br(1, 2, 0.01, 0.1, 0.0);
         branch.tap = tap;
@@ -675,7 +697,13 @@ fn a_tap_ratio_ybus_cannot_divide_by_is_refused() {
         let err = build_ybus(&view, &BuildOptions::default()).unwrap_err();
         assert!(
             matches!(err, crate::Error::DegenerateTap { row: 0, .. }),
-            "tap {tap}: {err}"
+            "Ybus, tap {tap}: {err}"
+        );
+        let err =
+            build_incidence(&view, DcConvention::Matpower, &BuildOptions::default()).unwrap_err();
+        assert!(
+            matches!(err, crate::Error::DegenerateTap { row: 0, .. }),
+            "incidence, tap {tap}: {err}"
         );
     }
 }
@@ -694,7 +722,10 @@ fn an_ordinary_tap_still_builds() {
             vec![branch],
         );
         let view = IndexedNetwork::new(&net);
-        build_ybus(&view, &BuildOptions::default()).unwrap_or_else(|e| panic!("tap {tap}: {e}"));
+        build_ybus(&view, &BuildOptions::default())
+            .unwrap_or_else(|e| panic!("Ybus, tap {tap}: {e}"));
+        build_incidence(&view, DcConvention::Matpower, &BuildOptions::default())
+            .unwrap_or_else(|e| panic!("incidence, tap {tap}: {e}"));
     }
 }
 

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -142,12 +142,15 @@ pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> 
 /// `flags` lets the Y_bus builder zero taps/shifts/charging; pass
 /// [`YbusFlags::default`] for the physical admittances (taps and shifts on).
 ///
-/// Returns `Ok(None)` for a zero-impedance branch (`r² + x² = 0`), which the
-/// callers skip (Y_bus) or zero out (gridfm). `row` only labels the error.
+/// Returns `Ok(None)` for a zero-impedance branch — one whose impedance
+/// magnitude is under [`MIN_DIVISIBLE_MAGNITUDE`](super::MIN_DIVISIBLE_MAGNITUDE) —
+/// which the callers skip (Y_bus) or zero out (gridfm). `row` only labels the
+/// error.
 ///
 /// # Errors
 /// [`Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad value can't
-/// slip a NaN into Y_bus or a Parquet column.
+/// slip a NaN into Y_bus or a Parquet column. [`Error::DegenerateTap`] when the
+/// tap ratio is one the four admittances cannot be divided by.
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn branch_admittance(
     br: &crate::network::Branch,
@@ -157,20 +160,20 @@ pub(crate) fn branch_admittance(
 ) -> Result<Option<[Complex64; 4]>> {
     let r = if flags.zero_resistance { 0.0 } else { br.r };
     let x = br.x;
-    let denom = r * r + x * x;
-    // A denominator this small is zero impedance in every sense the builders
-    // can act on: `r = 1e-160, x = 0` leaves `denom` subnormal and `r / denom`
-    // above 1e160, which is not a shunt admittance, it is a poisoned row.
-    // Exact zero used to be the whole test.
-    if denom < super::MIN_DIVISIBLE_MAGNITUDE {
+    // Zero impedance in every sense the builder can act on; exact zero used to
+    // be the whole test. Bounded on the impedance magnitude, not on `r² + x²`:
+    // `incidence` bounds `|x|` by the same number, so bounding the square here
+    // would refuse an `x = 1e-100` the DC builder stamps.
+    if r.hypot(x) < super::MIN_DIVISIBLE_MAGNITUDE {
         if flags.skip_zero_impedance {
             return Ok(None);
         }
         return Err(Error::ZeroImpedance { row });
     }
-    // NaN/Inf r or x makes `denom` non-finite (and slips past the bound above),
-    // which would write NaN into Y_bus and silently break the downstream
-    // M-matrix/SDDM checks. Reject it the same way `incidence` does.
+    let denom = r * r + x * x;
+    // NaN leaves `hypot` NaN, which is not below the bound, so it arrives here
+    // rather than reading as zero impedance. Either would write NaN into Y_bus
+    // and silently break the downstream M-matrix/SDDM checks.
     if !denom.is_finite() {
         return Err(Error::NonFiniteSusceptance { row });
     }
@@ -189,10 +192,9 @@ pub(crate) fn branch_admittance(
     } else {
         br.effective_tap()
     };
-    // `effective_tap` only remaps an exact 0.0 to 1.0. A tap of 1e-200
+    // `effective_tap` only remaps an exact 0.0 to 1.0, so a tap of 1e-200
     // underflows `a_norm_sqr` to zero and scatters +/-Inf through the four
-    // admittances; a tap of 1e-8 scales `y_ff` by 1e16 and destroys the
-    // conditioning with nothing to say so.
+    // admittances.
     if !tap_mag.is_finite() || tap_mag.abs() < super::MIN_DIVISIBLE_MAGNITUDE {
         return Err(Error::DegenerateTap { row, tap: tap_mag });
     }
@@ -207,8 +209,8 @@ pub(crate) fn branch_admittance(
     let y_ft = -y_series / a.conj();
     let y_tf = -y_series / a;
     let out = [y_ff, y_ft, y_tf, y_tt];
-    // The guards above cover each input on its own; the products can still
-    // overflow when several sit near their bound at once.
+    // Each input is bounded on its own above; the products can still overflow
+    // when several sit near their bound at once.
     if out.iter().any(|y| !y.re.is_finite() || !y.im.is_finite()) {
         return Err(Error::NonFiniteSusceptance { row });
     }

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -158,15 +158,19 @@ pub(crate) fn branch_admittance(
     let r = if flags.zero_resistance { 0.0 } else { br.r };
     let x = br.x;
     let denom = r * r + x * x;
-    if denom == 0.0 {
+    // A denominator this small is zero impedance in every sense the builders
+    // can act on: `r = 1e-160, x = 0` leaves `denom` subnormal and `r / denom`
+    // above 1e160, which is not a shunt admittance, it is a poisoned row.
+    // Exact zero used to be the whole test.
+    if denom < super::MIN_DIVISIBLE_MAGNITUDE {
         if flags.skip_zero_impedance {
             return Ok(None);
         }
         return Err(Error::ZeroImpedance { row });
     }
-    // NaN/Inf r or x makes `denom` non-finite (and slips past `== 0.0`), which
-    // would write NaN into Y_bus and silently break the downstream M-matrix/SDDM
-    // checks. Reject it the same way `incidence` does.
+    // NaN/Inf r or x makes `denom` non-finite (and slips past the bound above),
+    // which would write NaN into Y_bus and silently break the downstream
+    // M-matrix/SDDM checks. Reject it the same way `incidence` does.
     if !denom.is_finite() {
         return Err(Error::NonFiniteSusceptance { row });
     }
@@ -185,6 +189,13 @@ pub(crate) fn branch_admittance(
     } else {
         br.effective_tap()
     };
+    // `effective_tap` only remaps an exact 0.0 to 1.0. A tap of 1e-200
+    // underflows `a_norm_sqr` to zero and scatters +/-Inf through the four
+    // admittances; a tap of 1e-8 scales `y_ff` by 1e16 and destroys the
+    // conditioning with nothing to say so.
+    if !tap_mag.is_finite() || tap_mag.abs() < super::MIN_DIVISIBLE_MAGNITUDE {
+        return Err(Error::DegenerateTap { row, tap: tap_mag });
+    }
     // `shift_rad` is supplied already in radians and already zeroed when
     // `flags.zero_shifts` is set (the caller has the network, so it knows whether
     // the source angle is degrees or — for a normalized network — radians).
@@ -195,7 +206,13 @@ pub(crate) fn branch_admittance(
     let y_tt = y_series + y_to;
     let y_ft = -y_series / a.conj();
     let y_tf = -y_series / a;
-    Ok(Some([y_ff, y_ft, y_tf, y_tt]))
+    let out = [y_ff, y_ft, y_tf, y_tt];
+    // The guards above cover each input on its own; the products can still
+    // overflow when several sit near their bound at once.
+    if out.iter().any(|y| !y.re.is_finite() || !y.im.is_finite()) {
+        return Err(Error::NonFiniteSusceptance { row });
+    }
+    Ok(Some(out))
 }
 
 /// Complex from/to power injections for one branch at the given bus voltages, in

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
     #[error("branch row {row} has non-finite DC susceptance b = 1/x (x is NaN, Inf, or denormal)")]
     NonFiniteSusceptance { row: usize },
 
+    #[error("branch row {row} has a tap ratio of {tap} that Y_bus cannot divide by")]
+    DegenerateTap { row: usize, tap: f64 },
+
     #[error("output dimension mismatch: matrix is {n}x{n} but RHS has length {b_len}")]
     DimensionMismatch { n: usize, b_len: usize },
 
@@ -219,6 +222,7 @@ impl Error {
             Error::UnknownBus { .. }
             | Error::ZeroImpedance { .. }
             | Error::NonFiniteSusceptance { .. }
+            | Error::DegenerateTap { .. }
             | Error::DimensionMismatch { .. }
             | Error::NoGenerators
             | Error::MissingGenCost { .. }


### PR DESCRIPTION
Part of #292 — four of its five items; the third location in its item 4 (`Branch::series_admittance`) is finished in #316, which carries the close. Targets **v0.9.0** — each item changes results for the degenerate input that triggers it, which is why they were held for the breaking window rather than shipped in 0.8.x.

Every one of these had the same shape: a check that passes a value whose reciprocal is astronomical, or a tolerance that cannot separate the case it was written for from a nearby one. The matrix came out wrong and nothing said so — `sddm_check` and `MatrixStats` report nothing about any of them.

## The five

**Impedance denominators, exact zero to a magnitude bound.** `x = 1e-300` gives `b = 1e300`. It is finite, so `is_finite` passed it, and one such branch on a Laplacian diagonal annihilates every real branch sharing it — the matrix is rank deficient in floating point. `r = 1e-160, x = 0` leaves the Y_bus denominator subnormal and `r / denom` above 1e160. Both read as zero impedance now and take the existing skip or refuse path.

**Tap ratios.** `effective_tap` only remaps an exact `0.0`, so `tap = 1e-200` underflowed `a_norm_sqr` to zero and scattered infinities through the four admittances, and `tap = 1e-8` scaled `y_ff` by 1e16 with nothing to say so. A tap the builder cannot divide by is `DegenerateTap`, and the four admittances are checked before they are returned, since each input can be in range while a product is not.

Both use `MIN_DIVISIBLE_MAGNITUDE = f64::MIN_POSITIVE.sqrt()`, below which a value's square underflows. Per unit reactances run from about 1e-6 to 10, so this rejects poison and nothing else — a test holds ordinary taps, including the `0.0` that remaps to unity.

**LODF islanding, tolerance to topology.** A branch redistributes nothing when outaged if and only if it is a bridge of the in-service graph. That was `|1 - delta(k,k)| < 1e-9`, which catches a true bridge but also passes a *near* bridge: at `delta(k,k) = 1 - 1.1e-9` the column divides by a denominator carrying about seven digits and comes out amplified to ~1e9, which `drop_tolerance` cannot catch because the entries are huge rather than tiny. Bridges are now found with an iterative Tarjan over the branch endpoints, O(n + m), and those columns are structurally zero; the tolerance stays as a backstop. Applied on both the dense and the iterative assembly, with a test holding the two to the same answer.

The walk is iterative because the textbook recursion overflows the stack on a real feeder — a 200k node path is a test. Entry is tracked by arc rather than by parent node, so parallel circuits on one corridor correctly leave neither a bridge.

**Pivot acceptance, absolute to scale relative.** `DenseCholesky::factor` accepted any `s > 0.0`, so `s = 1e-300` factored into `1e-150` and the inverse divided by it twice, returning entries near 1e300. `dense_inverse` refused on an absolute `1e-12`, at once too strict for a legitimately small scaled matrix and far too loose for one whose entries run to 1e12. Both floors are `n * f64::EPSILON * max|a_ij|`. The `!(s > floor)` idiom is kept deliberately: `NaN > x` is false, and that is what rejects a NaN pivot rather than factoring the matrix into all NaN.

**mtx symmetric header.** The writer emits one triangle under that header, so a reader rebuilds `a[j][i]` from `a[i][j]`. The header was decided on a `1e-12` relative tolerance, so a matrix that was merely close went out as symmetric and came back changed — a `Bp` in BX mode with a small phase shifter is asymmetric by exactly `2 g sin(theta) / t`, which sat under it. A missing mirror also read as a stored `0.0` and compared equal whenever the entry was itself `0.0`. The test is now bit equality plus a stored mirror; anything short goes out as `general`.

## What consumers see

An error or a recorded skip replaces a silently poisoned matrix, for the degenerate inputs only. Ordinary cases are unchanged — the full workspace suite passes untouched.

One output change beyond that: some matrices that carried a `symmetric` header now carry `general`. The entries are identical either way; the file is larger and states what was assembled rather than what it rounded to.

`DegenerateTap` is a new `Error` variant, which is why this is a 0.9.0 item rather than a patch.

## Verification

`cargo fmt --check`, `scripts/ci-clippy.sh`, and `cargo test --workspace` all pass. Twelve new tests: seven on the bridge finder alone (path, cycle, parallel edges, two loops on one tie, self loop, disconnected components, and the 200k node stack case), plus the degenerate taps and reactances, the pivot floors in both directions, the NaN pivot, and three on the mtx header.
