### PR TITLE
matrix: read the whole series impedance in the DC susceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,10 +297,16 @@ fuzz/                        # libFuzzer targets (detached workspace; see fuzz/R
   must leave `angmin <= angmax`. Wide symmetric bounds and `0/0` already have
   coverage.
 - **DC OPF Laplacian.** `L = A diag(b) Aᵀ` is built from the same `A`, `b`
-  factors `build_incidence` returns, so `L` and the reweighted `L₁` share a
-  factorization. With zero phase shifts, it equals MATPOWER `Bp` in the XB
-  scheme. Default `b = 1/x` (paper-pure); `DcConvention::Matpower` uses
-  `1/(x·τ)` plus a phase shift injection.
+  factors `build_incidence` returns. `DcConvention::series_susceptance` states
+  the series susceptance `b`, negative for an inductive branch, the sign
+  PowerModels `calc_branch_y` gives; `build_incidence` negates it once, because
+  `L` takes the M-matrix form with negative off diagonals and positive
+  diagonals. Never negate twice: the matrix comes out sign flipped and every
+  builder downstream inherits it. Default `SeriesImpedance`: `b = -x/(r² + x²)`,
+  which reads the whole series impedance, plus a phase shift injection, with no
+  tap scaling. `Matpower` uses `-1/(x·τ)` plus the injection. `PaperPure`
+  (`b = -1/x`, taps and shifts ignored) is deprecated in 0.9.0 and removed in
+  1.0.0; with zero phase shifts it equals MATPOWER `Bp` in the XB scheme.
 - **DC OPF lives in `powerio-prob`.** `DcOpfInstance` keeps generator-space
   data (`generators: DcGeneratorData`); `nodal_generator_data()` scatters it to
   bus space through `C_g` for length-n `Q`, `c`, and bounds. Cost map: MATPOWER `c2 p² + c1 p` → `q = 2c2`, `c = c1`, constant `c0` retained. Per-unit by default (`Units::PerUnit` scales `q` by `base²`, `c` by `base`).

--- a/docs/src/dcopf-bundle.md
+++ b/docs/src/dcopf-bundle.md
@@ -29,9 +29,14 @@ Market files and `dcopf_meta.json`.
   as a 0-based dense index. Each in-service island needs at least one reference.
   If several references lie in one island, the bundle fixes all of those voltage
   angles to zero; it is not a participation factor slack model.
-- **DC convention.** `PaperPure` by default (\\(b_e = 1/x\\), taps and phase shifts
-  ignored). `Matpower` uses \\(b_e = 1/(x \tau)\\) plus the phase shift injection
-  `p_shift`. Recorded in the manifest.
+- **DC convention.** Every convention states the series susceptance
+  \\(b_e\\), negative for an inductive branch; the builder negates it once, so
+  `b.mtx` holds the flow coefficient in \\(f = b_e(\theta_f - \theta_t)\\),
+  positive for an inductive branch. `SeriesImpedance` by default:
+  \\(b_e = -x/(r^2 + x^2)\\) plus the phase shift injection `p_shift`, with no
+  tap scaling. `Matpower` uses \\(b_e = -1/(x \tau)\\) plus `p_shift`.
+  `PaperPure` (\\(b_e = -1/x\\), taps and shifts ignored) is deprecated in
+  0.9.0 and is removed in 1.0.0. Recorded in the manifest.
 
 ## Matrices
 

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -104,13 +104,23 @@ cubic costs, HVDC, or storage. These losses are returned as warnings.
   phase shift injection. The signed incidence matrix \\(A\\) combines with
   \\(b\\) to form the DC bus susceptance matrix
   \\(L = A \operatorname{diag}(b) A^\mathsf{T}\\), which feeds PTDF/LODF and the
-  DC OPF matrix projection. The default `PaperPure` is the textbook DC power flow weight
-  \\(b = 1/x\\), taps and shifts ignored; the resulting
-  \\(L = A \operatorname{diag}(b) A^\mathsf{T}\\)
-  matches MATPOWER `Bp` under `Scheme::Xb` when phase shifts are zero.
+  DC OPF matrix projection. Every convention states the series susceptance
+  \\(b\\), which is negative for an inductive branch, the same sign PowerModels
+  `calc_branch_y` gives. The builder negates it once, because \\(L\\) takes the
+  M-matrix form with negative off diagonal entries and positive diagonals.
+
+  The default `SeriesImpedance` uses
+  \\(b = -x/(r^2 + x^2) = \operatorname{Im}\\left(1/(r + jx)\right)\\), so it
+  reads the whole series impedance and not the reactance alone, plus the phase
+  shift injection vector `p_shift`. A tap does not scale it. It reduces to
+  \\(b = -1/x\\) when the branch has no resistance.
+
   `Matpower` reproduces MATPOWER's `makeBdc`:
-  \\(b = 1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus the phase shift
-  injection vector `p_shift`.
+  \\(b = -1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus `p_shift`.
+
+  `PaperPure` is the textbook \\(b = -1/x\\) with taps and shifts ignored. The
+  resulting \\(L\\) matches MATPOWER `Bp` under `Scheme::Xb` when phase shifts
+  are zero. It is deprecated in 0.9.0 and is removed in 1.0.0.
 
 ## Output
 

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -935,7 +935,7 @@ fn matrix_branch_batch(net: &Network, core: &IndexCore) -> Result<RecordBatch, S
     let view = IndexedNetwork::with_core(net, core);
     let parts = powerio_matrix::build_incidence(
         &view,
-        powerio_matrix::DcConvention::PaperPure,
+        powerio_matrix::DcConvention::default(),
         &powerio_matrix::BuildOptions::default(),
     )
     .map_err(|e| e.to_string())?;
@@ -1082,7 +1082,7 @@ fn matrix_incidence_batch(net: &Network, core: &IndexCore) -> Result<RecordBatch
     let view = IndexedNetwork::with_core(net, core);
     let parts = powerio_matrix::build_incidence(
         &view,
-        powerio_matrix::DcConvention::PaperPure,
+        powerio_matrix::DcConvention::default(),
         &powerio_matrix::BuildOptions::default(),
     )
     .map_err(|e| e.to_string())?;
@@ -1935,7 +1935,7 @@ Q\n";
         let view = IndexedNetwork::with_core(&n, &core);
         let incidence = powerio_matrix::build_incidence(
             &view,
-            powerio_matrix::DcConvention::PaperPure,
+            powerio_matrix::DcConvention::default(),
             &powerio_matrix::BuildOptions::default(),
         )
         .unwrap();

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -100,7 +100,7 @@ enum Command {
         #[arg(short, long)]
         output: PathBuf,
         /// DC susceptance convention.
-        #[arg(long, value_enum, default_value = "paper-pure")]
+        #[arg(long, value_enum, default_value = "series")]
         convention: DcConvArg,
         /// Unit system for power/cost quantities.
         #[arg(long, value_enum, default_value = "per-unit")]
@@ -123,7 +123,7 @@ enum Command {
         #[arg(short, long)]
         output: PathBuf,
         /// DC susceptance convention.
-        #[arg(long, value_enum, default_value = "paper-pure")]
+        #[arg(long, value_enum, default_value = "series")]
         convention: DcConvArg,
         /// Sensitivity solve path.
         #[arg(long, value_enum, default_value = "auto")]
@@ -522,15 +522,22 @@ impl From<SchemeArg> for Scheme {
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum DcConvArg {
-    PaperPure,
+    /// `b = x/(r² + x²)`, with phase shift injections.
+    #[value(name = "series", alias = "series-impedance")]
+    SeriesImpedance,
+    /// `b = 1/(x tau)`, with phase shift injections.
     Matpower,
+    /// `b = 1/x`. Accepted until 1.0.0; use `series`.
+    PaperPure,
 }
 
 impl From<DcConvArg> for DcConvention {
+    #[allow(deprecated)]
     fn from(value: DcConvArg) -> Self {
         match value {
-            DcConvArg::PaperPure => Self::PaperPure,
+            DcConvArg::SeriesImpedance => Self::SeriesImpedance,
             DcConvArg::Matpower => Self::Matpower,
+            DcConvArg::PaperPure => Self::PaperPure,
         }
     }
 }

--- a/powerio-matrix/benches/matrix.rs
+++ b/powerio-matrix/benches/matrix.rs
@@ -3,6 +3,10 @@
 //! These benches time derived matrix construction from an already parsed and
 //! indexed network. Parser throughput lives in `powerio/benches/parse.rs`; this
 //! file answers whether the sparse builders themselves changed.
+//!
+//! The benches hold `b = 1/x` so a timing series stays comparable across the
+//! 0.9.0 convention change.
+#![allow(deprecated)]
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use powerio_matrix::matrix::{

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -90,7 +90,9 @@ pub fn build_incidence(
         if !tap.is_finite() || tap.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE {
             return Err(Error::DegenerateTap { row: idx, tap });
         }
-        let b_e = conv.branch_susceptance(br.x, tap);
+        // Negated once here: the convention states `b`, negative for an
+        // inductive branch, and `L` takes the M-matrix form.
+        let b_e = -conv.series_susceptance(br.r, br.x, tap);
         // A NaN reactance slips past the guard above and poisons the whole
         // Laplacian.
         if !b_e.is_finite() {

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -113,7 +113,7 @@ pub struct SensitivityOptions {
 impl Default for SensitivityOptions {
     fn default() -> Self {
         Self {
-            convention: DcConvention::PaperPure,
+            convention: DcConvention::default(),
             solver: SensitivitySolver::Auto,
             drop_tolerance: PRUNE,
             cg_tolerance: DEFAULT_CG_TOLERANCE,

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -1,3 +1,7 @@
+//! These cases pin `b = 1/x`, so they name `DcConvention::PaperPure` until it
+//! is removed in 1.0.0.
+#![allow(deprecated)]
+
 use approx::assert_relative_eq;
 
 use crate::indexed::IndexedNetwork;

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -1,5 +1,10 @@
 //! DC OPF matrix forge: incidence, Laplacian, OPF instance, and the export
 //! bundle. Run against vendored MATPOWER cases.
+//!
+//! These cases pin `b = 1/x`, so they name `DcConvention::PaperPure` until it
+//! is removed in 1.0.0. `SeriesImpedance` gives a different weight for any
+//! branch that carries resistance.
+#![allow(deprecated)]
 
 use powerio_matrix::IndexedNetwork;
 use powerio_matrix::io::{read_mtx, write_sensitivity_mtx_with_options};
@@ -345,7 +350,9 @@ fn iterative_sensitivities_match_dense_oracle() {
     ] {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
-        let (dense_ptdf, dense_lodf) = build_ptdf_lodf(&view, DcConvention::PaperPure).unwrap();
+        // Both paths take the same convention: this compares the two solvers,
+        // not two weightings.
+        let (dense_ptdf, dense_lodf) = build_ptdf_lodf(&view, DcConvention::default()).unwrap();
         let iterative = build_ptdf_lodf_with_options(
             &view,
             &SensitivityOptions {

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -98,7 +98,8 @@ pub struct DcBranchData {
     pub to_bus: Vec<usize>,
     /// Branch coefficient in the selected power unit per radian.
     pub b: Vec<f64>,
-    /// Phase shift in radians. Zero under [`DcConvention::PaperPure`].
+    /// Phase shift in radians. Zero unless the convention carries phase shift
+    /// injections.
     pub shift: Vec<f64>,
     /// Thermal limit in the selected power unit. Zero means unlimited.
     pub f_max: Vec<f64>,
@@ -278,10 +279,14 @@ pub fn build_dc_opf_instance(
             }
             return Err(Error::ZeroImpedance { row: source_row });
         }
-        let branch_b = options
-            .convention
-            .branch_susceptance(branch.x, branch.effective_tap())
-            * b_scale;
+        // Negated: the convention states `b`, and this field is the flow
+        // coefficient in `f = b (theta_from - theta_to)`, positive for an
+        // inductive branch.
+        let branch_b =
+            -options
+                .convention
+                .series_susceptance(branch.r, branch.x, branch.effective_tap())
+                * b_scale;
         if !branch_b.is_finite() {
             return Err(Error::NonFiniteSusceptance { row: source_row });
         }

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -143,7 +143,7 @@ fn matpower_convention_applies_tap_and_phase_shift() {
     net.branches[0].tap = 1.25;
     net.branches[0].shift = 10.0;
     let view = IndexedNetwork::new(&net);
-    let paper = build_dc_opf_instance(&view, &DcOpfOptions::default()).expect("paper");
+    let series = build_dc_opf_instance(&view, &DcOpfOptions::default()).expect("series");
     let matpower = build_dc_opf_instance(
         &view,
         &DcOpfOptions {
@@ -153,8 +153,11 @@ fn matpower_convention_applies_tap_and_phase_shift() {
     )
     .expect("matpower");
 
-    assert_close(paper.branches.b[0], 1.0 / 0.2);
-    assert_close(paper.branches.shift[0], 0.0);
+    // Only Matpower scales the susceptance by the tap. This branch has no
+    // resistance, so the default reads the same `1/x` there.
+    assert_close(series.branches.b[0], 1.0 / 0.2);
+    // Both live conventions carry the phase shift.
+    assert_close(series.branches.shift[0], 10.0_f64.to_radians());
     let expected_b = 1.0 / (0.2 * 1.25);
     let expected_shift = 10.0_f64.to_radians();
     assert!((matpower.branches.b[0] - expected_b).abs() < 1e-12);

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -119,14 +119,17 @@ fn parse_scheme(s: &str) -> PyResult<Scheme> {
     }
 }
 
-/// Accepts `paper`/`paper-pure`/`pure` and `matpower`/`mp` (case- and
-/// separator-insensitive).
+/// Accepts `series`/`series-impedance`, `matpower`/`mp`, and
+/// `paper`/`paper-pure`/`pure` (case- and separator-insensitive). The `paper`
+/// spellings are accepted until 1.0.0.
+#[allow(deprecated)]
 fn parse_convention(s: &str) -> PyResult<DcConvention> {
     match normalize(s).as_str() {
-        "paper" | "paperpure" | "pure" => Ok(DcConvention::PaperPure),
+        "series" | "seriesimpedance" => Ok(DcConvention::SeriesImpedance),
         "matpower" | "mp" => Ok(DcConvention::Matpower),
+        "paper" | "paperpure" | "pure" => Ok(DcConvention::PaperPure),
         other => Err(PyValueError::new_err(format!(
-            "unknown convention {other:?}; expected 'paper' or 'matpower'"
+            "unknown convention {other:?}; expected 'series' or 'matpower'"
         ))),
     }
 }
@@ -140,7 +143,7 @@ fn sensitivity_options(
     convention: Option<&str>,
     solver: Option<&str>,
 ) -> PyResult<SensitivityOptions> {
-    let convention = parse_convention(convention.unwrap_or("paper"))?;
+    let convention = parse_convention(convention.unwrap_or("series"))?;
     let solver = match normalize(solver.unwrap_or("auto")).as_str() {
         "auto" => SensitivitySolver::Auto,
         "dense" => SensitivitySolver::Dense,
@@ -1079,7 +1082,7 @@ impl PyNetwork {
         py: Python<'py>,
         convention: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let conv = parse_convention(convention.unwrap_or("paper"))?;
+        let conv = parse_convention(convention.unwrap_or("series"))?;
         let view = IndexedNetwork::with_core(&self.inner, &self.core);
         let parts = build_incidence(&view, conv, &BuildOptions::default()).map_err(to_pyerr)?;
         let a = coo_triplets(py, &parts.a)?;
@@ -1096,7 +1099,7 @@ impl PyNetwork {
         py: Python<'py>,
         convention: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let conv = parse_convention(convention.unwrap_or("paper"))?;
+        let conv = parse_convention(convention.unwrap_or("series"))?;
         let view = IndexedNetwork::with_core(&self.inner, &self.core);
         let parts = build_incidence(&view, conv, &BuildOptions::default()).map_err(to_pyerr)?;
         let l = build_weighted_laplacian(&parts.a, &parts.b);
@@ -1187,7 +1190,7 @@ impl PyNetwork {
         let instance = build_dc_opf_instance(
             &view,
             &DcOpfOptions {
-                convention: parse_convention(convention.unwrap_or("paper"))?,
+                convention: parse_convention(convention.unwrap_or("series"))?,
                 units: parse_units(units.unwrap_or("perunit"))?,
                 ..DcOpfOptions::default()
             },

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -3,33 +3,110 @@
 use serde::{Deserialize, Serialize};
 
 /// Electrical convention used for DC branch coefficients.
+///
+/// Every variant states the series susceptance `b`, which is negative for an
+/// inductive branch. This is the sign PowerModels `calc_branch_y` gives, and
+/// the caller that assembles a matrix negates it: powerio's bus susceptance
+/// matrix takes the M-matrix form, with negative off diagonal entries and
+/// positive diagonals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum DcConvention {
-    /// Use `b = 1/x` and ignore transformer taps and phase shifts.
-    #[default]
+    /// Use `b = -1/x` and ignore transformer taps and phase shifts.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `SeriesImpedance`, which is the same rule with resistance included, or `Matpower`; removed in 1.0.0"
+    )]
     PaperPure,
-    /// Use `b = 1/(x tau)` and include phase shift injections, matching
+    /// Use `b = -1/(x tau)` and include phase shift injections, matching
     /// MATPOWER `makeBdc`.
     Matpower,
+    /// Use `b = -x/(r² + x²)` and include phase shift injections.
+    ///
+    /// This is `Im(1/(r + jx))`, the branch's own series susceptance, so it
+    /// reads the whole series impedance and not the reactance alone. It
+    /// reduces to `-1/x` when the resistance is zero. A transformer tap does
+    /// not scale it. Equivalent to PowerModels `calc_branch_y`, whose DC
+    /// formulation uses the same quantity.
+    #[default]
+    SeriesImpedance,
 }
 
 impl DcConvention {
-    /// Compute a branch susceptance from reactance and effective tap.
+    /// The series susceptance `b` from resistance, reactance, and effective
+    /// tap. Negative for an inductive branch. Only [`Self::Matpower`] reads
+    /// the tap, and only [`Self::SeriesImpedance`] reads the resistance.
     #[must_use]
-    pub fn branch_susceptance(self, reactance: f64, effective_tap: f64) -> f64 {
+    #[allow(deprecated)]
+    pub fn series_susceptance(self, resistance: f64, reactance: f64, effective_tap: f64) -> f64 {
         match self {
-            Self::PaperPure => 1.0 / reactance,
-            Self::Matpower => 1.0 / (reactance * effective_tap),
+            Self::PaperPure => -1.0 / reactance,
+            Self::Matpower => -1.0 / (reactance * effective_tap),
+            Self::SeriesImpedance => -reactance / (resistance * resistance + reactance * reactance),
         }
     }
 
     /// Whether phase shifts contribute to the nodal injection vector.
     #[must_use]
+    #[allow(deprecated)]
     pub fn includes_phase_shifts(self) -> bool {
         match self {
             Self::PaperPure => false,
-            Self::Matpower => true,
+            Self::Matpower | Self::SeriesImpedance => true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A resistanceless branch reads the same under both live conventions, so
+    /// the new default only moves a case that carries resistance.
+    #[test]
+    fn series_impedance_reduces_to_minus_one_over_x() {
+        let b = DcConvention::SeriesImpedance.series_susceptance(0.0, 0.25, 1.0);
+        assert!((b + 4.0).abs() < 1e-12);
+    }
+
+    /// `b = Im(1/(r + jx))` is negative for an inductive branch, the sign
+    /// PowerModels `calc_branch_y` gives.
+    #[test]
+    fn series_impedance_is_negative_for_an_inductive_branch() {
+        let b = DcConvention::SeriesImpedance.series_susceptance(0.01, 0.1, 1.0);
+        assert!(b < 0.0, "b = {b}");
+        assert!((b + 0.1 / (0.0001 + 0.01)).abs() < 1e-12);
+    }
+
+    /// Every live convention agrees on the sign, so a caller that negates once
+    /// cannot pick up a matrix of the wrong sign from the choice of variant.
+    #[test]
+    fn every_convention_agrees_on_the_sign() {
+        #[allow(deprecated)]
+        let all = [
+            DcConvention::PaperPure,
+            DcConvention::Matpower,
+            DcConvention::SeriesImpedance,
+        ];
+        for convention in all {
+            let b = convention.series_susceptance(0.01, 0.1, 1.0);
+            assert!(b < 0.0, "{convention:?} gave {b}");
+        }
+    }
+
+    /// Resistance moves the susceptance toward zero, by more as `r` grows
+    /// against `x`.
+    #[test]
+    fn resistance_lowers_the_susceptance_magnitude() {
+        let lossless = DcConvention::SeriesImpedance.series_susceptance(0.0, 0.1, 1.0);
+        let lossy = DcConvention::SeriesImpedance.series_susceptance(0.1, 0.1, 1.0);
+        assert!(lossy.abs() < lossless.abs());
+        assert!((lossy + 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn matpower_scales_by_the_tap() {
+        let b = DcConvention::Matpower.series_susceptance(0.01, 0.2, 2.0);
+        assert!((b + 2.5).abs() < 1e-12);
     }
 }

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -424,8 +424,8 @@ class Network:
         g, b = self.ybus_parts(include_taps, include_shifts)
         return (g + 1j * b).tocsr()
 
-    def ptdf(self, convention: str = "paper", solver: str = "auto"):
-        """DC PTDF (m×n). ``convention`` is ``"paper"`` or ``"matpower"``.
+    def ptdf(self, convention: str = "series", solver: str = "auto"):
+        """DC PTDF (m×n). ``convention`` is ``"series"`` or ``"matpower"``.
 
         ``solver`` is ``"auto"``, ``"dense"``, or ``"iterative"``. ``"auto"``
         uses the dense factorization on small cases and the iterative
@@ -433,15 +433,15 @@ class Network:
         """
         return _to_csr(self._inner.ptdf(convention, solver))
 
-    def lodf(self, convention: str = "paper", solver: str = "auto"):
+    def lodf(self, convention: str = "series", solver: str = "auto"):
         """DC LODF (m×m). ``solver`` as in :meth:`ptdf`."""
         return _to_csr(self._inner.lodf(convention, solver))
 
-    def weighted_laplacian(self, convention: str = "paper"):
+    def weighted_laplacian(self, convention: str = "series"):
         """Weighted Laplacian ``L = A diag(b) Aᵀ``."""
         return _to_csr(self._inner.weighted_laplacian(convention))
 
-    def incidence(self, convention: str = "paper") -> "Incidence":
+    def incidence(self, convention: str = "series") -> "Incidence":
         """Signed incidence factorization as an :data:`Incidence` tuple."""
         np = _require("numpy", "matrix")
         a, b, p_shift, branch_of_col = self._inner.incidence(convention)

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -3,7 +3,8 @@ from typing import Any, Dict, List, Literal, NamedTuple, Optional, Tuple, TypedD
 __version__: str
 
 Scheme = Literal["bx", "xb"]
-Convention = Literal["paper", "matpower"]
+# "paper" is accepted until 1.0.0.
+Convention = Literal["series", "matpower", "paper"]
 SensitivitySolver = Literal["auto", "dense", "iterative"]
 Units = Literal["perunit", "native"]
 GridfmOutputs = Dict[str, Any]

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -1007,7 +1007,7 @@ def _matrix_impl(
     json_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
     scheme: str = "bx",
-    convention: str = "paper",
+    convention: str = "series",
 ) -> dict:
     canonical = _MATRIX_KIND_ALIASES.get(kind.lower())
     if canonical is None:
@@ -1199,7 +1199,7 @@ def _matrix_tool(
     json_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
     scheme: str = "bx",
-    convention: str = "paper",
+    convention: str = "series",
 ) -> dict:
     """Build a transmission matrix output in COO form."""
     return _matrix_impl(
@@ -1344,7 +1344,7 @@ def matrix(
     json_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
     scheme: str = "bx",
-    convention: str = "paper",
+    convention: str = "series",
     *,
     format: Optional[str] = None,
     from_: Optional[str] = None,


### PR DESCRIPTION
`DcConvention` offered `b = 1/x` and MATPOWER's `b = 1/(x·τ)`. Neither reads the branch resistance, so a case with a real r/x ratio had no convention that described it, and every consumer that wanted one computed it by hand.

`SeriesImpedance` is `b = -x/(r² + x²)`, with phase shift injections and no tap scaling. It reduces to `-1/x` on a resistanceless branch, and it is the new default: a caller that passed no convention gets different numbers, and the gap grows with r/x, so it is small on transmission cases and large on distribution ones.

`branch_susceptance` becomes `series_susceptance` and takes the resistance. Every variant now states `b` with the sign `y = 1/(r + jx)` gives, matching PowerModels `calc_branch_y`, and the two callers that assemble from it negate once. Every matrix is unchanged. A test holds all three variants to one sign, so a caller that negates once cannot get a sign flipped matrix from the choice of variant.

`PaperPure` is deprecated and removed in 1.0.0. The CLI takes `--convention series` and Python takes `"series"`; the `paper` spellings parse until 1.0.0.

Second in the v0.9.0 stack, on top of #310.
