### PR TITLE
prob: carry the bus shunt conductance into the DC instance

### DIFF
--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -144,6 +144,14 @@ pub struct DcOpfInstance {
     pub reference_buses: Vec<usize>,
     /// Nodal active demand in dense bus order.
     pub p_d: Vec<f64>,
+    /// Nodal shunt conductance in dense bus order.
+    ///
+    /// The DC approximation holds the voltage magnitude at one per unit, so a
+    /// shunt draws the constant real power `g_s` and does not depend on the
+    /// angle. It belongs in the injection and not in the bus susceptance
+    /// matrix, whose row sums must stay zero. A nodal balance subtracts it
+    /// beside [`Self::p_d`], as MATPOWER `runpf` does.
+    pub g_s: Vec<f64>,
     /// Nodal phase shift injection in dense bus order.
     pub p_shift: Vec<f64>,
     pub generators: DcGeneratorData,
@@ -321,6 +329,7 @@ pub fn build_dc_opf_instance(
         bus_ids: (0..n_buses).map(|index| case.bus_id(index)).collect(),
         reference_buses: case.reference_bus_indices(),
         p_d: case.pd().iter().map(|value| value * p_scale).collect(),
+        g_s: case.gs().iter().map(|value| value * p_scale).collect(),
         p_shift,
         generators: DcGeneratorData {
             bus_of_gen,

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -137,6 +137,43 @@ fn cost_constant_term_is_kept() {
     assert_close(nodal.c0[problem.generators.bus_of_gen[0]], 5.0);
 }
 
+/// A bus shunt draws constant real power under the DC approximation. The
+/// instance must carry it: the bus susceptance matrix cannot, because its row
+/// sums are zero.
+#[test]
+fn bus_shunt_conductance_reaches_the_instance() {
+    let mut net = small_network();
+    net.shunts
+        .push(powerio::network::Shunt::new(BusId(30), 5.0, 0.0));
+    let view = IndexedNetwork::new(&net);
+    let base = view.base_mva();
+
+    let per_unit = build_dc_opf_instance(&view, &DcOpfOptions::default()).expect("per unit");
+    assert_eq!(per_unit.g_s.len(), per_unit.n_buses);
+    assert_close(per_unit.g_s[1], 5.0 / base);
+    assert_close(per_unit.g_s[0], 0.0);
+
+    let native = build_dc_opf_instance(
+        &view,
+        &DcOpfOptions {
+            units: Units::Native,
+            ..DcOpfOptions::default()
+        },
+    )
+    .expect("native");
+    assert_close(native.g_s[1], 5.0);
+}
+
+/// A case with no shunt reads zero, not a shorter vector.
+#[test]
+fn a_shuntless_case_carries_zero_conductance() {
+    let net = case9();
+    let problem =
+        build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default()).expect("build");
+    assert_eq!(problem.g_s.len(), problem.n_buses);
+    assert!(problem.g_s.iter().all(|value| value.abs() < 1e-12));
+}
+
 #[test]
 fn matpower_convention_applies_tap_and_phase_shift() {
     let mut net = small_network();


### PR DESCRIPTION
`build_dc_opf_instance` read `pd()` and never `gs()`, so a bus shunt had no effect anywhere in the DC OPF path. `build_ac_opf_instance` reads `gs()` already, so the two instances disagreed on the same case.

Under the DC approximation the voltage magnitude is one per unit, so a shunt draws the constant real power `g_s`. It is constant in the angle, so it belongs in the injection and not in the bus susceptance matrix, whose row sums are zero by construction. MATPOWER `runpf` subtracts `bus(:, GS) / baseMVA` in the same place.

`g_s` is its own vector, beside `p_d`, matching how the AC instance already keeps the shunt separate from the demand. Folding it into `p_d` would make that field mean two things.

The bundle writer does not emit this vector yet, so a bundle consumer still reads a case without its shunts. That goes with the bundle version bump later in the stack.

Third in the v0.9.0 stack, on top of #311.
