### PR TITLE
geo: absorb the coordinate sources a consumer hand rolls

### DIFF
--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -63,7 +63,7 @@ removes the raw keys from `extras`. Writers emit from `location`.
 
 | Format | Fields | Space |
 | --- | --- | --- |
-| PowerWorld aux | `Latitude:1`/`Longitude:1` bus columns (`SubNum` stays in extras: it is identity rather than geometry) | geographic |
+| PowerWorld aux | `Latitude:1`/`Longitude:1` bus columns, else the bare `Latitude`/`Longitude` pair (`SubNum` stays in extras: it is identity rather than geometry) | geographic |
 | pandapower | bus `geo` GeoJSON Point strings | geographic |
 | PyPSA | `buses.csv` `x`/`y` | geographic |
 | OpenDSS | `Buscoords` | unknown; a diagnostic identifies values within longitude and latitude bounds |
@@ -109,14 +109,20 @@ buscoords CSV (`bus, x, y`), CSV and JSON records with aliased field names
 endpoint pairs), and GeoJSON Point and LineString features. Features reference
 elements by up to three key fields, matched in order: `uid`, then `id`, then
 case insensitive `name`. Branch routes additionally fall back to the unordered
-`(from, to)` bus pair. A bare integer branch id is accepted on read as a
-1-based positional row alias and never written; the durable identity is the
-payload `uid`.
+`(from, to)` bus pair. A bare integer branch id (`branch`, `branchid`,
+`branchnumber`, `catsid`) is accepted on read as a 1-based positional row
+alias and never written; the durable identity is the payload `uid`. A branch
+key never reads from a bare `id` property, because GIS exports and RFC 7946
+tooling put a feature row counter there.
 
 `Network::geo_layer()` extracts, and `Network::apply_geo_layer(&layer)`
-applies and returns a `GeoApplyReport` with matched and unmatched counts. The
-multiconductor equivalents attach through `powerio-pkg` (`dist_geo_layer`,
-`apply_dist_geo_layer`). The CLI wraps the same surface:
+applies and returns a `GeoApplyReport` with the matched and unmatched feature
+counts plus `unlocated_buses` and `unlocated_branches`, the elements that
+carry no geometry when the pass ends. The two together tell a layer that
+matched nothing from a model that needed nothing; `report.require_located()`
+is the strict caller's one line check. The multiconductor equivalents attach
+through `powerio-pkg` (`dist_geo_layer`, `apply_dist_geo_layer`). The CLI
+wraps the same surface:
 
 ```console
 $ powerio geo extract case.aux -o case.geo.json
@@ -130,12 +136,19 @@ The `.pwd` reader returns `DisplayData::PowerWorld` with a `PwdDisplay`: canvas
 dimensions, a timestamp, and substation symbols with number, name, and diagram
 coordinates.
 
-Three helpers connect it to the geo model. `geo_layer_from_pwd` lifts the
+Four helpers connect it to the geo model. `geo_layer_from_pwd` lifts the
 substation symbols into a diagram space `GeoLayer` (also reachable as
-`powerio geo extract case.pwd`); `apply_substation_points` joins those points
-onto buses through the `SubNum` extras key; and `pwd_mercator_to_lonlat` is a
-documented, approximate inverse of the projection PowerWorld's auto generated
-layouts use, for consumers that want to place a diagram on a map.
+`powerio geo extract case.pwd`); `geo_layer_from_aux_substations` lifts the
+`Latitude` and `Longitude` columns of an aux `Substation` table into a
+geographic one; `apply_substation_points` joins either onto buses through the
+`SubNum` extras key; and `pwd_mercator_to_lonlat` is a documented,
+approximate inverse of the projection PowerWorld's auto generated layouts
+use, for consumers that want to place a diagram on a map.
+
+A bus row of a complete case export carries its own coordinates as well. The
+aux reader promotes the substation `Latitude:1`/`Longitude:1` pair, and the
+bus's own bare `Latitude`/`Longitude` pair, into `Bus.location`; a promoted
+pair leaves extras.
 
 Rust uses `parse_display_file` and `parse_display_bytes`. Python exposes the
 same names and returns `DisplayData(kind="powerworld", data=PwdDisplay(...))`.

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -2104,8 +2104,13 @@ pub unsafe extern "C" fn pio_geo_apply(
 /// One-line apply summary lifted into the returned handle's warnings.
 fn geo_apply_summary(report: &powerio::GeoApplyReport) -> String {
     format!(
-        "geo apply: {} bus point(s), {} branch route(s), {} unmatched feature(s)",
-        report.matched_buses, report.matched_branches, report.unmatched_features
+        "geo apply: {} bus point(s), {} branch route(s), {} unmatched feature(s), \
+         {} bus(es) with no location, {} branch(es) with no route",
+        report.matched_buses,
+        report.matched_branches,
+        report.unmatched_features,
+        report.unlocated_buses,
+        report.unlocated_branches
     )
 }
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -1704,6 +1704,10 @@ fn report_geo_apply(report: &powerio_matrix::geo::GeoApplyReport) {
         "applied: {} bus point(s), {} branch route(s), {} unmatched feature(s)",
         report.matched_buses, report.matched_branches, report.unmatched_features
     );
+    eprintln!(
+        "unplaced: {} bus(es) with no location, {} branch(es) with no route",
+        report.unlocated_buses, report.unlocated_branches
+    );
     for note in &report.notes {
         eprintln!("note: {note}");
     }

--- a/powerio-pkg/src/geo.rs
+++ b/powerio-pkg/src/geo.rs
@@ -155,6 +155,21 @@ impl GeoApplyTarget for DistApply<'_> {
              substation join"
         )
     }
+
+    fn unlocated_counts(&self) -> (usize, usize) {
+        (
+            self.net
+                .buses
+                .iter()
+                .filter(|bus| bus.location.is_none())
+                .count(),
+            self.net
+                .lines
+                .iter()
+                .filter(|line| line.route.is_none())
+                .count(),
+        )
+    }
 }
 
 /// Bus row lookups: payload row uid plus the lowercased string id.

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -1858,8 +1858,8 @@ fn parse_geo<'py>(
     Ok(out)
 }
 
-/// A `{matched_buses, matched_branches, unmatched_features, notes}` dict from
-/// one geo apply pass.
+/// A `{matched_buses, matched_branches, unmatched_features, unlocated_buses,
+/// unlocated_branches, notes}` dict from one geo apply pass.
 fn geo_report_dict<'py>(
     py: Python<'py>,
     report: &powerio_matrix::geo::GeoApplyReport,
@@ -1868,6 +1868,8 @@ fn geo_report_dict<'py>(
     out.set_item("matched_buses", report.matched_buses)?;
     out.set_item("matched_branches", report.matched_branches)?;
     out.set_item("unmatched_features", report.unmatched_features)?;
+    out.set_item("unlocated_buses", report.unlocated_buses)?;
+    out.set_item("unlocated_branches", report.unlocated_branches)?;
     out.set_item("notes", report.notes.clone())?;
     Ok(out)
 }

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -152,6 +152,11 @@ pub enum Error {
         reason: ScenarioMismatch,
     },
 
+    #[error(
+        "geo apply left {buses} bus(es) with no location and {branches} branch(es) with no route"
+    )]
+    UnlocatedElements { buses: usize, branches: usize },
+
     #[error("{format} read error: {message}")]
     FormatRead {
         format: &'static str,
@@ -237,7 +242,8 @@ impl Error {
             | Error::ScenarioIdOverflow { .. }
             | Error::NormalizedGridfmSnapshot { .. }
             | Error::NonFiniteGridfmValue { .. }
-            | Error::ScenarioShapeMismatch { .. } => C::Data,
+            | Error::ScenarioShapeMismatch { .. }
+            | Error::UnlocatedElements { .. } => C::Data,
             // Output-side serialization write failures.
             Error::Mtx(_) | Error::Parquet(_) => C::Output,
         }

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -454,26 +454,20 @@ fn read_bus(r: &Row) -> Result<Bus> {
     let id = bus_id_from_field(id_key, id_field)?;
     let name = first(r, &["BusName", "Name"]).map(ToString::to_string);
     let mut extras = Extras::new();
-    // Substation identity rides on the bus row in complete case exports.
-    // The substation coordinates (`Latitude:1`/`Longitude:1`) promote into
-    // the typed location and leave extras; `SubNum` stays, it is identity
-    // rather than geometry, as do the bus's own bare `Latitude`/`Longitude`.
+    // `SubNum` stays in extras: it is identity rather than geometry, and the
+    // substation join reads it back.
     let location = bus_location(r);
     keep_extras(
         r,
-        &[
-            "SubNum",
-            "SubNumber",
-            "Latitude",
-            "Longitude",
-            "OwnerNum",
-            "OwnerNumber",
-            "BANumber",
-        ],
+        &["SubNum", "SubNumber", "OwnerNum", "OwnerNumber", "BANumber"],
         &mut extras,
     );
     if location.is_none() {
-        keep_extras(r, &["Latitude:1", "Longitude:1"], &mut extras);
+        keep_extras(
+            r,
+            &["Latitude:1", "Longitude:1", "Latitude", "Longitude"],
+            &mut extras,
+        );
     }
     Ok(Bus {
         id: BusId(id),
@@ -498,10 +492,13 @@ fn read_bus(r: &Row) -> Result<Bus> {
 }
 
 /// The promoted geographic location: the substation `Latitude:1`/
-/// `Longitude:1` pair, when both parse finite.
+/// `Longitude:1` pair, else the bus's own bare `Latitude`/`Longitude` pair
+/// (older complete case exports), when both parse finite.
 fn bus_location(r: &Row) -> Option<crate::geo::Location> {
-    let lat = first(r, &["Latitude:1"])?.parse::<f64>().ok()?;
-    let lon = first(r, &["Longitude:1"])?.parse::<f64>().ok()?;
+    let lat = first(r, &["Latitude:1", "Latitude"])?.parse::<f64>().ok()?;
+    let lon = first(r, &["Longitude:1", "Longitude"])?
+        .parse::<f64>()
+        .ok()?;
     (lat.is_finite() && lon.is_finite()).then_some(crate::geo::Location {
         x: lon,
         y: lat,

--- a/powerio/src/format/powerworld/tests.rs
+++ b/powerio/src/format/powerworld/tests.rs
@@ -187,6 +187,28 @@ fn unmodeled_data_blocks_warn_on_parse() {
 }
 
 #[test]
+// Exact decimal fractions parsed from the fixture; bit equality is the assertion.
+#[allow(clippy::float_cmp)]
+fn bare_bus_latitude_and_longitude_promote_into_the_location() {
+    // Older complete case exports write the pair on the bus row itself,
+    // without the `:1` substation suffix.
+    let net = parse_powerworld(
+        "DATA (Bus, [BusNum, Latitude, Longitude])\n{\n1 34.2 -80.05\n2 34.3 \"\"\n}\n",
+    )
+    .unwrap();
+    let location = net.buses[0].location.expect("bus 1 location");
+    assert_eq!((location.x, location.y), (-80.05, 34.2));
+    assert!(!net.buses[0].extras.contains_key("Latitude"));
+    assert!(!net.buses[0].extras.contains_key("Longitude"));
+    // Half a pair promotes nothing, so the column stays in extras.
+    assert!(net.buses[1].location.is_none());
+    assert_eq!(
+        net.buses[1].extras.get("Latitude").and_then(|v| v.as_str()),
+        Some("34.3")
+    );
+}
+
+#[test]
 // Exact kV values parsed from the fixture; bit equality is the assertion.
 #[allow(clippy::float_cmp)]
 fn writer_sanitizes_bus_names_that_would_corrupt_a_value() {

--- a/powerio/src/geo/layer.rs
+++ b/powerio/src/geo/layer.rs
@@ -105,7 +105,30 @@ pub struct GeoApplyReport {
     pub matched_buses: usize,
     pub matched_branches: usize,
     pub unmatched_features: usize,
+    /// Buses that carry no location when the pass ends, counted over the
+    /// whole model. Read with `matched_buses`, it tells a layer that matched
+    /// nothing from a model that needed nothing.
+    pub unlocated_buses: usize,
+    /// Branches that carry no route when the pass ends.
+    pub unlocated_branches: usize,
     pub notes: Vec<String>,
+}
+
+impl GeoApplyReport {
+    /// Refuse a partial placement: every bus needs a location and every
+    /// branch a route.
+    ///
+    /// # Errors
+    /// [`Error::UnlocatedElements`] when either count is nonzero.
+    pub fn require_located(&self) -> Result<()> {
+        if self.unlocated_buses > 0 || self.unlocated_branches > 0 {
+            return Err(Error::UnlocatedElements {
+                buses: self.unlocated_buses,
+                branches: self.unlocated_branches,
+            });
+        }
+        Ok(())
+    }
 }
 
 impl GeoLayer {
@@ -263,7 +286,10 @@ const LAT_ALIASES: &[&str] = &["lat", "latitude", "y"];
 const LON_ALIASES: &[&str] = &["lon", "lng", "longitude", "x"];
 const FROM_ALIASES: &[&str] = &["fbus", "from", "frombus"];
 const TO_ALIASES: &[&str] = &["tbus", "to", "tobus"];
-const BRANCH_ID_ALIASES: &[&str] = &["branch", "branchid", "branchnumber", "catsid", "id"];
+/// No bare `id`: GIS exports and RFC 7946 tooling write a feature row counter
+/// there, and a bare integer id is read as a positional row alias, so a
+/// counter would place the route on an unrelated branch.
+const BRANCH_ID_ALIASES: &[&str] = &["branch", "branchid", "branchnumber", "catsid"];
 const PATH_ALIASES: &[&str] = &["path", "geometry", "coordinates"];
 const FROM_LAT_ALIASES: &[&str] = &["lat1", "fromlat"];
 const FROM_LON_ALIASES: &[&str] = &["lon1", "lng1", "fromlon", "fromlng"];
@@ -384,8 +410,9 @@ fn read_geojson_feature(feature: &Value, parsed: &mut GeoParsed) {
                     .push("skipped a Point feature with unusable coordinates".to_owned());
                 return;
             };
+            // Property values keep their case; only keys are normalized.
             let target = match target.as_deref() {
-                Some("substation") => GeoTarget::Substation,
+                Some(token) if token.eq_ignore_ascii_case("substation") => GeoTarget::Substation,
                 _ => GeoTarget::Bus,
             };
             parsed.layer.features.push(GeoFeature {
@@ -866,6 +893,9 @@ pub trait GeoApplyTarget {
     fn place_branch(&mut self, row: usize, path: &[[f64; 2]], kind: Option<CoordsKind>);
     /// Report note for substation features this target cannot place.
     fn substation_note(&self, count: usize) -> String;
+    /// Elements the model still has no geometry for, as (buses with no
+    /// location, branches with no route).
+    fn unlocated_counts(&self) -> (usize, usize);
 }
 
 /// One apply pass over a layer's features. The model-specific lookups and
@@ -901,6 +931,7 @@ pub fn apply_geo_features(layer: &GeoLayer, target: &mut impl GeoApplyTarget) ->
         report.unmatched_features += substations;
         report.notes.push(target.substation_note(substations));
     }
+    (report.unlocated_buses, report.unlocated_branches) = target.unlocated_counts();
     report
 }
 
@@ -938,6 +969,21 @@ impl GeoApplyTarget for BalancedApply<'_> {
 
     fn substation_note(&self, count: usize) -> String {
         format!("{count} substation feature(s) not applied; join them with apply_substation_points")
+    }
+
+    fn unlocated_counts(&self) -> (usize, usize) {
+        (
+            self.net
+                .buses
+                .iter()
+                .filter(|bus| bus.location.is_none())
+                .count(),
+            self.net
+                .branches
+                .iter()
+                .filter(|branch| branch.route.is_none())
+                .count(),
+        )
     }
 }
 

--- a/powerio/src/geo/layer.rs
+++ b/powerio/src/geo/layer.rs
@@ -972,19 +972,24 @@ impl GeoApplyTarget for BalancedApply<'_> {
     }
 
     fn unlocated_counts(&self) -> (usize, usize) {
-        (
-            self.net
-                .buses
-                .iter()
-                .filter(|bus| bus.location.is_none())
-                .count(),
-            self.net
-                .branches
-                .iter()
-                .filter(|branch| branch.route.is_none())
-                .count(),
-        )
+        unlocated_counts(self.net)
     }
+}
+
+/// Buses with no location and branches with no route. Every apply pass over a
+/// balanced network reports through this one count, so the substation join
+/// and the feature join cannot disagree.
+pub(super) fn unlocated_counts(net: &Network) -> (usize, usize) {
+    (
+        net.buses
+            .iter()
+            .filter(|bus| bus.location.is_none())
+            .count(),
+        net.branches
+            .iter()
+            .filter(|branch| branch.route.is_none())
+            .count(),
+    )
 }
 
 /// Bus row lookups for one apply pass: by uid (element uid and payload row

--- a/powerio/src/geo/mod.rs
+++ b/powerio/src/geo/mod.rs
@@ -10,7 +10,8 @@ pub use layer::{
     GeoGeometry, GeoLayer, GeoParsed, GeoTarget, apply_geo_features,
 };
 pub use pwd::{
-    PWD_MERCATOR_K, apply_substation_points, geo_layer_from_pwd, pwd_mercator_to_lonlat,
+    PWD_MERCATOR_K, apply_substation_points, geo_layer_from_aux_substations, geo_layer_from_pwd,
+    pwd_mercator_to_lonlat,
 };
 
 use serde::{Deserialize, Serialize};

--- a/powerio/src/geo/pwd.rs
+++ b/powerio/src/geo/pwd.rs
@@ -178,6 +178,7 @@ pub fn apply_substation_points(net: &mut Network, layer: &GeoLayer) -> GeoApplyR
             kind: layer.kind,
         });
     }
+    (report.unlocated_buses, report.unlocated_branches) = super::layer::unlocated_counts(net);
     report
 }
 

--- a/powerio/src/geo/pwd.rs
+++ b/powerio/src/geo/pwd.rs
@@ -1,11 +1,14 @@
-//! PowerWorld `.pwd` display promotion into the geo model.
+//! PowerWorld substation promotion into the geo model.
 //!
-//! The `.pwd` reader decodes substation symbols in diagram coordinates.
-//! [`geo_layer_from_pwd`] lifts them into a diagram space [`GeoLayer`];
-//! [`apply_substation_points`] joins those points onto buses through the
-//! `SubNum` extras key; [`pwd_mercator_to_lonlat`] is the documented,
-//! approximate inverse of the projection PowerWorld's auto generated layouts
-//! use, for consumers that want to place a diagram on a map.
+//! Two PowerWorld files carry substation coordinates. The `.pwd` display
+//! holds symbols in diagram coordinates, which [`geo_layer_from_pwd`] lifts
+//! into a diagram space [`GeoLayer`]; [`pwd_mercator_to_lonlat`] is the
+//! documented, approximate inverse of the projection PowerWorld's auto
+//! generated layouts use, for consumers that want to place a diagram on a
+//! map. The `.aux` `Substation` table holds latitude and longitude, which
+//! [`geo_layer_from_aux_substations`] lifts into a geographic layer.
+//! [`apply_substation_points`] joins either layer onto buses through the
+//! `SubNum` extras key.
 
 use std::collections::HashMap;
 
@@ -14,6 +17,7 @@ use serde_json::Value;
 use super::layer::{ElementKey, GeoApplyReport, GeoFeature, GeoGeometry, GeoLayer, GeoTarget};
 use super::{Canvas, CoordinateSpace, GeoMeta, Location};
 use crate::format::PwdDisplay;
+use crate::format::powerworld::AuxFile;
 use crate::network::Network;
 
 /// Scale of PowerWorld's auto generated layouts: `x = K·lon` and
@@ -63,6 +67,59 @@ pub fn geo_layer_from_pwd(display: &PwdDisplay) -> GeoLayer {
                 kind: None,
             })
             .collect(),
+    }
+}
+
+/// Lift the aux `Substation` table into a geographic [`GeoLayer`] with
+/// substation targets keyed by substation number. The number comes from
+/// `SubNum` or `Number` and the point from `Latitude` and `Longitude`, the
+/// column names PowerWorld writes itself, so they take no aliases. A row
+/// whose number or coordinate is absent or is not a finite number is
+/// skipped. Rows stay in file order, so a repeated substation number keeps
+/// the last point once [`apply_substation_points`] runs.
+#[must_use]
+pub fn geo_layer_from_aux_substations(aux: &AuxFile) -> GeoLayer {
+    let mut features = Vec::new();
+    for object in aux.data_of("Substation") {
+        let (Some(number), Some(latitude), Some(longitude)) = (
+            object
+                .field_index("SubNum")
+                .or_else(|| object.field_index("Number")),
+            object.field_index("Latitude"),
+            object.field_index("Longitude"),
+        ) else {
+            continue;
+        };
+        for row in &object.rows {
+            let field = |column: usize| -> Option<(&str, f64)> {
+                let text = row.values.get(column)?.trim();
+                let value = text.parse::<f64>().ok().filter(|value| value.is_finite())?;
+                Some((text, value))
+            };
+            let (Some((number, _)), Some((_, lat)), Some((_, lon))) =
+                (field(number), field(latitude), field(longitude))
+            else {
+                continue;
+            };
+            features.push(GeoFeature {
+                target: GeoTarget::Substation,
+                key: ElementKey {
+                    uid: None,
+                    id: Some(substation_key(number)),
+                    name: None,
+                    index: None,
+                },
+                geometry: GeoGeometry::Point([lon, lat]),
+                from: None,
+                to: None,
+                kind: None,
+            });
+        }
+    }
+    GeoLayer {
+        space: CoordinateSpace::Geographic { crs: None },
+        kind: None,
+        features,
     }
 }
 
@@ -132,18 +189,22 @@ fn bus_substation(bus: &crate::network::Bus) -> Option<String> {
         .get("SubNum")
         .or_else(|| bus.extras.get("SubNumber"))?;
     match value {
-        Value::Number(number) => Some(number.to_string()),
+        Value::Number(number) => Some(substation_key(&number.to_string())),
         Value::String(text) => {
             let trimmed = text.trim();
-            (!trimmed.is_empty()).then(|| {
-                // "12.0" and "12" name the same substation.
-                trimmed
-                    .parse::<f64>()
-                    .ok()
-                    .filter(|v| v.fract() == 0.0 && v.abs() < 1e15)
-                    .map_or_else(|| trimmed.to_owned(), |v| format!("{v:.0}"))
-            })
+            (!trimmed.is_empty()).then(|| substation_key(trimmed))
         }
         _ => None,
     }
+}
+
+/// The join key for one substation number. Every source of a substation
+/// number goes through this: "12.0" and "12" name the same substation, and
+/// the two sides of the join must spell it the same way.
+fn substation_key(number: &str) -> String {
+    number
+        .parse::<f64>()
+        .ok()
+        .filter(|v| v.fract() == 0.0 && v.abs() < 1e15)
+        .map_or_else(|| number.to_owned(), |v| format!("{v:.0}"))
 }

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -66,8 +66,8 @@ pub use format::{
 pub use gen_cost::{GenCostPatch, GenCostPolicyReport, MissingGenCostPolicy, parse_gen_cost_csv};
 pub use geo::{
     Canvas, CoordinateSpace, CoordsKind, ElementKey, GeoApplyReport, GeoFeature, GeoGeometry,
-    GeoLayer, GeoMeta, GeoParsed, GeoTarget, Location, apply_substation_points, geo_layer_from_pwd,
-    pwd_mercator_to_lonlat,
+    GeoLayer, GeoMeta, GeoParsed, GeoTarget, Location, apply_substation_points,
+    geo_layer_from_aux_substations, geo_layer_from_pwd, pwd_mercator_to_lonlat,
 };
 pub use indexed::{ConnectivityReport, IndexCore, IndexedNetwork};
 pub use network::{

--- a/powerio/tests/geo_layer.rs
+++ b/powerio/tests/geo_layer.rs
@@ -1,10 +1,11 @@
 //! GeoLayer: tolerant reads, canonical writes, extract/apply, and the
-//! PowerWorld `.pwd` promotion.
+//! PowerWorld substation promotion from `.pwd` and from `.aux`.
 
+use powerio::format::powerworld::parse_aux;
 use powerio::{
     Bus, BusId, BusType, CoordinateSpace, CoordsKind, GeoGeometry, GeoLayer, GeoTarget, Location,
-    Network, apply_substation_points, geo_layer_from_pwd, parse_display_file,
-    pwd_mercator_to_lonlat,
+    Network, apply_substation_points, geo_layer_from_aux_substations, geo_layer_from_pwd,
+    parse_display_file, pwd_mercator_to_lonlat,
 };
 
 fn parse(bytes: &[u8], hint: Option<&str>) -> powerio::GeoParsed {
@@ -106,6 +107,56 @@ fn geojson_features_read_points_and_linestrings() {
     assert_eq!(parsed.layer.features.len(), 2);
     assert_eq!(parsed.layer.features[0].target, GeoTarget::Bus);
     assert_eq!(parsed.layer.features[1].target, GeoTarget::Branch);
+}
+
+#[test]
+fn a_bare_feature_id_does_not_place_a_branch() {
+    // GIS exports and RFC 7946 tooling write a feature row counter under
+    // `properties.id`; a positional match would route an unrelated branch.
+    let text = r#"{
+      "type": "FeatureCollection",
+      "features": [
+        {"type": "Feature",
+         "geometry": {"type": "Point", "coordinates": [-80.05, 34.2]},
+         "properties": {"bus": "1"}},
+        {"type": "Feature",
+         "geometry": {"type": "LineString", "coordinates": [[-80.05, 34.2], [-80.1, 34.3]]},
+         "properties": {"id": 1}}
+      ]
+    }"#;
+    let parsed = parse(text.as_bytes(), None);
+    assert!(
+        parsed
+            .layer
+            .features
+            .iter()
+            .all(|f| f.target != GeoTarget::Branch),
+        "{:?}",
+        parsed.layer.features
+    );
+    let mut net = small_network();
+    let report = net.apply_geo_layer(&parsed.layer);
+    assert_eq!(report.matched_branches, 0);
+    assert!(net.branches[0].route.is_none());
+}
+
+#[test]
+fn a_capitalized_target_reads_as_a_substation() {
+    let text = r#"{
+      "type": "FeatureCollection",
+      "features": [
+        {"type": "Feature",
+         "geometry": {"type": "Point", "coordinates": [-89.6, 40.6]},
+         "properties": {"target": "Substation", "id": "1"}}
+      ]
+    }"#;
+    let parsed = parse(text.as_bytes(), None);
+    assert_eq!(parsed.layer.features[0].target, GeoTarget::Substation);
+
+    let mut net = small_network();
+    let report = net.apply_geo_layer(&parsed.layer);
+    assert_eq!(report.matched_buses, 0);
+    assert_eq!(report.unmatched_features, 1);
 }
 
 #[test]
@@ -264,6 +315,27 @@ fn apply_matches_source_uids() {
     assert!(net.buses[0].location.is_some());
 }
 
+#[test]
+fn a_layer_that_matches_nothing_still_counts_the_unlocated_model() {
+    let mut net = small_network();
+    let report =
+        net.apply_geo_layer(&parse(br#"[{"bus": "77", "lat": 34.4, "lon": -80.2}]"#, None).layer);
+    assert_eq!(report.matched_buses, 0);
+    assert_eq!(report.unlocated_buses, 2);
+    assert_eq!(report.unlocated_branches, 1);
+    assert!(report.require_located().is_err());
+
+    let text = r#"[
+      {"bus": "1", "lat": 34.2, "lon": -80.05},
+      {"bus": "2", "lat": 34.3, "lon": -80.1},
+      {"from_bus": 1, "to_bus": 2, "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}
+    ]"#;
+    let report = net.apply_geo_layer(&parse(text.as_bytes(), None).layer);
+    assert_eq!(report.unlocated_buses, 0);
+    assert_eq!(report.unlocated_branches, 0);
+    report.require_located().expect("everything placed");
+}
+
 // ---------------------------------------------------------------------------
 // PowerWorld .pwd promotion
 // ---------------------------------------------------------------------------
@@ -310,6 +382,77 @@ fn pwd_promotes_to_a_diagram_layer_and_joins_on_subnum() {
         "{:?}",
         report.notes
     );
+}
+
+// ---------------------------------------------------------------------------
+// PowerWorld aux Substation promotion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn aux_substations_lift_into_a_geographic_layer_that_joins_on_subnum() {
+    let text =
+        std::fs::read_to_string("../tests/data/powerworld/ACTIVSg200.aux").expect("read aux");
+    let layer = geo_layer_from_aux_substations(&parse_aux(&text).expect("parse aux"));
+    assert!(matches!(
+        layer.space,
+        CoordinateSpace::Geographic { crs: None }
+    ));
+    assert!(!layer.features.is_empty());
+    assert!(
+        layer
+            .features
+            .iter()
+            .all(|f| f.target == GeoTarget::Substation)
+    );
+
+    // Every bus of the same export carries a SubNum, so the join places all
+    // of them at the coordinates the aux reader promoted itself.
+    let mut net = powerio::parse_file("../tests/data/powerworld/ACTIVSg200.aux", None)
+        .expect("parse aux")
+        .network;
+    let placed: Vec<Option<Location>> = net.buses.iter().map(|bus| bus.location).collect();
+    let report = apply_substation_points(&mut net, &layer);
+    assert_eq!(report.matched_buses, net.buses.len());
+    assert_eq!(report.unmatched_features, 0);
+    let joined: Vec<Option<Location>> = net.buses.iter().map(|bus| bus.location).collect();
+    assert_eq!(joined, placed);
+}
+
+#[test]
+fn aux_substation_rows_skip_unusable_fields_and_keep_file_order() {
+    let aux = parse_aux(
+        "DATA (Substation, [SubNum, Latitude, Longitude])\n{\n\
+         12.0 34.2 -80.05\n\
+         13 nan -80.10\n\
+         14 34.4 \"\"\n\
+         12 35.0 -81.00\n}\n",
+    )
+    .expect("parse aux");
+    let layer = geo_layer_from_aux_substations(&aux);
+    // "12.0" and "12" name one substation; the non-finite and the empty row
+    // are dropped.
+    let keys: Vec<Option<&str>> = layer.features.iter().map(|f| f.key.id.as_deref()).collect();
+    assert_eq!(keys, [Some("12"), Some("12")]);
+    assert_eq!(
+        layer.features[0].geometry,
+        GeoGeometry::Point([-80.05, 34.2])
+    );
+    assert_eq!(
+        layer.features[1].geometry,
+        GeoGeometry::Point([-81.0, 35.0])
+    );
+
+    // A bus carrying the number as a JSON number joins the same way, and the
+    // later duplicate wins.
+    let mut net = small_network();
+    net.buses[0]
+        .extras
+        .insert("SubNum".to_owned(), serde_json::json!(12.0));
+    let report = apply_substation_points(&mut net, &layer);
+    assert_eq!(report.matched_buses, 2);
+    let location = net.buses[0].location.expect("bus 1 location");
+    assert_eq!((location.x, location.y), (-81.0, 35.0));
+    assert!(net.buses[1].location.is_none());
 }
 
 #[test]

--- a/powerio/tests/geo_layer.rs
+++ b/powerio/tests/geo_layer.rs
@@ -414,6 +414,7 @@ fn aux_substations_lift_into_a_geographic_layer_that_joins_on_subnum() {
     let report = apply_substation_points(&mut net, &layer);
     assert_eq!(report.matched_buses, net.buses.len());
     assert_eq!(report.unmatched_features, 0);
+    assert_eq!(report.unlocated_buses, 0);
     let joined: Vec<Option<Location>> = net.buses.iter().map(|bus| bus.location).collect();
     assert_eq!(joined, placed);
 }
@@ -453,6 +454,22 @@ fn aux_substation_rows_skip_unusable_fields_and_keep_file_order() {
     let location = net.buses[0].location.expect("bus 1 location");
     assert_eq!((location.x, location.y), (-81.0, 35.0));
     assert!(net.buses[1].location.is_none());
+}
+
+#[test]
+fn a_substation_join_counts_the_buses_it_leaves_unplaced() {
+    let aux = parse_aux("DATA (Substation, [SubNum, Latitude, Longitude])\n{\n7 34.2 -80.05\n}\n")
+        .expect("parse aux");
+    let mut net = small_network();
+    net.buses[0]
+        .extras
+        .insert("SubNum".to_owned(), serde_json::json!("7"));
+    let report = apply_substation_points(&mut net, &geo_layer_from_aux_substations(&aux));
+    assert_eq!(report.matched_buses, 1);
+    // Bus 2 is in no substation, and the join places no route.
+    assert_eq!(report.unlocated_buses, 1);
+    assert_eq!(report.unlocated_branches, 1);
+    assert!(report.require_located().is_err());
 }
 
 #[test]

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -291,8 +291,11 @@ class Network:
 
         ``text`` is any form :func:`parse_geo` accepts; this case is
         unchanged. The report carries ``matched_buses``, ``matched_branches``,
-        ``unmatched_features``, and ``notes``. The placed copy drops the
-        retained source text, so a same-format write re-serializes.
+        ``unmatched_features``, ``unlocated_buses``, ``unlocated_branches``,
+        and ``notes``. The two unlocated counts cover the whole case when the
+        pass ends, so a layer that matched nothing reads apart from a case
+        that needed nothing. The placed copy drops the retained source text,
+        so a same-format write re-serializes.
         """
         inner, report = self._inner.apply_geo_layer(text, name_hint)
         return Network(inner), report

--- a/python/tests/test_geo.py
+++ b/python/tests/test_geo.py
@@ -39,6 +39,9 @@ def test_network_apply_and_extract_round_trip():
     placed, report = net.apply_geo_layer(BUSCOORDS)
     assert report["matched_buses"] == 2
     assert report["unmatched_features"] == 0
+    # The counts cover the whole case, so a caller sees what the layer left.
+    assert report["unlocated_buses"] == 7
+    assert report["unlocated_branches"] == 9
     # The input case is unchanged; the placed copy carries the layer.
     with pytest.raises(ValueError):
         net.geo_layer()


### PR DESCRIPTION
Five changes to the geo reader so a consumer that reads PowerWorld coordinates itself can drop its copy, plus a fix to a check that could not fail.

**A branch key no longer reads a bare `id`.** GIS exports and RFC 7946 tooling write a feature row counter there, and a bare integer id is read as a 1-based positional row alias, so a counter put the route on an unrelated branch whenever counter order and case branch order disagreed. `branch`, `branchid`, `branchnumber` and `catsid` stay. A bus key keeps `id`, since bus matching has no positional fallback.

**`geo_layer_from_aux_substations`** lifts the aux `Substation` table into a geographic layer, the sibling of `geo_layer_from_pwd` for a case with no display file. The number comes from `SubNum` or `Number`, the point from `Latitude` and `Longitude`; a row with an absent or non-finite field is skipped. Both sides of the substation join spell the number through one helper, so `12.0` and `12` name one substation whichever source stated it.

**The aux bus reader promotes a bare `Latitude`/`Longitude` pair** when the row states no `Latitude:1`/`Longitude:1` pair, which is the shape older complete case exports write. The coordinate columns stay in extras only when nothing promoted, so a location is never carried twice.

**`GeoApplyReport` counts `unlocated_buses` and `unlocated_branches`** over the whole model, so a caller can tell "no geo data supplied" from "geo data supplied and nothing matched". `require_located` refuses either count nonzero.

**`apply_substation_points` built its own report**, so both unlocated counts came back zero from the substation join and `require_located` passed whatever that join left behind. A check that cannot fail reads as coverage proof, which is worse than no check. The count moves into one `unlocated_counts` that both join paths call.

The three bindings carry the counts: the Python report dict gains both fields, `powerio geo apply` prints an unplaced line, and the C ABI apply summary states both. Neither summary is a versioned document, so both extend without a version decision.

Sixth in the v0.9.0 stack, on top of #314.
