### PR TITLE
v0.9.0: the fixes the review of the stack below produced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,15 +297,12 @@ fuzz/                        # libFuzzer targets (detached workspace; see fuzz/R
   must leave `angmin <= angmax`. Wide symmetric bounds and `0/0` already have
   coverage.
 - **DC OPF Laplacian.** `L = A diag(b) Aᵀ` is built from the same `A`, `b`
-  factors `build_incidence` returns. `DcConvention::series_susceptance` states
-  the series susceptance `b`, negative for an inductive branch, the sign
-  PowerModels `calc_branch_y` gives; `build_incidence` negates it once, because
-  `L` takes the M-matrix form with negative off diagonals and positive
-  diagonals. Never negate twice: the matrix comes out sign flipped and every
-  builder downstream inherits it. Default `SeriesImpedance`: `b = -x/(r² + x²)`,
+  factors `build_incidence` returns. `b` is positive for an inductive branch,
+  the DC model convention MATPOWER `makeBdc` uses; the AC series susceptance
+  `Im(1/(r+jx))` is its negation. Default `SeriesImpedance`: `b = x/(r² + x²)`,
   which reads the whole series impedance, plus a phase shift injection, with no
-  tap scaling. `Matpower` uses `-1/(x·τ)` plus the injection. `PaperPure`
-  (`b = -1/x`, taps and shifts ignored) is deprecated in 0.9.0 and removed in
+  tap scaling. `Matpower` uses `1/(x·τ)` plus the injection. `PaperPure`
+  (`b = 1/x`, taps and shifts ignored) is deprecated in 0.9.0 and removed in
   1.0.0; with zero phase shifts it equals MATPOWER `Bp` in the XB scheme.
 - **DC OPF lives in `powerio-prob`.** `DcOpfInstance` keeps generator-space
   data (`generators: DcGeneratorData`); `nodal_generator_data()` scatters it to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,7 +301,7 @@ fuzz/                        # libFuzzer targets (detached workspace; see fuzz/R
   the DC model convention MATPOWER `makeBdc` uses; the AC series susceptance
   `Im(1/(r+jx))` is its negation. Default `SeriesImpedance`: `b = x/(r² + x²)`,
   which reads the whole series impedance, plus a phase shift injection, with no
-  tap scaling. `Matpower` uses `1/(x·τ)` plus the injection. `PaperPure`
+  tap scaling. `Matpower` uses `1/(x·τ)` plus the injection. `ReactanceOnly`
   (`b = 1/x`, taps and shifts ignored) is deprecated in 0.9.0 and removed in
   1.0.0; with zero phase shifts it equals MATPOWER `Bp` in the XB scheme.
 - **DC OPF lives in `powerio-prob`.** `DcOpfInstance` keeps generator-space

--- a/docs/src/dcopf-bundle.md
+++ b/docs/src/dcopf-bundle.md
@@ -29,14 +29,12 @@ Market files and `dcopf_meta.json`.
   as a 0-based dense index. Each in-service island needs at least one reference.
   If several references lie in one island, the bundle fixes all of those voltage
   angles to zero; it is not a participation factor slack model.
-- **DC convention.** Every convention states the series susceptance
-  \\(b_e\\), negative for an inductive branch; the builder negates it once, so
-  `b.mtx` holds the flow coefficient in \\(f = b_e(\theta_f - \theta_t)\\),
-  positive for an inductive branch. `SeriesImpedance` by default:
-  \\(b_e = -x/(r^2 + x^2)\\) plus the phase shift injection `p_shift`, with no
-  tap scaling. `Matpower` uses \\(b_e = -1/(x \tau)\\) plus `p_shift`.
-  `PaperPure` (\\(b_e = -1/x\\), taps and shifts ignored) is deprecated in
-  0.9.0 and is removed in 1.0.0. Recorded in the manifest.
+- **DC convention.** `b.mtx` holds \\(b_e\\), positive for an inductive branch,
+  the coefficient in \\(f = b_e(\theta_f - \theta_t)\\). `SeriesImpedance` by
+  default: \\(b_e = x/(r^2 + x^2)\\) plus the phase shift injection `p_shift`,
+  with no tap scaling. `Matpower` uses \\(b_e = 1/(x \tau)\\) plus `p_shift`.
+  `PaperPure` (\\(b_e = 1/x\\), taps and shifts ignored) is deprecated in 0.9.0
+  and is removed in 1.0.0. Recorded in the manifest.
 
 ## Matrices
 

--- a/docs/src/dcopf-bundle.md
+++ b/docs/src/dcopf-bundle.md
@@ -33,7 +33,7 @@ Market files and `dcopf_meta.json`.
   the coefficient in \\(f = b_e(\theta_f - \theta_t)\\). `SeriesImpedance` by
   default: \\(b_e = x/(r^2 + x^2)\\) plus the phase shift injection `p_shift`,
   with no tap scaling. `Matpower` uses \\(b_e = 1/(x \tau)\\) plus `p_shift`.
-  `PaperPure` (\\(b_e = 1/x\\), taps and shifts ignored) is deprecated in 0.9.0
+  `ReactanceOnly` (\\(b_e = 1/x\\), taps and shifts ignored) is deprecated in 0.9.0
   and is removed in 1.0.0. Recorded in the manifest.
 
 ## Matrices
@@ -48,7 +48,9 @@ Market files and `dcopf_meta.json`.
 
 ## Vectors
 
-Bus-indexed (length \\(n\\)): `pd` (load), `q`/`c`/`c0` (cost diag/linear/constant),
+Bus-indexed (length \\(n\\)): `pd` (load), `gs` (shunt conductance, the constant
+real power a shunt draws at one per unit voltage; a nodal balance subtracts it
+beside `pd`), `q`/`c`/`c0` (cost diag/linear/constant),
 `pmax`/`pmin`
 (generation bounds), `e_r` (reference indicator: \\(1\\) at every reference bus, else \\(0\\)),
 `p_shift` (phase shift injection, all zero unless `Matpower` + shifters).
@@ -69,7 +71,7 @@ each generator. A bus with one generator keeps that generator's curve.
 
 ## Manifest (`dcopf_meta.json`)
 
-Schema `powerio.dcopf` version `0.3.0` writes Matrix Market files plus
+Schema `powerio.dcopf` version `0.4.0` writes Matrix Market files plus
 structured metadata:
 
 - `dimensions`: `n_buses`, `n_source_branches`, `n_branch_columns`,

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -109,14 +109,14 @@ cubic costs, HVDC, or storage. These losses are returned as warnings.
   \\(\operatorname{Im}\\left(1/(r + jx)\right)\\) is its negation.
 
   The default `SeriesImpedance` uses \\(b = x/(r^2 + x^2)\\), so it reads the
-  whole series impedance and not the reactance alone, plus the phase shift
+  whole series impedance, plus the phase shift
   injection vector `p_shift`. A tap does not scale it. It reduces to
   \\(b = 1/x\\) when the branch has no resistance.
 
   `Matpower` reproduces MATPOWER's `makeBdc`:
   \\(b = 1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus `p_shift`.
 
-  `PaperPure` is the textbook \\(b = 1/x\\) with taps and shifts ignored. The
+  `ReactanceOnly` (the 0.8 `PaperPure`) is the textbook \\(b = 1/x\\) with taps and shifts ignored. The
   resulting \\(L\\) matches MATPOWER `Bp` under `Scheme::Xb` when phase shifts
   are zero. It is deprecated in 0.9.0 and is removed in 1.0.0.
 

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -104,21 +104,19 @@ cubic costs, HVDC, or storage. These losses are returned as warnings.
   phase shift injection. The signed incidence matrix \\(A\\) combines with
   \\(b\\) to form the DC bus susceptance matrix
   \\(L = A \operatorname{diag}(b) A^\mathsf{T}\\), which feeds PTDF/LODF and the
-  DC OPF matrix projection. Every convention states the series susceptance
-  \\(b\\), which is negative for an inductive branch, the same sign PowerModels
-  `calc_branch_y` gives. The builder negates it once, because \\(L\\) takes the
-  M-matrix form with negative off diagonal entries and positive diagonals.
+  DC OPF matrix projection. \\(b\\) is positive for an inductive branch, the DC
+  model convention MATPOWER `makeBdc` uses; the AC series susceptance
+  \\(\operatorname{Im}\\left(1/(r + jx)\right)\\) is its negation.
 
-  The default `SeriesImpedance` uses
-  \\(b = -x/(r^2 + x^2) = \operatorname{Im}\\left(1/(r + jx)\right)\\), so it
-  reads the whole series impedance and not the reactance alone, plus the phase
-  shift injection vector `p_shift`. A tap does not scale it. It reduces to
-  \\(b = -1/x\\) when the branch has no resistance.
+  The default `SeriesImpedance` uses \\(b = x/(r^2 + x^2)\\), so it reads the
+  whole series impedance and not the reactance alone, plus the phase shift
+  injection vector `p_shift`. A tap does not scale it. It reduces to
+  \\(b = 1/x\\) when the branch has no resistance.
 
   `Matpower` reproduces MATPOWER's `makeBdc`:
-  \\(b = -1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus `p_shift`.
+  \\(b = 1/(x\tau)\\) for a transformer with tap ratio \\(\tau\\), plus `p_shift`.
 
-  `PaperPure` is the textbook \\(b = -1/x\\) with taps and shifts ignored. The
+  `PaperPure` is the textbook \\(b = 1/x\\) with taps and shifts ignored. The
   resulting \\(L\\) matches MATPOWER `Bp` under `Scheme::Xb` when phase shifts
   are zero. It is deprecated in 0.9.0 and is removed in 1.0.0.
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -527,7 +527,9 @@ enum DcConvArg {
     SeriesImpedance,
     /// `b = 1/(x tau)`, with phase shift injections.
     Matpower,
-    /// `b = 1/x`. Accepted until 1.0.0; use `series`.
+    /// `b = 1/x`. Accepted until 1.0.0; use `series`. The 0.8 spelling
+    /// `paper-pure` stays an alias so an existing command line still runs.
+    #[value(name = "reactance-only", alias = "paper-pure", alias = "paper")]
     ReactanceOnly,
 }
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -528,7 +528,7 @@ enum DcConvArg {
     /// `b = 1/(x tau)`, with phase shift injections.
     Matpower,
     /// `b = 1/x`. Accepted until 1.0.0; use `series`.
-    PaperPure,
+    ReactanceOnly,
 }
 
 impl From<DcConvArg> for DcConvention {
@@ -537,7 +537,7 @@ impl From<DcConvArg> for DcConvention {
         match value {
             DcConvArg::SeriesImpedance => Self::SeriesImpedance,
             DcConvArg::Matpower => Self::Matpower,
-            DcConvArg::PaperPure => Self::PaperPure,
+            DcConvArg::ReactanceOnly => Self::PaperPure,
         }
     }
 }

--- a/powerio-matrix/benches/matrix.rs
+++ b/powerio-matrix/benches/matrix.rs
@@ -62,7 +62,7 @@ fn bench_dcopf_parts(c: &mut Criterion) {
         b.iter(|| {
             build_incidence(
                 black_box(&view),
-                black_box(DcConvention::PaperPure),
+                black_box(DcConvention::ReactanceOnly),
                 black_box(&BuildOptions::default()),
             )
             .unwrap()
@@ -70,7 +70,7 @@ fn bench_dcopf_parts(c: &mut Criterion) {
     });
 
     let incidence =
-        build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+        build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
     c.bench_function("dcopf_laplacian_case118", |b| {
         b.iter(|| build_weighted_laplacian(black_box(&incidence.a), black_box(&incidence.b)));
     });
@@ -90,7 +90,9 @@ fn bench_dense_sensitivities(c: &mut Criterion) {
     let net = network("case118");
     let view = IndexedNetwork::new(&net);
     c.bench_function("sensitivity_ptdf_lodf_case118", |b| {
-        b.iter(|| build_ptdf_lodf(black_box(&view), black_box(DcConvention::PaperPure)).unwrap());
+        b.iter(|| {
+            build_ptdf_lodf(black_box(&view), black_box(DcConvention::ReactanceOnly)).unwrap()
+        });
     });
 }
 

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -24,9 +24,9 @@
 //! the model; [`IndexedNetwork`] maps them to dense indices in `[0, n)`. `tap == 0` means
 //! `tap = 1`. `build_bprime` and `build_bdoubleprime` follow MATPOWER `makeB`;
 //! Y_bus keeps tap magnitudes and phase shifts.
-//! Branch terminal admittance is stored per unit. DC incidence uses `b = 1/x`
-//! by default. [`DcConvention::Matpower`] uses `1/(x·τ)` and phase shift
-//! injection. The full reference across every matrix is in
+//! Branch terminal admittance is stored per unit. DC incidence uses
+//! `b = x/(r² + x²)` by default. [`DcConvention::Matpower`] uses `1/(x·τ)`, and
+//! both carry phase shift injection. The full reference across every matrix is in
 //! [the matrix guide](https://eigenergy.github.io/powerio/guide/matrices.html).
 
 // Re-export the powerio data layer so one import covers model and matrix types, and so

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -84,13 +84,9 @@ pub fn build_incidence(
             }
             continue;
         }
-        // `Matpower` divides by the tap here and Y_bus divides by it always, so
-        // one bound decides both. `effective_tap` only remaps an exact 0.0.
-        let tap = br.effective_tap();
-        if !tap.is_finite() || tap.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE {
-            return Err(Error::DegenerateTap { row: idx, tap });
-        }
-        let b_e = conv.branch_susceptance(br.r, br.x, tap);
+        // `Matpower` divides the susceptance by the tap, so it is bounded here
+        // by the same rule Y_bus and the instance builders apply.
+        let b_e = conv.branch_susceptance(br.r, br.x, br.divisible_tap(idx)?);
         // A NaN reactance slips past the guard above and poisons the whole
         // Laplacian.
         if !b_e.is_finite() {

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -90,9 +90,7 @@ pub fn build_incidence(
         if !tap.is_finite() || tap.abs() < crate::matrix::MIN_DIVISIBLE_MAGNITUDE {
             return Err(Error::DegenerateTap { row: idx, tap });
         }
-        // Negated once here: the convention states `b`, negative for an
-        // inductive branch, and `L` takes the M-matrix form.
-        let b_e = -conv.series_susceptance(br.r, br.x, tap);
+        let b_e = conv.branch_susceptance(br.r, br.x, tap);
         // A NaN reactance slips past the guard above and poisons the whole
         // Laplacian.
         if !b_e.is_finite() {

--- a/powerio-matrix/src/matrix/mod.rs
+++ b/powerio-matrix/src/matrix/mod.rs
@@ -44,15 +44,9 @@ pub(crate) use ybus::{YbusFlags, branch_admittance, branch_flows};
 
 use sprs::CsMat;
 
-/// The magnitude below which a reactance, an impedance, or a tap ratio stops
-/// being a number the builders can divide by.
-///
-/// It is `f64::MIN_POSITIVE.sqrt()`: the square of anything smaller underflows
-/// to zero, and the reciprocal is above 1e153, which annihilates every real
-/// branch sharing its diagonal. Each builder compares a magnitude against it —
-/// `|x|`, `hypot(r, x)`, the tap — never `r² + x²`, which is a square. Per unit
-/// reactances run from 1e-6 to 10, so it rejects poison and nothing else.
-pub(crate) const MIN_DIVISIBLE_MAGNITUDE: f64 = 1.491_668_146_240_041_3e-154;
+// The bound the matrix and instance builders share; it lives beside the DC
+// convention because both are properties of the branch primitives.
+pub(crate) use powerio::dc::MIN_DIVISIBLE_MAGNITUDE;
 
 /// Which MATPOWER fast decoupled scheme to use.
 ///

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -1,4 +1,4 @@
-//! These cases pin `b = 1/x`, so they name `DcConvention::PaperPure` until it
+//! These cases pin `b = 1/x`, so they name `DcConvention::ReactanceOnly` until it
 //! is removed in 1.0.0.
 #![allow(deprecated)]
 
@@ -171,7 +171,8 @@ fn bprime_cancels_tap_magnitude_and_keeps_phase_shift() {
         "Ybus keeps the transformer tap magnitude"
     );
 
-    let inc = build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+    let inc =
+        build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
     let dc_l = build_weighted_laplacian(&inc.a, &inc.b).to_dense();
     assert_relative_eq!(dc_l[[0, 1]], -5.0, max_relative = 1e-12);
     assert!(
@@ -542,7 +543,7 @@ fn zero_impedance_policy_is_shared_across_matrix_builders() {
     assert_eq!(ybus_stats.skipped_zero_impedance, 1);
     assert_eq!(ybus_stats.skipped_zero_impedance_branches, vec![0]);
 
-    let inc = build_incidence(&view, DcConvention::PaperPure, &opts).unwrap();
+    let inc = build_incidence(&view, DcConvention::ReactanceOnly, &opts).unwrap();
     assert_eq!(inc.skipped_zero_impedance.count, 1);
     assert_eq!(inc.skipped_zero_impedance.branch_indices, vec![0]);
 }
@@ -560,7 +561,7 @@ fn zero_impedance_policy_can_error_instead_of_skipping() {
     assert!(matches!(bprime, crate::Error::ZeroImpedance { row: 0 }));
     let ybus = build_ybus(&view, &opts).unwrap_err();
     assert!(matches!(ybus, crate::Error::ZeroImpedance { row: 0 }));
-    let inc = build_incidence(&view, DcConvention::PaperPure, &opts).unwrap_err();
+    let inc = build_incidence(&view, DcConvention::ReactanceOnly, &opts).unwrap_err();
     assert!(matches!(inc, crate::Error::ZeroImpedance { row: 0 }));
 }
 
@@ -641,7 +642,8 @@ fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
     );
     let view = IndexedNetwork::new(&net);
 
-    let inc = build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+    let inc =
+        build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
     assert_eq!(inc.skipped_zero_impedance.count, 1);
     assert_eq!(inc.skipped_zero_impedance.branch_indices, vec![0]);
 
@@ -649,7 +651,7 @@ fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
         skip_zero_impedance: false,
         ..Default::default()
     };
-    let err = build_incidence(&view, DcConvention::PaperPure, &strict).unwrap_err();
+    let err = build_incidence(&view, DcConvention::ReactanceOnly, &strict).unwrap_err();
     assert!(
         matches!(err, crate::Error::ZeroImpedance { row: 0 }),
         "{err}"
@@ -674,7 +676,7 @@ fn a_reactance_the_builders_can_divide_by_is_stamped_by_both() {
     let view = IndexedNetwork::new(&net);
     let opts = BuildOptions::default();
 
-    let inc = build_incidence(&view, DcConvention::PaperPure, &opts).unwrap();
+    let inc = build_incidence(&view, DcConvention::ReactanceOnly, &opts).unwrap();
     assert_eq!(inc.skipped_zero_impedance.count, 0);
     assert_relative_eq!(inc.b[0], 1e100, max_relative = 1e-12);
 
@@ -747,7 +749,7 @@ fn self_loop_with_zero_reactance_drops_unconditionally() {
     let view = IndexedNetwork::new(&net);
 
     let opts = BuildOptions::default();
-    let inc = build_incidence(&view, DcConvention::PaperPure, &opts).unwrap();
+    let inc = build_incidence(&view, DcConvention::ReactanceOnly, &opts).unwrap();
     assert_eq!(inc.skipped_zero_impedance.count, 0);
     assert!(inc.skipped_zero_impedance.branch_indices.is_empty());
 
@@ -755,7 +757,7 @@ fn self_loop_with_zero_reactance_drops_unconditionally() {
         skip_zero_impedance: false,
         ..Default::default()
     };
-    build_incidence(&view, DcConvention::PaperPure, &strict)
+    build_incidence(&view, DcConvention::ReactanceOnly, &strict)
         .expect("a self-loop must not trip ZeroImpedance even when skip_zero_impedance is false");
 }
 

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -187,17 +187,13 @@ pub(crate) fn branch_admittance(
     let y_fr = Complex64::new(charging.g_fr, charging.b_fr);
     let y_to = Complex64::new(charging.g_to, charging.b_to);
 
+    // A tap of 1e-200 underflows `a_norm_sqr` to zero and scatters +/-Inf
+    // through the four admittances.
     let tap_mag = if flags.unity_taps {
         1.0
     } else {
-        br.effective_tap()
+        br.divisible_tap(row)?
     };
-    // `effective_tap` only remaps an exact 0.0 to 1.0, so a tap of 1e-200
-    // underflows `a_norm_sqr` to zero and scatters +/-Inf through the four
-    // admittances.
-    if !tap_mag.is_finite() || tap_mag.abs() < super::MIN_DIVISIBLE_MAGNITUDE {
-        return Err(Error::DegenerateTap { row, tap: tap_mag });
-    }
     // `shift_rad` is supplied already in radians and already zeroed when
     // `flags.zero_shifts` is set (the caller has the network, so it knows whether
     // the source angle is degrees or — for a normalized network — radians).

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -1,7 +1,7 @@
 //! DC OPF matrix forge: incidence, Laplacian, OPF instance, and the export
 //! bundle. Run against vendored MATPOWER cases.
 //!
-//! These cases pin `b = 1/x`, so they name `DcConvention::PaperPure` until it
+//! These cases pin `b = 1/x`, so they name `DcConvention::ReactanceOnly` until it
 //! is removed in 1.0.0. `SeriesImpedance` gives a different weight for any
 //! branch that carries resistance.
 #![allow(deprecated)]
@@ -123,7 +123,7 @@ fn laplacian_equals_bprime_xb() {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let bp = build_bprime(
             &view,
@@ -154,7 +154,7 @@ fn incidence_structure() {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         let (n, m) = (inc.n(), inc.m());
         assert_eq!(inc.a.rows(), n);
         assert_eq!(inc.a.cols(), m);
@@ -185,7 +185,7 @@ fn laplacian_is_psd_with_constant_kernel() {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let d = dense(&l);
         let n = d.len();
@@ -207,7 +207,7 @@ fn grounded_laplacian_is_spd() {
         let view = IndexedNetwork::new(&case);
         let r = view.reference_bus_index().unwrap();
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         let l = build_weighted_laplacian(&inc.a, &inc.b);
         let lg = ground_at(&l, r);
         assert_eq!(lg.rows(), view.n() - 1);
@@ -222,7 +222,7 @@ fn flow_map_reconstructs_laplacian() {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         let flow = build_flow_map(&inc.a, &inc.b); // B Aᵀ, m×n
         assert_eq!(flow.rows(), inc.m());
         assert_eq!(flow.cols(), inc.n());
@@ -295,8 +295,8 @@ fn ptdf_satisfies_kcl() {
         let view = IndexedNetwork::new(&case);
         let r = view.reference_bus_index().unwrap();
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
-        let ptdf = build_ptdf(&view, DcConvention::PaperPure).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
+        let ptdf = build_ptdf(&view, DcConvention::ReactanceOnly).unwrap();
         assert_eq!(ptdf.rows(), inc.m());
         assert_eq!(ptdf.cols(), view.n());
         let m = dense(&(&inc.a * &ptdf)); // n × n
@@ -326,9 +326,9 @@ fn lodf_diagonal_is_minus_one() {
     for path in CASES {
         let case = load(path);
         let view = IndexedNetwork::new(&case);
-        let lodf = build_lodf(&view, DcConvention::PaperPure).unwrap();
+        let lodf = build_lodf(&view, DcConvention::ReactanceOnly).unwrap();
         let inc =
-            build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+            build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
         assert_eq!(lodf.rows(), inc.m());
         assert_eq!(lodf.cols(), inc.m());
         let d = dense(&lodf);
@@ -597,7 +597,7 @@ fn ptdf_matches_analytic_triangle() {
     // Inject at bus j, withdraw at slack; read the flow on each branch.
     let case = triangle();
     let view = IndexedNetwork::new(&case);
-    let ptdf = dense(&build_ptdf(&view, DcConvention::PaperPure).unwrap());
+    let ptdf = dense(&build_ptdf(&view, DcConvention::ReactanceOnly).unwrap());
     let expected = [
         [0.0, -2.0 / 3.0, -1.0 / 3.0], // e0: 1→2
         [0.0, -1.0 / 3.0, -2.0 / 3.0], // e1: 1→3
@@ -621,7 +621,7 @@ fn lodf_matches_analytic_triangle() {
     // two, giving ±1 entries.
     let case = triangle();
     let view = IndexedNetwork::new(&case);
-    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
+    let lodf = dense(&build_lodf(&view, DcConvention::ReactanceOnly).unwrap());
     let expected = [[-1.0, 1.0, -1.0], [1.0, -1.0, 1.0], [-1.0, 1.0, -1.0]];
     for (l, row) in expected.iter().enumerate() {
         for (k, &want) in row.iter().enumerate() {
@@ -646,7 +646,7 @@ fn matpower_convention_tap_and_shift() {
     let view = IndexedNetwork::new(&case);
 
     // PaperPure ignores tap and shift: b = 1/x, no phase injection.
-    let pp = build_incidence(&view, DcConvention::PaperPure, &BuildOptions::default()).unwrap();
+    let pp = build_incidence(&view, DcConvention::ReactanceOnly, &BuildOptions::default()).unwrap();
     assert!((pp.b[0] - 1.0 / x).abs() < 1e-12);
     assert!(pp.p_shift.iter().all(|&v| v == 0.0));
 
@@ -675,7 +675,7 @@ fn radial_lodf_is_negative_identity() {
         vec![branch(1, 2, 0.1), branch(2, 3, 0.1)],
     );
     let view = IndexedNetwork::new(&case);
-    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
+    let lodf = dense(&build_lodf(&view, DcConvention::ReactanceOnly).unwrap());
     for l in 0..2 {
         for k in 0..2 {
             let want = if l == k { -1.0 } else { 0.0 };
@@ -697,8 +697,8 @@ fn ptdf_handles_indefinite_but_invertible_laplacian() {
     );
     let view = IndexedNetwork::new(&case);
 
-    let ptdf = dense(&build_ptdf(&view, DcConvention::PaperPure).unwrap());
-    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
+    let ptdf = dense(&build_ptdf(&view, DcConvention::ReactanceOnly).unwrap());
+    let lodf = dense(&build_lodf(&view, DcConvention::ReactanceOnly).unwrap());
 
     assert_eq!(ptdf.len(), 1);
     assert!(ptdf[0][0].abs() < 1e-12);
@@ -722,12 +722,12 @@ fn ungrounded_island_errors() {
     );
     let view = IndexedNetwork::new(&case);
     assert_eq!(view.n_connected_components(), 2);
-    let p = build_ptdf(&view, DcConvention::PaperPure).unwrap_err();
+    let p = build_ptdf(&view, DcConvention::ReactanceOnly).unwrap_err();
     assert!(
         matches!(p, Error::UngroundedComponent { components: 1 }),
         "ptdf: {p:?}"
     );
-    let l = build_lodf(&view, DcConvention::PaperPure).unwrap_err();
+    let l = build_lodf(&view, DcConvention::ReactanceOnly).unwrap_err();
     assert!(
         matches!(l, Error::UngroundedComponent { components: 1 }),
         "lodf: {l:?}"
@@ -751,7 +751,7 @@ fn two_grounded_islands_solve_block_diagonal() {
     );
     let view = IndexedNetwork::new(&case);
     assert_eq!(view.reference_bus_indices(), vec![0, 2]);
-    let ptdf = dense(&build_ptdf(&view, DcConvention::PaperPure).unwrap());
+    let ptdf = dense(&build_ptdf(&view, DcConvention::ReactanceOnly).unwrap());
     // Branch 0 is in island {0,1}; its only nonzero sensitivity is to that
     // island's non-slack bus (col 1). Branch 1 is in island {2,3} → col 3.
     // Both reference columns (0 and 2) are zero. The sign is −1: a unit
@@ -793,7 +793,7 @@ fn multi_reference_two_refs_one_island() {
     );
     let view = IndexedNetwork::new(&case);
     assert_eq!(view.reference_bus_indices(), vec![0, 2]);
-    let ptdf = dense(&build_ptdf(&view, DcConvention::PaperPure).unwrap());
+    let ptdf = dense(&build_ptdf(&view, DcConvention::ReactanceOnly).unwrap());
     // Both reference columns (0 and 2) are zero; the middle bus (col 1) splits.
     for (l, row) in ptdf.iter().enumerate() {
         assert!(row[0].abs() < 1e-12, "ref col 0 nonzero on branch {l}");
@@ -834,7 +834,7 @@ fn lodf_two_refs_multi_reference_triangle() {
     );
     let view = IndexedNetwork::new(&case);
     assert_eq!(view.reference_bus_indices(), vec![0, 2]);
-    let lodf = dense(&build_lodf(&view, DcConvention::PaperPure).unwrap());
+    let lodf = dense(&build_lodf(&view, DcConvention::ReactanceOnly).unwrap());
     let expected = [[-1.0, 0.0, -1.0], [0.0, -1.0, 0.0], [-1.0, 0.0, -1.0]];
     for (l, row) in expected.iter().enumerate() {
         for (k, &want) in row.iter().enumerate() {

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use powerio::{BusId, Error, IndexedNetwork, Result};
 
-use crate::{ReferenceBuses, Units, nodal};
+use crate::{ReferenceBuses, Units, limits, nodal};
 
 /// Options for AC OPF instance assembly.
 ///
@@ -358,7 +358,7 @@ pub fn build_ac_opf_instance(
         // A synthesized bound is per unit power already, so the admittance
         // multiplier is the one that puts it in the selected unit system.
         if options.synthesize_unrated_limits && branch.rate_a <= 0.0 {
-            let window = amin.abs().max(amax.abs());
+            let window = limits::angle_window(amin, amax);
             s_max.push(
                 branch.synthesize_rate_a(window, network.buses[from].vmax, network.buses[to].vmax)
                     * y_scale,

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -264,13 +264,7 @@ pub fn build_ac_opf_instance(
         let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
             gen_index: source_row,
         })?;
-        let (q_raw, c_raw, c0_raw) =
-            cost.quadratic_with_constant()
-                .ok_or(Error::UnsupportedCostModel {
-                    gen_index: source_row,
-                    model: cost.model,
-                    ncost: cost.ncost,
-                })?;
+        let (q_raw, c_raw, c0_raw) = nodal::quadratic_terms(cost, source_row)?;
         bus_of_gen.push(bus);
         generator_rows.push(source_row);
         cost_q.push(q_raw * q_scale);

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -332,7 +332,7 @@ pub fn build_ac_opf_instance(
             // lands on the bus diagonal, exactly as `build_ybus` folds it.
             // With t = tap·e^{jθ}: Yff + Yft + Ytf + Ytt
             //   = (y + y_fr)/tap² + (y + y_to) − y·2cos(θ)/tap.
-            let tap = branch.effective_tap();
+            let tap = branch.divisible_tap(source_row)?;
             let tap_squared = tap * tap;
             let cross = 2.0 * case.angle_radians(branch.shift).cos() / tap;
             g_s[from] += ((series_g + charging.g_fr) / tap_squared + (series_g + charging.g_to)
@@ -353,7 +353,7 @@ pub fn build_ac_opf_instance(
         b_to.push(charging.b_to * y_scale);
         let amin = case.angle_radians(branch.angmin);
         let amax = case.angle_radians(branch.angmax);
-        tap.push(branch.effective_tap());
+        tap.push(branch.divisible_tap(source_row)?);
         shift.push(case.angle_radians(branch.shift));
         // A synthesized bound is per unit power already, so the admittance
         // multiplier is the one that puts it in the selected unit system.

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -285,18 +285,21 @@ pub fn build_dc_opf_instance(
             // DC flow, and its shift injection cancels at its own bus.
             continue;
         }
-        if branch.x == 0.0 {
+        // The reactance the DC matrix builders bound, on the same rule: an
+        // `x = 1e-300` gives a finite `b = 1e300` that annihilates every real
+        // branch sharing a bus with it. Exact zero used to be the whole test.
+        if branch.x.abs() < powerio::dc::MIN_DIVISIBLE_MAGNITUDE {
             if options.skip_zero_impedance {
                 skipped_zero_impedance.push(source_row);
                 continue;
             }
             return Err(Error::ZeroImpedance { row: source_row });
         }
-        let branch_b =
-            options
-                .convention
-                .branch_susceptance(branch.r, branch.x, branch.effective_tap())
-                * b_scale;
+        let branch_b = options.convention.branch_susceptance(
+            branch.r,
+            branch.x,
+            branch.divisible_tap(source_row)?,
+        ) * b_scale;
         if !branch_b.is_finite() {
             return Err(Error::NonFiniteSusceptance { row: source_row });
         }

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use powerio::{BusId, DcConvention, Error, IndexedNetwork, Result};
 
-use crate::{ReferenceBuses, nodal};
+use crate::{ReferenceBuses, limits, nodal};
 
 /// Unit system for power and generator cost data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -161,8 +161,8 @@ pub struct DcOpfInstance {
     ///
     /// The DC approximation holds the voltage magnitude at one per unit, so a
     /// shunt draws the constant real power `g_s` and does not depend on the
-    /// angle. It belongs in the injection and not in the bus susceptance
-    /// matrix, whose row sums must stay zero. A nodal balance subtracts it
+    /// angle. It belongs in the injection: the bus susceptance matrix keeps
+    /// zero row sums and carries no shunt. A nodal balance subtracts it
     /// beside [`Self::p_d`], as MATPOWER `runpf` does.
     pub g_s: Vec<f64>,
     /// Nodal phase shift injection in dense bus order.
@@ -318,7 +318,7 @@ pub fn build_dc_opf_instance(
         // A synthesized bound is per unit power already, so the admittance
         // multiplier is the one that puts it in the selected unit system.
         if options.synthesize_unrated_limits && branch.rate_a <= 0.0 {
-            let window = amin.abs().max(amax.abs());
+            let window = limits::angle_window(amin, amax);
             f_max
                 .push(branch.synthesize_rate_a(window, buses[from].vmax, buses[to].vmax) * b_scale);
         } else {

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -291,13 +291,10 @@ pub fn build_dc_opf_instance(
             }
             return Err(Error::ZeroImpedance { row: source_row });
         }
-        // Negated: the convention states `b`, and this field is the flow
-        // coefficient in `f = b (theta_from - theta_to)`, positive for an
-        // inductive branch.
         let branch_b =
-            -options
+            options
                 .convention
-                .series_susceptance(branch.r, branch.x, branch.effective_tap())
+                .branch_susceptance(branch.r, branch.x, branch.effective_tap())
                 * b_scale;
         if !branch_b.is_finite() {
             return Err(Error::NonFiniteSusceptance { row: source_row });

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -239,13 +239,7 @@ pub fn build_dc_opf_instance(
         let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
             gen_index: source_row,
         })?;
-        let (q_raw, c_raw, c0_raw) =
-            cost.quadratic_with_constant()
-                .ok_or(Error::UnsupportedCostModel {
-                    gen_index: source_row,
-                    model: cost.model,
-                    ncost: cost.ncost,
-                })?;
+        let (q_raw, c_raw, c0_raw) = nodal::quadratic_terms(cost, source_row)?;
         bus_of_gen.push(bus);
         generator_rows.push(source_row);
         q.push(q_raw * q_scale);

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -104,7 +104,8 @@ pub struct DcGeneratorData {
 pub struct DcBranchData {
     pub from_bus: Vec<usize>,
     pub to_bus: Vec<usize>,
-    /// Branch coefficient in the selected power unit per radian.
+    /// Branch susceptance in the selected power unit per radian, positive for
+    /// an inductive branch.
     pub b: Vec<f64>,
     /// Phase shift in radians. Zero unless the convention carries phase shift
     /// injections.

--- a/powerio-prob/src/lib.rs
+++ b/powerio-prob/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod ac;
 mod dc;
+mod limits;
 mod nodal;
 mod reference;
 pub mod scopf;

--- a/powerio-prob/src/lib.rs
+++ b/powerio-prob/src/lib.rs
@@ -24,4 +24,6 @@ pub use dc::{
 };
 pub use powerio::{DcConvention, Error, Result};
 pub use reference::ReferenceBuses;
-pub use scopf::{ScopfError, ScopfInstance, ScopfResult, build_scopf_instance_from_str};
+pub use scopf::{
+    ScopfDeviceClassLayout, ScopfError, ScopfInstance, ScopfResult, build_scopf_instance_from_str,
+};

--- a/powerio-prob/src/limits.rs
+++ b/powerio-prob/src/limits.rs
@@ -1,0 +1,39 @@
+//! The branch angle window the synthesized thermal limit reads.
+//!
+//! Both OPF builders synthesize a bound for an unrated branch from
+//! [`Branch::synthesize_rate_a`](powerio::Branch::synthesize_rate_a), and both
+//! read the window out of the same two fields, so the rule lives here once.
+
+/// The widest angle difference a branch may hold, in radians, from its
+/// converted `angmin`/`angmax` pair.
+///
+/// `angmin == angmax == 0` states no constraint, the MATPOWER spelling that
+/// `Network::to_normalized` widens to a pad, so a raw case and a normalized
+/// one describe the same branch. Reading that pair as a zero wide window would
+/// give a zero synthesized limit, which the instance then reads back as
+/// unlimited. A window wider than the half turn is held at `pi` by
+/// `synthesize_rate_a` itself.
+pub(crate) fn angle_window(angle_min_rad: f64, angle_max_rad: f64) -> f64 {
+    if angle_min_rad == 0.0 && angle_max_rad == 0.0 {
+        return std::f64::consts::PI;
+    }
+    angle_min_rad.abs().max(angle_max_rad.abs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::angle_window;
+
+    #[test]
+    fn the_window_is_the_wider_of_the_two_magnitudes() {
+        let window = 30.0_f64.to_radians();
+        assert!((angle_window(-window, window) - window).abs() < 1e-15);
+        assert!((angle_window(0.1, window) - window).abs() < 1e-15);
+        assert!((angle_window(-window, 0.1) - window).abs() < 1e-15);
+    }
+
+    #[test]
+    fn a_zero_pair_states_no_constraint() {
+        assert!((angle_window(0.0, 0.0) - std::f64::consts::PI).abs() < 1e-15);
+    }
+}

--- a/powerio-prob/src/matrix/bundle.rs
+++ b/powerio-prob/src/matrix/bundle.rs
@@ -10,7 +10,7 @@ use crate::{DcOpfInstance, Units};
 use super::build_dc_opf_matrices;
 
 const DCOPF_SCHEMA: &str = "powerio.dcopf";
-const DCOPF_SCHEMA_VERSION: &str = "0.3.0";
+const DCOPF_SCHEMA_VERSION: &str = "0.4.0";
 
 /// Cost policy information recorded in a bundle manifest.
 #[derive(Debug, Clone)]
@@ -165,6 +165,7 @@ pub fn write_dcopf_bundle(
     put_vec(&dir, "pmin.mtx", &nodal.pmin, &mut files)?;
     put_vec(&dir, "fmax.mtx", &instance.branches.f_max, &mut files)?;
     put_vec(&dir, "pd.mtx", &instance.p_d, &mut files)?;
+    put_vec(&dir, "gs.mtx", &instance.g_s, &mut files)?;
     put_vec(
         &dir,
         "angle_min.mtx",

--- a/powerio-prob/src/nodal.rs
+++ b/powerio-prob/src/nodal.rs
@@ -8,6 +8,34 @@
 //! the bus total can reach. Cost aggregation is an approximation, stated in
 //! [`combine_costs`].
 
+use powerio::network::GenCost;
+
+use crate::{Error, Result};
+
+/// `(q, c, c0)` of one generator's cost row, as both instance builders read it.
+///
+/// A MATPOWER model 2 row often carries a leading coefficient near 1e-17 that
+/// the source produced by rounding. It states a linear curve, and reading it as
+/// quadratic gives `1/q` near 1e17 wherever the curvature is inverted.
+///
+/// # Errors
+/// [`Error::UnsupportedCostModel`] for a row that states no quadratic curve.
+pub(crate) fn quadratic_terms(cost: &GenCost, gen_index: usize) -> Result<(f64, f64, f64)> {
+    let (q, c, c0) = cost
+        .quadratic_with_constant()
+        .ok_or(Error::UnsupportedCostModel {
+            gen_index,
+            model: cost.model,
+            ncost: cost.ncost,
+        })?;
+    let q = if q.abs() <= GenCost::LEADING_COEFF_TOL {
+        0.0
+    } else {
+        q
+    };
+    Ok((q, c, c0))
+}
+
 /// Sum of a generator column vector over the bus of each generator.
 pub(crate) fn sum_by_bus(n_buses: usize, bus_of_gen: &[usize], values: &[f64]) -> Vec<f64> {
     let mut totals = vec![0.0; n_buses];
@@ -109,11 +137,9 @@ impl BusCost {
             self.only = (q, c, c0);
         }
         self.c0 += c0;
-        // A quadratic term at or below the artifact tolerance states a linear
-        // curve the source rounded. Reading it as quadratic gives `1/q` above
-        // 1e12, which swamps the parallel sum and prices the whole bus as
-        // nearly free.
-        if q > powerio::network::GenCost::LEADING_COEFF_TOL {
+        // `quadratic_terms` has already zeroed a rounding artifact, which would
+        // otherwise give `1/q` near 1e17 and price the whole bus as free.
+        if q > 0.0 {
             self.reciprocal_q += 1.0 / q;
             self.weighted_c += c / q;
             self.weighted_c_squared += c * c / q;
@@ -157,7 +183,11 @@ mod tests {
     /// nearly free.
     #[test]
     fn a_rounding_artifact_reads_as_a_linear_curve() {
-        let costs = combine_costs(1, &[0, 0], &[2e-17, 0.2], &[3.0, 5.0], &[0.0, 0.0]);
+        let artifact = GenCost::new(2, 0.0, 0.0, vec![1e-17, 3.0, 0.0]);
+        let (q, c, c0) = quadratic_terms(&artifact, 0).expect("a model 2 row");
+        assert_eq!((q, c, c0), (0.0, 3.0, 0.0));
+
+        let costs = combine_costs(1, &[0, 0], &[q, 0.2], &[c, 5.0], &[c0, 0.0]);
         assert_eq!(costs.q, vec![0.0]);
         assert_eq!(costs.c, vec![3.0], "the cheaper linear term sets the bus");
     }

--- a/powerio-prob/src/nodal.rs
+++ b/powerio-prob/src/nodal.rs
@@ -109,7 +109,11 @@ impl BusCost {
             self.only = (q, c, c0);
         }
         self.c0 += c0;
-        if q > 0.0 {
+        // A quadratic term at or below the artifact tolerance states a linear
+        // curve the source rounded. Reading it as quadratic gives `1/q` above
+        // 1e12, which swamps the parallel sum and prices the whole bus as
+        // nearly free.
+        if q > powerio::network::GenCost::LEADING_COEFF_TOL {
             self.reciprocal_q += 1.0 / q;
             self.weighted_c += c / q;
             self.weighted_c_squared += c * c / q;
@@ -146,6 +150,16 @@ mod tests {
         assert_eq!(costs.q, vec![0.0, 0.3]);
         assert_eq!(costs.c, vec![0.0, 7.0]);
         assert_eq!(costs.c0, vec![0.0, 11.0]);
+    }
+
+    /// A rounding artifact states a linear curve. Read as quadratic it gives
+    /// `1/q` near 1e17, which swamps the parallel sum and prices the bus as
+    /// nearly free.
+    #[test]
+    fn a_rounding_artifact_reads_as_a_linear_curve() {
+        let costs = combine_costs(1, &[0, 0], &[2e-17, 0.2], &[3.0, 5.0], &[0.0, 0.0]);
+        assert_eq!(costs.q, vec![0.0]);
+        assert_eq!(costs.c, vec![3.0], "the cheaper linear term sets the bus");
     }
 
     #[test]

--- a/powerio-prob/src/scopf/projection.rs
+++ b/powerio-prob/src/scopf/projection.rs
@@ -12,7 +12,7 @@ use super::goc3::{
 use super::types::{
     ScopfAcContingencySurvivors, ScopfAcLineRow, ScopfAcLineSurvivorRow, ScopfActiveReserveRow,
     ScopfActiveReserveSetRow, ScopfBusRow, ScopfCostRow, ScopfDcContingencyFlowRow, ScopfDcLineRow,
-    ScopfDeviceRow, ScopfEnergyWindowMaxCsRow, ScopfEnergyWindowMaxPrRow,
+    ScopfDeviceClassLayout, ScopfDeviceRow, ScopfEnergyWindowMaxCsRow, ScopfEnergyWindowMaxPrRow,
     ScopfEnergyWindowMinCsRow, ScopfEnergyWindowMinPrRow, ScopfEnergyWindowPeriodMaxCsRow,
     ScopfEnergyWindowPeriodMaxPrRow, ScopfEnergyWindowPeriodMinCsRow,
     ScopfEnergyWindowPeriodMinPrRow, ScopfEnergyWindows, ScopfFixedPhaseRow, ScopfFixedRatioRow,
@@ -1024,15 +1024,13 @@ fn build_violation_cost(tables: &Goc3Adapter) -> ScopfViolationCost {
     }
 }
 
-/// `(producers_first, contiguous)` over the `simple_dispatchable_device`
-/// section in document order: whether the producer run starts before the
-/// consumer run, and whether each class is one unbroken run. Document order is
-/// the index rule for every per-class index here, so the two facts are read
-/// off the same order and need no UID shape.
-fn device_class_blocks(tables: &Goc3Adapter) -> Result<(bool, bool)> {
+/// How the two device classes sit in the `simple_dispatchable_device`
+/// section, read in document order. Document order is the index rule for
+/// every per-class index here, so this needs no UID shape.
+fn device_class_blocks(tables: &Goc3Adapter) -> Result<ScopfDeviceClassLayout> {
     let mut runs: Vec<&str> = Vec::new();
-    for uid in tables.sdd_order() {
-        let kind = sdd_device_type(tables.sdd.get(&uid)?);
+    for uid in tables.sdd.uids() {
+        let kind = sdd_device_type(tables.sdd.get(uid)?);
         let kind = if kind == "consumer" {
             "consumer"
         } else {
@@ -1042,8 +1040,12 @@ fn device_class_blocks(tables: &Goc3Adapter) -> Result<(bool, bool)> {
             runs.push(kind);
         }
     }
-    let producers_first = runs.first() != Some(&"consumer");
-    Ok((producers_first, runs.len() <= 2))
+    if runs.len() > 2 {
+        return Ok(ScopfDeviceClassLayout::Interleaved);
+    }
+    Ok(ScopfDeviceClassLayout::Contiguous {
+        producers_first: runs.first() != Some(&"consumer"),
+    })
 }
 
 fn project_scopf_instance(tables: &Goc3Adapter) -> Result<ScopfInstance> {
@@ -1053,7 +1055,7 @@ fn project_scopf_instance(tables: &Goc3Adapter) -> Result<ScopfInstance> {
         cost_vector_pr,
         cost_vector_cs,
     } = build_static_projection(tables)?;
-    let (producers_first, device_classes_contiguous) = device_class_blocks(tables)?;
+    let device_class_layout = device_class_blocks(tables)?;
     Ok(ScopfInstance {
         static_data,
         lengths,
@@ -1062,8 +1064,7 @@ fn project_scopf_instance(tables: &Goc3Adapter) -> Result<ScopfInstance> {
         ac_contingency_survivors: build_ac_contingency_survivors(tables)?,
         dc_contingency_flows: build_dc_contingency_flows(tables)?,
         violation_cost: build_violation_cost(tables),
-        producers_first,
-        device_classes_contiguous,
+        device_class_layout,
     })
 }
 

--- a/powerio-prob/src/scopf/projection.rs
+++ b/powerio-prob/src/scopf/projection.rs
@@ -34,19 +34,32 @@ fn sdd_device_type(obj: &Map<String, Value>) -> &str {
 }
 
 /// One required 0/1 mode flag on a `simple_dispatchable_device` row. GOC3
-/// writes these as JSON numbers, so a boolean is rejected by name.
+/// writes these as JSON numbers, so a boolean is rejected by name. A writer
+/// that emits every number as a float states the same flag as `0.0`/`1.0`, so
+/// the value is read as a number and then required to be one of the two.
 fn require_flag(obj: &Map<String, Value>, uid: &str, key: &str) -> Result<i64> {
     let raw = obj.get(key).ok_or_else(|| {
         json_error(format!(
             "simple_dispatchable_device `{uid}` missing `{key}`"
         ))
     })?;
-    match raw.as_i64() {
-        Some(v @ (0 | 1)) => Ok(v),
-        _ => Err(json_error(format!(
+    // 0 and 1 are exact in binary floating point, so equality is the right
+    // test here: it takes the two flags and nothing near them.
+    #[allow(clippy::float_cmp)]
+    let flag = raw.as_f64().and_then(|value| {
+        if value == 0.0 {
+            Some(0)
+        } else if value == 1.0 {
+            Some(1)
+        } else {
+            None
+        }
+    });
+    flag.ok_or_else(|| {
+        json_error(format!(
             "simple_dispatchable_device `{uid}` `{key}` is not 0 or 1"
-        ))),
-    }
+        ))
+    })
 }
 
 fn validate_period_len(

--- a/powerio-prob/src/scopf/types.rs
+++ b/powerio-prob/src/scopf/types.rs
@@ -455,12 +455,34 @@ pub struct ScopfInstance {
     pub ac_contingency_survivors: ScopfAcContingencySurvivors,
     pub dc_contingency_flows: Vec<ScopfDcContingencyFlowRow>,
     pub violation_cost: ScopfViolationCost,
-    /// Whether the producer block precedes the consumer block in document
-    /// order. A model that stacks both classes into one variable vector needs
-    /// this to place its per-class offsets.
-    pub producers_first: bool,
-    /// Whether each device class occupies one unbroken run of the
-    /// `simple_dispatchable_device` section. A per-class offset into a stacked
-    /// variable vector is a bijection only when this holds.
-    pub device_classes_contiguous: bool,
+    pub device_class_layout: ScopfDeviceClassLayout,
+}
+
+/// How the two device classes sit in the `simple_dispatchable_device` section.
+///
+/// A model that stacks producers and consumers into one variable vector
+/// addresses a device by a per class offset, which is a bijection only when
+/// each class owns one unbroken run. Reading the order without that
+/// precondition is the one mistake this type makes unavailable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+#[non_exhaustive]
+pub enum ScopfDeviceClassLayout {
+    /// Each class is one unbroken run. `producers_first` says which run
+    /// starts first.
+    Contiguous { producers_first: bool },
+    /// The two classes interleave, so no per class offset addresses a device.
+    Interleaved,
+}
+
+impl ScopfDeviceClassLayout {
+    /// Whether the producer run starts before the consumer run, or `None`
+    /// when the classes interleave and no offset scheme holds.
+    #[must_use]
+    pub fn producers_first(self) -> Option<bool> {
+        match self {
+            Self::Contiguous { producers_first } => Some(producers_first),
+            Self::Interleaved => None,
+        }
+    }
 }

--- a/powerio-prob/src/scopf/wire.rs
+++ b/powerio-prob/src/scopf/wire.rs
@@ -264,8 +264,7 @@ pub fn to_wire_value(instance: &ScopfInstance) -> ScopfResult<Value> {
         ac_contingency_survivors,
         dc_contingency_flows,
         violation_cost,
-        producers_first,
-        device_classes_contiguous,
+        device_class_layout,
     } = instance;
     let mut wire = Map::new();
     wire.insert("static".to_owned(), wire_static(static_data)?);
@@ -284,10 +283,9 @@ pub fn to_wire_value(instance: &ScopfInstance) -> ScopfResult<Value> {
         wire_rows(dc_contingency_flows)?,
     );
     wire.insert("violation_cost".to_owned(), wire_object(violation_cost)?);
-    wire.insert("producers_first".to_owned(), Value::from(*producers_first));
     wire.insert(
-        "device_classes_contiguous".to_owned(),
-        Value::from(*device_classes_contiguous),
+        "device_class_layout".to_owned(),
+        serde_json::to_value(device_class_layout)?,
     );
     Ok(serde_json::to_value(WireEnvelope {
         schema: SCOPF_WIRE_SCHEMA,

--- a/powerio-prob/tests/acopf.rs
+++ b/powerio-prob/tests/acopf.rs
@@ -306,6 +306,50 @@ fn zero_impedance_skip_or_reject() {
 }
 
 #[test]
+fn an_impedance_the_instance_cannot_divide_by_reads_as_zero_impedance() {
+    // #292, the rule the matrix builders apply: the bound is on the impedance
+    // magnitude, so `x = 1e-300` is refused and the `x = 1e-100` beside it,
+    // whose square is just as small, is still a branch the instance carries.
+    let mut net = small_network();
+    net.branches.insert(0, branch(10, 30, 0.0, 1e-300));
+    let view = IndexedNetwork::new(&net);
+    let skipped = build_ac_opf_instance(&view, &AcOpfOptions::default()).expect("skip");
+    assert_eq!(skipped.branches.skipped_zero_impedance, vec![0]);
+
+    let error = build_ac_opf_instance(
+        &view,
+        &AcOpfOptions {
+            skip_zero_impedance: false,
+            ..AcOpfOptions::default()
+        },
+    )
+    .expect_err("reject");
+    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+
+    let mut small_x = small_network();
+    small_x.branches[0].r = 0.0;
+    small_x.branches[0].x = 1e-100;
+    let problem =
+        build_ac_opf_instance(&IndexedNetwork::new(&small_x), &AcOpfOptions::default()).expect("x");
+    assert_eq!(problem.branches.skipped_zero_impedance, Vec::<usize>::new());
+    assert_close(problem.branches.b[0], -1e100);
+}
+
+#[test]
+fn a_tap_the_instance_cannot_divide_by_is_refused() {
+    for tap in [1e-200, f64::NAN, f64::INFINITY] {
+        let mut net = small_network();
+        net.branches[0].tap = tap;
+        let error = build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default())
+            .expect_err("a tap the pi model divides by must be refused");
+        assert!(
+            matches!(error, Error::DegenerateTap { row: 0, .. }),
+            "tap {tap}: {error}"
+        );
+    }
+}
+
+#[test]
 fn out_of_service_exclusion() {
     let mut net = case9();
     net.generators[1].in_service = false;

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -183,6 +183,15 @@ fn an_unrated_branch_takes_a_synthesized_limit_on_request() {
     let wide = build_dc_opf_instance(&IndexedNetwork::new(&wide), &options).expect("wide bounds");
     assert_close(wide.branches.f_max[0], 1.1 * 2.2 / 0.2);
 
+    // `0/0` is the MATPOWER spelling of the same unconstrained branch, so it
+    // reaches the same bound. Reading it as a zero wide window would give a
+    // zero limit, which the instance reads back as unlimited.
+    let mut zero = net.clone();
+    zero.branches[0].angmin = 0.0;
+    zero.branches[0].angmax = 0.0;
+    let zero = build_dc_opf_instance(&IndexedNetwork::new(&zero), &options).expect("zero bounds");
+    assert_close(zero.branches.f_max[0], 1.1 * 2.2 / 0.2);
+
     let mut rated = net.clone();
     rated.branches[0].rate_a = 50.0;
     let kept = build_dc_opf_instance(&IndexedNetwork::new(&rated), &options).expect("rated branch");
@@ -490,10 +499,13 @@ mod matrix_tests {
         )
         .expect("manifest json");
         assert_eq!(manifest["schema"], "powerio.dcopf");
-        assert_eq!(manifest["schema_version"], "0.3.0");
+        assert_eq!(manifest["schema_version"], "0.4.0");
         let c0_gen =
             powerio_matrix::io::read_vector_mtx(bundle.dir.join("c0_gen.mtx")).expect("c0_gen");
         assert_eq!(c0_gen, problem.generators.c0);
+        // The shunt conductance a nodal balance subtracts beside `pd`.
+        let g_s = powerio_matrix::io::read_vector_mtx(bundle.dir.join("gs.mtx")).expect("gs");
+        assert_eq!(g_s, problem.g_s);
         let c0 = powerio_matrix::io::read_vector_mtx(bundle.dir.join("c0.mtx")).expect("c0");
         assert_eq!(c0, problem.nodal_generator_data().c0);
         assert_eq!(manifest["dimensions"]["n_buses"], problem.n_buses);

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -441,6 +441,22 @@ fn a_tap_the_instance_cannot_divide_by_is_refused() {
 }
 
 #[test]
+fn a_cost_rounding_artifact_reaches_neither_space() {
+    // A model 2 row carrying a leading 1e-17 from the source's rounding states
+    // a linear curve. Generator space used to keep it, so the same case read
+    // two ways gave two curves.
+    let mut net = small_network();
+    net.generators[0].cost = Some(GenCost::new(2, 0.0, 0.0, vec![1e-17, 2.0, 5.0]));
+    let problem =
+        build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default()).expect("build");
+    assert_eq!(problem.generators.q[0].to_bits(), 0.0_f64.to_bits());
+    assert_eq!(
+        problem.nodal_generator_data().q[0].to_bits(),
+        0.0_f64.to_bits()
+    );
+}
+
+#[test]
 fn zero_base_mva_is_rejected() {
     let mut net = small_network();
     net.base_mva = 0.0;

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -400,6 +400,47 @@ fn zero_reactance_can_be_skipped_or_rejected() {
 }
 
 #[test]
+fn a_reactance_the_instance_cannot_divide_by_reads_as_zero_impedance() {
+    // #292, the rule the matrix builders apply: `x = 1e-300` gives a finite
+    // `b = 1e300` that annihilates every real branch sharing a bus with it.
+    let mut net = small_network();
+    net.branches.insert(0, branch(10, 30, 1e-300));
+    let view = IndexedNetwork::new(&net);
+    let skipped = build_dc_opf_instance(&view, &DcOpfOptions::default()).expect("skip");
+    assert_eq!(skipped.branches.skipped_zero_impedance, vec![0]);
+
+    let error = build_dc_opf_instance(
+        &view,
+        &DcOpfOptions {
+            skip_zero_impedance: false,
+            ..DcOpfOptions::default()
+        },
+    )
+    .expect_err("reject");
+    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+}
+
+#[test]
+fn a_tap_the_instance_cannot_divide_by_is_refused() {
+    for tap in [1e-200, f64::NAN, f64::INFINITY] {
+        let mut net = small_network();
+        net.branches[0].tap = tap;
+        let error = build_dc_opf_instance(
+            &IndexedNetwork::new(&net),
+            &DcOpfOptions {
+                convention: DcConvention::Matpower,
+                ..DcOpfOptions::default()
+            },
+        )
+        .expect_err("a tap the susceptance divides by must be refused");
+        assert!(
+            matches!(error, Error::DegenerateTap { row: 0, .. }),
+            "tap {tap}: {error}"
+        );
+    }
+}
+
+#[test]
 fn zero_base_mva_is_rejected() {
     let mut net = small_network();
     net.base_mva = 0.0;

--- a/powerio-prob/tests/scopf.rs
+++ b/powerio-prob/tests/scopf.rs
@@ -1,6 +1,8 @@
 use powerio::BusId;
 use powerio_prob::scopf::wire::{SCOPF_WIRE_SCHEMA, SCOPF_WIRE_VERSION, to_wire_value};
-use powerio_prob::{ScopfError, ScopfInstance, build_scopf_instance_from_str};
+use powerio_prob::{
+    ScopfDeviceClassLayout, ScopfError, ScopfInstance, build_scopf_instance_from_str,
+};
 use serde_json::Value;
 
 const SMALL: &str = include_str!("data/goc3_small.json");
@@ -454,8 +456,12 @@ fn violation_prices_are_each_optional() {
 #[test]
 fn device_class_blocks_are_read_in_document_order() {
     let instance = small_instance();
-    assert!(instance.producers_first);
-    assert!(instance.device_classes_contiguous);
+    assert_eq!(
+        instance.device_class_layout,
+        ScopfDeviceClassLayout::Contiguous {
+            producers_first: true
+        }
+    );
 
     let mut doc: Value = serde_json::from_str(SMALL).expect("fixture json");
     let devices = doc["network"]["simple_dispatchable_device"]
@@ -464,8 +470,12 @@ fn device_class_blocks_are_read_in_document_order() {
     devices.swap(0, 1);
     let text = serde_json::to_string(&doc).expect("serialize");
     let instance = build_scopf_instance_from_str(&text, "goc3-json").expect("build");
-    assert!(!instance.producers_first);
-    assert!(instance.device_classes_contiguous);
+    assert_eq!(
+        instance.device_class_layout,
+        ScopfDeviceClassLayout::Contiguous {
+            producers_first: false
+        }
+    );
 }
 
 #[test]
@@ -485,9 +495,15 @@ fn interleaved_device_classes_are_reported() {
     ts.push(third_ts);
     let text = serde_json::to_string(&doc).expect("serialize");
     let instance = build_scopf_instance_from_str(&text, "goc3-json").expect("build");
-    assert!(
-        !instance.device_classes_contiguous,
+    assert_eq!(
+        instance.device_class_layout,
+        ScopfDeviceClassLayout::Interleaved,
         "producer, consumer, producer is three runs"
+    );
+    assert_eq!(
+        instance.device_class_layout.producers_first(),
+        None,
+        "no offset scheme holds, so there is no order to read"
     );
 }
 
@@ -538,6 +554,10 @@ fn the_validation_case_indexes_every_row_in_document_order() {
         }
     }
 
-    assert!(instance.producers_first);
-    assert!(instance.device_classes_contiguous);
+    assert_eq!(
+        instance.device_class_layout,
+        ScopfDeviceClassLayout::Contiguous {
+            producers_first: true
+        }
+    );
 }

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -127,7 +127,7 @@ fn parse_convention(s: &str) -> PyResult<DcConvention> {
     match normalize(s).as_str() {
         "series" | "seriesimpedance" => Ok(DcConvention::SeriesImpedance),
         "matpower" | "mp" => Ok(DcConvention::Matpower),
-        "paper" | "paperpure" | "pure" => Ok(DcConvention::PaperPure),
+        "paper" | "paperpure" | "pure" => Ok(DcConvention::ReactanceOnly),
         other => Err(PyValueError::new_err(format!(
             "unknown convention {other:?}; expected 'series' or 'matpower'"
         ))),

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -2,6 +2,16 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The magnitude below which a reactance, an impedance, or a tap ratio stops
+/// being a number a builder can divide by.
+///
+/// It is `f64::MIN_POSITIVE.sqrt()`: the square of anything smaller underflows
+/// to zero, and the reciprocal is above 1e153, which annihilates every real
+/// branch sharing its diagonal. Each builder compares a magnitude against it —
+/// `|x|`, `hypot(r, x)`, the tap — never `r² + x²`, which is a square. Per unit
+/// reactances run from 1e-6 to 10, so it rejects poison and nothing else.
+pub const MIN_DIVISIBLE_MAGNITUDE: f64 = 1.491_668_146_240_041_3e-154;
+
 /// Rule for the DC branch susceptance `b`.
 ///
 /// `b` is positive for an inductive branch, the DC model convention MATPOWER

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -16,7 +16,7 @@ pub enum DcConvention {
         since = "0.9.0",
         note = "use `SeriesImpedance`, which is the same rule with resistance included, or `Matpower`; removed in 1.0.0"
     )]
-    PaperPure,
+    ReactanceOnly,
     /// `b = 1/(x tau)` with phase shift injections, matching MATPOWER
     /// `makeBdc`.
     Matpower,
@@ -31,6 +31,12 @@ pub enum DcConvention {
 }
 
 impl DcConvention {
+    /// The 0.8 spelling of [`Self::ReactanceOnly`], which named neither the
+    /// tool nor the formula.
+    #[deprecated(since = "0.9.0", note = "renamed to `ReactanceOnly`; removed in 1.0.0")]
+    #[allow(deprecated, non_upper_case_globals)]
+    pub const PaperPure: Self = Self::ReactanceOnly;
+
     /// The branch susceptance from resistance, reactance, and effective tap.
     /// Only [`Self::Matpower`] reads the tap, and only
     /// [`Self::SeriesImpedance`] reads the resistance.
@@ -38,7 +44,7 @@ impl DcConvention {
     #[allow(deprecated)]
     pub fn branch_susceptance(self, resistance: f64, reactance: f64, effective_tap: f64) -> f64 {
         match self {
-            Self::PaperPure => 1.0 / reactance,
+            Self::ReactanceOnly => 1.0 / reactance,
             Self::Matpower => 1.0 / (reactance * effective_tap),
             Self::SeriesImpedance => reactance / (resistance * resistance + reactance * reactance),
         }
@@ -49,7 +55,7 @@ impl DcConvention {
     #[allow(deprecated)]
     pub fn includes_phase_shifts(self) -> bool {
         match self {
-            Self::PaperPure => false,
+            Self::ReactanceOnly => false,
             Self::Matpower | Self::SeriesImpedance => true,
         }
     }

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -12,18 +12,22 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 pub enum DcConvention {
     /// `b = 1/x`, ignoring transformer taps and phase shifts.
+    ///
+    /// The serde alias keeps the 0.8 spelling readable, so a manifest or an
+    /// instance written before the rename still deserializes.
     #[deprecated(
         since = "0.9.0",
         note = "use `SeriesImpedance`, which is the same rule with resistance included, or `Matpower`; removed in 1.0.0"
     )]
+    #[serde(alias = "PaperPure")]
     ReactanceOnly,
     /// `b = 1/(x tau)` with phase shift injections, matching MATPOWER
     /// `makeBdc`.
     Matpower,
     /// `b = x/(r² + x²)` with phase shift injections.
     ///
-    /// Reads the whole series impedance and not the reactance alone, so it
-    /// describes a branch with a real r/x ratio. A transformer tap does not
+    /// Reads the whole series impedance, so it describes a branch with a real
+    /// r/x ratio. A transformer tap does not
     /// scale it, and it reduces to `1/x` when the resistance is zero.
     /// PowerModels' DC formulation uses the same quantity.
     #[default]

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -2,47 +2,45 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Electrical convention used for DC branch coefficients.
+/// Rule for the DC branch susceptance `b`.
 ///
-/// Every variant states the series susceptance `b`, which is negative for an
-/// inductive branch. This is the sign PowerModels `calc_branch_y` gives, and
-/// the caller that assembles a matrix negates it: powerio's bus susceptance
-/// matrix takes the M-matrix form, with negative off diagonal entries and
-/// positive diagonals.
+/// `b` is positive for an inductive branch, the DC model convention MATPOWER
+/// `makeBdc` uses. It is the edge weight of the bus susceptance matrix and the
+/// coefficient in `f = b (theta_from - theta_to)`. The AC series susceptance
+/// `Im(1/(r + jx))` is its negation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum DcConvention {
-    /// Use `b = -1/x` and ignore transformer taps and phase shifts.
+    /// `b = 1/x`, ignoring transformer taps and phase shifts.
     #[deprecated(
         since = "0.9.0",
         note = "use `SeriesImpedance`, which is the same rule with resistance included, or `Matpower`; removed in 1.0.0"
     )]
     PaperPure,
-    /// Use `b = -1/(x tau)` and include phase shift injections, matching
-    /// MATPOWER `makeBdc`.
+    /// `b = 1/(x tau)` with phase shift injections, matching MATPOWER
+    /// `makeBdc`.
     Matpower,
-    /// Use `b = -x/(r² + x²)` and include phase shift injections.
+    /// `b = x/(r² + x²)` with phase shift injections.
     ///
-    /// This is `Im(1/(r + jx))`, the branch's own series susceptance, so it
-    /// reads the whole series impedance and not the reactance alone. It
-    /// reduces to `-1/x` when the resistance is zero. A transformer tap does
-    /// not scale it. Equivalent to PowerModels `calc_branch_y`, whose DC
-    /// formulation uses the same quantity.
+    /// Reads the whole series impedance and not the reactance alone, so it
+    /// describes a branch with a real r/x ratio. A transformer tap does not
+    /// scale it, and it reduces to `1/x` when the resistance is zero.
+    /// PowerModels' DC formulation uses the same quantity.
     #[default]
     SeriesImpedance,
 }
 
 impl DcConvention {
-    /// The series susceptance `b` from resistance, reactance, and effective
-    /// tap. Negative for an inductive branch. Only [`Self::Matpower`] reads
-    /// the tap, and only [`Self::SeriesImpedance`] reads the resistance.
+    /// The branch susceptance from resistance, reactance, and effective tap.
+    /// Only [`Self::Matpower`] reads the tap, and only
+    /// [`Self::SeriesImpedance`] reads the resistance.
     #[must_use]
     #[allow(deprecated)]
-    pub fn series_susceptance(self, resistance: f64, reactance: f64, effective_tap: f64) -> f64 {
+    pub fn branch_susceptance(self, resistance: f64, reactance: f64, effective_tap: f64) -> f64 {
         match self {
-            Self::PaperPure => -1.0 / reactance,
-            Self::Matpower => -1.0 / (reactance * effective_tap),
-            Self::SeriesImpedance => -reactance / (resistance * resistance + reactance * reactance),
+            Self::PaperPure => 1.0 / reactance,
+            Self::Matpower => 1.0 / (reactance * effective_tap),
+            Self::SeriesImpedance => reactance / (resistance * resistance + reactance * reactance),
         }
     }
 
@@ -64,49 +62,23 @@ mod tests {
     /// A resistanceless branch reads the same under both live conventions, so
     /// the new default only moves a case that carries resistance.
     #[test]
-    fn series_impedance_reduces_to_minus_one_over_x() {
-        let b = DcConvention::SeriesImpedance.series_susceptance(0.0, 0.25, 1.0);
-        assert!((b + 4.0).abs() < 1e-12);
+    fn series_impedance_reduces_to_one_over_x() {
+        let b = DcConvention::SeriesImpedance.branch_susceptance(0.0, 0.25, 1.0);
+        assert!((b - 4.0).abs() < 1e-12);
     }
 
-    /// `b = Im(1/(r + jx))` is negative for an inductive branch, the sign
-    /// PowerModels `calc_branch_y` gives.
+    /// Resistance lowers the susceptance, by more as `r` grows against `x`.
     #[test]
-    fn series_impedance_is_negative_for_an_inductive_branch() {
-        let b = DcConvention::SeriesImpedance.series_susceptance(0.01, 0.1, 1.0);
-        assert!(b < 0.0, "b = {b}");
-        assert!((b + 0.1 / (0.0001 + 0.01)).abs() < 1e-12);
-    }
-
-    /// Every live convention agrees on the sign, so a caller that negates once
-    /// cannot pick up a matrix of the wrong sign from the choice of variant.
-    #[test]
-    fn every_convention_agrees_on_the_sign() {
-        #[allow(deprecated)]
-        let all = [
-            DcConvention::PaperPure,
-            DcConvention::Matpower,
-            DcConvention::SeriesImpedance,
-        ];
-        for convention in all {
-            let b = convention.series_susceptance(0.01, 0.1, 1.0);
-            assert!(b < 0.0, "{convention:?} gave {b}");
-        }
-    }
-
-    /// Resistance moves the susceptance toward zero, by more as `r` grows
-    /// against `x`.
-    #[test]
-    fn resistance_lowers_the_susceptance_magnitude() {
-        let lossless = DcConvention::SeriesImpedance.series_susceptance(0.0, 0.1, 1.0);
-        let lossy = DcConvention::SeriesImpedance.series_susceptance(0.1, 0.1, 1.0);
-        assert!(lossy.abs() < lossless.abs());
-        assert!((lossy + 5.0).abs() < 1e-12);
+    fn resistance_lowers_the_susceptance() {
+        let lossless = DcConvention::SeriesImpedance.branch_susceptance(0.0, 0.1, 1.0);
+        let lossy = DcConvention::SeriesImpedance.branch_susceptance(0.1, 0.1, 1.0);
+        assert!(lossy < lossless);
+        assert!((lossy - 5.0).abs() < 1e-12);
     }
 
     #[test]
     fn matpower_scales_by_the_tap() {
-        let b = DcConvention::Matpower.series_susceptance(0.01, 0.2, 2.0);
-        assert!((b + 2.5).abs() < 1e-12);
+        let b = DcConvention::Matpower.branch_susceptance(0.01, 0.2, 2.0);
+        assert!((b - 2.5).abs() < 1e-12);
     }
 }

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -456,18 +456,21 @@ fn read_bus(r: &Row) -> Result<Bus> {
     let mut extras = Extras::new();
     // `SubNum` stays in extras: it is identity rather than geometry, and the
     // substation join reads it back.
-    let location = bus_location(r);
+    let promoted = bus_location(r);
+    let location = promoted.map(|(location, _)| location);
     keep_extras(
         r,
         &["SubNum", "SubNumber", "OwnerNum", "OwnerNumber", "BANumber"],
         &mut extras,
     );
-    if location.is_none() {
-        keep_extras(
-            r,
-            &["Latitude:1", "Longitude:1", "Latitude", "Longitude"],
-            &mut extras,
-        );
+    // Only the pair that promoted leaves extras. A complete case export
+    // carries both pairs, and the one the location did not come from is
+    // unmodeled data like any other column.
+    let used = promoted.map_or([""; 2], |(_, pair)| pair);
+    for key in ["Latitude:1", "Longitude:1", "Latitude", "Longitude"] {
+        if !used.contains(&key) {
+            keep_extras(r, &[key], &mut extras);
+        }
     }
     Ok(Bus {
         id: BusId(id),
@@ -491,19 +494,31 @@ fn read_bus(r: &Row) -> Result<Bus> {
     })
 }
 
-/// The promoted geographic location: the substation `Latitude:1`/
-/// `Longitude:1` pair, else the bus's own bare `Latitude`/`Longitude` pair
-/// (older complete case exports), when both parse finite.
-fn bus_location(r: &Row) -> Option<crate::geo::Location> {
-    let lat = first(r, &["Latitude:1", "Latitude"])?.parse::<f64>().ok()?;
-    let lon = first(r, &["Longitude:1", "Longitude"])?
-        .parse::<f64>()
-        .ok()?;
-    (lat.is_finite() && lon.is_finite()).then_some(crate::geo::Location {
-        x: lon,
-        y: lat,
-        kind: None,
-    })
+/// The promoted geographic location and the column pair it came from: the
+/// substation `Latitude:1`/`Longitude:1` pair, else the bus's own bare
+/// `Latitude`/`Longitude` pair (older complete case exports). A pair promotes
+/// only when both of its own columns parse finite, so a half filled pair never
+/// pairs a latitude with the other pair's longitude.
+fn bus_location(r: &Row) -> Option<(crate::geo::Location, [&'static str; 2])> {
+    for pair in [["Latitude:1", "Longitude:1"], ["Latitude", "Longitude"]] {
+        let (Some(lat), Some(lon)) = (
+            first(r, &pair[..1]).and_then(|v| v.parse::<f64>().ok()),
+            first(r, &pair[1..]).and_then(|v| v.parse::<f64>().ok()),
+        ) else {
+            continue;
+        };
+        if lat.is_finite() && lon.is_finite() {
+            return Some((
+                crate::geo::Location {
+                    x: lon,
+                    y: lat,
+                    kind: None,
+                },
+                pair,
+            ));
+        }
+    }
+    None
 }
 
 fn read_load(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Load> {

--- a/powerio/src/format/powerworld/tests.rs
+++ b/powerio/src/format/powerworld/tests.rs
@@ -209,6 +209,39 @@ fn bare_bus_latitude_and_longitude_promote_into_the_location() {
 }
 
 #[test]
+// Exact decimal fractions parsed from the fixture; bit equality is the assertion.
+#[allow(clippy::float_cmp)]
+fn a_bus_row_promotes_one_coordinate_pair_and_keeps_the_other() {
+    // A complete case export carries both pairs. The substation pair wins,
+    // and the bus's own pair stays in extras as unmodeled data.
+    let net = parse_powerworld(
+        "DATA (Bus, [BusNum, Latitude:1, Longitude:1, Latitude, Longitude])\n\
+         {\n1 34.2 -80.05 30.1 -90.5\n2 \"\" -80.10 34.4 -80.20\n}\n",
+    )
+    .unwrap();
+    let location = net.buses[0].location.expect("bus 1 location");
+    assert_eq!((location.x, location.y), (-80.05, 34.2));
+    assert_eq!(
+        net.buses[0].extras.get("Latitude").and_then(|v| v.as_str()),
+        Some("30.1")
+    );
+    assert!(!net.buses[0].extras.contains_key("Latitude:1"));
+
+    // Half of the substation pair promotes nothing from that pair, so the
+    // bus's own pair promotes whole. Mixing the two would place the bus at
+    // the substation's longitude.
+    let location = net.buses[1].location.expect("bus 2 location");
+    assert_eq!((location.x, location.y), (-80.20, 34.4));
+    assert_eq!(
+        net.buses[1]
+            .extras
+            .get("Longitude:1")
+            .and_then(|v| v.as_str()),
+        Some("-80.10")
+    );
+}
+
+#[test]
 // Exact kV values parsed from the fixture; bit equality is the assertion.
 #[allow(clippy::float_cmp)]
 fn writer_sanitizes_bus_names_that_would_corrupt_a_value() {

--- a/powerio/src/geo/layer.rs
+++ b/powerio/src/geo/layer.rs
@@ -286,9 +286,6 @@ const LAT_ALIASES: &[&str] = &["lat", "latitude", "y"];
 const LON_ALIASES: &[&str] = &["lon", "lng", "longitude", "x"];
 const FROM_ALIASES: &[&str] = &["fbus", "from", "frombus"];
 const TO_ALIASES: &[&str] = &["tbus", "to", "tobus"];
-/// No bare `id`: GIS exports and RFC 7946 tooling write a feature row counter
-/// there, and a bare integer id is read as a positional row alias, so a
-/// counter would place the route on an unrelated branch.
 const BRANCH_ID_ALIASES: &[&str] = &["branch", "branchid", "branchnumber", "catsid"];
 const PATH_ALIASES: &[&str] = &["path", "geometry", "coordinates"];
 const FROM_LAT_ALIASES: &[&str] = &["lat1", "fromlat"];
@@ -464,7 +461,14 @@ fn point_key(record: &Record) -> ElementKey {
 /// Key for a branch record. A bare unsigned integer id is a positional row
 /// alias (read only); everything else matches by string id or name.
 fn branch_key(record: &Record) -> ElementKey {
-    let id = record.string(BRANCH_ID_ALIASES);
+    // GIS exports and RFC 7946 tooling write a feature row counter under `id`,
+    // which would place the route on an unrelated branch. A named identifier
+    // there still matches a uid, so only the integer case is dropped.
+    let id = record.string(BRANCH_ID_ALIASES).or_else(|| {
+        record
+            .string(&["id"])
+            .filter(|raw| raw.parse::<usize>().is_err())
+    });
     let index = id
         .as_deref()
         .and_then(|raw| raw.parse::<usize>().ok())

--- a/powerio/src/geo/pwd.rs
+++ b/powerio/src/geo/pwd.rs
@@ -53,18 +53,12 @@ pub fn geo_layer_from_pwd(display: &PwdDisplay) -> GeoLayer {
         features: display
             .substations
             .iter()
-            .map(|substation| GeoFeature {
-                target: GeoTarget::Substation,
-                key: ElementKey {
-                    uid: None,
-                    id: Some(substation.number.to_string()),
-                    name: (!substation.name.is_empty()).then(|| substation.name.clone()),
-                    index: None,
-                },
-                geometry: GeoGeometry::Point([substation.x, substation.y]),
-                from: None,
-                to: None,
-                kind: None,
+            .map(|substation| {
+                substation_feature(
+                    substation_key(&substation.number.to_string()),
+                    (!substation.name.is_empty()).then(|| substation.name.clone()),
+                    [substation.x, substation.y],
+                )
             })
             .collect(),
     }
@@ -101,19 +95,7 @@ pub fn geo_layer_from_aux_substations(aux: &AuxFile) -> GeoLayer {
             else {
                 continue;
             };
-            features.push(GeoFeature {
-                target: GeoTarget::Substation,
-                key: ElementKey {
-                    uid: None,
-                    id: Some(substation_key(number)),
-                    name: None,
-                    index: None,
-                },
-                geometry: GeoGeometry::Point([lon, lat]),
-                from: None,
-                to: None,
-                kind: None,
-            });
+            features.push(substation_feature(substation_key(number), None, [lon, lat]));
         }
     }
     GeoLayer {
@@ -196,6 +178,24 @@ fn bus_substation(bus: &crate::network::Bus) -> Option<String> {
             (!trimmed.is_empty()).then(|| substation_key(trimmed))
         }
         _ => None,
+    }
+}
+
+/// One substation point, keyed for [`apply_substation_points`]. Every
+/// substation source builds its features through this.
+fn substation_feature(id: String, name: Option<String>, point: [f64; 2]) -> GeoFeature {
+    GeoFeature {
+        target: GeoTarget::Substation,
+        key: ElementKey {
+            uid: None,
+            id: Some(id),
+            name,
+            index: None,
+        },
+        geometry: GeoGeometry::Point(point),
+        from: None,
+        to: None,
+        kind: None,
     }
 }
 

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -828,6 +828,22 @@ impl Branch {
         if self.tap == 0.0 { 1.0 } else { self.tap }
     }
 
+    /// [`effective_tap`](Self::effective_tap) for a builder that divides by it,
+    /// which the remap of an exact 0.0 does not make safe on its own.
+    ///
+    /// # Errors
+    /// [`Error::DegenerateTap`] under
+    /// [`MIN_DIVISIBLE_MAGNITUDE`](crate::dc::MIN_DIVISIBLE_MAGNITUDE), where a
+    /// tap scales an admittance past anything a matrix can carry. `row` only
+    /// labels the error.
+    pub fn divisible_tap(&self, row: usize) -> Result<f64> {
+        let tap = self.effective_tap();
+        if !tap.is_finite() || tap.abs() < crate::dc::MIN_DIVISIBLE_MAGNITUDE {
+            return Err(Error::DegenerateTap { row, tap });
+        }
+        Ok(tap)
+    }
+
     /// Per terminal shunt admittance, deriving the legacy symmetric MATPOWER
     /// charging model when the richer field is absent.
     #[must_use]
@@ -839,18 +855,21 @@ impl Branch {
     /// Series admittance `(g, b) = (r, −x) / (r² + x²)` of the branch pi
     /// model, the primitive beside [`effective_tap`](Self::effective_tap) and
     /// [`terminal_charging`](Self::terminal_charging). `Ok(None)` for a zero
-    /// impedance branch (`r² + x² = 0`); the caller decides whether that is a
-    /// skip or an error.
+    /// impedance branch — one whose impedance magnitude is under
+    /// [`MIN_DIVISIBLE_MAGNITUDE`](crate::dc::MIN_DIVISIBLE_MAGNITUDE); the
+    /// caller decides whether that is a skip or an error.
     ///
     /// # Errors
     /// [`Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad
     /// value cannot write NaN or a silent zero downstream. `row` only labels
     /// the error.
     pub fn series_admittance(&self, row: usize) -> Result<Option<(f64, f64)>> {
-        let denom = self.r * self.r + self.x * self.x;
-        if denom == 0.0 {
+        // The bound is on the impedance magnitude; `denom` is its square, and
+        // bounding that would refuse impedances the DC builders divide by.
+        if self.r.hypot(self.x) < crate::dc::MIN_DIVISIBLE_MAGNITUDE {
             return Ok(None);
         }
+        let denom = self.r * self.r + self.x * self.x;
         if !denom.is_finite() {
             return Err(Error::NonFiniteSusceptance { row });
         }

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -178,6 +178,9 @@ impl GenCost {
         if self.coeffs.len() < self.ncost {
             return None;
         }
+        // Matches on the stated arity, so a cubic row is refused even when its
+        // leading coefficient is zero. `quadratic_with_constant_tol` is the
+        // reader that lowers the order first.
         match self.ncost {
             3 => Some((2.0 * self.coeffs[0], self.coeffs[1], self.coeffs[2])),
             2 => Some((0.0, self.coeffs[0], self.coeffs[1])),

--- a/powerio/tests/geo_layer.rs
+++ b/powerio/tests/geo_layer.rs
@@ -160,6 +160,23 @@ fn a_capitalized_target_reads_as_a_substation() {
 }
 
 #[test]
+fn a_named_feature_id_still_matches_a_branch_uid() {
+    // Dropping the counter case must not drop the whole key: a foreign record
+    // that writes a source uid under `id` matches it.
+    let text = r#"[{"id": "tie-a", "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}]"#;
+    let parsed = parse(text.as_bytes(), None);
+    let feature = &parsed.layer.features[0];
+    assert_eq!(feature.target, GeoTarget::Branch);
+    assert_eq!(feature.key.index, None);
+
+    let mut net = small_network();
+    net.branches[0].uid = Some("tie-a".to_owned());
+    let report = net.apply_geo_layer(&parsed.layer);
+    assert_eq!(report.matched_branches, 1);
+    assert!(net.branches[0].route.is_some());
+}
+
+#[test]
 fn positional_branch_id_is_a_read_only_row_alias() {
     let text = r#"[{"branch": 1, "lat1": 34.2, "lon1": -80.05, "lat2": 34.3, "lon2": -80.1}]"#;
     let parsed = parse(text.as_bytes(), None);


### PR DESCRIPTION
The seven commits a review of the six branches below produced. They cut across four of those branches each, so they cannot be split back into them without inventing an arrangement that was never built or tested. They are reviewed here as one unit.

- **`matrix: state the DC susceptance once, positive`** — `series_susceptance` becomes `branch_susceptance` and returns a positive Laplacian edge weight, so the two assembly callers stop negating and the sign is stated in one place.
- **`prob: make the device class layout one type, and name the DC rule`** — the SCOPF device class layout becomes one type instead of parallel fields, and `DcConvention::PaperPure` becomes `ReactanceOnly`, which names the formula rather than a paper. `PaperPure` survives as a deprecated const with a serde alias and is removed in 1.0.0.
- **`prob: repair the defects the v0.9.0 review found`** — the substantive fixes, including `powerio-prob/src/limits.rs` and the PowerWorld map.
- **`prob: read a rounding artifact as a linear curve when costs combine`** and **`prob: read a cost row one way in both spaces`** — the leading coefficient tolerance is applied in generator space and bus space alike, so aggregation and the single generator path agree on what a 1e-17 quadratic term means.
- **`core: state the divisible bound once, and divide by a bounded tap`** — `Branch::divisible_tap(idx)` replaces the guard each builder wrote for itself, so Y_bus, the incidence build and both instance builders apply one bound.
- **`geo: drop the counter case of a bare `id`, not the whole key`** — narrows the branch key change in #315 to the case that motivated it.

Top of the v0.9.0 stack, on top of #315.

Verified on this branch: `cargo fmt --all --check`, `scripts/ci-clippy.sh`, `scripts/capi-header-parity.sh`, and `cargo test --workspace --exclude powerio-py` at 51 binaries and 1262 tests, zero failures.


Closes #292. #310 covers four of its five items; the third location in its item 4, `Branch::series_admittance` in `powerio/src/network.rs`, was still on the exact-zero `denom == 0.0` test until this branch bounded it on impedance magnitude like the other two. AC OPF instance building reaches that function, so the issue is not finished until this merges.
