### PR TITLE
core: one version number in every document powerio authors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ powerio-matrix/               # matrices + graph views on powerio
 powerio-prob/                 # problem instances on powerio
 ├── src/dc.rs                # DcOpfInstance, build_dc_opf_instance
 ├── src/ac.rs                # AcOpfInstance, build_ac_opf_instance
-├── src/scopf/               # ScopfInstance, GOC3 projection, versioned wire
+├── src/scopf/               # ScopfInstance, GOC3 projection, Julia document
 └── src/matrix/bundle.rs     # DC OPF bundle directory + manifest (feature = "matrix")
 
 powerio-dist/                 # multiconductor distribution model (no powerio dep)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossterm",
+ "powerio",
  "powerio-dist",
  "powerio-matrix",
  "powerio-pkg",

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -1,14 +1,18 @@
 # Published JSON Schema documents
 
-Each directory is a schema identifier path. `pio-package/0.2/schema.json` is the
-current `.pio.json` document schema and the only one
+Each directory is a schema identifier path, named for the powerio lineage that
+serves it: `0.9` while the major is 0, `1` afterwards. The current one is the
+only document
 `cargo run -p powerio-pkg --example generate_schemas --features schema -- docs/schema`
-emits; `rust.yml` regenerates it on every pull request and fails on a diff.
+emits; `rust.yml` regenerates it on every pull request and fails on a diff. The
+path moves when and only when a document stops loading, which is the same rule
+the reader applies to `powerio_version`.
 
 ## Retired lineages are still served
 
-`pio-package/0.1/`, `pio-payload-balanced/1/`, and `pio-payload-multiconductor/1/`
-are frozen copies of the v0.7.x documents. **Do not delete them.**
+`pio-package/0.1/`, `pio-package/0.2/`, `pio-payload-balanced/1/`, and
+`pio-payload-multiconductor/1/` are frozen copies of what earlier releases
+published. **Do not delete them.**
 
 A `.pio.json` written before v0.8.0 carries these identifiers as literal field
 values:

--- a/docs/schema/pio-package/0.8/schema.json
+++ b/docs/schema/pio-package/0.8/schema.json
@@ -1,0 +1,5038 @@
+{
+  "$defs": {
+    "ActivePowerReference": {
+      "enum": [
+        "P_AVAILABLE",
+        "P_MAX",
+        "S_MAX"
+      ],
+      "type": "string"
+    },
+    "ActivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "W"
+      ],
+      "type": "string"
+    },
+    "Area": {
+      "description": "An area record: the area's scheduled net interchange and its swing bus.\n\nThe [`number`](Area::number) matches the `area` field carried on each\n[`Bus`]; this table holds the per-area metadata (the interchange target and\nthe area slack) that the bus number alone can't. Maps to the PSS/E area record\n(`I, ISW, PDES, PTOL, ARNAME`).",
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "net_interchange": {
+          "description": "Scheduled net interchange (MW); positive is export out of the area.",
+          "format": "double",
+          "type": "number"
+        },
+        "number": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "slack_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The area swing (slack) bus, or `None` when unset."
+        },
+        "tolerance": {
+          "description": "Interchange tolerance bandwidth (MW).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "number",
+        "net_interchange",
+        "tolerance"
+      ],
+      "type": "object"
+    },
+    "Branch": {
+      "properties": {
+        "angmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "angmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "b": {
+          "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
+          "format": "double",
+          "type": "number"
+        },
+        "charging": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCharging"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Per terminal shunt admittance (p.u.). If absent, derive symmetric\nsusceptance from [`b`](Branch::b)."
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TransformerControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Regulating-transformer control data, when this branch is a transformer\nunder automatic tap or phase control. `None` for lines and for fixed-ratio\ntransformers. `#[serde(default)]` so JSON written before the field existed\nstill deserializes."
+        },
+        "current_ratings": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchCurrentRatings"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Current ratings, when the source distinguishes them from MVA ratings."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "r": {
+          "description": "Series resistance (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "rating_sets": {
+          "default": [],
+          "description": "Additional MVA rating sets beyond A/B/C. Matrix builders continue to use\n`rate_a` unless they opt into one of these named sets.",
+          "items": {
+            "$ref": "#/$defs/BranchRatingSet"
+          },
+          "type": "array"
+        },
+        "route": {
+          "description": "Polyline route in the network's coordinate space (`Network.geo`),\npresent only when a source provides intermediate geometry; endpoint\nonly rendering derives from the bus locations. `#[serde(default)]` so\nJSON written before the field existed still deserializes.",
+          "items": {
+            "$ref": "#/$defs/Location"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "solution": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BranchSolution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solved branch flow values, when present in a case snapshot."
+        },
+        "tap": {
+          "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "description": "Series reactance (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "r",
+        "x",
+        "b",
+        "rate_a",
+        "rate_b",
+        "rate_c",
+        "tap",
+        "shift",
+        "in_service",
+        "angmin",
+        "angmax",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BranchCharging": {
+      "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
+      "properties": {
+        "b_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "b_to": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_fr": {
+          "format": "double",
+          "type": "number"
+        },
+        "g_to": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "g_fr",
+        "b_fr",
+        "g_to",
+        "b_to"
+      ],
+      "type": "object"
+    },
+    "BranchCurrentRatings": {
+      "description": "Current limits for a branch, in source units.",
+      "properties": {
+        "c_rating_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "c_rating_c": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "c_rating_a",
+        "c_rating_b",
+        "c_rating_c"
+      ],
+      "type": "object"
+    },
+    "BranchRatingSet": {
+      "description": "Extra branch MVA rating set beyond the canonical A/B/C columns.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "rate_mva": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "name",
+        "rate_mva"
+      ],
+      "type": "object"
+    },
+    "BranchSolution": {
+      "description": "Solved branch terminal flows in MW/MVAr.",
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf",
+        "qf",
+        "pt",
+        "qt"
+      ],
+      "type": "object"
+    },
+    "Bus": {
+      "properties": {
+        "area": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "base_kv": {
+          "format": "double",
+          "type": "number"
+        },
+        "evhi": {
+          "default": null,
+          "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "evlo": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "id": {
+          "$ref": "#/$defs/BusId",
+          "description": "Stable bus id (1-based in MATPOWER; preserved verbatim)."
+        },
+        "kind": {
+          "$ref": "#/$defs/BusType"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "uid": {
+          "description": "Stable row identity for `.pio.json` payloads and operating point updates:\nthe source record uid where the format defines one (GOC3), synthesized at\npackage build otherwise. `#[serde(default)]` so JSON written before the\nfield existed still deserializes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "va": {
+          "description": "Voltage angle (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "vm": {
+          "description": "Voltage magnitude (p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "vmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "vmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "zone": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "id",
+        "kind",
+        "vm",
+        "va",
+        "base_kv",
+        "vmax",
+        "vmin",
+        "area",
+        "zone",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "BusId": {
+      "description": "A source bus ID, preserved from the input format.\n\nMATPOWER IDs are 1-based and can contain gaps. They are distinct from the\nzero based dense indices produced by\n[`IndexedNetwork::bus_index`](crate::IndexedNetwork::bus_index). JSON stores\nthis type as an integer.",
+      "format": "uint",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "BusType": {
+      "description": "Bus type per MATPOWER convention: 1=PQ, 2=PV, 3=ref/slack, 4=isolated.",
+      "enum": [
+        "PQ",
+        "PV",
+        "REF",
+        "ISOLATED"
+      ],
+      "type": "string"
+    },
+    "Canvas": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Canvas2": {
+      "description": "Diagram canvas metadata.",
+      "properties": {
+        "height": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "units": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "width": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Confidence": {
+      "description": "How confident the source map entry is.",
+      "enum": [
+        "exact",
+        "high",
+        "medium",
+        "low"
+      ],
+      "type": "string"
+    },
+    "Configuration": {
+      "enum": [
+        "wye",
+        "delta",
+        "single_phase"
+      ],
+      "type": "string"
+    },
+    "ControlVoltageReference": {
+      "enum": [
+        "PN_PER_PHASE",
+        "PP_PER_PHASE",
+        "PP_AVERAGED",
+        "PG_AVERAGED",
+        "PN_AVERAGED",
+        "PG_PER_PHASE"
+      ],
+      "type": "string"
+    },
+    "CoordsKind": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
+      ],
+      "type": "string"
+    },
+    "CoordsKind2": {
+      "description": "Coordinate provenance.",
+      "enum": [
+        "source",
+        "synthetic",
+        "manual",
+        "derived"
+      ],
+      "type": "string"
+    },
+    "DerivedMetadata": {
+      "description": "Optional derived metadata: matrix statistics, solver table metadata, and\ncache keys.\nEmpty by default; the scaffold never populates it.",
+      "properties": {
+        "cache_keys": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "matrix_stats": true,
+        "normalized_solver_tables": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NormalizedSolverTableMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "DiagnosticCode": {
+      "description": "A stable, dotted diagnostic code, e.g. `EMIT.PSSE.DROP_ANGLE_LIMITS`.\n\nThe leading segment is the namespace and names the stage family:\n`PARSE`, `READ`, `IR`, `VALIDATE`, `FIDELITY`, `LOWER`, `EMIT`, `BINDING`,\n`PARTNER`, `PERF`. The conventional shape is `NAMESPACE.SOURCE_OR_TARGET.SPECIFIC`.",
+      "type": "string"
+    },
+    "DiagnosticSeverity": {
+      "description": "Severity, ordered worst-last so [`Ord`] gives the dominant severity of a set.",
+      "oneOf": [
+        {
+          "const": "debug",
+          "description": "Useful in development; normally hidden.",
+          "type": "string"
+        },
+        {
+          "const": "info",
+          "description": "A provenance or normalization event worth recording.",
+          "type": "string"
+        },
+        {
+          "const": "warning",
+          "description": "Usable, but semantics were defaulted, approximated, lost, or the target\nis incomplete.",
+          "type": "string"
+        },
+        {
+          "const": "error",
+          "description": "The package exists but the model is not valid for the intended use\nwithout repair.",
+          "type": "string"
+        },
+        {
+          "const": "fatal",
+          "description": "The package could not be produced.",
+          "type": "string"
+        }
+      ]
+    },
+    "DiagnosticStage": {
+      "description": "The compiler stage that emitted a diagnostic.",
+      "enum": [
+        "parse",
+        "read",
+        "canonicalize",
+        "validate",
+        "lower",
+        "emit",
+        "bind",
+        "partner"
+      ],
+      "type": "string"
+    },
+    "DistBus": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "grounded": {
+          "description": "Terminals tied to ground with zero impedance.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Location2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Optional bus coordinates in the network coordinate space."
+        },
+        "terminals": {
+          "description": "Ordered terminal names; OpenDSS node numbers as strings.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "v_min": {
+          "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vn_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vneg_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vpn_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpn_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpos_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vpos_min": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "vpp_max": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vpp_min": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "vzero_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "terminals",
+        "grounded",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistCapacitor": {
+      "description": "A rated capacitor bank (BMOPF schema 0.1.0 `capacitor`): `q_rated` vars\ndelivered at `v_nom` volts across the element terminals, distinct from the\nraw admittance [`DistShunt`]. The DSS converter still lowers OpenDSS\ncapacitors to shunt B matrices; this element carries capacitors that arrive\nas BMOPF input.",
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "q_rated": {
+          "description": "Nameplate rated reactive power of the whole bank, vars.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_nom": {
+          "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "q_rated",
+        "v_nom",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistControlProfile": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "power_factor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PowerFactorControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_var": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltVarControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "volt_watt": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VoltWattControl"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistGenerator": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "cost": {
+          "description": "$/kWh; no OpenDSS equivalent, so it is None until a format supplies it.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_max": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "default": null,
+          "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_nom": {
+          "description": "Setpoint, watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_max": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_nom": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "s_max": {
+          "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistIbr": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "control_profile": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "default": null,
+          "description": "Per conductor current limits, amperes.",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_avail": {
+          "description": "Available active power, watts.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_max": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "p_min": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "prime_mover": {
+          "$ref": "#/$defs/IbrPrimeMover"
+        },
+        "q_max": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "q_min": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "s_max": {
+          "description": "Per phase apparent power nameplate ratings, volt amperes.",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "topology": {
+          "$ref": "#/$defs/IbrTopology"
+        },
+        "voltage_aggregation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IbrVoltageAggregation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "topology",
+        "prime_mover",
+        "s_max",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLine": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "length": {
+          "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "linecode": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "route": {
+          "description": "Polyline route in the network's coordinate space (`DistNetwork.geo`),\npresent only when a source provides intermediate geometry.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes.",
+          "items": {
+            "$ref": "#/$defs/Location2"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "s_max": {
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "linecode",
+        "length",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLineCode": {
+      "properties": {
+        "b_from": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "b_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g_from": {
+          "description": "Shunt admittance halves at each end, S per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "g_to": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "i_max": {
+          "default": null,
+          "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "n_conductors": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "r_series": {
+          "description": "Series impedance, ohm per meter.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "s_max": {
+          "default": null,
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "source": {
+          "description": "Provenance of the impedance matrices (BMOPF `source`, e.g. \"fem\",\n\"datasheet\", \"import\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x_series": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "n_conductors",
+        "r_series",
+        "x_series",
+        "g_from",
+        "b_from",
+        "g_to",
+        "b_to",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoad": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "configuration": {
+          "$ref": "#/$defs/Configuration"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "p_nom": {
+          "description": "Watts per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_nom": {
+          "description": "Vars per phase.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "voltage_model": {
+          "$ref": "#/$defs/DistLoadVoltageModel"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "configuration",
+        "p_nom",
+        "q_nom",
+        "voltage_model",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistLoadVoltageModel": {
+      "oneOf": [
+        {
+          "description": "Constant power load. `v_nom` is volts per active phase when the source\nstates it.",
+          "properties": {
+            "model": {
+              "const": "constant_power",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant current load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_current",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Constant impedance load. `v_nom` is volts per active phase.",
+          "properties": {
+            "model": {
+              "const": "constant_impedance",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load coefficients by active phase. `v_nom` is volts per active\nphase; alpha terms apply to active power and beta terms to reactive\npower.",
+          "properties": {
+            "alpha_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "alpha_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_i": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "beta_z": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "zip",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "alpha_z",
+            "alpha_i",
+            "alpha_p",
+            "beta_z",
+            "beta_i",
+            "beta_p"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model by active phase. `v_nom` is volts per active\nphase.",
+          "properties": {
+            "gamma_p": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "gamma_q": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "model": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "v_nom": {
+              "items": {
+                "format": "double",
+                "type": "number"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "model",
+            "v_nom",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "DistNetwork": {
+      "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
+      "properties": {
+        "base_frequency": {
+          "description": "Hz.",
+          "format": "double",
+          "type": "number"
+        },
+        "buses": {
+          "items": {
+            "$ref": "#/$defs/DistBus"
+          },
+          "type": "array"
+        },
+        "capacitors": {
+          "items": {
+            "$ref": "#/$defs/DistCapacitor"
+          },
+          "type": "array"
+        },
+        "commands": {
+          "description": "Source commands and options the typed model does not interpret\n(`solve`, `set mode=...`), in order, as (verb, args).",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "control_profiles": {
+          "items": {
+            "$ref": "#/$defs/DistControlProfile"
+          },
+          "type": "array"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "generators": {
+          "items": {
+            "$ref": "#/$defs/DistGenerator"
+          },
+          "type": "array"
+        },
+        "geo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GeoMeta2"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ibrs": {
+          "items": {
+            "$ref": "#/$defs/DistIbr"
+          },
+          "type": "array"
+        },
+        "linecodes": {
+          "items": {
+            "$ref": "#/$defs/DistLineCode"
+          },
+          "type": "array"
+        },
+        "lines": {
+          "items": {
+            "$ref": "#/$defs/DistLine"
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "$ref": "#/$defs/DistLoad"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "options": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "shunts": {
+          "items": {
+            "$ref": "#/$defs/DistShunt"
+          },
+          "type": "array"
+        },
+        "source_format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DistSourceFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sources": {
+          "description": "BMOPF allows exactly one; the model allows any number and the BMOPF\nwriter warns beyond the first.",
+          "items": {
+            "$ref": "#/$defs/VoltageSource"
+          },
+          "type": "array"
+        },
+        "switches": {
+          "items": {
+            "$ref": "#/$defs/DistSwitch"
+          },
+          "type": "array"
+        },
+        "transformers": {
+          "items": {
+            "$ref": "#/$defs/DistTransformer"
+          },
+          "type": "array"
+        },
+        "untyped": {
+          "items": {
+            "$ref": "#/$defs/UntypedObject"
+          },
+          "type": "array"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "base_frequency",
+        "buses",
+        "linecodes",
+        "lines",
+        "switches",
+        "transformers",
+        "loads",
+        "generators",
+        "shunts",
+        "sources",
+        "untyped",
+        "commands",
+        "options",
+        "warnings",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistShunt": {
+      "properties": {
+        "b": {
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Total siemens in conductor order.",
+          "items": {
+            "items": {
+              "format": "double",
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "g",
+        "b",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistSourceFormat": {
+      "description": "Where the network came from; fixes the echo tier target.",
+      "enum": [
+        "dss",
+        "bmopf-json",
+        "pmd-json"
+      ],
+      "type": "string"
+    },
+    "DistSwitch": {
+      "properties": {
+        "bus_from": {
+          "type": "string"
+        },
+        "bus_to": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "i_max": {
+          "default": null,
+          "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
+          "items": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "open": {
+          "type": "boolean"
+        },
+        "terminal_map_from": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "terminal_map_to": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus_from",
+        "bus_to",
+        "terminal_map_from",
+        "terminal_map_to",
+        "open",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "DistTransformer": {
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phases": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "windings": {
+          "items": {
+            "$ref": "#/$defs/Winding2"
+          },
+          "type": "array"
+        },
+        "xsc_pct": {
+          "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "windings",
+        "xsc_pct",
+        "phases",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "ElementRef": {
+      "anyOf": [
+        {
+          "properties": {
+            "row": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "row"
+          ]
+        },
+        {
+          "properties": {
+            "source_uid": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "source_uid"
+          ]
+        }
+      ],
+      "description": "A row in one table of the static payload.\n\n`source_uid` is the row's payload identity: when the referenced table\ncarries `uid` values, a present `source_uid` resolves the target row and a\npresent `row` must agree with it. In a table without uids (packages written\nbefore payload identity existed), `source_uid` is advisory and `row`\naddresses the update alone. In the document, `row` may be omitted when\n`source_uid` is given.",
+      "properties": {
+        "row": {
+          "description": "Zero based row index in `table`, when the producer addressed one.\n`None` on refs built by [`ElementRef::by_source_uid`], which address by\nidentity alone.",
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "source_uid": {
+          "description": "The row's payload identity (its `uid` field), when the producer knows it.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "table": {
+          "description": "Payload table name, such as `loads`, `generators`, `branches`, or `hvdc`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "table"
+      ],
+      "type": "object"
+    },
+    "ElementUpdate": {
+      "description": "Field values to apply to one static payload row.",
+      "properties": {
+        "element": {
+          "$ref": "#/$defs/ElementRef",
+          "description": "Table row to update."
+        },
+        "fields": {
+          "additionalProperties": true,
+          "description": "JSON field values to overwrite on that row.",
+          "type": "object"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format for this update.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "element"
+      ],
+      "type": "object"
+    },
+    "GenCost": {
+      "description": "A generator cost curve (`mpc.gencost` row).",
+      "properties": {
+        "coeffs": {
+          "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "model": {
+          "description": "1 = piecewise linear, 2 = polynomial.",
+          "format": "uint8",
+          "maximum": 255,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "ncost": {
+          "description": "Number of cost coefficients (polynomial) or breakpoints (piecewise).",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "shutdown": {
+          "format": "double",
+          "type": "number"
+        },
+        "startup": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "model",
+        "startup",
+        "shutdown",
+        "ncost",
+        "coeffs"
+      ],
+      "type": "object"
+    },
+    "Generator": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "caps": {
+          "additionalProperties": {
+            "format": "double",
+            "type": "number"
+          },
+          "default": {},
+          "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
+          "type": "object"
+        },
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mbase": {
+          "format": "double",
+          "type": "number"
+        },
+        "pg": {
+          "description": "Real power set point (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qg": {
+          "description": "Reactive power set point (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "regulated_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The remote bus whose voltage this generator regulates, when that is not its\nown terminal bus (PSS/E `IREG`). `None` means it regulates its own bus.\nPart of the cross-element voltage-control graph: a format that names a\nremote regulated bus (PSS/E) keeps it across a round trip instead of\ncollapsing every generator onto its own terminal. `#[serde(default)]` so\nJSON written before the field existed still deserializes."
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vg": {
+          "description": "Voltage set point (p.u.).",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "pg",
+        "qg",
+        "pmax",
+        "pmin",
+        "qmax",
+        "qmin",
+        "vg",
+        "mbase",
+        "in_service"
+      ],
+      "type": "object"
+    },
+    "GeoMeta": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
+      "type": "object"
+    },
+    "GeoMeta2": {
+      "description": "Network level coordinate metadata.",
+      "oneOf": [
+        {
+          "description": "x = longitude and y = latitude in decimal degrees. `None` means EPSG:4326.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "geographic",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Planar coordinates, with the CRS named when known.",
+          "properties": {
+            "crs": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "space": {
+              "const": "projected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Drawing coordinates with no earth referent.",
+          "properties": {
+            "canvas": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/Canvas2"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "space": {
+              "const": "diagram",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "The source did not declare a coordinate space.",
+          "properties": {
+            "space": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "space"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Default provenance for points without their own `kind`."
+        }
+      },
+      "type": "object"
+    },
+    "Hvdc": {
+      "description": "A two-terminal HVDC line (MATPOWER `dcline`).\n\n`pf`/`pt`/`qf`/`qt` are stored in MATPOWER's sign convention regardless of\nsource: the PowerModels reader un-flips `pt`/`qf`/`qt` on the way in, and the\nPowerModels writer re-flips them on the way out (PowerModels.jl uses the\nopposite sign). The flip is a format-boundary translation, so a derived view\nlike `to_normalized` keeps the MATPOWER convention and only scales to per unit.",
+      "properties": {
+        "cost": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GenCost"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "loss0": {
+          "format": "double",
+          "type": "number"
+        },
+        "loss1": {
+          "format": "double",
+          "type": "number"
+        },
+        "pf": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "pmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "pt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmaxt": {
+          "format": "double",
+          "type": "number"
+        },
+        "qminf": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmint": {
+          "format": "double",
+          "type": "number"
+        },
+        "qt": {
+          "format": "double",
+          "type": "number"
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vf": {
+          "format": "double",
+          "type": "number"
+        },
+        "vt": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "in_service",
+        "pf",
+        "pt",
+        "qf",
+        "qt",
+        "vf",
+        "vt",
+        "pmin",
+        "pmax",
+        "qminf",
+        "qmaxf",
+        "qmint",
+        "qmaxt",
+        "loss0",
+        "loss1",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "IbrPrimeMover": {
+      "enum": [
+        "PV",
+        "BATTERY",
+        "GENERIC",
+        "STATCOM",
+        "DSTATCOM"
+      ],
+      "type": "string"
+    },
+    "IbrTopology": {
+      "enum": [
+        "SINGLE_PHASE",
+        "THREE_LEG",
+        "FOUR_LEG"
+      ],
+      "type": "string"
+    },
+    "IbrVoltageAggregation": {
+      "enum": [
+        "PER_PHASE",
+        "AVERAGE"
+      ],
+      "type": "string"
+    },
+    "Impedance": {
+      "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
+      "properties": {
+        "base_mva": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "r",
+        "x",
+        "base_mva"
+      ],
+      "type": "object"
+    },
+    "Load": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p": {
+          "description": "Active demand (MW).",
+          "format": "double",
+          "type": "number"
+        },
+        "q": {
+          "description": "Reactive demand (MVAr).",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "voltage_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LoadVoltageModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Voltage dependence, when the source states one. `None` is constant power."
+        }
+      },
+      "required": [
+        "bus",
+        "p",
+        "q",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "LoadVoltageModel": {
+      "description": "Voltage dependence for a transmission load.",
+      "oneOf": [
+        {
+          "description": "Explicit constant power marker.",
+          "properties": {
+            "kind": {
+              "const": "constant_power",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "ZIP load split in source units. The three active parts sum to\n[`Load::p`], and the three reactive parts sum to [`Load::q`].",
+          "properties": {
+            "kind": {
+              "const": "zip",
+              "type": "string"
+            },
+            "load_type": {
+              "default": null,
+              "description": "Source load type code, when a format has one (PSS/E `ID`/`LOADTYPE`\nstyle metadata).",
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "p_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "p_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_current": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_impedance": {
+              "format": "double",
+              "type": "number"
+            },
+            "q_constant_power": {
+              "format": "double",
+              "type": "number"
+            },
+            "scaling": {
+              "default": null,
+              "description": "Source scaling factor, when a format has one.",
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p_constant_power",
+            "q_constant_power",
+            "p_constant_current",
+            "q_constant_current",
+            "p_constant_impedance",
+            "q_constant_impedance"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
+          "properties": {
+            "gamma_p": {
+              "format": "double",
+              "type": "number"
+            },
+            "gamma_q": {
+              "format": "double",
+              "type": "number"
+            },
+            "kind": {
+              "const": "exponential",
+              "type": "string"
+            },
+            "p": {
+              "format": "double",
+              "type": "number"
+            },
+            "q": {
+              "format": "double",
+              "type": "number"
+            },
+            "v_nom": {
+              "default": null,
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "p",
+            "q",
+            "gamma_p",
+            "gamma_q"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Location": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
+    },
+    "Location2": {
+      "description": "A point attached to one model element.",
+      "properties": {
+        "kind": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CoordsKind2"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Per point provenance when it differs from the network default."
+        },
+        "x": {
+          "description": "X coordinate. In geographic space this is longitude.",
+          "format": "double",
+          "type": "number"
+        },
+        "y": {
+          "description": "Y coordinate. In geographic space this is latitude.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "type": "object"
+    },
+    "LoweringRecord": {
+      "description": "One lowering/normalization/emission pass and what it changed.",
+      "properties": {
+        "approximations": {
+          "description": "Approximations the pass introduced (e.g. \"Kron reduction of neutral\").",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "assumptions": {
+          "description": "Modeling assumptions the pass relied on (e.g. \"balanced four-wire feeder\").",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "diagnostics": {
+          "items": {
+            "$ref": "#/$defs/StructuredDiagnostic"
+          },
+          "type": "array"
+        },
+        "dropped_fields": {
+          "description": "Fields/constraints dropped because the output family cannot carry them.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "input_kind": {
+          "$ref": "#/$defs/ModelKind"
+        },
+        "options": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "output_kind": {
+          "$ref": "#/$defs/ModelKind"
+        },
+        "pass": {
+          "description": "A stable pass name, e.g. `normalize-balanced` or `multiconductor-to-balanced`.",
+          "type": "string"
+        },
+        "validation_status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "pass",
+        "input_kind",
+        "output_kind",
+        "validation_status"
+      ],
+      "type": "object"
+    },
+    "MappingKind": {
+      "description": "How a canonical field relates to its source value.",
+      "oneOf": [
+        {
+          "const": "exact",
+          "description": "Copied verbatim from the source.",
+          "type": "string"
+        },
+        {
+          "const": "defaulted",
+          "description": "Materialized from a format default rather than the source text.",
+          "type": "string"
+        },
+        {
+          "const": "inferred",
+          "description": "Inferred from other source data.",
+          "type": "string"
+        },
+        {
+          "const": "converted_units",
+          "description": "Converted into canonical units (e.g. ohms to per unit).",
+          "type": "string"
+        },
+        {
+          "const": "lowered",
+          "description": "Produced by a lowering pass (e.g. positive-sequence equivalent).",
+          "type": "string"
+        },
+        {
+          "const": "aggregated",
+          "description": "One canonical field aggregated from several source records.",
+          "type": "string"
+        },
+        {
+          "const": "split",
+          "description": "One source record split into several canonical fields/elements.",
+          "type": "string"
+        },
+        {
+          "const": "synthetic",
+          "description": "Synthesized with no direct source (e.g. a generated bus id).",
+          "type": "string"
+        },
+        {
+          "const": "retained_extra",
+          "description": "Extra data from the source preserved verbatim.",
+          "type": "string"
+        }
+      ]
+    },
+    "ModelKind": {
+      "description": "Which concrete static-grid IR family the payload is.",
+      "oneOf": [
+        {
+          "const": "balanced",
+          "description": "Scalar positive-sequence transmission model ([`powerio::BalancedNetwork`]).",
+          "type": "string"
+        },
+        {
+          "const": "multiconductor",
+          "description": "Wire-coordinate distribution model ([`powerio_dist::MulticonductorNetwork`]).",
+          "type": "string"
+        }
+      ]
+    },
+    "ModelPayload": {
+      "description": "The one IR payload a package carries, tagged by `kind` in JSON so the payload\nis self-describing in addition to the top-level `model_kind`.\n\nThe payload is the serde snapshot of the PowerIO Rust IR\n([`powerio::Network`] / [`powerio_dist::DistNetwork`]); changes to it are\ndocument changes under the package `schema_version`. See\n`docs/src/pio-json-schema.md`.",
+      "oneOf": [
+        {
+          "properties": {
+            "balanced_network": {
+              "$ref": "#/$defs/Network"
+            },
+            "kind": {
+              "const": "balanced",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "balanced_network"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "multiconductor",
+              "type": "string"
+            },
+            "multiconductor_network": {
+              "$ref": "#/$defs/DistNetwork"
+            }
+          },
+          "required": [
+            "kind",
+            "multiconductor_network"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "Network": {
+      "description": "A balanced network with stable source bus IDs and separate element tables.",
+      "properties": {
+        "areas": {
+          "default": [],
+          "description": "Area records: scheduled interchange and per-area swing bus. Distinct from\nthe bare `area` number on each [`Bus`]; this is the area's metadata, which\nevery conversion dropped before. `#[serde(default)]` so older JSON still\ndeserializes.",
+          "items": {
+            "$ref": "#/$defs/Area"
+          },
+          "type": "array"
+        },
+        "base_frequency": {
+          "default": 60.0,
+          "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
+          "format": "double",
+          "type": "number"
+        },
+        "base_mva": {
+          "format": "double",
+          "type": "number"
+        },
+        "branches": {
+          "items": {
+            "$ref": "#/$defs/Branch"
+          },
+          "type": "array"
+        },
+        "buses": {
+          "items": {
+            "$ref": "#/$defs/Bus"
+          },
+          "type": "array"
+        },
+        "generators": {
+          "items": {
+            "$ref": "#/$defs/Generator"
+          },
+          "type": "array"
+        },
+        "geo": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GeoMeta"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "hvdc": {
+          "items": {
+            "$ref": "#/$defs/Hvdc"
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "$ref": "#/$defs/Load"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "shunts": {
+          "items": {
+            "$ref": "#/$defs/Shunt"
+          },
+          "type": "array"
+        },
+        "solver": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SolverParams"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Solver / solution-control metadata when the source carries it, else `None`.\n`#[serde(default)]` so older JSON still deserializes."
+        },
+        "source_format": {
+          "$ref": "#/$defs/SourceFormat"
+        },
+        "storage": {
+          "items": {
+            "$ref": "#/$defs/Storage"
+          },
+          "type": "array"
+        },
+        "switches": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Switch"
+          },
+          "type": "array"
+        },
+        "transformers_3w": {
+          "default": [],
+          "description": "Three-winding transformers, kept as typed records rather than folded into\n`branches`, so a star point and the per-winding data survive a round trip.\n`#[serde(default)]` so JSON written before the field existed still\ndeserializes. [`IndexedNetwork`](crate::IndexedNetwork) lowers each\nin-service record into a star bus plus three branches (via\n[`Transformer3W::star_expansion`]) before building any matrix, so a\n3-winding transformer does appear in `Y_bus`/connectivity; the canonical\nmodel keeps the typed record for round-trip fidelity.",
+          "items": {
+            "$ref": "#/$defs/Transformer3W"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "base_mva",
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "generators",
+        "storage",
+        "hvdc",
+        "source_format"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableMetadata": {
+      "description": "Compact package metadata for `Network::to_normalized_solver_tables`.",
+      "properties": {
+        "branch_from_arc_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "branch_to_arc_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "bus_ids": {
+          "items": {
+            "$ref": "#/$defs/BusId"
+          },
+          "type": "array"
+        },
+        "component_labels": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "pass": {
+          "type": "string"
+        },
+        "reference_bus_indices": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "row_counts": {
+          "$ref": "#/$defs/NormalizedSolverTableRowCounts"
+        },
+        "source_rows": {
+          "$ref": "#/$defs/NormalizedSolverTableSourceRows"
+        },
+        "units": {
+          "$ref": "#/$defs/SolverTableUnits"
+        }
+      },
+      "required": [
+        "pass",
+        "units",
+        "row_counts",
+        "bus_ids",
+        "reference_bus_indices",
+        "component_labels",
+        "branch_from_arc_indices",
+        "branch_to_arc_indices",
+        "source_rows"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableRowCounts": {
+      "description": "Row counts for every normalized solver table.",
+      "properties": {
+        "arcs": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "branches": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "buses": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "generators": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "hvdc": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "loads": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "shunts": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "storage": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "switches": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "switches",
+        "arcs",
+        "generators",
+        "storage",
+        "hvdc"
+      ],
+      "type": "object"
+    },
+    "NormalizedSolverTableSourceRows": {
+      "description": "Source row provenance vectors for normalized solver tables.",
+      "properties": {
+        "branches": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "buses": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "generators": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "hvdc": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "loads": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "shunts": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "storage": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        },
+        "switches": {
+          "items": {
+            "format": "uint",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "buses",
+        "loads",
+        "shunts",
+        "branches",
+        "switches",
+        "generators",
+        "storage",
+        "hvdc"
+      ],
+      "type": "object"
+    },
+    "ObjectSummary": {
+      "description": "Element counts, topology, and unit conventions, for a quick read of a package\nwithout deserializing the whole payload.",
+      "properties": {
+        "elements": {
+          "additionalProperties": {
+            "format": "uint64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "description": "Element type name -> count, e.g. `{\"buses\": 118, \"branches\": 186}`.",
+          "type": "object"
+        },
+        "topology": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObjectTopology"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "units": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObjectUnits"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "ObjectTopology": {
+      "properties": {
+        "connected_components": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "reference_buses": {
+          "description": "Reference bus ids as strings (balanced ids are integers, multiconductor\nids are strings; strings cover both).",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ObjectUnits": {
+      "properties": {
+        "angle": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_mva": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "power": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "OperatingPoint": {
+      "description": "One replayable operating state over the package's static payload.",
+      "properties": {
+        "index": {
+          "description": "Zero based period index. Labels and durations live on the shared\n[`TimeAxis`], indexed by this.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format for this point.",
+          "type": "object"
+        },
+        "updates": {
+          "description": "Field updates to apply to the static payload.",
+          "items": {
+            "$ref": "#/$defs/ElementUpdate"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "index"
+      ],
+      "type": "object"
+    },
+    "OperatingPointSeries": {
+      "description": "A format neutral series of operating points over a package's static payload.",
+      "properties": {
+        "metadata": {
+          "additionalProperties": true,
+          "description": "Metadata from the source format, such as `source_format`.",
+          "type": "object"
+        },
+        "points": {
+          "description": "Ordered operating states. Each state is addressed by its `index`.",
+          "items": {
+            "$ref": "#/$defs/OperatingPoint"
+          },
+          "type": "array"
+        },
+        "time_axis": {
+          "$ref": "#/$defs/TimeAxis",
+          "description": "Shared period count, durations, and labels."
+        }
+      },
+      "required": [
+        "time_axis"
+      ],
+      "type": "object"
+    },
+    "Origin": {
+      "description": "Where the package came from. Internally tagged on `kind` in JSON, so a reader\ndistinguishes an in-memory model, a single text file (with or without\nretained source), a folder dataset, a partially decoded binary, a derived\nproduct of a lowering pass, or a composite of several sources.\n\nThe `hash` field is named consistently across all `Origin` variants.",
+      "oneOf": [
+        {
+          "description": "Built in process, no source artifact.",
+          "properties": {
+            "kind": {
+              "const": "in_memory",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "format": {
+              "type": "string"
+            },
+            "hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "file",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "retained_source": {
+              "default": false,
+              "description": "Whether the original source text was retained for a byte-exact\nsame-format echo. The retained text itself is not embedded in the\npackage; this only records that it exists at the frontend.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "file_hashes": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "format": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "folder",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "decoded_sections": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "format": {
+              "type": "string"
+            },
+            "hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "const": "binary_file",
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "format"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "A model produced by a lowering/normalization pass from another package.",
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "options": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "parent_package_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pass": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "pass"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Several sources combined, e.g. a static case plus a profile set.",
+          "properties": {
+            "kind": {
+              "const": "composite",
+              "type": "string"
+            },
+            "sources": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "kind",
+            "sources"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "PowerFactorControl": {
+      "properties": {
+        "pf": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pf"
+      ],
+      "type": "object"
+    },
+    "Producer": {
+      "description": "The tool and build that produced the package.",
+      "properties": {
+        "features": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "git_commit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "tool": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "tool",
+        "version"
+      ],
+      "type": "object"
+    },
+    "ReactivePowerReference": {
+      "enum": [
+        "VAR_MAX",
+        "VAR_AVAILABLE"
+      ],
+      "type": "string"
+    },
+    "ReactivePowerUnit": {
+      "enum": [
+        "VA_FRACTION",
+        "VAR"
+      ],
+      "type": "string"
+    },
+    "Shunt": {
+      "properties": {
+        "b": {
+          "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
+          "format": "double",
+          "type": "number"
+        },
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "control": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SwitchedShuntControl"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Switching-control data when this is a switched (adjustable) shunt; `None`\nfor a fixed shunt. `#[serde(default)]` so JSON written before the field\nexisted still deserializes."
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "g": {
+          "description": "Shunt conductance (MW at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "g",
+        "b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "ShuntBlock": {
+      "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
+      "properties": {
+        "b": {
+          "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
+          "format": "double",
+          "type": "number"
+        },
+        "steps": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "steps",
+        "b"
+      ],
+      "type": "object"
+    },
+    "SolverParams": {
+      "description": "Solver / solution-control metadata: the Newton tolerance and iteration cap,\nthe zero-impedance threshold, and the per-quantity adjustment-enable flags.\n\nEach field is optional because a source states only the ones it carries. No\npower flow physics, but it determines whether a downstream solver reproduces\nthe source tool's converged answer. Maps to the PSS/E v34+ system-wide block\n(`GENERAL THRSHZ`, `NEWTON TOLN`/`ITMXN`, `SOLVER ACTAPS`/`AREAIN`/`PHSHFT`/\n`DCTAPS`/`SWSHNT`).",
+      "properties": {
+        "adjust_area_interchange": {
+          "description": "Whether the solver adjusts area interchange (`SOLVER AREAIN`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_dc_taps": {
+          "description": "Whether the solver adjusts DC line taps (`SOLVER DCTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_phase_shift": {
+          "description": "Whether the solver adjusts phase-shift angles (`SOLVER PHSHFT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_switched_shunt": {
+          "description": "Whether the solver adjusts switched shunts (`SOLVER SWSHNT`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "adjust_taps": {
+          "description": "Whether the solver adjusts transformer taps (`SOLVER ACTAPS`).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "max_iterations": {
+          "description": "Newton iteration cap (`NEWTON ITMXN`).",
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "newton_tolerance": {
+          "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "zero_impedance_threshold": {
+          "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "SolverTableUnits": {
+      "description": "Units carried by [`NormalizedSolverTables`].",
+      "properties": {
+        "admittance": {
+          "type": "string"
+        },
+        "angle": {
+          "type": "string"
+        },
+        "dense_index_base": {
+          "type": "string"
+        },
+        "impedance": {
+          "type": "string"
+        },
+        "power": {
+          "type": "string"
+        },
+        "voltage": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "power",
+        "voltage",
+        "angle",
+        "impedance",
+        "admittance",
+        "dense_index_base"
+      ],
+      "type": "object"
+    },
+    "SourceDescriptor": {
+      "description": "A declared source artifact, referenced from source maps and diagnostics by\nits `id`. (`sources[]` in the package.)",
+      "properties": {
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "kind"
+      ],
+      "type": "object"
+    },
+    "SourceFormat": {
+      "description": "Which format a [`Network`] was read from. Drives the same format byte exact\necho on write.",
+      "oneOf": [
+        {
+          "enum": [
+            "Matpower",
+            "PowerModelsJson",
+            "EgretJson",
+            "Psse",
+            "PowerWorld",
+            "PandapowerJson"
+          ],
+          "type": "string"
+        },
+        {
+          "const": "Pslf",
+          "description": "Read from a GE PSLF `.epc` case. Same source text is retained, so a\nsame-format write echoes it byte-for-byte; a cross-format or\nsource-dropped write goes through the `.epc` serializer\n([`write_pslf`](crate::write_pslf)).",
+          "type": "string"
+        },
+        {
+          "const": "PowerWorldBinary",
+          "description": "Read from a PowerWorld `.pwb` binary case. Read only: there is no\n`.pwb` writer and no retained source text, so writing goes through\nanother format's writer.",
+          "type": "string"
+        },
+        {
+          "const": "InMemory",
+          "description": "Built in memory, for example from synth or an edited case; no source text.",
+          "type": "string"
+        },
+        {
+          "const": "Normalized",
+          "description": "A normalized derived form ([`Network::to_normalized`]): per unit, radians,\nfiltered, source bus ids preserved. Distinct from\n[`InMemory`](SourceFormat::InMemory) so consumers can tell a per unit\nproduct from a raw in memory network; it has no source text and a different\nunit basis than a parsed network.",
+          "type": "string"
+        },
+        {
+          "const": "Gridfm",
+          "description": "Read back from a gridfm-datakit Parquet dataset (the ML→classical bridge,\n`powerio-matrix`'s `read_gridfm_dataset`). A lossy, power flow complete\nreconstruction with no retained source text: original bus ids are\nsynthesized `1..n`, per element load/shunt granularity is folded to one\nsynthetic element per bus, and HVDC/storage/piecewise costs are absent.",
+          "type": "string"
+        },
+        {
+          "const": "PypsaCsv",
+          "description": "Read from a PyPSA CSV folder. This is a folder format rather than a\nsingle retained text document, so same-format writes are canonicalized.",
+          "type": "string"
+        },
+        {
+          "const": "Goc3Json",
+          "description": "Read from an ARPA-E GO Challenge 3 JSON input document. The source is a\nunit commitment data set; the neutral transmission model keeps a static\nfirst interval network and retains the source text for the full data.",
+          "type": "string"
+        },
+        {
+          "const": "SurgeJson",
+          "description": "Read from a Surge native JSON document.",
+          "type": "string"
+        },
+        {
+          "const": "DeepMindOpfDataJson",
+          "description": "Read from one raw JSON document in a DeepMind OPFData release. The\nsource carries both solver initial values and a solution. The balanced\nmodel represents the solved snapshot and retains the source for an\nexact write back to the same format.",
+          "type": "string"
+        }
+      ]
+    },
+    "SourceMapEntry": {
+      "description": "One `element_path -> source` mapping.",
+      "properties": {
+        "confidence": {
+          "$ref": "#/$defs/Confidence"
+        },
+        "element_path": {
+          "description": "JSON pointer (or best-effort locator) into the package payload.",
+          "type": "string"
+        },
+        "mapping_kind": {
+          "$ref": "#/$defs/MappingKind"
+        },
+        "source_ref": {
+          "$ref": "#/$defs/SourceRef"
+        }
+      },
+      "required": [
+        "element_path",
+        "source_ref",
+        "mapping_kind",
+        "confidence"
+      ],
+      "type": "object"
+    },
+    "SourceRef": {
+      "description": "A pointer into one source artifact: where a canonical field came from.",
+      "properties": {
+        "byte_offset": {
+          "description": "Byte offset, for binary sources.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "column": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "field": {
+          "description": "Canonical field / property name, e.g. `vm`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "raw_token": {
+          "description": "Raw token / value, when safe to embed.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "record": {
+          "description": "Record / section / object type, e.g. `bus`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_id"
+      ],
+      "type": "object"
+    },
+    "Storage": {
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "charge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "charge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "discharge_efficiency": {
+          "format": "double",
+          "type": "number"
+        },
+        "discharge_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy": {
+          "format": "double",
+          "type": "number"
+        },
+        "energy_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "p_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "ps": {
+          "format": "double",
+          "type": "number"
+        },
+        "q_loss": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmax": {
+          "format": "double",
+          "type": "number"
+        },
+        "qmin": {
+          "format": "double",
+          "type": "number"
+        },
+        "qs": {
+          "format": "double",
+          "type": "number"
+        },
+        "r": {
+          "format": "double",
+          "type": "number"
+        },
+        "thermal_rating": {
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "x": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "ps",
+        "qs",
+        "energy",
+        "energy_rating",
+        "charge_rating",
+        "discharge_rating",
+        "charge_efficiency",
+        "discharge_efficiency",
+        "thermal_rating",
+        "qmin",
+        "qmax",
+        "r",
+        "x",
+        "p_loss",
+        "q_loss",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "StructuredDiagnostic": {
+      "description": "One structured finding.",
+      "properties": {
+        "code": {
+          "$ref": "#/$defs/DiagnosticCode"
+        },
+        "details": {
+          "additionalProperties": true,
+          "description": "Code-specific structured payload, e.g. `{\"dropped_fields\": [\"angmin\"]}`.",
+          "type": "object"
+        },
+        "element_path": {
+          "description": "JSON pointer (or best-effort locator) of the element the finding is about.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "type": "string"
+        },
+        "safe_to_ignore": {
+          "description": "Workflows for which this finding is safe to ignore, e.g.\n`[\"power_flow\", \"opf\"]`. Empty means \"no such assurance\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "severity": {
+          "$ref": "#/$defs/DiagnosticSeverity"
+        },
+        "source_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "stage": {
+          "$ref": "#/$defs/DiagnosticStage"
+        },
+        "suggested_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "code",
+        "severity",
+        "stage",
+        "message"
+      ],
+      "type": "object"
+    },
+    "StudyBlock": {
+      "description": "Additive study block stored on a package envelope.",
+      "properties": {
+        "app": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "author": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base_operating_point": {
+          "format": "uint",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "commits": {
+          "items": {
+            "$ref": "#/$defs/StudyCommit"
+          },
+          "type": "array"
+        },
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "StudyCommit": {
+      "description": "One cumulative commit in a study block.",
+      "properties": {
+        "created_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "edits": {
+          "items": {
+            "$ref": "#/$defs/StudyEdit"
+          },
+          "type": "array"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "additionalProperties": true,
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "StudyEdit": {
+      "oneOf": [
+        {
+          "properties": {
+            "bus": {
+              "$ref": "#/$defs/ElementRef"
+            },
+            "kind": {
+              "const": "demand_delta"
+            },
+            "p_mw": {
+              "type": "number"
+            },
+            "q_mvar": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "kind",
+            "bus",
+            "p_mw"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "branch": {
+              "$ref": "#/$defs/ElementRef"
+            },
+            "delta_mw": {
+              "type": "number"
+            },
+            "kind": {
+              "const": "rating_delta"
+            }
+          },
+          "required": [
+            "kind",
+            "branch",
+            "delta_mw"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "set_fields"
+            },
+            "update": {
+              "$ref": "#/$defs/ElementUpdate"
+            }
+          },
+          "required": [
+            "kind",
+            "update"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": true,
+          "properties": {
+            "kind": {
+              "not": {
+                "enum": [
+                  "demand_delta",
+                  "rating_delta",
+                  "set_fields"
+                ]
+              },
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ],
+      "type": "object"
+    },
+    "Switch": {
+      "description": "A transmission switch. Closed switches are preserved as data; matrix builders\ndo not lower them into zero impedance branches.",
+      "properties": {
+        "closed": {
+          "type": "boolean"
+        },
+        "current_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "from": {
+          "$ref": "#/$defs/BusId"
+        },
+        "pf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "pt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qf": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "qt": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "thermal_rating": {
+          "default": null,
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "to": {
+          "$ref": "#/$defs/BusId"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "from",
+        "to",
+        "closed",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntControl": {
+      "description": "Switching-control data for a switched shunt ([`Shunt::control`]): the mode,\nthe regulated voltage band and bus, the reactive-range percentage, and the\nadjustable susceptance blocks. The shunt's [`b`](Shunt::b) is the initial\nvalue within the blocks' total range.",
+      "properties": {
+        "blocks": {
+          "items": {
+            "$ref": "#/$defs/ShuntBlock"
+          },
+          "type": "array"
+        },
+        "control_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The regulated bus; `None` means the shunt regulates its own bus."
+        },
+        "mode": {
+          "$ref": "#/$defs/SwitchedShuntMode"
+        },
+        "rmpct": {
+          "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
+          "format": "double",
+          "type": "number"
+        },
+        "vhigh": {
+          "description": "Regulated voltage band (per unit).",
+          "format": "double",
+          "type": "number"
+        },
+        "vlow": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "vhigh",
+        "vlow",
+        "rmpct",
+        "blocks"
+      ],
+      "type": "object"
+    },
+    "SwitchedShuntMode": {
+      "description": "How a switched shunt adjusts its susceptance. Maps to the PSS/E `MODSW` code.",
+      "oneOf": [
+        {
+          "const": "locked",
+          "description": "Fixed at its initial susceptance, no automatic switching (`MODSW` 0).",
+          "type": "string"
+        },
+        {
+          "const": "continuous",
+          "description": "Continuous adjustment within the block range (`MODSW` 1).",
+          "type": "string"
+        },
+        {
+          "const": "discrete",
+          "description": "Discrete adjustment in fixed steps (`MODSW` 2 and up).",
+          "type": "string"
+        }
+      ]
+    },
+    "TimeAxis": {
+      "description": "The time axis shared by every operating point in the series.",
+      "properties": {
+        "duration_hours": {
+          "description": "Optional duration per period, in hours.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "labels": {
+          "description": "Optional display labels for the periods.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "periods": {
+          "description": "Number of periods available in the series.",
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "periods"
+      ],
+      "type": "object"
+    },
+    "Transformer3W": {
+      "description": "A three winding transformer with three terminal buses joined at a star point.\n\nSeries impedance is stored for winding pairs 1-2, 2-3, and 3-1. The record\nalso retains star point voltage and per winding control data. PSS/E three\nwinding records and PSLF tertiary winding records map to this type.\n[`star_expansion`](Transformer3W::star_expansion) turns it into the synthetic\nstar bus plus three branches for a consumer that works in the bus-branch model;\n[`IndexedNetwork`](crate::IndexedNetwork) applies it before building any matrix,\nso a 3-winding transformer contributes to `Y_bus` and connectivity.",
+      "properties": {
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "in_service": {
+          "type": "boolean"
+        },
+        "mag_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "mag_g": {
+          "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
+          "format": "double",
+          "type": "number"
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "star_va": {
+          "format": "double",
+          "type": "number"
+        },
+        "star_vm": {
+          "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
+          "format": "double",
+          "type": "number"
+        },
+        "uid": {
+          "description": "Stable row identity; see [`Bus::uid`].",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "windings": {
+          "description": "The three windings, in order (primary, secondary, tertiary).",
+          "items": {
+            "$ref": "#/$defs/Winding"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "z": {
+          "description": "Pairwise series impedance `[z12, z23, z31]` (primary-secondary,\nsecondary-tertiary, tertiary-primary), each per unit on the system base\nwith its declared MVA base.",
+          "items": {
+            "$ref": "#/$defs/Impedance"
+          },
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        }
+      },
+      "required": [
+        "windings",
+        "z",
+        "star_vm",
+        "star_va",
+        "mag_g",
+        "mag_b",
+        "in_service",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "TransformerControl": {
+      "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
+      "properties": {
+        "band_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "band_min": {
+          "format": "double",
+          "type": "number"
+        },
+        "controlled_bus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BusId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "mode": {
+          "$ref": "#/$defs/TransformerControlMode"
+        },
+        "mva_base": {
+          "format": "double",
+          "type": "number"
+        },
+        "ntp": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tap_max": {
+          "format": "double",
+          "type": "number"
+        },
+        "tap_min": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mode",
+        "tap_min",
+        "tap_max",
+        "band_min",
+        "band_max",
+        "ntp",
+        "mva_base"
+      ],
+      "type": "object"
+    },
+    "TransformerControlMode": {
+      "description": "What a regulating transformer's tap (or phase shift) automatically controls.\nMaps to the PSS/E control code `COD` and the PSLF transformer `type`.",
+      "oneOf": [
+        {
+          "const": "fixed",
+          "description": "Fixed ratio, no automatic adjustment (PSS/E `COD` 0/±4, PSLF type 1).",
+          "type": "string"
+        },
+        {
+          "const": "voltage",
+          "description": "Bus voltage control via tap (LTC; PSS/E `COD` ±1, PSLF type 2).",
+          "type": "string"
+        },
+        {
+          "const": "reactive_flow",
+          "description": "Reactive power flow control via tap (PSS/E `COD` ±2).",
+          "type": "string"
+        },
+        {
+          "const": "active_flow",
+          "description": "Active power flow control via phase shift (PSS/E `COD` ±3, PSLF type 4).",
+          "type": "string"
+        }
+      ]
+    },
+    "UntypedObject": {
+      "description": "An object the reader recognized but does not type: preserved by class,\nname, and raw property text so conversions can warn precisely.",
+      "properties": {
+        "class": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "props": {
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "class",
+        "name",
+        "props"
+      ],
+      "type": "object"
+    },
+    "ValidationCounts": {
+      "description": "Counts per severity. All five are always present; zero where unused.",
+      "properties": {
+        "debug": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "error": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "fatal": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "info": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "warning": {
+          "default": 0,
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "ValidationPass": {
+      "description": "The status of one named validation pass.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "name",
+        "status"
+      ],
+      "type": "object"
+    },
+    "ValidationStatus": {
+      "description": "Overall validation status, ordered worst-last.",
+      "enum": [
+        "ok",
+        "info",
+        "warning",
+        "error",
+        "fatal"
+      ],
+      "type": "string"
+    },
+    "ValidationSummary": {
+      "description": "A cheap-to-inspect summary of validation: an overall status, per-severity\ncounts, and the named passes that ran.",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/ValidationCounts"
+        },
+        "passes": {
+          "items": {
+            "$ref": "#/$defs/ValidationPass"
+          },
+          "type": "array"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts"
+      ],
+      "type": "object"
+    },
+    "VoltVarControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_min_for_q": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "p_min_for_q_max": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "q_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "q_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "q_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReactivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "q_limits"
+      ],
+      "type": "object"
+    },
+    "VoltWattControl": {
+      "properties": {
+        "breakpoints": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_limits": {
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "p_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "p_unit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivePowerUnit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "voltage_reference": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ControlVoltageReference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "breakpoints",
+        "p_limits"
+      ],
+      "type": "object"
+    },
+    "VoltageSource": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "extras": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_angle": {
+          "description": "Radians per terminal.",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "v_magnitude": {
+          "description": "Volts per terminal (0.0 on grounded terminals).",
+          "items": {
+            "format": "double",
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "bus",
+        "terminal_map",
+        "v_magnitude",
+        "v_angle",
+        "extras"
+      ],
+      "type": "object"
+    },
+    "Winding": {
+      "description": "One winding of a [`Transformer3W`]: its terminal bus, off-nominal ratio, phase\nshift, nominal voltage, and thermal ratings.",
+      "properties": {
+        "bus": {
+          "$ref": "#/$defs/BusId"
+        },
+        "nominal_kv": {
+          "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
+          "format": "double",
+          "type": "number"
+        },
+        "rate_a": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_b": {
+          "format": "double",
+          "type": "number"
+        },
+        "rate_c": {
+          "format": "double",
+          "type": "number"
+        },
+        "shift": {
+          "description": "Phase shift (degrees).",
+          "format": "double",
+          "type": "number"
+        },
+        "tap": {
+          "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "bus",
+        "tap",
+        "shift",
+        "nominal_kv",
+        "rate_a",
+        "rate_b",
+        "rate_c"
+      ],
+      "type": "object"
+    },
+    "Winding2": {
+      "properties": {
+        "bus": {
+          "type": "string"
+        },
+        "conn": {
+          "$ref": "#/$defs/WindingConn"
+        },
+        "r_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "r_pct": {
+          "description": "Winding resistance, percent of the winding base.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "s_rating": {
+          "description": "Volt amperes.",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "tap": {
+          "format": "double",
+          "type": "number"
+        },
+        "terminal_map": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "v_ref": {
+          "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "x_neutral": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "bus",
+        "terminal_map",
+        "conn",
+        "v_ref",
+        "s_rating",
+        "r_pct",
+        "tap"
+      ],
+      "type": "object"
+    },
+    "WindingConn": {
+      "enum": [
+        "wye",
+        "delta"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://powerio.dev/schema/pio-package/0.8",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "A versioned package containing one model payload, provenance, diagnostics,\nvalidation results, and lowering history. Serializes to `.pio.json`.\n\n`model_kind` is stored explicitly and is authoritative; the payload is also\nself-describing (tagged by `kind`). [`NetworkPackage::kind_is_consistent`]\nasserts the two agree. The reader ignores unknown top level fields from a\nnewer producer.",
+  "properties": {
+    "created_at": {
+      "description": "RFC 3339 build timestamp. Left `None` by default for deterministic,\nround-trip-stable output; set explicitly when a timestamp is wanted.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "derived": {
+      "$ref": "#/$defs/DerivedMetadata"
+    },
+    "diagnostics": {
+      "items": {
+        "$ref": "#/$defs/StructuredDiagnostic"
+      },
+      "type": "array"
+    },
+    "lowering_history": {
+      "items": {
+        "$ref": "#/$defs/LoweringRecord"
+      },
+      "type": "array"
+    },
+    "model": {
+      "$ref": "#/$defs/ModelPayload"
+    },
+    "model_kind": {
+      "$ref": "#/$defs/ModelKind",
+      "description": "Explicit model kind. Authoritative; never inferred from field presence."
+    },
+    "operating_points": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/OperatingPointSeries"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Replayable operating states over the static payload. The package\nconstructors and setters omit empty series for static single state cases."
+    },
+    "origin": {
+      "$ref": "#/$defs/Origin"
+    },
+    "package_id": {
+      "description": "Stable content id, e.g. `\"sha256:...\"`. The scaffold leaves it `None`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "powerio_version": {
+      "default": "",
+      "description": "The powerio version that wrote this document; see\n[`powerio::version`].\n\nA document that states none deserializes to the empty string, which no\nlineage accepts, so the gate stays closed and the reader can name the\nrelease that wrote it. It must never default to the current version:\nthat lets a document opt out of the gate by dropping the field, and a\nfield an older lineage spells differently then arrives as its `serde`\ndefault with no error and no warning.",
+      "type": "string"
+    },
+    "producer": {
+      "$ref": "#/$defs/Producer"
+    },
+    "source_maps": {
+      "items": {
+        "$ref": "#/$defs/SourceMapEntry"
+      },
+      "type": "array"
+    },
+    "sources": {
+      "items": {
+        "$ref": "#/$defs/SourceDescriptor"
+      },
+      "type": "array"
+    },
+    "study": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StudyBlock"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Cumulative interactive edits over the package payload."
+    },
+    "summary": {
+      "$ref": "#/$defs/ObjectSummary",
+      "default": {}
+    },
+    "validation": {
+      "$ref": "#/$defs/ValidationSummary"
+    }
+  },
+  "required": [
+    "producer",
+    "model_kind",
+    "model",
+    "origin",
+    "validation"
+  ],
+  "title": "NetworkPackage",
+  "type": "object"
+}

--- a/docs/src/capi-arrow.md
+++ b/docs/src/capi-arrow.md
@@ -24,7 +24,7 @@ Matrix schema metadata carries:
 
 ```text
 powerio.table
-powerio.schema_version
+powerio.version
 powerio.format
 powerio.row_axis
 powerio.col_axis
@@ -51,13 +51,13 @@ Shape:
 
 ```json
 {
-  "schema_version": "1",
+  "powerio_version": "0.9.0",
   "producer": "powerio-capi",
   "tables": [
     {
       "id": 17,
       "name": "bprime",
-      "schema_version": "1",
+      "powerio_version": "0.9.0",
       "format": "coo",
       "feature_requirements": ["arrow", "matrix"],
       "available": true,
@@ -97,5 +97,5 @@ behavior.
 `PioNetwork` Arrow tables describe a network or a generic matrix projection.
 They do not carry solver cost policy or a solver formulation. `powerio-prob`
 owns complete problem instances. The C `prob` feature currently exposes a
-matrix free SCOPF instance through a versioned JSON wire document. DC OPF
+matrix free SCOPF instance through a JSON document. DC OPF
 instances and bundles have no C entry points.

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -52,7 +52,7 @@ the document without guessing whether it holds balanced or multiconductor data.
 
 A `.pio.json` document always carries:
 
-- `schema_version` (semver), the one version number for the whole document;
+- `powerio_version` (semver), the powerio release that wrote the document;
 - `producer` metadata;
 - `model_kind`, explicit and authoritative;
 - `model`, the typed model payload, tagged by `kind`;
@@ -89,7 +89,7 @@ requirements are in [the `.pio.json` format chapter](pio-json-schema.md).
 ### Model JSON stability
 
 The model JSON changes are document changes, covered by the one
-`schema_version`. Model rows carry stable `uid` identities that operating
+`powerio_version`. Model rows carry stable `uid` identities that operating
 point updates resolve against. The bump rules are in
 [the `.pio.json` format chapter](pio-json-schema.md).
 

--- a/docs/src/geo-and-display.md
+++ b/docs/src/geo-and-display.md
@@ -81,7 +81,7 @@ next to a DSS master, a GeoJSON export from a GIS tool, a layout computed by a
 renderer. The container is `GeoLayer`, surfaced as `DisplayData::Geo` beside
 the PowerWorld `.pwd` display path.
 
-The canonical wire form is a GeoJSON FeatureCollection with one foreign
+The canonical form is a GeoJSON FeatureCollection with one foreign
 member, suggested extension `.geo.json`:
 
 ```json

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -39,7 +39,7 @@ Verb taxonomy:
 | Materialize operating point | `pkg.materialize_operating_point(i)` | `pkg.materialize_operating_point(i)` | — | `pio_package_materialize_operating_point` |
 | `.pio.json` study block | `pkg.study()` | `pkg.study()` | — | `pio_package_study_json` |
 | Materialize study commit | `pkg.materialize_study_commit(i)` | `pkg.materialize_study_commit(i)` | — | `pio_package_materialize_study_commit` |
-| Parse SCOPF instance | `build_scopf_instance_from_str` | `parse_scopf(text, from_="goc3-json")` | versioned wire adapter | `pio_scopf_parse_str` |
+| Parse SCOPF instance | `build_scopf_instance_from_str` | `parse_scopf(text, from_="goc3-json")` | Julia document adapter | `pio_scopf_parse_str` |
 | Normalized copy | `net.to_normalized()` | `net.to_normalized()` | `to_normalized(net)` | `pio_normalize` |
 | Dense tables | typed table API | `to_dense` | `to_dense` | `pio_*` extractors |
 | PyPSA CSV folder | `read_pypsa_csv_folder` / `write_pypsa_csv_folder` | `read_pypsa_csv_folder` / `net.write_pypsa_csv_folder` | `parse_file(dir; from="pypsa-csv")` / `write_pypsa_csv_folder` | `pio_parse_file` / `pio_write_dir` + `"pypsa-csv"` |

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -42,20 +42,20 @@ the same operations as `pio_to_json` and `pio_from_json`.
 ABI v4 continues to accept `powerio-json` in `pio_parse_str` and
 `pio_to_format`. Those format tokens are compatibility aliases. Removing them requires a future C ABI version change.
 
-## Versioning: `pio-package/0.2` {#pio-package}
+## Versioning {#pio-package}
 
-One version number covers the whole document, model JSON included:
-`schema_version`, semver, currently `0.2.1`. A `.pio.json` file is a
-regenerable snapshot, so the reader's only versioning job is telling the caller
-when a file needs regenerating.
+Every document powerio authors states one number, `powerio_version`: the
+powerio release that wrote it. There is no separate schema number for the
+document, the payload, or the model JSON. A `.pio.json` file is a regenerable
+snapshot, so the reader's only versioning job is telling the caller when a file
+needs regenerating.
 
-- While the major is 0, an incompatible change to any field bumps the minor
-  (cargo 0.x semantics) and additive changes bump the patch. From 1.0.0 on,
-  incompatible changes bump the major.
-- A reader accepts its own lineage: the exact major.minor pair while the major
-  is 0, the major alone afterwards. Anything else is rejected with an error
-  naming the supported lineage and telling the caller to regenerate the
-  package from its source case.
+- A reader accepts its own lineage: the major and minor pair while the major is
+  0, the major alone afterwards. That is what cargo and Pkg already mean by a
+  0.x bump. Anything else is rejected with an error naming the release that
+  wrote the document and the release that must regenerate it.
+- A document that states no `powerio_version` came from 0.8.x or earlier. The
+  reader names that release rather than reporting a missing field.
 - A reader tolerates unknown top-level fields (they are ignored without
   error), so a same lineage document from a newer producer still loads.
 
@@ -68,7 +68,7 @@ documents. It does not define a standalone case format.
 
 | field | type | required | notes |
 |---|---|---|---|
-| `schema_version` | string (semver) | yes | document version; required on read; other lineages rejected |
+| `powerio_version` | string (semver) | yes | the powerio release that wrote the document; other lineages rejected |
 | `producer` | object | yes | `{tool, version, git_commit?, features[]}` |
 | `package_id` | string | no | stable content id, e.g. `"sha256:..."`; unset by the scaffold |
 | `created_at` | string (RFC 3339) | no | unset by default for deterministic output |
@@ -105,10 +105,10 @@ later families can be added).
 ## The Model JSON
 
 Each payload is what its Rust model serializes; changes to it are changes to
-the document and follow the `schema_version` rules above. The generated JSON
+the document and follow the `powerio_version` rules above. The generated JSON
 Schema is derived from the serde models and checked in CI against the committed
 `docs/schema/**/schema.json` files. The model's rustdoc is the field reference,
-and the balanced payload's wire form is additionally held to a committed
+and the balanced payload's serialized form is additionally held to a committed
 golden file by `powerio/tests/snapshot_schema.rs`.
 
 ### The balanced model JSON {#pio-payload-balanced}
@@ -272,7 +272,7 @@ bindings, or MCP operations.
 
 ```json
 {
-  "schema_version": "0.2.1",
+  "powerio_version": "0.9.0",
   "producer": { "tool": "powerio", "version": "0.8.0" },
   "model_kind": "multiconductor",
   "model": {

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -90,7 +90,7 @@ print(first.number, first.name, first.x, first.y)
 ## Problem instances
 
 `parse_scopf(text, from_="goc3-json")` assembles a matrix free SCOPF problem
-instance and returns its versioned wire document as a Python dictionary. The
+instance and returns its Julia compatibility document as a Python dictionary. The
 document declares its schema version and uses 1-based indices for language
 compatibility. Source UIDs and source bus IDs remain separate from those
 indices. Invalid JSON, duplicate identities, missing references, and period

--- a/powerio-capi/examples/smoke.c
+++ b/powerio-capi/examples/smoke.c
@@ -313,8 +313,8 @@ int main(int argc, char **argv) {
         CHECK(dist_caps != NULL, "pio_dist_capabilities_json returned NULL");
         CHECK(strstr(dist_caps, "\"dist\":true") != NULL,
               "dist capabilities did not report dist=true");
-        CHECK(strstr(dist_caps, "\"schema_version\":\"1.1.0\"") != NULL,
-              "dist capabilities schema_version mismatch");
+        CHECK(strstr(dist_caps, "\"powerio_version\":") != NULL,
+              "dist capabilities powerio_version missing");
         CHECK(strstr(dist_caps, "\"bmopf_schema_version\":") != NULL,
               "bmopf schema vintage missing from capabilities");
         CHECK(strstr(dist_caps, "\"bmopf_fixed_taps\":true") != NULL,

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -51,8 +51,6 @@ pub const PIO_ARROW_TABLE_BDOUBLEPRIME: i32 = 18;
 pub const PIO_ARROW_TABLE_MATRIX_BUS: i32 = 19;
 pub const PIO_ARROW_TABLE_MATRIX_BRANCH: i32 = 20;
 
-pub(crate) const ARROW_SCHEMA_VERSION: &str = "1";
-
 // These values are the ABI: the `PIO_ARROW_TABLE_*` macros in include/powerio.h
 // are hand-synced to them. The set is append-only: these ids and each table's
 // column order are frozen, a new table takes the next id and extends
@@ -162,7 +160,6 @@ fn catalog_value() -> serde_json::Value {
         serde_json::json!({
             "id": id,
             "name": name,
-            "schema_version": ARROW_SCHEMA_VERSION,
             "format": format,
             "feature_requirements": feature_requirements,
             "available": available,
@@ -175,7 +172,7 @@ fn catalog_value() -> serde_json::Value {
         })
     };
     serde_json::json!({
-        "schema_version": ARROW_SCHEMA_VERSION,
+        powerio::version::VERSION_KEY: powerio::VERSION,
         "producer": "powerio-capi",
         "tables": [
             table_spec(PIO_ARROW_TABLE_BUS, "bus", "record_batch", &["arrow"], true, None, None, units_source(), &[
@@ -1208,10 +1205,7 @@ fn matrix_metadata(
 ) -> HashMap<String, String> {
     HashMap::from([
         ("powerio.table".to_owned(), table.to_owned()),
-        (
-            "powerio.schema_version".to_owned(),
-            ARROW_SCHEMA_VERSION.to_owned(),
-        ),
+        ("powerio.version".to_owned(), powerio::VERSION.to_owned()),
         ("powerio.format".to_owned(), "coo".to_owned()),
         ("powerio.index_space".to_owned(), "solver_bus".to_owned()),
         ("powerio.row_axis".to_owned(), row_axis.to_owned()),
@@ -1225,10 +1219,7 @@ fn matrix_metadata(
 fn axis_metadata(table: &str) -> HashMap<String, String> {
     HashMap::from([
         ("powerio.table".to_owned(), table.to_owned()),
-        (
-            "powerio.schema_version".to_owned(),
-            ARROW_SCHEMA_VERSION.to_owned(),
-        ),
+        ("powerio.version".to_owned(), powerio::VERSION.to_owned()),
         ("powerio.format".to_owned(), "axis_map".to_owned()),
         ("powerio.row_axis".to_owned(), table.to_owned()),
     ])
@@ -1389,8 +1380,8 @@ mod tests {
         let mut obj = serde_json::Map::new();
         obj.insert("table".to_owned(), serde_json::json!(table_name));
         obj.insert(
-            "schema_version".to_owned(),
-            serde_json::json!(metadata.get("powerio.schema_version").unwrap()),
+            powerio::version::VERSION_KEY.to_owned(),
+            serde_json::json!(metadata.get("powerio.version").unwrap()),
         );
         obj.insert(
             "format".to_owned(),
@@ -1457,8 +1448,8 @@ mod tests {
         let mut obj = serde_json::Map::new();
         obj.insert("table".to_owned(), serde_json::json!(table_name));
         obj.insert(
-            "schema_version".to_owned(),
-            serde_json::json!(metadata.get("powerio.schema_version").unwrap()),
+            powerio::version::VERSION_KEY.to_owned(),
+            serde_json::json!(metadata.get("powerio.version").unwrap()),
         );
         obj.insert(
             "format".to_owned(),
@@ -1697,7 +1688,7 @@ mod tests {
     #[test]
     fn arrow_catalog_lists_ids_columns_axes_and_features() {
         let catalog: serde_json::Value = serde_json::from_str(&catalog_json()).unwrap();
-        assert_eq!(catalog["schema_version"], ARROW_SCHEMA_VERSION);
+        assert_eq!(catalog[powerio::version::VERSION_KEY], powerio::VERSION);
         let tables = catalog["tables"].as_array().unwrap();
         let find = |name: &str| {
             tables
@@ -1760,7 +1751,7 @@ mod tests {
         let metadata = rb.schema();
         let metadata = metadata.metadata();
         assert_eq!(metadata.get("powerio.table").unwrap(), "bprime");
-        assert_eq!(metadata.get("powerio.schema_version").unwrap(), "1");
+        assert_eq!(metadata.get("powerio.version").unwrap(), powerio::VERSION);
         assert_eq!(metadata.get("powerio.format").unwrap(), "coo");
         assert_eq!(metadata.get("powerio.index_space").unwrap(), "solver_bus");
         assert_eq!(metadata.get("powerio.row_axis").unwrap(), "matrix_bus");
@@ -1773,7 +1764,7 @@ mod tests {
         let imported_schema = Schema::try_from(&schema).unwrap();
         let metadata = imported_schema.metadata();
         assert_eq!(metadata.get("powerio.table").unwrap(), "bprime");
-        assert_eq!(metadata.get("powerio.schema_version").unwrap(), "1");
+        assert_eq!(metadata.get("powerio.version").unwrap(), powerio::VERSION);
         assert_eq!(metadata.get("powerio.format").unwrap(), "coo");
         assert_eq!(metadata.get("powerio.index_space").unwrap(), "solver_bus");
         assert_eq!(metadata.get("powerio.row_axis").unwrap(), "matrix_bus");

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -4305,7 +4305,7 @@ mpc.branch = [
             let v: serde_json::Value = serde_json::from_str(&text).unwrap();
 
             assert_eq!(v["schema"], "powerio.scopf.julia");
-            assert_eq!(v["schema_version"], "1.0.0");
+            assert_eq!(v[powerio::version::VERSION_KEY], powerio::VERSION);
             assert_eq!(v["index_base"], 1);
             assert_eq!(v["instance"]["lengths"]["I"], 2);
             assert_eq!(v["instance"]["static"]["acl_branch"][0]["j_ln"], 1);
@@ -4674,7 +4674,7 @@ mpc.branch = [
         let text = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap().to_owned();
         unsafe { pio_string_free(ptr) };
         let catalog: serde_json::Value = serde_json::from_str(&text).unwrap();
-        assert_eq!(catalog["schema_version"], "1");
+        assert_eq!(catalog[powerio::version::VERSION_KEY], powerio::VERSION);
         assert!(catalog["tables"].as_array().unwrap().iter().any(|table| {
             table["id"] == serde_json::json!(PIO_ARROW_TABLE_MATRIX_BUS)
                 && table["name"] == serde_json::json!("matrix_bus")

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -802,7 +802,7 @@ pub unsafe extern "C" fn pio_summary_json(
                     .map(|&idx| v.bus_id(idx).0)
                     .collect();
                 let summary = serde_json::json!({
-                    "schema_version": 1,
+                    powerio::version::VERSION_KEY: powerio::VERSION,
                     "name": c.net.name,
                     "source_format": format!("{:?}", c.net.source_format),
                     "base_mva": c.net.base_mva,
@@ -1997,7 +1997,7 @@ pub unsafe extern "C" fn pio_package_lower_multiconductor_to_balanced(
 
 // ---------------------------------------------------------------------------
 // Geographic layer API. String in and string out, no new object lifetimes:
-// the canonical wire form is a GeoJSON FeatureCollection with the
+// the canonical form is a GeoJSON FeatureCollection with the
 // `powerio_geo` foreign member (see the geo chapter of the guide).
 // ---------------------------------------------------------------------------
 
@@ -2134,7 +2134,7 @@ pub unsafe extern "C" fn pio_scopf_parse_str(
     }
 }
 
-/// Serialize a SCOPF instance using the versioned wire schema. The JSON records
+/// Serialize a SCOPF instance as its Julia compatibility document. The JSON records
 /// its schema version and index base. Free the returned string with
 /// `pio_string_free`. Returns `NULL` for a null handle or serialization error.
 #[cfg(feature = "prob")]
@@ -2153,7 +2153,7 @@ pub unsafe extern "C" fn pio_scopf_to_json(
                 let instance = instance
                     .as_ref()
                     .ok_or_else(|| "SCOPF instance handle is NULL".to_string())?;
-                powerio_prob::scopf::wire::to_wire_json(&instance.instance)
+                powerio_prob::scopf::json::to_json(&instance.instance)
                     .map_err(|error| error.to_string())
             },
         )
@@ -2426,7 +2426,7 @@ pub unsafe extern "C" fn pio_dist_summary_json(
                     .as_ref()
                     .ok_or_else(|| "distribution network handle is NULL".to_string())?;
                 let summary = serde_json::json!({
-                    "schema_version": 1,
+                    powerio::version::VERSION_KEY: powerio::VERSION,
                     "name": net.net.name.as_deref(),
                     "source_format": net.net.source_format.map(|f| f.name()),
                     "base_frequency": net.net.base_frequency,
@@ -4285,7 +4285,7 @@ mpc.branch = [
 
     #[cfg(feature = "prob")]
     #[test]
-    fn scopf_handle_serializes_versioned_wire_json() {
+    fn scopf_handle_serializes_its_julia_document() {
         let text = CString::new(GOC3_SMALL_FIXTURE).unwrap();
         let from = CString::new("goc3-json").unwrap();
         let feature = CString::new("prob").unwrap();
@@ -5061,7 +5061,10 @@ mpc.branch = [
             );
             let value: serde_json::Value =
                 serde_json::from_str(unsafe { CStr::from_ptr(summary) }.to_str().unwrap()).unwrap();
-            assert_eq!(value["schema_version"], serde_json::json!(1));
+            assert_eq!(
+                value[powerio::version::VERSION_KEY],
+                serde_json::json!(powerio::VERSION)
+            );
             assert_eq!(value["source_format"], serde_json::json!("dss"));
             assert_eq!(value["base_frequency"], serde_json::json!(60.0));
             assert_eq!(value["counts"]["buses"], serde_json::json!(2));

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -232,18 +232,14 @@ pub extern "C" fn pio_dist_abi_version() -> u32 {
     PIO_DIST_ABI_VERSION
 }
 
-/// Version of the capability document: the JSON shape that
-/// `pio_dist_capabilities_json` returns. It is not the BMOPF schema
-/// version; the document reports that in `bmopf_schema_version`. Flags
-/// are additive, and each addition bumps the minor version.
-#[cfg(feature = "dist")]
-const DIST_CAPABILITIES_DOC_VERSION: &str = "1.1.0";
-
 #[cfg(feature = "dist")]
 fn dist_capabilities_json() -> String {
     serde_json::json!({
         "dist": true,
-        "schema_version": DIST_CAPABILITIES_DOC_VERSION,
+        // This document is powerio's own, so it states the release that wrote
+        // it. The BMOPF schema it reports below belongs to the task force, and
+        // its version is theirs to set.
+        powerio::version::VERSION_KEY: powerio::VERSION,
         "bmopf_fixed_taps": true,
         "bmopf_center_tap_leakage": true,
         "bmopf_delta_wye_leakage": true,
@@ -295,33 +291,19 @@ pub extern "C" fn pio_schema_versions_json() -> *mut c_char {
 
 /// The body of [`pio_schema_versions_json`], called inside the panic guard.
 fn schema_versions_json_ptr() -> *mut c_char {
-    // `None` serializes to `null`: the build cannot speak that format.
-    #[cfg(feature = "pkg")]
-    let package = Some(powerio_pkg::PIO_PACKAGE_SCHEMA_VERSION);
-    #[cfg(not(feature = "pkg"))]
-    let package: Option<&str> = None;
-
-    #[cfg(feature = "arrow")]
-    let arrow = Some(arrow_export::ARROW_SCHEMA_VERSION);
-    #[cfg(not(feature = "arrow"))]
-    let arrow: Option<&str> = None;
-
-    #[cfg(feature = "dist")]
-    let dist_capabilities = Some(DIST_CAPABILITIES_DOC_VERSION);
-    #[cfg(not(feature = "dist"))]
-    let dist_capabilities: Option<&str> = None;
-
+    // Every document powerio authors states one version, the release that
+    // wrote it, so this report needs one key for all of them. What stays
+    // separate is the C handshake integer and any foreign schema this build
+    // speaks, whose version belongs to whoever owns that schema.
     #[cfg(feature = "dist")]
     let bmopf_schema = Some(powerio_dist::BMOPF_SCHEMA_VERSION);
+    // `None` serializes to `null`: the build cannot speak that format.
     #[cfg(not(feature = "dist"))]
     let bmopf_schema: Option<&str> = None;
 
     let doc = serde_json::json!({
-        "schema_version": "1.0.0",
+        powerio::version::VERSION_KEY: powerio::VERSION,
         "abi": PIO_ABI_VERSION,
-        "package": package,
-        "arrow": arrow,
-        "dist_capabilities": dist_capabilities,
         "bmopf_schema": bmopf_schema,
     });
     into_cstring(doc.to_string()).unwrap_or(std::ptr::null_mut())
@@ -4227,8 +4209,8 @@ mpc.branch = [
             );
             let v = package_json(pkg);
             assert_eq!(
-                v["schema_version"],
-                serde_json::json!(powerio_pkg::PIO_PACKAGE_SCHEMA_VERSION)
+                v[powerio::version::VERSION_KEY],
+                serde_json::json!(powerio::VERSION)
             );
             assert_eq!(v["model_kind"], serde_json::json!("balanced"));
             assert_eq!(v["model"]["kind"], serde_json::json!("balanced"));
@@ -4896,44 +4878,36 @@ mpc.branch = [
         }
 
         #[test]
-        fn schema_versions_json_matches_the_constants_the_library_stamps() {
+        fn version_report_states_one_powerio_version_and_the_foreign_ones() {
             let raw = pio_schema_versions_json();
             assert!(!raw.is_null());
             let text = unsafe { CStr::from_ptr(raw) }.to_str().unwrap().to_owned();
             unsafe { pio_string_free(raw) };
             let doc: serde_json::Value = serde_json::from_str(&text).unwrap();
 
-            assert_eq!(doc["schema_version"], serde_json::json!("1.0.0"));
+            // One key for every document powerio authors, and the C handshake
+            // integer, which is a different mechanism.
+            assert_eq!(
+                doc[powerio::version::VERSION_KEY],
+                serde_json::json!(powerio::VERSION)
+            );
             assert_eq!(doc["abi"], serde_json::json!(PIO_ABI_VERSION));
 
-            // Each reported version must equal the constant stamped into the
-            // documents, not a copy of it.
-            #[cfg(feature = "pkg")]
-            assert_eq!(
-                doc["package"],
-                serde_json::json!(powerio_pkg::PIO_PACKAGE_SCHEMA_VERSION)
-            );
+            // The per document numbers this report used to carry are gone,
+            // not renamed: a binding that still reads one must fail loudly.
+            for retired in ["schema_version", "package", "arrow", "dist_capabilities"] {
+                assert_eq!(doc[retired], serde_json::Value::Null, "{retired}");
+            }
+
+            // A foreign schema keeps its owner's version, which is the whole
+            // reason this report exists.
             #[cfg(feature = "dist")]
             assert_eq!(
                 doc["bmopf_schema"],
                 serde_json::json!(powerio_dist::BMOPF_SCHEMA_VERSION)
             );
-            #[cfg(feature = "arrow")]
-            assert_eq!(
-                doc["arrow"],
-                serde_json::json!(crate::arrow_export::ARROW_SCHEMA_VERSION)
-            );
-            #[cfg(not(feature = "arrow"))]
-            assert_eq!(doc["arrow"], serde_json::Value::Null);
-
-            let caps_raw = pio_dist_capabilities_json();
-            let caps_text = unsafe { CStr::from_ptr(caps_raw) }
-                .to_str()
-                .unwrap()
-                .to_owned();
-            unsafe { pio_string_free(caps_raw) };
-            let caps: serde_json::Value = serde_json::from_str(&caps_text).unwrap();
-            assert_eq!(doc["dist_capabilities"], caps["schema_version"]);
+            #[cfg(not(feature = "dist"))]
+            assert_eq!(doc["bmopf_schema"], serde_json::Value::Null);
         }
 
         #[test]
@@ -4950,7 +4924,7 @@ mpc.branch = [
                 caps,
                 serde_json::json!({
                     "dist": true,
-                    "schema_version": DIST_CAPABILITIES_DOC_VERSION,
+                    powerio::version::VERSION_KEY: powerio::VERSION,
                     "bmopf_fixed_taps": true,
                     "bmopf_center_tap_leakage": true,
                     "bmopf_delta_wye_leakage": true,
@@ -5147,8 +5121,8 @@ mpc.branch = [
             assert_eq!(vendored["version"], caps["bmopf_schema_version"]);
 
             assert_eq!(
-                caps["schema_version"],
-                serde_json::json!(DIST_CAPABILITIES_DOC_VERSION)
+                caps[powerio::version::VERSION_KEY],
+                serde_json::json!(powerio::VERSION)
             );
         }
 

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -20,6 +20,9 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
+# The hub crate directly, for `powerio::version`: the CLI authors a summary
+# document and must stamp it with the same key every other one carries.
+powerio.workspace = true
 powerio-matrix = { workspace = true, features = ["gridfm"] }
 powerio-prob = { workspace = true, features = ["matrix"] }
 # Unconditional: the CLI always ships the distribution surface (`convert

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -25,8 +25,6 @@ mod tui;
 use cases::infer_input_family;
 use powerio_matrix::format::routing::SourceFormat as DetectedFormat;
 
-const SUMMARY_SCHEMA_VERSION: &str = "0.1";
-
 #[derive(Parser, Debug)]
 #[command(name = "powerio", version, about)]
 struct Cli {
@@ -1296,7 +1294,7 @@ fn transmission_summary_json(
     let view = powerio_matrix::IndexedNetwork::new(net);
     json!({
         "schema": "powerio.summary",
-        "schema_version": SUMMARY_SCHEMA_VERSION,
+        powerio::version::VERSION_KEY: powerio::VERSION,
         "domain": "transmission",
         "model": "balanced",
         "name": net.name,
@@ -1326,7 +1324,7 @@ fn transmission_summary_json(
 fn distribution_summary_json(net: &powerio_dist::DistNetwork) -> serde_json::Value {
     json!({
         "schema": "powerio.summary",
-        "schema_version": SUMMARY_SCHEMA_VERSION,
+        powerio::version::VERSION_KEY: powerio::VERSION,
         "domain": "distribution",
         "model": "multiconductor",
         "name": net.name,
@@ -1915,7 +1913,7 @@ mod tests {
         let parsed = powerio_matrix::parse_file(data("case9.m"), None).unwrap();
         let value = transmission_summary_json(&parsed.network, &parsed.warnings);
         assert_eq!(value["schema"], "powerio.summary");
-        assert_eq!(value["schema_version"], "0.1");
+        assert_eq!(value[powerio::version::VERSION_KEY], powerio::VERSION);
         assert_eq!(value["domain"], "transmission");
         assert_eq!(value["model"], "balanced");
         assert_eq!(value["json_format"], "powerio-json");
@@ -1955,7 +1953,7 @@ mod tests {
         let net = powerio_dist::parse_file(data("dist/micro/xfmr_single_phase.dss"), None).unwrap();
         let value = distribution_summary_json(&net);
         assert_eq!(value["schema"], "powerio.summary");
-        assert_eq!(value["schema_version"], "0.1");
+        assert_eq!(value[powerio::version::VERSION_KEY], powerio::VERSION);
         assert_eq!(value["domain"], "distribution");
         assert_eq!(value["model"], "multiconductor");
         assert_eq!(value["json_format"], "bmopf-json");

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -2105,7 +2105,7 @@ mod tests {
     #[test]
     fn package_helper_returns_stdout_text() {
         let (text, _) = package_text(&data("case9.m"), None, 0).unwrap();
-        assert!(text.contains("\"schema_version\""));
+        assert!(text.contains(&format!("\"{}\"", powerio::version::VERSION_KEY)));
         let pkg = NetworkPackage::from_json(&text).unwrap();
         assert_eq!(pkg.summary.elements["buses"], 9);
     }

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -159,10 +159,7 @@ fn package_overwrites_existing_output_file() {
 
     let text = std::fs::read_to_string(&out_path).unwrap();
     let value: serde_json::Value = serde_json::from_str(&text).unwrap();
-    assert_eq!(
-        value["schema_version"],
-        powerio_pkg::PIO_PACKAGE_SCHEMA_VERSION
-    );
+    assert_eq!(value[powerio::version::VERSION_KEY], powerio::VERSION);
     assert!(!text.contains("sentinel"), "{text}");
 
     let _ = std::fs::remove_file(out_path);

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -936,7 +936,7 @@ pub struct DistNetwork {
     pub warnings: Vec<String>,
     /// Structured findings from the parse session. An `Error` entry means
     /// the network is incomplete (for example a refused include). Skipped
-    /// in the `.pio.json` payload: the wire spelling is a v0.9 register
+    /// in the `.pio.json` payload: the serialized spelling is a v0.9
     /// decision, and package diagnostics live in the envelope.
     #[serde(skip)]
     pub parse_diagnostics: Vec<crate::diagnostics::StructuredDiagnostic>,

--- a/powerio-pkg/examples/generate_schemas.rs
+++ b/powerio-pkg/examples/generate_schemas.rs
@@ -24,13 +24,15 @@ mod generate {
             .nth(1)
             .map_or_else(|| PathBuf::from("docs/schema"), PathBuf::from);
 
-        // One published document per format lineage; it embeds every payload
+        // One published document per powerio lineage; it embeds every payload
         // type. The `$id` names the published location and is not written into
-        // `.pio.json` files.
+        // `.pio.json` files. The lineage is the same one the reader accepts, so
+        // the path moves when and only when a document stops loading.
+        let lineage = powerio::version::lineage_path();
         write_schema::<powerio_pkg::NetworkPackage>(
             &out,
-            "pio-package/0.2",
-            "https://powerio.dev/schema/pio-package/0.2",
+            &format!("pio-package/{lineage}"),
+            &format!("https://powerio.dev/schema/pio-package/{lineage}"),
         )?;
 
         Ok(())

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -58,8 +58,8 @@ pub use model::{ModelKind, ModelPayload};
 pub use operating::{ElementRef, ElementUpdate, OperatingPoint, OperatingPointSeries, TimeAxis};
 pub use package::{
     DerivedMetadata, NetworkPackage, NormalizedSolverTableMetadata, NormalizedSolverTableRowCounts,
-    NormalizedSolverTableSourceRows, PIO_PACKAGE_SCHEMA_VERSION, READ_GRIDFM_FIDELITY_WARNING,
-    READ_TRANSMISSION_PARSE_WARNING, ensure_payload_uids,
+    NormalizedSolverTableSourceRows, READ_GRIDFM_FIDELITY_WARNING, READ_TRANSMISSION_PARSE_WARNING,
+    ensure_payload_uids,
 };
 pub use provenance::{
     Confidence, MappingKind, Origin, Producer, SourceDescriptor, SourceMapEntry, SourceRef,

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -143,7 +143,7 @@ impl OperatingPoint {
 /// carries `uid` values, a present `source_uid` resolves the target row and a
 /// present `row` must agree with it. In a table without uids (packages written
 /// before payload identity existed), `source_uid` is advisory and `row`
-/// addresses the update alone. On the wire, `row` may be omitted when
+/// addresses the update alone. In the document, `row` may be omitted when
 /// `source_uid` is given.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -218,23 +218,23 @@ impl<'de> Deserialize<'de> for ElementRef {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
         #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-        struct Wire {
+        struct Stated {
             table: String,
             #[serde(default)]
             row: Option<usize>,
             #[serde(default)]
             source_uid: Option<String>,
         }
-        let wire = Wire::deserialize(deserializer)?;
-        if wire.row.is_none() && wire.source_uid.is_none() {
+        let stated = Stated::deserialize(deserializer)?;
+        if stated.row.is_none() && stated.source_uid.is_none() {
             return Err(serde::de::Error::custom(
                 "element ref needs `row` or `source_uid`",
             ));
         }
         Ok(Self {
-            table: wire.table,
-            row: wire.row,
-            source_uid: wire.source_uid,
+            table: stated.table,
+            row: stated.row,
+            source_uid: stated.source_uid,
         })
     }
 }
@@ -534,7 +534,7 @@ pub(crate) fn json_error(message: impl Into<String>) -> serde_json::Error {
 /// Apply one operating point to the payload and return the updated model plus
 /// the JSON Pointer paths of every field written, computed from the resolved
 /// rows so stale provenance cleanup follows identity resolution, never a stale
-/// wire row.
+/// stated row.
 pub(crate) fn apply_operating_point_to_model(
     model: &ModelPayload,
     point: &OperatingPoint,
@@ -670,9 +670,9 @@ pub(crate) fn resolve_update(
 }
 
 /// Resolve one element ref to a payload row. A `source_uid` that resolves in a
-/// uid bearing table is authoritative and a present wire `row` must agree with
+/// uid bearing table is authoritative and a present `row` must agree with
 /// it; an unknown or duplicated uid in such a table is an error; a table without
-/// uids falls back to the wire row.
+/// uids falls back to the stated row.
 pub(crate) fn resolve_update_row(
     payload: &Map<String, Value>,
     indexes: &mut HashMap<String, IdentityIndex>,
@@ -696,12 +696,12 @@ pub(crate) fn resolve_update_row(
         }
         Some(uid) => match index.by_uid.get(uid) {
             Some(&row) => {
-                if let Some(wire_row) = element.row
-                    && wire_row != row
+                if let Some(stated_row) = element.row
+                    && stated_row != row
                 {
                     return Err(format!(
                         "update for table `{table_name}` names uid `{uid}` (row {row}) \
-                         but carries row {wire_row}"
+                         but carries row {stated_row}"
                     ));
                 }
                 row

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -477,9 +477,9 @@ impl NetworkPackage {
                 "package has no operating point {index}"
             ))
         })?;
-        // Applying resolves each update's row (identity first, wire row as
+        // Applying resolves each update's row (identity first, stated row as
         // fallback), so the stale provenance paths come from the same
-        // resolution rather than the wire row values.
+        // resolution rather than the stated row values.
         let (updated_model, updated_paths) = apply_operating_point_to_model(&self.model, point)?;
         let had_normalized_solver_tables = self.derived.normalized_solver_tables.is_some();
         let options = materialize_operating_point_options(index);
@@ -927,7 +927,7 @@ const SANE_VALIDATION_CODES: [&str; 10] = [
 ];
 
 /// Check every operating point update against the payload's identity index:
-/// unknown `source_uid`, a wire `row` that contradicts the resolved row,
+/// unknown `source_uid`, a stated `row` that contradicts the resolved row,
 /// ambiguous (duplicate) payload uids, and rows out of range all become Error
 /// diagnostics, so `pio_package_validate` rejects a package whose updates
 /// reference unknown identities without materializing it.

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -28,27 +28,11 @@ use crate::study::{StudyBlock, apply_study_to_model, check_study_identities};
 use crate::summary::{ObjectSummary, ObjectTopology, ObjectUnits};
 use crate::validation::{ValidationPass, ValidationStatus, ValidationSummary};
 
-/// The `.pio.json` format version (semver), the one version number for the
-/// whole document, payload included. While the major is 0, an incompatible
-/// change to any field bumps the minor and additive changes bump the patch
-/// (cargo 0.x semantics); from 1.0.0 on, incompatible changes bump the major.
-/// The reader rejects a file from a different lineage with an error telling
-/// the caller to regenerate it from the source case.
-///
-/// 0.2.0: the `schema`, `payload_schema`, and `payload_schema_version` fields
-/// were removed, and the multiconductor bus `vsym_min`/`vsym_max` arrays
-/// became the per-sequence scalars `vpos_min`/`vpos_max`/`vneg_max`/
-/// `vzero_max`/`vn_max` (BMOPF schema 0.1.0).
-///
-/// 0.2.1: multiconductor bounds, ratings, and line lengths accept `null`
-/// for a nonfinite value (#268). Same 0.2 lineage; the reader accepts both.
-pub const PIO_PACKAGE_SCHEMA_VERSION: &str = "0.2.1";
-
 pub const READ_TRANSMISSION_PARSE_WARNING: &str = "READ.TRANSMISSION.PARSE_WARNING";
 pub const READ_GRIDFM_FIDELITY_WARNING: &str = "READ.GRIDFM.FIDELITY_WARNING";
 
-fn default_schema_version() -> String {
-    PIO_PACKAGE_SCHEMA_VERSION.to_owned()
+fn default_powerio_version() -> String {
+    powerio::VERSION.to_owned()
 }
 
 /// Optional derived metadata: matrix statistics, solver table metadata, and
@@ -166,16 +150,17 @@ impl From<&NormalizedSolverTables> for NormalizedSolverTableMetadata {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[non_exhaustive]
 pub struct NetworkPackage {
-    /// The `.pio.json` format version (semver); see
-    /// [`PIO_PACKAGE_SCHEMA_VERSION`].
+    /// The powerio version that wrote this document; see
+    /// [`powerio::version`].
     ///
-    /// Required. It used to default to the current version when absent, which
-    /// let a document opt out of the lineage gate by dropping the field: a
-    /// 0.1-era payload then read under 0.2 rules, and a field the two spell
-    /// differently arrived as its `serde` default with no error and no
-    /// warning. That is the misreading the gate exists to stop, so a document
-    /// must now state its lineage.
-    pub schema_version: String,
+    /// A document that states none deserializes to the empty string, which no
+    /// lineage accepts, so the gate stays closed and the reader can name the
+    /// release that wrote it. It must never default to the current version:
+    /// that lets a document opt out of the gate by dropping the field, and a
+    /// field an older lineage spells differently then arrives as its `serde`
+    /// default with no error and no warning.
+    #[serde(default)]
+    pub powerio_version: String,
     pub producer: Producer,
     /// Stable content id, e.g. `"sha256:..."`. The scaffold leaves it `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -225,7 +210,7 @@ impl NetworkPackage {
         let diagnostics = Vec::new();
         let validation = ValidationSummary::from_diagnostics(&diagnostics);
         Self {
-            schema_version: default_schema_version(),
+            powerio_version: default_powerio_version(),
             producer: Producer::powerio(),
             package_id: None,
             created_at: None,
@@ -392,7 +377,7 @@ impl NetworkPackage {
         let validation = ValidationSummary::from_diagnostics(&diagnostics);
 
         Self {
-            schema_version: default_schema_version(),
+            powerio_version: default_powerio_version(),
             producer: Producer::powerio(),
             package_id: None,
             created_at: None,
@@ -503,7 +488,7 @@ impl NetworkPackage {
         // make an explicit carry-or-clear decision here instead of silently
         // riding along stale.
         let mut package = Self {
-            schema_version: self.schema_version.clone(),
+            powerio_version: self.powerio_version.clone(),
             producer: self.producer.clone(),
             // A derived package is new content: it records the parent's id in
             // its origin and never inherits it as its own (as in
@@ -612,7 +597,7 @@ impl NetworkPackage {
         let options = materialize_study_commit_options(study, commit_index);
 
         let mut package = Self {
-            schema_version: base.schema_version.clone(),
+            powerio_version: base.powerio_version.clone(),
             producer: base.producer.clone(),
             package_id: None,
             created_at: base.created_at.clone(),
@@ -703,13 +688,10 @@ impl NetworkPackage {
                 "invalid .pio.json package envelope: {e}"
             ))
         })?;
-        if !Self::supports_schema_version(&pkg.schema_version) {
-            return Err(<serde_json::Error as serde::de::Error>::custom(format!(
-                "unsupported .pio.json schema_version {}; this reader supports {}; \
-                 regenerate the package from its source case",
-                pkg.schema_version,
-                supported_lineage_label()
-            )));
+        if !powerio::version::supports(&pkg.powerio_version) {
+            return Err(<serde_json::Error as serde::de::Error>::custom(
+                powerio::version::reject(".pio.json", &pkg.powerio_version),
+            ));
         }
         if !pkg.kind_is_consistent() {
             return Err(<serde_json::Error as serde::de::Error>::custom(
@@ -719,19 +701,17 @@ impl NetworkPackage {
         Ok(pkg)
     }
 
-    /// Whether this reader accepts the document's `schema_version`.
+    /// Whether this reader accepts the document's `powerio_version`.
     ///
     /// The `.pio.json` compatibility rule: unknown top level fields from a
     /// newer producer are ignored, versions in the reader's lineage load, and
-    /// anything else is rejected before payload use. The lineage is the major
-    /// version once it reaches 1, and the exact major.minor pair while the
-    /// major is 0 (cargo 0.x semantics: a 0.x minor bump is incompatible).
+    /// anything else is rejected before payload use.
+    #[deprecated(
+        since = "0.9.0",
+        note = "use `powerio::version::supports`, which every powerio authored document shares; removed in 1.0.0"
+    )]
     pub fn supports_schema_version(version: &str) -> bool {
-        let Some((major, minor)) = schema_lineage(version) else {
-            return false;
-        };
-        let (current_major, current_minor) = supported_lineage();
-        major == current_major && (major != 0 || minor == current_minor)
+        powerio::version::supports(version)
     }
 
     #[must_use]
@@ -905,67 +885,6 @@ fn materialize_study_commit_options(
         options.insert("base_operating_point".to_owned(), serde_json::json!(index));
     }
     options
-}
-
-fn schema_lineage(version: &str) -> Option<(u64, u64)> {
-    // Accept a semver core `MAJOR.MINOR.PATCH` with an optional prerelease
-    // (`-...`) or build (`+...`) tag: same-lineage additive versions load, so a
-    // forward-compatible writer that stamps e.g. `0.2.1-rc.1` is not rejected.
-    // Split the build tag off first: `+` cannot appear in a prerelease, but a
-    // hyphen is legal inside build metadata (`1.0.0+build-x`), so splitting on
-    // `-` first would cut inside the build tag and reject a valid version.
-    let (rest, build) = match version.split_once('+') {
-        Some((rest, build)) => (rest, Some(build)),
-        None => (version, None),
-    };
-    let (core, pre) = match rest.split_once('-') {
-        Some((core, pre)) => (core, Some(pre)),
-        None => (rest, None),
-    };
-    if pre.is_some_and(|s| !valid_semver_suffix(s))
-        || build.is_some_and(|s| !valid_semver_suffix(s))
-    {
-        return None;
-    }
-    let mut parts = core.split('.');
-    let major = parts.next()?;
-    let minor = parts.next()?;
-    let patch = parts.next()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    let major = parse_semver_number(major)?;
-    let minor = parse_semver_number(minor)?;
-    parse_semver_number(patch)?;
-    Some((major, minor))
-}
-
-fn parse_semver_number(s: &str) -> Option<u64> {
-    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) || (s.len() > 1 && s.starts_with('0'))
-    {
-        return None;
-    }
-    s.parse().ok()
-}
-
-fn valid_semver_suffix(s: &str) -> bool {
-    !s.is_empty()
-        && s.split('.').all(|part| {
-            !part.is_empty() && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
-        })
-}
-
-fn supported_lineage() -> (u64, u64) {
-    schema_lineage(PIO_PACKAGE_SCHEMA_VERSION).expect("package schema version is valid semver")
-}
-
-/// The lineage this reader accepts, spelled for error messages: `0.2.x` while
-/// the major is 0, `major version N` afterwards.
-fn supported_lineage_label() -> String {
-    match supported_lineage() {
-        (0, minor) => format!("0.{minor}.x"),
-        (major, _) => format!("major version {major}"),
-    }
 }
 
 /// Add a stable UID to each payload row that does not have one.
@@ -2338,28 +2257,50 @@ fn multiconductor_source_maps(
 #[cfg(test)]
 mod tests {
     #[test]
-    fn schema_lineage_parses_semver_suffixes() {
-        assert_eq!(super::schema_lineage("1.2.3"), Some((1, 2)));
-        assert_eq!(super::schema_lineage("1.0.0-rc.1"), Some((1, 0)));
-        // A hyphen inside build metadata is legal semver; splitting on `-`
-        // first used to cut inside the build tag and reject the version.
-        assert_eq!(super::schema_lineage("1.0.0+build-x"), Some((1, 0)));
-        assert_eq!(super::schema_lineage("0.2.0+2026-07-21"), Some((0, 2)));
-        assert_eq!(super::schema_lineage("1.0.0-rc-1+b-2"), Some((1, 0)));
-        assert_eq!(super::schema_lineage("1.0"), None);
-        assert_eq!(super::schema_lineage("1.0.0-"), None);
-        assert_eq!(super::schema_lineage("01.0.0"), None);
+    fn a_package_states_the_powerio_version_that_wrote_it() {
+        let net = powerio::BalancedNetwork::in_memory("demo", 100.0, vec![], vec![]);
+        let pkg = super::NetworkPackage::from_balanced(net);
+        assert_eq!(pkg.powerio_version, powerio::VERSION);
+        let text = pkg.to_json().unwrap();
+        assert!(
+            text.contains(&format!("\"powerio_version\":\"{}\"", powerio::VERSION)),
+            "{text}"
+        );
+        assert!(
+            !text.contains("schema_version"),
+            "the per document schema number is gone: {text}"
+        );
     }
 
     #[test]
-    fn version_gate_is_exact_minor_while_major_is_zero() {
-        use super::NetworkPackage;
-        assert!(NetworkPackage::supports_schema_version("0.2.0"));
-        assert!(NetworkPackage::supports_schema_version("0.2.7"));
-        assert!(!NetworkPackage::supports_schema_version("0.1.1"));
-        assert!(!NetworkPackage::supports_schema_version("0.3.0"));
-        assert!(!NetworkPackage::supports_schema_version("1.0.0"));
-        assert!(!NetworkPackage::supports_schema_version("garbage"));
+    fn a_package_from_an_older_lineage_is_refused_by_name() {
+        // What every 0.8.x release wrote: `schema_version`, no
+        // `powerio_version`. The reader must name the release rather than
+        // report a missing field.
+        let net = powerio::BalancedNetwork::in_memory("demo", 100.0, vec![], vec![]);
+        let text = super::NetworkPackage::from_balanced(net)
+            .to_json()
+            .unwrap()
+            .replacen("\"powerio_version\"", "\"schema_version\"", 1);
+        let err = super::NetworkPackage::from_json(&text)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("before powerio 0.9.0"), "{err}");
+        assert!(err.contains("regenerate"), "{err}");
+    }
+
+    #[test]
+    fn a_package_from_a_future_lineage_is_refused_with_both_versions() {
+        let net = powerio::BalancedNetwork::in_memory("demo", 100.0, vec![], vec![]);
+        let mut pkg = super::NetworkPackage::from_balanced(net);
+        pkg.powerio_version = "9.9.9".to_owned();
+        let text = pkg.to_json().unwrap();
+        let err = super::NetworkPackage::from_json(&text)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("9.9.9"), "{err}");
+        assert!(err.contains(powerio::VERSION), "{err}");
+        assert!(err.contains("regenerate"), "{err}");
     }
 
     #[test]

--- a/powerio-pkg/src/study.rs
+++ b/powerio-pkg/src/study.rs
@@ -158,14 +158,14 @@ impl Serialize for StudyEdit {
         match self {
             Self::DemandDelta { bus, p_mw, q_mvar } => {
                 #[derive(Serialize)]
-                struct Wire<'a> {
+                struct Stated<'a> {
                     kind: &'static str,
                     bus: &'a ElementRef,
                     p_mw: f64,
                     #[serde(skip_serializing_if = "Option::is_none")]
                     q_mvar: Option<f64>,
                 }
-                Wire {
+                Stated {
                     kind: "demand_delta",
                     bus,
                     p_mw: *p_mw,
@@ -175,12 +175,12 @@ impl Serialize for StudyEdit {
             }
             Self::RatingDelta { branch, delta_mw } => {
                 #[derive(Serialize)]
-                struct Wire<'a> {
+                struct Stated<'a> {
                     kind: &'static str,
                     branch: &'a ElementRef,
                     delta_mw: f64,
                 }
-                Wire {
+                Stated {
                     kind: "rating_delta",
                     branch,
                     delta_mw: *delta_mw,
@@ -189,11 +189,11 @@ impl Serialize for StudyEdit {
             }
             Self::SetFields { update } => {
                 #[derive(Serialize)]
-                struct Wire<'a> {
+                struct Stated<'a> {
                     kind: &'static str,
                     update: &'a ElementUpdate,
                 }
-                Wire {
+                Stated {
                     kind: "set_fields",
                     update,
                 }
@@ -217,39 +217,39 @@ impl<'de> Deserialize<'de> for StudyEdit {
         match kind {
             "demand_delta" => {
                 #[derive(Deserialize)]
-                struct Wire {
+                struct Stated {
                     bus: ElementRef,
                     p_mw: f64,
                     #[serde(default)]
                     q_mvar: Option<f64>,
                 }
-                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                let stated = serde_json::from_value::<Stated>(value).map_err(D::Error::custom)?;
                 Ok(Self::DemandDelta {
-                    bus: wire.bus,
-                    p_mw: wire.p_mw,
-                    q_mvar: wire.q_mvar,
+                    bus: stated.bus,
+                    p_mw: stated.p_mw,
+                    q_mvar: stated.q_mvar,
                 })
             }
             "rating_delta" => {
                 #[derive(Deserialize)]
-                struct Wire {
+                struct Stated {
                     branch: ElementRef,
                     delta_mw: f64,
                 }
-                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                let stated = serde_json::from_value::<Stated>(value).map_err(D::Error::custom)?;
                 Ok(Self::RatingDelta {
-                    branch: wire.branch,
-                    delta_mw: wire.delta_mw,
+                    branch: stated.branch,
+                    delta_mw: stated.delta_mw,
                 })
             }
             "set_fields" => {
                 #[derive(Deserialize)]
-                struct Wire {
+                struct Stated {
                     update: ElementUpdate,
                 }
-                let wire = serde_json::from_value::<Wire>(value).map_err(D::Error::custom)?;
+                let stated = serde_json::from_value::<Stated>(value).map_err(D::Error::custom)?;
                 Ok(Self::SetFields {
-                    update: wire.update,
+                    update: stated.update,
                 })
             }
             other => Ok(Self::Unknown {

--- a/powerio-pkg/tests/frozen_schemas.rs
+++ b/powerio-pkg/tests/frozen_schemas.rs
@@ -18,11 +18,16 @@ fn fnv1a(bytes: &[u8]) -> u64 {
 
 #[test]
 fn retired_schema_documents_stay_published_byte_for_byte() {
-    let frozen: [(&str, usize, u64); 3] = [
+    let frozen: [(&str, usize, u64); 4] = [
         (
             "../docs/schema/pio-package/0.1/schema.json",
             125_750,
             0xe5af_9f64_b26e_edc2,
+        ),
+        (
+            "../docs/schema/pio-package/0.2/schema.json",
+            130_344,
+            0x944c_3d7a_721d_1da9,
         ),
         (
             "../docs/schema/pio-payload-balanced/1/schema.json",
@@ -46,7 +51,7 @@ fn retired_schema_documents_stay_published_byte_for_byte() {
         assert_eq!(
             (bytes.len(), fnv1a(&bytes)),
             (len, hash),
-            "{path} changed, but it is frozen at its v0.7.3 bytes: documents in the wild \
+            "{path} changed, but it is frozen at the bytes its release published: documents in the wild \
              validate against it by URL, so edits belong in a NEW identifier path, not here \
              (see docs/schema/README.md)"
         );

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -5,10 +5,10 @@ use std::collections::BTreeMap;
 use powerio_pkg::{
     Confidence, DiagnosticCode, DiagnosticSeverity, DiagnosticStage, ElementRef, ElementUpdate,
     MappingKind, ModelKind, MulticonductorToBalancedOptions, MulticonductorToBalancedReadiness,
-    NetworkPackage, OperatingPoint, OperatingPointSeries, Origin, PIO_PACKAGE_SCHEMA_VERSION,
-    READ_TRANSMISSION_PARSE_WARNING, SequenceTransformConvention, SourceDescriptor, SourceMapEntry,
-    SourceRef, StructuredDiagnostic, StudyBlock, StudyCommit, StudyEdit, TimeAxis,
-    ValidationStatus, check_multiconductor_to_balanced_lowering, ensure_payload_uids,
+    NetworkPackage, OperatingPoint, OperatingPointSeries, Origin, READ_TRANSMISSION_PARSE_WARNING,
+    SequenceTransformConvention, SourceDescriptor, SourceMapEntry, SourceRef, StructuredDiagnostic,
+    StudyBlock, StudyCommit, StudyEdit, TimeAxis, ValidationStatus,
+    check_multiconductor_to_balanced_lowering, ensure_payload_uids,
     lower_multiconductor_to_balanced,
 };
 
@@ -264,57 +264,71 @@ fn assert_json_roundtrips(pkg: &NetworkPackage) {
 }
 
 #[test]
-fn schema_version_is_present_and_required() {
+fn powerio_version_is_present_and_required() {
     let pkg = balanced_package();
-    assert_eq!(pkg.schema_version, PIO_PACKAGE_SCHEMA_VERSION);
+    assert_eq!(pkg.powerio_version, powerio::VERSION);
 
     // A document without the field is refused. Defaulting it to the current
-    // version would let a 0.1-era package skip the lineage gate by dropping
-    // the field: every payload difference between the two lineages would then
-    // arrive as a serde default, with no error and no warning.
+    // version would let a package from an older lineage skip the gate by
+    // dropping the field: every payload difference between the two lineages
+    // would then arrive as a serde default, with no error and no warning.
     let mut v = serde_json::to_value(&pkg).unwrap();
-    v.as_object_mut().unwrap().remove("schema_version");
+    v.as_object_mut().unwrap().remove("powerio_version");
     let err = NetworkPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap_err();
-    assert!(
-        err.to_string().contains("schema_version"),
-        "the error must name the missing field: {err}"
-    );
+    let msg = err.to_string();
+    assert!(msg.contains("before powerio 0.9.0"), "got: {msg}");
+    assert!(msg.contains("regenerate"), "got: {msg}");
 }
 
 #[test]
 fn version_gate_rejects_other_lineages_and_says_regenerate() {
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();
+    let (major, minor) = lineage(powerio::VERSION);
+    assert_eq!(major, 0, "update this test at 1.0.0");
 
-    // A file from the 0.1.x lineage (every release through 0.7.2) is rejected
-    // with an error naming the supported lineage and the remedy.
-    v["schema_version"] = serde_json::json!("0.1.1");
+    // A file from the previous minor is rejected with an error naming this
+    // build's lineage and the remedy. While the major is 0 a minor bump is
+    // incompatible, which is what cargo and Pkg already mean by 0.x.
+    v["powerio_version"] = serde_json::json!(format!("0.{}.1", minor - 1));
     let err = NetworkPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap_err();
     let msg = err.to_string();
-    assert!(
-        msg.contains("unsupported .pio.json schema_version 0.1.1"),
-        "got: {msg}"
-    );
-    assert!(msg.contains("0.2.x"), "got: {msg}");
+    assert!(msg.contains(&format!("0.{}.1", minor - 1)), "got: {msg}");
+    assert!(msg.contains(&format!("0.{minor}.x")), "got: {msg}");
     assert!(msg.contains("regenerate"), "got: {msg}");
 
     // Same lineage, additive patch: loads.
-    v["schema_version"] = serde_json::json!("0.2.3");
+    v["powerio_version"] = serde_json::json!(format!("0.{minor}.99"));
     NetworkPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
 
     // Later lineages and garbage: rejected.
-    for bad in ["0.3.0", "1.0.0", "not-semver"] {
-        v["schema_version"] = serde_json::json!(bad);
+    for bad in [
+        format!("0.{}.0", minor + 1),
+        "1.0.0".into(),
+        "not-semver".into(),
+    ] {
+        v["powerio_version"] = serde_json::json!(bad);
         NetworkPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap_err();
     }
 
-    // Fields this lineage removed are ignored as unknown, as any unknown top
+    // Fields an older lineage wrote are ignored as unknown, as any unknown top
     // level field from another producer is; the version gate is the only
     // arbiter.
-    v["schema_version"] = serde_json::json!(PIO_PACKAGE_SCHEMA_VERSION);
+    v["powerio_version"] = serde_json::json!(powerio::VERSION);
+    v["schema_version"] = serde_json::json!("0.2.1");
     v["payload_schema"] = serde_json::json!("https://powerio.dev/schema/pio-payload-balanced/1");
     v["payload_schema_version"] = serde_json::json!("1.1.0");
     NetworkPackage::from_json(&serde_json::to_string(&v).unwrap()).unwrap();
+}
+
+/// The `(major, minor)` of a semver string, for tests that must express a
+/// neighbouring lineage without hardcoding this release's number.
+fn lineage(version: &str) -> (u64, u64) {
+    let core = version.split(['-', '+']).next().unwrap();
+    let mut parts = core.split('.');
+    let major = parts.next().unwrap().parse().unwrap();
+    let minor = parts.next().unwrap().parse().unwrap();
+    (major, minor)
 }
 
 #[test]
@@ -1050,37 +1064,41 @@ fn unknown_future_fields_are_tolerated() {
 }
 
 #[test]
-fn future_same_lineage_schema_version_is_tolerated() {
+fn a_future_patch_of_this_lineage_is_tolerated() {
     // A newer patch in the reader's lineage with a field this reader does not
     // know: both are additive, so the document loads.
+    let (_, minor) = lineage(powerio::VERSION);
+    let future = format!("0.{minor}.99");
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();
     v.as_object_mut()
         .unwrap()
-        .insert("schema_version".to_owned(), serde_json::json!("0.2.9"));
+        .insert("powerio_version".to_owned(), serde_json::json!(future));
     v.as_object_mut()
         .unwrap()
         .insert("future_field".to_owned(), serde_json::json!({"x": 1}));
     let json = serde_json::to_string(&v).unwrap();
 
-    let back = NetworkPackage::from_json(&json).expect("same lineage schema version loads");
-    assert_eq!(back.schema_version, "0.2.9");
+    let back = NetworkPackage::from_json(&json).expect("same lineage patch loads");
+    assert_eq!(back.powerio_version, future);
     assert_eq!(back.model_kind(), ModelKind::Balanced);
 }
 
 #[test]
-fn same_lineage_prerelease_or_build_schema_version_is_tolerated() {
-    for version in ["0.2.0-rc.1", "0.2.0+build.5", "0.2.1-alpha.2+exp"] {
+fn a_prerelease_or_build_tag_of_this_lineage_is_tolerated() {
+    let (_, minor) = lineage(powerio::VERSION);
+    for suffix in ["-rc.1", "+build.5", "-alpha.2+exp"] {
+        let version = format!("0.{minor}.0{suffix}");
         let pkg = balanced_package();
         let mut v = serde_json::to_value(&pkg).unwrap();
         v.as_object_mut()
             .unwrap()
-            .insert("schema_version".to_owned(), serde_json::json!(version));
+            .insert("powerio_version".to_owned(), serde_json::json!(version));
         let json = serde_json::to_string(&v).unwrap();
 
         let back = NetworkPackage::from_json(&json)
             .unwrap_or_else(|e| panic!("same-lineage {version} should load: {e}"));
-        assert_eq!(back.schema_version, version);
+        assert_eq!(back.powerio_version, version);
     }
 }
 
@@ -1118,24 +1136,22 @@ fn normalized_solver_table_metadata_records_dense_identities() {
 }
 
 #[test]
-fn incompatible_schema_major_is_rejected() {
+fn an_incompatible_major_is_rejected() {
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();
     v.as_object_mut()
         .unwrap()
-        .insert("schema_version".to_owned(), serde_json::json!("1.0.0"));
+        .insert("powerio_version".to_owned(), serde_json::json!("1.0.0"));
     let json = serde_json::to_string(&v).unwrap();
 
     let err = NetworkPackage::from_json(&json).expect_err("major version mismatch must fail");
-    assert!(
-        err.to_string()
-            .contains("unsupported .pio.json schema_version 1.0.0"),
-        "{err}"
-    );
+    let msg = err.to_string();
+    assert!(msg.contains("`powerio_version` 1.0.0"), "{msg}");
+    assert!(msg.contains("regenerate"), "{msg}");
 }
 
 #[test]
-fn invalid_schema_version_is_rejected() {
+fn a_version_that_is_not_semver_is_rejected() {
     let pkg = balanced_package();
     for version in [
         "0",
@@ -1150,13 +1166,13 @@ fn invalid_schema_version_is_rejected() {
         let mut v = serde_json::to_value(&pkg).unwrap();
         v.as_object_mut()
             .unwrap()
-            .insert("schema_version".to_owned(), serde_json::json!(version));
+            .insert("powerio_version".to_owned(), serde_json::json!(version));
         let json = serde_json::to_string(&v).unwrap();
 
         let err = NetworkPackage::from_json(&json).expect_err("invalid semver must fail");
         assert!(
             err.to_string()
-                .contains(&format!("unsupported .pio.json schema_version {version}")),
+                .contains(&format!("`powerio_version` {version}")),
             "{err}"
         );
     }
@@ -1784,10 +1800,7 @@ fn package_synthesizes_row_identity() {
     assert_eq!(net.branches[0].uid.as_deref(), Some("branches:0"));
 
     let v = serde_json::to_value(&pkg).unwrap();
-    assert_eq!(
-        v["schema_version"],
-        serde_json::json!(PIO_PACKAGE_SCHEMA_VERSION)
-    );
+    assert_eq!(v["powerio_version"], serde_json::json!(powerio::VERSION));
     assert_eq!(
         v["model"]["balanced_network"]["buses"][0]["uid"],
         serde_json::json!("buses:0")

--- a/powerio-prob/src/matrix/bundle.rs
+++ b/powerio-prob/src/matrix/bundle.rs
@@ -10,7 +10,6 @@ use crate::{DcOpfInstance, Units};
 use super::build_dc_opf_matrices;
 
 const DCOPF_SCHEMA: &str = "powerio.dcopf";
-const DCOPF_SCHEMA_VERSION: &str = "0.4.0";
 
 /// Cost policy information recorded in a bundle manifest.
 #[derive(Debug, Clone)]
@@ -44,7 +43,6 @@ pub struct DcOpfOutputs {
 #[derive(Serialize)]
 struct DcOpfMeta<'a> {
     schema: &'static str,
-    schema_version: &'static str,
     case_name: &'a str,
     base_mva: f64,
     dimensions: DcOpfDimensions,
@@ -191,7 +189,6 @@ pub fn write_dcopf_bundle(
     };
     let meta = DcOpfMeta {
         schema: DCOPF_SCHEMA,
-        schema_version: DCOPF_SCHEMA_VERSION,
         case_name: &instance.name,
         base_mva: instance.base_mva,
         dimensions: DcOpfDimensions {

--- a/powerio-prob/src/scopf/json.rs
+++ b/powerio-prob/src/scopf/json.rs
@@ -1,6 +1,6 @@
-//! Versioned Julia compatibility wire format.
+//! The Julia compatibility document.
 //!
-//! The conversion is structural: every struct that reaches the wire classifies
+//! The conversion is structural: every struct that reaches the document classifies
 //! each of its fields as a 0-based internal index (renumbered to 1-based), a
 //! renamed field (Julia spells some names in Greek or uppercase), or a value
 //! passed through unchanged. The classification destructures the struct
@@ -26,37 +26,38 @@ use super::types::{
 };
 use super::{ScopfInstance, ScopfResult};
 
-pub const SCOPF_WIRE_SCHEMA: &str = "powerio.scopf.julia";
-pub const SCOPF_WIRE_VERSION: &str = "1.0.0";
+pub const SCOPF_SCHEMA: &str = "powerio.scopf.julia";
 
 #[derive(Serialize)]
-struct WireEnvelope {
+struct Envelope {
     schema: &'static str,
-    schema_version: &'static str,
+    /// The powerio release that wrote this document; see [`powerio::version`].
+    #[serde(rename = "powerio_version")]
+    powerio_version: &'static str,
     index_base: usize,
     instance: Value,
 }
 
-/// Wire conversion of one serialized object: the fields holding 0-based
-/// internal indices and the fields renamed on the wire.
-trait WireFields: Serialize {
+/// One serialized object: the fields holding 0-based internal indices
+/// and the fields renamed in the document.
+trait SerializedFields: Serialize {
     /// Serialized names of the fields holding 0-based internal indices.
     /// External identity (`BusId`, `uid`) is never listed.
     const INDEX_FIELDS: &'static [&'static str] = &[];
-    /// `(internal, wire)` name pairs.
+    /// `(internal, document)` name pairs.
     const RENAMED_FIELDS: &'static [(&'static str, &'static str)] = &[];
 }
 
-/// Classify every field of one struct that reaches the wire. The generated function
+/// Classify every field of one struct that reaches the document. The generated function
 /// destructures the struct exhaustively, so this fails to compile whenever a
 /// field is added, removed, or renamed in `types.rs` without reclassifying it.
-macro_rules! wire_fields {
+macro_rules! serialized_fields {
     ($row:ident {
         index: [$($index:ident),* $(,)?],
         values: [$($value:ident),* $(,)?]
         $(, renamed: [$($from:ident => $to:literal),+ $(,)?])? $(,)?
     }) => {
-        impl WireFields for $row {
+        impl SerializedFields for $row {
             const INDEX_FIELDS: &'static [&'static str] = &[$(stringify!($index)),*];
             $(const RENAMED_FIELDS: &'static [(&'static str, &'static str)] =
                 &[$((stringify!($from), $to)),+];)?
@@ -70,49 +71,49 @@ macro_rules! wire_fields {
     };
 }
 
-wire_fields!(ScopfBusRow {
+serialized_fields!(ScopfBusRow {
     index: [],
     values: [i, uid, v_min, v_max],
 });
-wire_fields!(ScopfShuntRow {
+serialized_fields!(ScopfShuntRow {
     index: [j_sh],
     values: [uid, bus, g_sh, b_sh],
 });
-wire_fields!(ScopfAcLineRow {
+serialized_fields!(ScopfAcLineRow {
     index: [j_ln],
     values: [
         uid, to_bus, fr_bus, c_su, c_sd, s_max, g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to
     ],
 });
-wire_fields!(ScopfTransformerRow {
+serialized_fields!(ScopfTransformerRow {
     index: [j_xf],
     values: [
         uid, to_bus, fr_bus, c_su, c_sd, s_max, g_sr, b_sr, b_ch, g_fr, g_to, b_fr, b_to
     ],
 });
-wire_fields!(ScopfDcLineRow {
+serialized_fields!(ScopfDcLineRow {
     index: [j_dc],
     values: [
         uid, pdc_max, qdc_fr_min, qdc_to_min, qdc_fr_max, qdc_to_max, to_bus, fr_bus
     ],
 });
-wire_fields!(ScopfVariablePhaseRow {
+serialized_fields!(ScopfVariablePhaseRow {
     index: [j_xf],
     values: [phi_min, phi_max],
 });
-wire_fields!(ScopfFixedPhaseRow {
+serialized_fields!(ScopfFixedPhaseRow {
     index: [j_xf],
     values: [phi_o],
 });
-wire_fields!(ScopfVariableRatioRow {
+serialized_fields!(ScopfVariableRatioRow {
     index: [j_xf],
     values: [tau_min, tau_max],
 });
-wire_fields!(ScopfFixedRatioRow {
+serialized_fields!(ScopfFixedRatioRow {
     index: [j_xf],
     values: [tau_o],
 });
-wire_fields!(ScopfDeviceRow {
+serialized_fields!(ScopfDeviceRow {
     index: [],
     values: [
         bus,
@@ -159,7 +160,7 @@ wire_fields!(ScopfDeviceRow {
         q_p0
     ],
 });
-wire_fields!(ScopfActiveReserveRow {
+serialized_fields!(ScopfActiveReserveRow {
     index: [n_p],
     values: [uid, c_rgu, c_rgd, c_scr, c_nsc, c_rru, c_rrd, p_rru_min, p_rrd_min],
     renamed: [
@@ -169,19 +170,19 @@ wire_fields!(ScopfActiveReserveRow {
         sigma_nsc => "σ_nsc",
     ],
 });
-wire_fields!(ScopfReactiveReserveRow {
+serialized_fields!(ScopfReactiveReserveRow {
     index: [n_q],
     values: [uid, c_qru, c_qrd, q_qru_min, q_qrd_min],
 });
-wire_fields!(ScopfActiveReserveSetRow {
+serialized_fields!(ScopfActiveReserveSetRow {
     index: [n_p],
     values: [i, uid],
 });
-wire_fields!(ScopfReactiveReserveSetRow {
+serialized_fields!(ScopfReactiveReserveSetRow {
     index: [n_q],
     values: [i, uid],
 });
-wire_fields!(ScopfLengths {
+serialized_fields!(ScopfLengths {
     index: [],
     values: [],
     renamed: [
@@ -201,61 +202,61 @@ wire_fields!(ScopfLengths {
         k => "K",
     ],
 });
-wire_fields!(ScopfViolationCost {
+serialized_fields!(ScopfViolationCost {
     index: [],
     values: [p_bus, q_bus, s, e],
 });
-wire_fields!(ScopfEnergyWindowMaxPrRow {
+serialized_fields!(ScopfEnergyWindowMaxPrRow {
     index: [w_en_max_pr_ind],
     values: [uid, a_en_max_start, a_en_max_end, e_max],
 });
-wire_fields!(ScopfEnergyWindowMaxCsRow {
+serialized_fields!(ScopfEnergyWindowMaxCsRow {
     index: [w_en_max_cs_ind],
     values: [uid, a_en_max_start, a_en_max_end, e_max],
 });
-wire_fields!(ScopfEnergyWindowMinPrRow {
+serialized_fields!(ScopfEnergyWindowMinPrRow {
     index: [w_en_min_pr_ind],
     values: [uid, a_en_min_start, a_en_min_end, e_min],
 });
-wire_fields!(ScopfEnergyWindowMinCsRow {
+serialized_fields!(ScopfEnergyWindowMinCsRow {
     index: [w_en_min_cs_ind],
     values: [uid, a_en_min_start, a_en_min_end, e_min],
 });
-wire_fields!(ScopfEnergyWindowPeriodMaxPrRow {
+serialized_fields!(ScopfEnergyWindowPeriodMaxPrRow {
     index: [w_en_max_pr_ind, t],
     values: [uid, dt],
 });
-wire_fields!(ScopfEnergyWindowPeriodMaxCsRow {
+serialized_fields!(ScopfEnergyWindowPeriodMaxCsRow {
     index: [w_en_max_cs_ind, t],
     values: [uid, dt],
 });
-wire_fields!(ScopfEnergyWindowPeriodMinPrRow {
+serialized_fields!(ScopfEnergyWindowPeriodMinPrRow {
     index: [w_en_min_pr_ind, t],
     values: [uid, dt],
 });
-wire_fields!(ScopfEnergyWindowPeriodMinCsRow {
+serialized_fields!(ScopfEnergyWindowPeriodMinCsRow {
     index: [w_en_min_cs_ind, t],
     values: [uid, dt],
 });
-wire_fields!(ScopfPriceBlockRow {
+serialized_fields!(ScopfPriceBlockRow {
     index: [flat_k, t, m],
     values: [uid, c_en, p_max],
 });
-wire_fields!(ScopfAcLineSurvivorRow {
+serialized_fields!(ScopfAcLineSurvivorRow {
     index: [ctg, j_ln],
     values: [uid, to_bus, fr_bus, b_sr, s_max_ctg],
 });
-wire_fields!(ScopfTransformerSurvivorRow {
+serialized_fields!(ScopfTransformerSurvivorRow {
     index: [ctg, j_xf],
     values: [uid, to_bus, fr_bus, b_sr, s_max_ctg],
 });
-wire_fields!(ScopfDcContingencyFlowRow {
+serialized_fields!(ScopfDcContingencyFlowRow {
     index: [flat_jtk_dc, ctg, j_dc, t],
     values: [to_bus, fr_bus, dt],
 });
 
-/// Convert an internal instance to the versioned 1-based Julia wire format.
-pub fn to_wire_value(instance: &ScopfInstance) -> ScopfResult<Value> {
+/// Convert an internal instance to the 1-based Julia document.
+pub fn to_json_value(instance: &ScopfInstance) -> ScopfResult<Value> {
     let ScopfInstance {
         static_data,
         lengths,
@@ -266,41 +267,47 @@ pub fn to_wire_value(instance: &ScopfInstance) -> ScopfResult<Value> {
         violation_cost,
         device_class_layout,
     } = instance;
-    let mut wire = Map::new();
-    wire.insert("static".to_owned(), wire_static(static_data)?);
-    wire.insert("lengths".to_owned(), wire_object(lengths)?);
-    wire.insert(
+    let mut fields = Map::new();
+    fields.insert("static".to_owned(), serialize_static(static_data)?);
+    fields.insert("lengths".to_owned(), serialize_object(lengths)?);
+    fields.insert(
         "energy_windows".to_owned(),
-        wire_energy_windows(energy_windows)?,
+        serialize_energy_windows(energy_windows)?,
     );
-    wire.insert("price_blocks".to_owned(), wire_price_blocks(price_blocks)?);
-    wire.insert(
+    fields.insert(
+        "price_blocks".to_owned(),
+        serialize_price_blocks(price_blocks)?,
+    );
+    fields.insert(
         "ac_contingency_survivors".to_owned(),
-        wire_survivors(ac_contingency_survivors)?,
+        serialize_survivors(ac_contingency_survivors)?,
     );
-    wire.insert(
+    fields.insert(
         "dc_contingency_flows".to_owned(),
-        wire_rows(dc_contingency_flows)?,
+        serialize_rows(dc_contingency_flows)?,
     );
-    wire.insert("violation_cost".to_owned(), wire_object(violation_cost)?);
-    wire.insert(
+    fields.insert(
+        "violation_cost".to_owned(),
+        serialize_object(violation_cost)?,
+    );
+    fields.insert(
         "device_class_layout".to_owned(),
         serde_json::to_value(device_class_layout)?,
     );
-    Ok(serde_json::to_value(WireEnvelope {
-        schema: SCOPF_WIRE_SCHEMA,
-        schema_version: SCOPF_WIRE_VERSION,
+    Ok(serde_json::to_value(Envelope {
+        schema: SCOPF_SCHEMA,
+        powerio_version: powerio::VERSION,
         index_base: 1,
-        instance: Value::Object(wire),
+        instance: Value::Object(fields),
     })?)
 }
 
-/// Serialize an internal instance as the versioned 1-based Julia wire format.
-pub fn to_wire_json(instance: &ScopfInstance) -> ScopfResult<String> {
-    Ok(serde_json::to_string(&to_wire_value(instance)?)?)
+/// Serialize an internal instance as the 1-based Julia document.
+pub fn to_json(instance: &ScopfInstance) -> ScopfResult<String> {
+    Ok(serde_json::to_string(&to_json_value(instance)?)?)
 }
 
-fn wire_static(data: &ScopfStaticData) -> ScopfResult<Value> {
+fn serialize_static(data: &ScopfStaticData) -> ScopfResult<Value> {
     let ScopfStaticData {
         bus,
         shunt,
@@ -321,39 +328,42 @@ fn wire_static(data: &ScopfStaticData) -> ScopfResult<Value> {
         reactive_reserve_set_cs,
     } = data;
     let mut object = Map::new();
-    object.insert("bus".to_owned(), wire_rows(bus)?);
-    object.insert("shunt".to_owned(), wire_rows(shunt)?);
-    object.insert("acl_branch".to_owned(), wire_rows(acl_branch)?);
-    object.insert("acx_branch".to_owned(), wire_rows(acx_branch)?);
-    object.insert("vpd".to_owned(), wire_rows(vpd)?);
-    object.insert("fpd".to_owned(), wire_rows(fpd)?);
-    object.insert("vwr".to_owned(), wire_rows(vwr)?);
-    object.insert("fwr".to_owned(), wire_rows(fwr)?);
-    object.insert("dc_branch".to_owned(), wire_rows(dc_branch)?);
-    object.insert("prod".to_owned(), wire_rows(prod)?);
-    object.insert("cons".to_owned(), wire_rows(cons)?);
-    object.insert("active_reserve".to_owned(), wire_rows(active_reserve)?);
-    object.insert("reactive_reserve".to_owned(), wire_rows(reactive_reserve)?);
+    object.insert("bus".to_owned(), serialize_rows(bus)?);
+    object.insert("shunt".to_owned(), serialize_rows(shunt)?);
+    object.insert("acl_branch".to_owned(), serialize_rows(acl_branch)?);
+    object.insert("acx_branch".to_owned(), serialize_rows(acx_branch)?);
+    object.insert("vpd".to_owned(), serialize_rows(vpd)?);
+    object.insert("fpd".to_owned(), serialize_rows(fpd)?);
+    object.insert("vwr".to_owned(), serialize_rows(vwr)?);
+    object.insert("fwr".to_owned(), serialize_rows(fwr)?);
+    object.insert("dc_branch".to_owned(), serialize_rows(dc_branch)?);
+    object.insert("prod".to_owned(), serialize_rows(prod)?);
+    object.insert("cons".to_owned(), serialize_rows(cons)?);
+    object.insert("active_reserve".to_owned(), serialize_rows(active_reserve)?);
+    object.insert(
+        "reactive_reserve".to_owned(),
+        serialize_rows(reactive_reserve)?,
+    );
     object.insert(
         "active_reserve_set_pr".to_owned(),
-        wire_rows(active_reserve_set_pr)?,
+        serialize_rows(active_reserve_set_pr)?,
     );
     object.insert(
         "active_reserve_set_cs".to_owned(),
-        wire_rows(active_reserve_set_cs)?,
+        serialize_rows(active_reserve_set_cs)?,
     );
     object.insert(
         "reactive_reserve_set_pr".to_owned(),
-        wire_rows(reactive_reserve_set_pr)?,
+        serialize_rows(reactive_reserve_set_pr)?,
     );
     object.insert(
         "reactive_reserve_set_cs".to_owned(),
-        wire_rows(reactive_reserve_set_cs)?,
+        serialize_rows(reactive_reserve_set_cs)?,
     );
     Ok(Value::Object(object))
 }
 
-fn wire_energy_windows(windows: &ScopfEnergyWindows) -> ScopfResult<Value> {
+fn serialize_energy_windows(windows: &ScopfEnergyWindows) -> ScopfResult<Value> {
     let ScopfEnergyWindows {
         w_en_max_pr,
         w_en_max_cs,
@@ -365,57 +375,57 @@ fn wire_energy_windows(windows: &ScopfEnergyWindows) -> ScopfResult<Value> {
         t_w_en_min_cs,
     } = windows;
     let mut object = Map::new();
-    object.insert("W_en_max_pr".to_owned(), wire_rows(w_en_max_pr)?);
-    object.insert("W_en_max_cs".to_owned(), wire_rows(w_en_max_cs)?);
-    object.insert("W_en_min_pr".to_owned(), wire_rows(w_en_min_pr)?);
-    object.insert("W_en_min_cs".to_owned(), wire_rows(w_en_min_cs)?);
-    object.insert("T_w_en_max_pr".to_owned(), wire_rows(t_w_en_max_pr)?);
-    object.insert("T_w_en_max_cs".to_owned(), wire_rows(t_w_en_max_cs)?);
-    object.insert("T_w_en_min_pr".to_owned(), wire_rows(t_w_en_min_pr)?);
-    object.insert("T_w_en_min_cs".to_owned(), wire_rows(t_w_en_min_cs)?);
+    object.insert("W_en_max_pr".to_owned(), serialize_rows(w_en_max_pr)?);
+    object.insert("W_en_max_cs".to_owned(), serialize_rows(w_en_max_cs)?);
+    object.insert("W_en_min_pr".to_owned(), serialize_rows(w_en_min_pr)?);
+    object.insert("W_en_min_cs".to_owned(), serialize_rows(w_en_min_cs)?);
+    object.insert("T_w_en_max_pr".to_owned(), serialize_rows(t_w_en_max_pr)?);
+    object.insert("T_w_en_max_cs".to_owned(), serialize_rows(t_w_en_max_cs)?);
+    object.insert("T_w_en_min_pr".to_owned(), serialize_rows(t_w_en_min_pr)?);
+    object.insert("T_w_en_min_cs".to_owned(), serialize_rows(t_w_en_min_cs)?);
     Ok(Value::Object(object))
 }
 
-fn wire_price_blocks(blocks: &ScopfPriceBlocks) -> ScopfResult<Value> {
+fn serialize_price_blocks(blocks: &ScopfPriceBlocks) -> ScopfResult<Value> {
     let ScopfPriceBlocks { producer, consumer } = blocks;
     let mut object = Map::new();
-    object.insert("producer".to_owned(), wire_rows(producer)?);
-    object.insert("consumer".to_owned(), wire_rows(consumer)?);
+    object.insert("producer".to_owned(), serialize_rows(producer)?);
+    object.insert("consumer".to_owned(), serialize_rows(consumer)?);
     Ok(Value::Object(object))
 }
 
-fn wire_survivors(survivors: &ScopfAcContingencySurvivors) -> ScopfResult<Value> {
+fn serialize_survivors(survivors: &ScopfAcContingencySurvivors) -> ScopfResult<Value> {
     let ScopfAcContingencySurvivors { ln, xf } = survivors;
     let mut object = Map::new();
-    object.insert("ln".to_owned(), wire_nested_rows(ln)?);
-    object.insert("xf".to_owned(), wire_nested_rows(xf)?);
+    object.insert("ln".to_owned(), serialize_nested_rows(ln)?);
+    object.insert("xf".to_owned(), serialize_nested_rows(xf)?);
     Ok(Value::Object(object))
 }
 
-fn wire_rows<R: WireFields>(rows: &[R]) -> ScopfResult<Value> {
+fn serialize_rows<R: SerializedFields>(rows: &[R]) -> ScopfResult<Value> {
     rows.iter()
-        .map(wire_object)
+        .map(serialize_object)
         .collect::<ScopfResult<Vec<_>>>()
         .map(Value::from)
 }
 
-fn wire_nested_rows<R: WireFields>(groups: &[Vec<R>]) -> ScopfResult<Value> {
+fn serialize_nested_rows<R: SerializedFields>(groups: &[Vec<R>]) -> ScopfResult<Value> {
     groups
         .iter()
-        .map(|group| wire_rows(group))
+        .map(|group| serialize_rows(group))
         .collect::<ScopfResult<Vec<_>>>()
         .map(Value::from)
 }
 
-/// Serialize one struct, renumber its declared index fields, apply its wire
+/// Serialize one struct, renumber its declared index fields, apply its
 /// renames. The declared fields always exist in the serialized object (the
 /// classification is compile-checked against the struct), so a miss here means
 /// a `serde` attribute changed the serialized name; fail loudly.
-fn wire_object<R: WireFields>(row: &R) -> ScopfResult<Value> {
+fn serialize_object<R: SerializedFields>(row: &R) -> ScopfResult<Value> {
     let mut value = serde_json::to_value(row)?;
     let Some(object) = value.as_object_mut() else {
         return Err(ScopfError::invalid(
-            "wire struct did not serialize to a JSON object",
+            "struct did not serialize to a JSON object",
         ));
     };
     for &field in R::INDEX_FIELDS {

--- a/powerio-prob/src/scopf/mod.rs
+++ b/powerio-prob/src/scopf/mod.rs
@@ -1,8 +1,8 @@
 mod error;
 mod goc3;
+pub mod json;
 mod projection;
 mod types;
-pub mod wire;
 
 pub use error::{ScopfError, ScopfResult};
 pub use projection::build_scopf_instance_from_str;

--- a/powerio-prob/src/scopf/projection.rs
+++ b/powerio-prob/src/scopf/projection.rs
@@ -704,7 +704,7 @@ fn sdd_windows(
 /// Pure function of `tables`.
 // Four max/min x producer/consumer variants, each packed into its own
 // distinctly-named row struct to keep Julia's exact field spelling on the
-// wire (see the module doc comment); the packing is what pushes this over
+// document (see the module doc comment); the packing is what pushes this over
 // the line budget.
 #[allow(clippy::too_many_lines)]
 fn build_energy_windows(tables: &Goc3Adapter) -> Result<ScopfEnergyWindows> {

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -556,7 +556,7 @@ mod matrix_tests {
         )
         .expect("manifest json");
         assert_eq!(manifest["schema"], "powerio.dcopf");
-        assert_eq!(manifest["schema_version"], "0.4.0");
+        assert_eq!(manifest["powerio_version"], powerio::VERSION);
         let c0_gen =
             powerio_matrix::io::read_vector_mtx(bundle.dir.join("c0_gen.mtx")).expect("c0_gen");
         assert_eq!(c0_gen, problem.generators.c0);

--- a/powerio-prob/tests/scopf.rs
+++ b/powerio-prob/tests/scopf.rs
@@ -1,5 +1,5 @@
 use powerio::BusId;
-use powerio_prob::scopf::wire::{SCOPF_WIRE_SCHEMA, SCOPF_WIRE_VERSION, to_wire_value};
+use powerio_prob::scopf::json::{SCOPF_SCHEMA, to_json_value};
 use powerio_prob::{
     ScopfDeviceClassLayout, ScopfError, ScopfInstance, build_scopf_instance_from_str,
 };
@@ -99,29 +99,29 @@ fn julia_wire_adapter_is_versioned_and_one_based() {
             .is_some()
     );
 
-    let wire = to_wire_value(&instance).expect("serialize wire value");
-    assert_eq!(wire["schema"], SCOPF_WIRE_SCHEMA);
-    assert_eq!(wire["schema_version"], SCOPF_WIRE_VERSION);
-    assert_eq!(wire["index_base"], 1);
-    assert_eq!(wire["instance"]["static"]["acl_branch"][0]["j_ln"], 1);
-    assert_eq!(wire["instance"]["static"]["active_reserve"][0]["n_p"], 1);
-    assert_eq!(wire["instance"]["price_blocks"]["producer"][0]["t"], 1);
-    assert_eq!(wire["instance"]["static"]["bus"][0]["i"], 1);
+    let doc = to_json_value(&instance).expect("serialize the document");
+    assert_eq!(doc["schema"], SCOPF_SCHEMA);
+    assert_eq!(doc["powerio_version"], powerio::VERSION);
+    assert_eq!(doc["index_base"], 1);
+    assert_eq!(doc["instance"]["static"]["acl_branch"][0]["j_ln"], 1);
+    assert_eq!(doc["instance"]["static"]["active_reserve"][0]["n_p"], 1);
+    assert_eq!(doc["instance"]["price_blocks"]["producer"][0]["t"], 1);
+    assert_eq!(doc["instance"]["static"]["bus"][0]["i"], 1);
     assert!(
-        wire["instance"]["static"]["active_reserve"][0]
+        doc["instance"]["static"]["active_reserve"][0]
             .get("σ_rgu")
             .is_some()
     );
-    assert!(wire["instance"]["lengths"].get("L_J_ln").is_some());
+    assert!(doc["instance"]["lengths"].get("L_J_ln").is_some());
     // Renumbering is per declared field: counts and value fields pass
     // through unchanged even where a name doubles as an index elsewhere
     // (`p_max` on price blocks vs devices, `L_T` vs `t`).
     assert_eq!(
-        wire["instance"]["lengths"]["L_T"],
+        doc["instance"]["lengths"]["L_T"],
         u64::try_from(instance.lengths.l_t).expect("period count")
     );
     assert_eq!(
-        wire["instance"]["price_blocks"]["producer"][0]["p_max"],
+        doc["instance"]["price_blocks"]["producer"][0]["p_max"],
         instance.price_blocks.producer[0].p_max
     );
 }

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -1874,7 +1874,7 @@ fn geo_report_dict<'py>(
     Ok(out)
 }
 
-/// Parse SCOPF source text and return the versioned wire document as JSON.
+/// Parse SCOPF source text and return its Julia compatibility document as JSON.
 #[pyfunction(signature = (text, from_ = "goc3-json"))]
 fn parse_scopf(text: &str, from_: &str) -> PyResult<String> {
     let instance =
@@ -1884,7 +1884,7 @@ fn parse_scopf(text: &str, from_: &str) -> PyResult<String> {
             }
             error => PowerIOParseError::new_err(error.to_string()),
         })?;
-    powerio_prob::scopf::wire::to_wire_json(&instance)
+    powerio_prob::scopf::json::to_json(&instance)
         .map_err(|error| PowerIOParseError::new_err(error.to_string()))
 }
 

--- a/powerio/src/geo/layer.rs
+++ b/powerio/src/geo/layer.rs
@@ -16,9 +16,6 @@ use super::{Canvas, CoordinateSpace, CoordsKind, GeoMeta, Location};
 use crate::network::{BusId, Network};
 use crate::{Error, Result};
 
-/// Version of the `powerio_geo` foreign member this crate writes.
-pub const GEO_LAYER_VERSION: &str = "0.1.0";
-
 /// Suggested extension for the canonical document.
 pub const GEO_LAYER_EXTENSION: &str = "geo.json";
 
@@ -198,13 +195,16 @@ impl GeoLayer {
         Ok(self.to_geojson())
     }
 
-    /// Serialize the canonical wire form: a GeoJSON FeatureCollection with the
+    /// Serialize the canonical form: a GeoJSON FeatureCollection with the
     /// `powerio_geo` foreign member. Valid RFC 7946 GeoJSON when the space is
     /// geographic, so GIS tools open it directly.
     #[must_use]
     pub fn to_geojson(&self) -> String {
         let mut member = Map::new();
-        member.insert("version".to_owned(), json!(GEO_LAYER_VERSION));
+        member.insert(
+            crate::version::VERSION_KEY.to_owned(),
+            json!(crate::VERSION),
+        );
         let detail = match &self.space {
             CoordinateSpace::Geographic { crs } | CoordinateSpace::Projected { crs } => {
                 crs.as_ref().map(crs_entry)
@@ -1031,7 +1031,7 @@ impl BalancedBusIndex {
             .as_ref()
             .and_then(|uid| self.uids.get(uid))
             .or_else(|| {
-                // A numeric id is the external BusId; a string id (one wire
+                // A numeric id is the external BusId; a string id (one serialized
                 // form serves the string-keyed multiconductor model too)
                 // matches the bus name.
                 let id = key.id.as_ref()?;

--- a/powerio/src/geo/mod.rs
+++ b/powerio/src/geo/mod.rs
@@ -6,8 +6,8 @@ mod layer;
 mod pwd;
 
 pub use layer::{
-    ElementKey, GEO_LAYER_EXTENSION, GEO_LAYER_VERSION, GeoApplyReport, GeoApplyTarget, GeoFeature,
-    GeoGeometry, GeoLayer, GeoParsed, GeoTarget, apply_geo_features,
+    ElementKey, GEO_LAYER_EXTENSION, GeoApplyReport, GeoApplyTarget, GeoFeature, GeoGeometry,
+    GeoLayer, GeoParsed, GeoTarget, apply_geo_features,
 };
 pub use pwd::{
     PWD_MERCATOR_K, apply_substation_points, geo_layer_from_aux_substations, geo_layer_from_pwd,
@@ -79,7 +79,7 @@ pub enum CoordinateSpace {
 }
 
 impl CoordinateSpace {
-    /// The wire token naming the space family (`geographic`, `projected`,
+    /// The serialized token naming the space family (`geographic`, `projected`,
     /// `diagram`, `unknown`), as the `powerio_geo` member spells it.
     #[must_use]
     pub fn token(&self) -> &'static str {

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -48,6 +48,7 @@ pub mod network;
 mod normalize;
 mod operations;
 pub mod solver_tables;
+pub mod version;
 
 pub use dc::DcConvention;
 pub use error::{ElementCounts, Error, ErrorCategory, Result, ScenarioMismatch};

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -1134,7 +1134,7 @@ fn default_caps() -> GenCaps {
 /// The named map makes a new key purely additive: an old document simply lacks it
 /// (deserializes to `None`), and an unknown key from a newer document is ignored.
 /// In memory `caps` stays a fixed array, so the per-generator allocation cost the
-/// array avoids is unchanged; only the wire form is named.
+/// array avoids is unchanged; only the serialized form is named.
 mod caps_serde {
     use super::{GEN_EXTRA_KEYS, GenCaps};
     use serde::de::{Deserialize, Deserializer};

--- a/powerio/src/version.rs
+++ b/powerio/src/version.rs
@@ -1,0 +1,156 @@
+//! The version every powerio authored document carries, and the rule a reader
+//! applies to it.
+//!
+//! powerio implements case formats and authors none. A file it writes for a
+//! foreign format carries that format's own version, which powerio reproduces
+//! and never sets. A document powerio authors instead carries [`VERSION`] under
+//! the key `powerio_version`, and [`supports`] decides whether this build reads
+//! it.
+
+use crate::VERSION;
+
+/// The key every powerio authored document uses for [`VERSION`].
+pub const VERSION_KEY: &str = "powerio_version";
+
+/// Whether this build reads a document stamped `version`.
+///
+/// A document loads when it shares this build's lineage: the major version once
+/// it reaches 1, and the major and minor pair while the major is 0, which is
+/// what cargo and Pkg already mean by a 0.x bump. A version this function
+/// cannot parse as semver never loads.
+#[must_use]
+pub fn supports(version: &str) -> bool {
+    let Some((major, minor)) = lineage(version) else {
+        return false;
+    };
+    let (current_major, current_minor) = current_lineage();
+    major == current_major && (major != 0 || minor == current_minor)
+}
+
+/// The message for a document this build does not read.
+///
+/// `document` names the artifact, spelled as a caller would recognize it
+/// (`.pio.json`, `the DC OPF bundle manifest`). An empty `version` is the
+/// document that states none, which every release before 0.9.0 wrote.
+#[must_use]
+pub fn reject(document: &str, version: &str) -> String {
+    let states = if version.is_empty() {
+        format!("{document} states no `{VERSION_KEY}`, so it was written before powerio 0.9.0")
+    } else {
+        format!("{document} states `{VERSION_KEY}` {version}")
+    };
+    format!(
+        "{states}; this build reads {}; regenerate it with powerio {VERSION}",
+        lineage_label()
+    )
+}
+
+/// The lineage this build reads, spelled for a message: `0.9.x` while the major
+/// is 0, `major version N` afterwards.
+#[must_use]
+pub fn lineage_label() -> String {
+    match current_lineage() {
+        (0, minor) => format!("0.{minor}.x"),
+        (major, _) => format!("major version {major}"),
+    }
+}
+
+fn current_lineage() -> (u64, u64) {
+    lineage(VERSION).expect("the crate version is valid semver")
+}
+
+fn lineage(version: &str) -> Option<(u64, u64)> {
+    // Accept a semver core `MAJOR.MINOR.PATCH` with an optional prerelease
+    // (`-...`) or build (`+...`) tag, so a forward compatible writer that
+    // stamps e.g. `0.9.1-rc.1` is not rejected. Split the build tag off first:
+    // `+` cannot appear in a prerelease, but a hyphen is legal inside build
+    // metadata (`1.0.0+build-x`), so splitting on `-` first would cut inside
+    // the build tag and reject a valid version.
+    let (rest, build) = match version.split_once('+') {
+        Some((rest, build)) => (rest, Some(build)),
+        None => (version, None),
+    };
+    let (core, pre) = match rest.split_once('-') {
+        Some((core, pre)) => (core, Some(pre)),
+        None => (rest, None),
+    };
+    if pre.is_some_and(|s| !valid_suffix(s)) || build.is_some_and(|s| !valid_suffix(s)) {
+        return None;
+    }
+    let mut parts = core.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    let patch = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let major = parse_number(major)?;
+    let minor = parse_number(minor)?;
+    parse_number(patch)?;
+    Some((major, minor))
+}
+
+fn parse_number(s: &str) -> Option<u64> {
+    if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) || (s.len() > 1 && s.starts_with('0'))
+    {
+        return None;
+    }
+    s.parse().ok()
+}
+
+fn valid_suffix(s: &str) -> bool {
+    !s.is_empty()
+        && s.split('.').all(|part| {
+            !part.is_empty() && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lineage_parses_semver_suffixes() {
+        assert_eq!(lineage("1.2.3"), Some((1, 2)));
+        assert_eq!(lineage("1.0.0-rc.1"), Some((1, 0)));
+        // A hyphen inside build metadata is legal semver; splitting on `-`
+        // first used to cut inside the build tag and reject the version.
+        assert_eq!(lineage("1.0.0+build-x"), Some((1, 0)));
+        assert_eq!(lineage("0.9.0"), Some((0, 9)));
+    }
+
+    #[test]
+    fn lineage_rejects_what_is_not_semver() {
+        for bad in [
+            "", "1", "1.2", "1.2.3.4", "01.2.3", "1.x.3", "1.2.3-", "1.2.3+",
+        ] {
+            assert_eq!(lineage(bad), None, "{bad}");
+        }
+    }
+
+    #[test]
+    fn this_build_reads_its_own_version() {
+        assert!(supports(VERSION));
+    }
+
+    #[test]
+    fn a_zero_x_minor_is_its_own_lineage() {
+        // While the major is 0 a minor bump is incompatible, so 0.8 and 0.9
+        // do not read each other. Both are read by their own patches.
+        let (major, minor) = current_lineage();
+        assert_eq!(major, 0, "update this test at 1.0.0");
+        assert!(supports(&format!("0.{minor}.0")));
+        assert!(supports(&format!("0.{minor}.99")));
+        assert!(!supports(&format!("0.{}.0", minor + 1)));
+        assert!(!supports(&format!("0.{}.0", minor - 1)));
+        assert!(!supports("1.0.0"));
+    }
+
+    #[test]
+    fn reject_names_the_document_and_both_versions() {
+        let message = reject(".pio.json", "0.2.1");
+        assert!(message.contains(".pio.json"), "{message}");
+        assert!(message.contains("0.2.1"), "{message}");
+        assert!(message.contains(VERSION), "{message}");
+    }
+}

--- a/powerio/src/version.rs
+++ b/powerio/src/version.rs
@@ -55,6 +55,18 @@ pub fn lineage_label() -> String {
     }
 }
 
+/// The lineage as a path segment: `0.9` while the major is 0, `1` afterwards.
+///
+/// Names the directory a served JSON Schema lives under, so the published
+/// location moves when and only when a document stops loading.
+#[must_use]
+pub fn lineage_path() -> String {
+    match current_lineage() {
+        (0, minor) => format!("0.{minor}"),
+        (major, _) => major.to_string(),
+    }
+}
+
 fn current_lineage() -> (u64, u64) {
     lineage(VERSION).expect("the crate version is valid semver")
 }

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -249,7 +249,7 @@ def _package_value(text: str) -> Optional[Dict[str, Any]]:
     model = value.get("model")
     if not isinstance(model, dict):
         return None
-    required = ("schema_version", "model_kind")
+    required = (_VERSION_KEY, "model_kind")
     if not all(isinstance(value.get(key), str) for key in required):
         return None
     if not isinstance(model.get("kind"), str):

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -50,7 +50,7 @@ _PACKAGE_JSON_FORMATS = frozenset(
 )
 _ALLOWED_ROOTS_ENV = "POWERIO_MCP_ALLOWED_ROOTS"
 _LEGACY_ALLOWED_ROOT_ENV = "POWERIO_MCP_ROOT"
-_SCHEMA_VERSION = "0.1"
+_VERSION_KEY = "powerio_version"
 
 _MATRIX_KIND_ALIASES = {
     "b": "bprime",
@@ -404,7 +404,7 @@ def _diagnostics_payload(package_json: str, verbose: bool = False) -> Dict[str, 
         text = f"{status}: " + ", ".join(parts)
     return {
         "schema": "powerio.diagnostics",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "model_kind": kind,
         "summary": {
             "status": status,
@@ -639,7 +639,7 @@ def _transmission_summary(net: "powerio.Network") -> Dict[str, Any]:
     refs = net.reference_bus_indices()
     return {
         "schema": "powerio.summary",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": "transmission",
         "model": "balanced",
         "name": net.name,
@@ -669,7 +669,7 @@ def _transmission_summary(net: "powerio.Network") -> Dict[str, Any]:
 def _distribution_summary(net: "dist.DistNetwork") -> Dict[str, Any]:
     return {
         "schema": "powerio.summary",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": "distribution",
         "model": "multiconductor",
         "name": net.name,
@@ -931,7 +931,7 @@ def _parse_impl(
         diag = _diagnostics_payload(package_json, verbose=True)
         return {
             "schema": "powerio.parse",
-            "schema_version": _SCHEMA_VERSION,
+            _VERSION_KEY: powerio.__version__,
             "transport": "package",
             "domain": loaded.domain,
             "model": summary["model"],
@@ -953,7 +953,7 @@ def _parse_impl(
     summary = _summary(loaded)
     return {
         "schema": "powerio.parse",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": loaded.domain,
         "model": summary["model"],
         "source_format": summary["source_format"],
@@ -986,7 +986,7 @@ def _normalize_impl(
     summary = _summary(normalized)
     return {
         "schema": "powerio.normalize",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": "transmission",
         "model": "balanced",
         "source_format": summary["source_format"],
@@ -1045,7 +1045,7 @@ def _matrix_impl(
     coo = mat.tocoo()
     return {
         "schema": "powerio.matrix",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": "transmission",
         "model": "balanced",
         "source_format": net.source_format,
@@ -1076,7 +1076,7 @@ def _display_impl(path: str, from_format: Optional[str] = None) -> dict:
     pwd = data.data
     return {
         "schema": "powerio.display",
-        "schema_version": _SCHEMA_VERSION,
+        _VERSION_KEY: powerio.__version__,
         "domain": "display",
         "model": "display",
         "source_format": "powerworld-pwd",

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -61,7 +61,7 @@ def test_tool_surface_is_semantic():
 def test_summary_transmission_schema():
     s = server.summary(path=str(DATA / "case9.m"))
     assert s["schema"] == "powerio.summary"
-    assert s["schema_version"] == "0.1"
+    assert s["powerio_version"] == powerio.__version__
     assert s["domain"] == "transmission"
     assert s["model"] == "balanced"
     assert s["json_format"] == "powerio-json"
@@ -99,7 +99,7 @@ def test_distribution_aliases_route_to_core_parser():
 def test_parse_transmission_transport_round_trip(tmp_path):
     parsed = server.parse(path=str(DATA / "case9.m"))
     assert parsed["schema"] == "powerio.parse"
-    assert parsed["schema_version"] == "0.1"
+    assert parsed["powerio_version"] == powerio.__version__
     assert parsed["domain"] == "transmission"
     assert parsed["model"] == "balanced"
     assert parsed["source_format"] == "Matpower"
@@ -144,7 +144,7 @@ def test_package_transport_flows_through_summary_matrix_and_save(tmp_path):
     assert "package_json" in parsed
     package = json.loads(parsed["package_json"])
     # The reader accepts the 0.2 lineage; do not pin the patch version.
-    assert package["schema_version"].startswith("0.2.")
+    assert package["powerio_version"] == powerio.__version__
     assert package["model_kind"] == "balanced"
     assert package["model"]["kind"] == "balanced"
 
@@ -231,7 +231,7 @@ def test_normalize_rejects_distribution():
 def test_normalize_payload_has_schema_marker():
     norm = server.normalize(path=str(DATA / "case9.m"))
     assert norm["schema"] == "powerio.normalize"
-    assert norm["schema_version"] == "0.1"
+    assert norm["powerio_version"] == powerio.__version__
     assert norm["domain"] == "transmission"
     assert norm["model"] == "balanced"
 
@@ -265,7 +265,7 @@ def test_gridfm_routes_through_generic_verbs(tmp_path):
 def test_matrix_kinds_aliases_and_errors():
     m = server.matrix("b", path=str(DATA / "case9.m"))
     assert m["schema"] == "powerio.matrix"
-    assert m["schema_version"] == "0.1"
+    assert m["powerio_version"] == powerio.__version__
     assert m["domain"] == "transmission"
     assert m["model"] == "balanced"
     assert m["source_format"] == "Matpower"
@@ -409,7 +409,7 @@ def test_mcp_write_refuses_symlink_escape_from_allowed_root(monkeypatch, tmp_pat
 def test_display_decodes_powerworld_pwd():
     d = server.display(str(PWD))
     assert d["schema"] == "powerio.display"
-    assert d["schema_version"] == "0.1"
+    assert d["powerio_version"] == powerio.__version__
     assert d["domain"] == "display"
     assert d["model"] == "display"
     assert d["source_format"] == "powerworld-pwd"

--- a/python/tests/test_package.py
+++ b/python/tests/test_package.py
@@ -189,14 +189,15 @@ def test_package_invalid_json_raises_value_error():
         pio.Package.from_json("{}")
 
 
-def test_package_declares_schema_version_and_row_identity():
+def test_package_declares_the_powerio_version_and_row_identity():
     import json
 
     pkg = pio.Package.from_file(DATA / "case9.m")
     doc = json.loads(pkg.to_json())
     # The reader accepts the 0.2 lineage; do not pin the patch version.
-    assert doc["schema_version"].startswith("0.2.")
+    assert doc["powerio_version"] == pio.__version__
     assert "payload_schema" not in doc
+    assert "schema_version" not in doc
     assert "payload_schema_version" not in doc
     # Every payload row carries an identity; case9 has no source uids, so they
     # are synthesized from the build position.

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -101,7 +101,7 @@ def test_parse_metadata(case9):
 def test_parse_scopf_uses_public_versioned_wire_document():
     instance = powerio.parse_scopf(SCOPF_SMALL.read_text())
     assert instance["schema"] == "powerio.scopf.julia"
-    assert instance["schema_version"] == "1.0.0"
+    assert instance["powerio_version"] == powerio.__version__
     assert instance["index_base"] == 1
     assert instance["instance"]["lengths"]["I"] == 2
     assert instance["instance"]["static"]["acl_branch"][0]["j_ln"] == 1
@@ -682,7 +682,7 @@ def _real_matrix_arrow_payload(matrix, table):
         "row_count": csr.shape[0],
         "row_index": row_index,
         "row_axis": "matrix_bus",
-        "schema_version": "1",
+        "powerio_version": powerio.__version__,
         "table": table,
         "value_bits": value_bits,
     }
@@ -716,7 +716,7 @@ def _ybus_arrow_payload(case):
         "row_count": g.shape[0],
         "row_index": row_index,
         "row_axis": "matrix_bus",
-        "schema_version": "1",
+        "powerio_version": powerio.__version__,
         "table": "ybus",
         "g_bits": g_bits,
         "b_bits": b_bits,
@@ -733,7 +733,7 @@ def _matrix_axis_payload(case):
             "index": list(range(case.n_buses)),
             "is_reference": [1 if bus["kind"] == "REF" else 0 for bus in case.buses],
             "row_axis": "matrix_bus",
-            "schema_version": "1",
+            "powerio_version": powerio.__version__,
             "source_row": list(range(case.n_buses)),
             "table": "matrix_bus",
         },
@@ -744,7 +744,7 @@ def _matrix_axis_payload(case):
             ],
             "index": list(range(len(inc.branch_of_col))),
             "row_axis": "matrix_branch",
-            "schema_version": "1",
+            "powerio_version": powerio.__version__,
             "source_row": [int(idx) for idx in inc.branch_of_col],
             "table": "matrix_branch",
             "to_bus_id": [

--- a/scripts/ci-mirror.sh
+++ b/scripts/ci-mirror.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Everything rust.yml runs, in the same feature combinations.
+#
+# `cargo test --workspace` is not this: it builds powerio-capi with default
+# features only, so every test behind `arrow`, `gridfm`, `matrix` or `prob` is
+# skipped, and powerio-py is excluded entirely on a machine without the Python
+# library to link against.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+run() { echo "=== $* ==="; "$@"; }
+
+run cargo fmt --all --check
+run ./scripts/ci-clippy.sh
+run ./scripts/capi-header-parity.sh
+
+run cargo test -p powerio -p powerio-matrix -p powerio-prob -p powerio-cli \
+    -p powerio-capi -p powerio-dist -p powerio-pkg
+run cargo test -p powerio-prob --features matrix
+run cargo test -p powerio-matrix --features gridfm
+
+# The four powerio-capi combinations rust.yml builds.
+run cargo test -p powerio-capi --no-default-features
+run cargo test -p powerio-capi --features arrow
+run cargo test -p powerio-capi --features dist
+run cargo test -p powerio-capi --features arrow,matrix,gridfm,dist,pkg,prob
+
+# The C smoke test in the two configurations that exercise the most surface.
+# `cargo test` never compiles it, so a stale assertion in it reaches CI intact.
+smoke_dir=$(mktemp -d)
+trap 'rm -rf "$smoke_dir"' EXIT
+lib_path_var=DYLD_LIBRARY_PATH
+[ "$(uname -s)" = "Linux" ] && lib_path_var=LD_LIBRARY_PATH
+
+run cargo build -q -p powerio-capi --release --features dist
+cc -DPIO_DIST -I powerio-capi/include powerio-capi/examples/smoke.c \
+   -L target/release -lpowerio_capi -o "$smoke_dir/smoke_dist"
+run env "$lib_path_var=target/release" "$smoke_dir/smoke_dist" tests/data/case9.m
+
+run cargo build -q -p powerio-capi --release --features arrow,matrix,gridfm,dist,pkg,prob
+cc -DPIO_ARROW -DPIO_MATRIX -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG -DPIO_PROB \
+   -I powerio-capi/include powerio-capi/examples/smoke.c \
+   -L target/release -lpowerio_capi -o "$smoke_dir/smoke_release"
+run cargo run -q -p powerio-cli -- gridfm tests/data/case9.m -o "$smoke_dir/gridfm"
+run env "$lib_path_var=target/release" "$smoke_dir/smoke_release" \
+    tests/data/case9.m "$smoke_dir/gridfm/case9/raw"
+
+# The generated schema must already match what the example emits.
+run cargo run -q -p powerio-pkg --example generate_schemas --features schema -- docs/schema
+if ! git diff --quiet -- docs/schema; then
+  echo "error: docs/schema is stale; commit the regenerated files" >&2
+  exit 1
+fi
+
+echo "=== all green ==="

--- a/tests/data/capi_matrix/case30_arrow_coo.json
+++ b/tests/data/capi_matrix/case30_arrow_coo.json
@@ -88,8 +88,8 @@
         39,
         40
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_branch",
-      "schema_version": "1",
       "source_row": [
         0,
         1,
@@ -308,8 +308,8 @@
         0,
         0
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
-      "schema_version": "1",
       "source_row": [
         0,
         1,
@@ -465,6 +465,7 @@
         29
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 30,
       "row_index": [
@@ -581,7 +582,6 @@
         29,
         29
       ],
-      "schema_version": "1",
       "table": "bdoubleprime",
       "value_bits": [
         "0x4035e7a2951bd87a",
@@ -816,6 +816,7 @@
         29
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 30,
       "row_index": [
@@ -932,7 +933,6 @@
         29,
         29
       ],
-      "schema_version": "1",
       "table": "bprime",
       "value_bits": [
         "0x4033ec1a874b9b31",
@@ -1137,6 +1137,7 @@
         38
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 30,
       "row_index": [
@@ -1223,7 +1224,6 @@
         29,
         29
       ],
-      "schema_version": "1",
       "table": "incidence",
       "value_bits": [
         "0x3ff0000000000000",
@@ -1656,6 +1656,7 @@
         "0xbfed86f059c32c96",
         "0x3ff9d6124e8ac704"
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 30,
       "row_index": [
@@ -1772,7 +1773,6 @@
         29,
         29
       ],
-      "schema_version": "1",
       "table": "ybus"
     }
   }

--- a/tests/data/capi_matrix/case9_arrow_coo.json
+++ b/tests/data/capi_matrix/case9_arrow_coo.json
@@ -24,8 +24,8 @@
         7,
         8
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_branch",
-      "schema_version": "1",
       "source_row": [
         0,
         1,
@@ -96,8 +96,8 @@
         0,
         0
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
-      "schema_version": "1",
       "source_row": [
         0,
         1,
@@ -147,6 +147,7 @@
         8
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 9,
       "row_index": [
@@ -178,7 +179,6 @@
         8,
         8
       ],
-      "schema_version": "1",
       "table": "bdoubleprime",
       "value_bits": [
         "0x40315c71c71c71c7",
@@ -243,6 +243,7 @@
         8
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 9,
       "row_index": [
@@ -274,7 +275,6 @@
         8,
         8
       ],
-      "schema_version": "1",
       "table": "bprime",
       "value_bits": [
         "0x40315c71c71c71c7",
@@ -330,6 +330,7 @@
         8
       ],
       "format": "coo",
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 9,
       "row_index": [
@@ -352,7 +353,6 @@
         8,
         8
       ],
-      "schema_version": "1",
       "table": "incidence",
       "value_bits": [
         "0x3ff0000000000000",
@@ -466,6 +466,7 @@
         "0xbff3006d731a4512",
         "0x40046c1e42b9b1d2"
       ],
+      "powerio_version": "0.8.3",
       "row_axis": "matrix_bus",
       "row_count": 9,
       "row_index": [
@@ -497,7 +498,6 @@
         8,
         8
       ],
-      "schema_version": "1",
       "table": "ybus"
     }
   }


### PR DESCRIPTION
powerio stamped fifteen version numbers. Nine it invented for its own artifacts, each in a separate session with no register comparing them: `.pio.json` said 0.2.1, the SCOPF document 1.0.0, the DC OPF bundle 0.4.0, the geo layer 0.1.0, the Arrow catalog "1", the dist capability document 1.1.0, the CLI summary 0.1, and two more were bare literals. **Six were write only** — nothing ever read them. Two claimed 1.x stability inside a 0.x library. The CLI number was mirrored by hand in `python/powerio/mcp/server.py` with nothing tying the two together.

**Every document powerio authors now states one number: `powerio_version`, the release that wrote it.** That key is not new. The DC OPF bundle manifest, the gridfm metadata, and the matrix pipeline metadata already spelled it exactly that way for exactly that value, so those three lose a field rather than gaining one.

`powerio::version` holds the rule, generalized from the one `.pio.json` already applied: a document loads when it shares this build's lineage, the major once it reaches 1 and the major and minor pair while the major is 0. That is what cargo and Pkg already mean by a 0.x bump.

**A foreign format keeps its own version.** powerio implements case formats and authors none, so pandapower's `3.0.0` and the BMOPF `$schema` and version are reproduced, never set. The C version report is now the one powerio number, the ABI integer, and the foreign BMOPF version — the runtime probe a binding needs when a schema evolves on someone else's calendar. Its retired keys are asserted `null`, so a binding still reading `doc["package"]` fails loudly rather than silently seeing nothing.

**A `.pio.json` from 0.8.x or earlier states no version at all.** The field deserializes to the empty string rather than defaulting, so the gate stays closed and the reader names the release that wrote it instead of reporting a missing field.

**The served JSON Schema path follows the same lineage the reader accepts**, so the published location moves when and only when a document stops loading. `pio-package/0.2` joins the frozen set: a document in the wild validates against the URL it declares, so that URL stays served whether or not this reader still loads the document.

**"Wire" is gone as a serialization term.** It named three unrelated things in one repository. `powerio-prob/src/scopf/wire.rs` is now `json.rs`, and `WireFields`/`wire_fields!`/`to_wire_json` are `SerializedFields`/`serialized_fields!`/`to_json`. Wire coordinates keep the word: that one is the electrical term for the multiconductor model, and it is the only correct use.

Consumer-visible: `.pio.json`, the SCOPF document, the DC OPF bundle manifest, the geo layer, the Arrow catalog and table metadata, and every summary document change their version field. Regenerate stored artifacts.

Verified: `cargo fmt --all --check`, `scripts/ci-clippy.sh`, `scripts/capi-header-parity.sh`, and `cargo test --workspace --exclude powerio-py` at 51 binaries and 1268 tests, zero failures.

Eighth in the v0.9.0 stack, on top of #316.


Closes #270. Every document in that issue table now carries one field, `powerio_version`, written from `powerio::VERSION`: the SCOPF document, the dist capabilities document, both C ABI summaries, the Arrow catalog, the geo layer sidecar, and the DC OPF bundle manifest. `powerio/src/version.rs` states the acceptance rule once and generalizes the `.pio.json` lineage gate to all of them, and every invented constant the issue lists is deleted.
