### PR TITLE
core: give each crate the errors it raises

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2092,6 +2092,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,6 +2078,7 @@ dependencies = [
  "sha2",
  "sprs",
  "tempfile",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -2103,6 +2104,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -27,6 +27,7 @@ path = "src/lib.rs"
 
 [dependencies]
 powerio.workspace = true
+thiserror = "2"
 sprs.workspace = true
 num-complex.workspace = true
 serde.workspace = true

--- a/powerio-matrix/src/error.rs
+++ b/powerio-matrix/src/error.rs
@@ -1,0 +1,208 @@
+//! Failures the matrix and dataset builders raise.
+//!
+//! [`Error`] carries what this crate constructs and wraps [`powerio::Error`]
+//! for everything the hub raises underneath, so `?` moves a hub failure across
+//! the boundary without restating it. A caller that only wants the coarse
+//! split reads [`Error::category`], which is the same taxonomy the hub uses.
+
+use thiserror::Error as ThisError;
+
+/// A matrix, sensitivity, or dataset failure.
+#[derive(Debug, ThisError)]
+#[non_exhaustive]
+pub enum Error {
+    /// A failure from the balanced model, its readers, or its writers.
+    #[error(transparent)]
+    Core(#[from] powerio::Error),
+
+    /// An underlying I/O failure reading or writing a file.
+    ///
+    /// Routed through the hub's variant so the message a caller sees is the
+    /// same one every other powerio surface prints for the same failure.
+    #[error(transparent)]
+    Io(std::io::Error),
+
+    #[error("output dimension mismatch: matrix is {n}x{n} but RHS has length {b_len}")]
+    DimensionMismatch { n: usize, b_len: usize },
+
+    #[error("dimension mismatch: `{what}` expected length {expected}, got {got}")]
+    ShapeMismatch {
+        what: &'static str,
+        expected: usize,
+        got: usize,
+    },
+
+    #[error(
+        "DC sensitivity solve failed: the reference-grounded Laplacian is singular even though every component is grounded"
+    )]
+    SingularNetwork,
+
+    #[error("invalid DC sensitivity option: {reason}")]
+    InvalidSensitivityOptions { reason: String },
+
+    #[error(
+        "DC sensitivity iterative solve did not converge after {iterations} iterations (relative residual {relative_residual:.3e})"
+    )]
+    SensitivitySolveDidNotConverge {
+        iterations: usize,
+        relative_residual: f64,
+    },
+
+    #[error("matrix-market I/O: {0}")]
+    Mtx(String),
+
+    #[error("gridfm Parquet export: {0}")]
+    Parquet(String),
+
+    #[error("gridfm scenario batch is empty; provide at least one snapshot")]
+    EmptyScenarioBatch,
+
+    #[error("gridfm scenario id overflows i64 when numbering snapshot {index} from base {base}")]
+    ScenarioIdOverflow {
+        base: i64,
+        /// 0-based position of the snapshot whose `base + index` overflowed.
+        index: usize,
+    },
+
+    #[error(
+        "gridfm snapshot scenario {scenario} is normalized; gridfm export expects raw MW and degree fields"
+    )]
+    NormalizedGridfmSnapshot { scenario: i64 },
+
+    #[error(
+        "gridfm snapshot scenario {scenario} has non-finite {element} row {row} field `{field}`: {value}"
+    )]
+    NonFiniteGridfmValue {
+        scenario: i64,
+        element: &'static str,
+        row: usize,
+        field: &'static str,
+        value: f64,
+    },
+
+    #[error(
+        "gridfm snapshot {index} doesn't match the first snapshot's element set: {reason}; \
+         a scenario batch shares one base element set (same bus/branch/gen counts and bus-id order)"
+    )]
+    ScenarioShapeMismatch {
+        /// 0-based position of the offending snapshot in the batch (independent
+        /// of the snapshot's scenario id).
+        index: usize,
+        reason: ScenarioMismatch,
+    },
+}
+
+impl Error {
+    /// Classify this error, using the hub's taxonomy.
+    ///
+    /// The match is exhaustive over the variant set, so a new variant must be
+    /// classified here before it compiles.
+    #[must_use]
+    pub fn category(&self) -> powerio::ErrorCategory {
+        use powerio::ErrorCategory as C;
+        match self {
+            Error::Core(inner) => inner.category(),
+            Error::Io(_) => C::Io,
+            // A well-formed case that cannot satisfy a requested operation.
+            Error::DimensionMismatch { .. }
+            | Error::ShapeMismatch { .. }
+            | Error::SingularNetwork
+            | Error::InvalidSensitivityOptions { .. }
+            | Error::SensitivitySolveDidNotConverge { .. }
+            | Error::EmptyScenarioBatch
+            | Error::ScenarioIdOverflow { .. }
+            | Error::NormalizedGridfmSnapshot { .. }
+            | Error::NonFiniteGridfmValue { .. }
+            | Error::ScenarioShapeMismatch { .. } => C::Data,
+            // Output-side serialization write failures.
+            Error::Mtx(_) | Error::Parquet(_) => C::Output,
+        }
+    }
+}
+
+/// The element counts that define a scenario batch's shared base shape. Named
+/// (rather than a bare `(usize, usize, usize)`) so the three same-typed fields
+/// can't be transposed silently in an error message or a comparison.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ElementCounts {
+    pub buses: usize,
+    pub branches: usize,
+    pub gens: usize,
+}
+
+impl std::fmt::Display for ElementCounts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} buses, {} branches, {} gens",
+            self.buses, self.branches, self.gens
+        )
+    }
+}
+
+/// Why a gridfm scenario snapshot doesn't line up with the first snapshot's
+/// base element set (the row-stack keeps every table schema-consistent by
+/// requiring the same element counts and bus-id ordering across snapshots).
+///
+/// This enum is `#[non_exhaustive]`; downstream matches must include a wildcard
+/// arm.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScenarioMismatch {
+    /// Element counts differ.
+    Counts {
+        expected: ElementCounts,
+        got: ElementCounts,
+    },
+    /// Counts match, but the buses are listed in a different order (so the dense
+    /// bus index wouldn't mean the same bus across snapshots).
+    BusOrder,
+}
+
+impl std::fmt::Display for ScenarioMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Counts { expected, got } => {
+                write!(f, "got ({got}) vs the first snapshot's ({expected})")
+            }
+            Self::BusOrder => {
+                write!(f, "counts match but the bus ids are in a different order")
+            }
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::Io(error)
+    }
+}
+
+/// The result type every fallible entry point in this crate returns.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use powerio::ErrorCategory::{Data, Output, Parse};
+
+    #[test]
+    fn category_pins_the_intended_buckets() {
+        assert_eq!(Error::SingularNetwork.category(), Data);
+        assert_eq!(Error::EmptyScenarioBatch.category(), Data);
+        assert_eq!(Error::Mtx("write failed".into()).category(), Output);
+        assert_eq!(Error::Parquet("write failed".into()).category(), Output);
+    }
+
+    #[test]
+    fn a_wrapped_hub_error_keeps_its_own_category() {
+        let wrapped: Error = powerio::Error::MissingField("bus").into();
+        assert_eq!(wrapped.category(), Parse);
+        // And its message, byte for byte: the C ABI reports errors as text, so
+        // a wrapper that restated the message would change what a binding sees.
+        assert_eq!(
+            wrapped.to_string(),
+            powerio::Error::MissingField("bus").to_string()
+        );
+    }
+}

--- a/powerio-matrix/src/io/gridfm.rs
+++ b/powerio-matrix/src/io/gridfm.rs
@@ -247,12 +247,12 @@ struct GridfmMeta {
 /// for one snapshot.
 ///
 /// # Errors
-/// [`Error::ReferenceBusCount`] unless the case has exactly one reference bus
+/// [`powerio::Error::ReferenceBusCount`] unless the case has exactly one reference bus
 /// (graphkit needs a slack), [`Error::NormalizedGridfmSnapshot`] for a normalized
 /// input, [`Error::NonFiniteGridfmValue`] for a NaN/Inf physical quantity (or a
 /// NaN limit — `±Inf` limits are the valid unbounded sentinel) that would reach
-/// Parquet, [`Error::NonFiniteSusceptance`] if a finite branch impedance still
-/// yields a non-finite admittance, and [`Error::UnknownBus`] if a generator or
+/// Parquet, [`powerio::Error::NonFiniteSusceptance`] if a finite branch impedance still
+/// yields a non-finite admittance, and [`powerio::Error::UnknownBus`] if a generator or
 /// branch references a bus the network doesn't define.
 pub fn gridfm_record_batches(
     net: &Network,
@@ -738,7 +738,7 @@ fn gen_batch(snaps: &[SnapshotView]) -> Result<RecordBatch> {
         // One pass over the snapshot's generators: every column gets one push per
         // generator, in dense source order.
         for (row, g) in view.generators().iter().enumerate() {
-            let i = view.bus_index(g.bus).ok_or(Error::UnknownBus {
+            let i = view.bus_index(g.bus).ok_or(powerio::Error::UnknownBus {
                 bus_id: g.bus,
                 element_index: row,
             })?;
@@ -831,11 +831,11 @@ fn branch_batch(snaps: &[SnapshotView], opts: &GridfmOptions) -> Result<RecordBa
         idx.extend(0..branches.len() as i64);
 
         for (row, br) in branches.iter().enumerate() {
-            let i = view.bus_index(br.from).ok_or(Error::UnknownBus {
+            let i = view.bus_index(br.from).ok_or(powerio::Error::UnknownBus {
                 bus_id: br.from,
                 element_index: row,
             })?;
-            let j = view.bus_index(br.to).ok_or(Error::UnknownBus {
+            let j = view.bus_index(br.to).ok_or(powerio::Error::UnknownBus {
                 bus_id: br.to,
                 element_index: row,
             })?;
@@ -1076,7 +1076,7 @@ pub struct GridfmRead {
 /// come from the caller (the disk path reads them from `gridfm_meta.json`).
 ///
 /// # Errors
-/// [`Error::FormatRead`] if a required column is missing or mistyped, a column
+/// [`powerio::Error::FormatRead`] if a required column is missing or mistyped, a column
 /// carries nulls, a dense index is negative, or `scenario` isn't present; plus
 /// whatever [`Network::validate`] rejects (duplicate / dangling bus ids).
 pub fn read_gridfm_network(
@@ -1293,10 +1293,11 @@ fn build_network_from_columns(
         let mut avail = bus.scenario.clone();
         avail.sort_unstable();
         avail.dedup();
-        return Err(Error::FormatRead {
+        return Err(powerio::Error::FormatRead {
             format: "gridfm",
             message: format!("scenario {scenario} not present; available: {avail:?}"),
-        });
+        }
+        .into());
     }
 
     let bus_id = &bus.bus;
@@ -1515,12 +1516,12 @@ fn resolve_raw_dir(dir: &Path) -> Result<PathBuf> {
     // Surface read_dir / entry IO errors (missing dir, permissions) rather than
     // masking them as "no dataset found".
     let mut matches: Vec<PathBuf> = Vec::new();
-    let entries = std::fs::read_dir(dir).map_err(|e| Error::FormatRead {
+    let entries = std::fs::read_dir(dir).map_err(|e| powerio::Error::FormatRead {
         format: "gridfm",
         message: format!("reading directory {}: {e}", dir.display()),
     })?;
     for entry in entries {
-        let entry = entry.map_err(|e| Error::FormatRead {
+        let entry = entry.map_err(|e| powerio::Error::FormatRead {
             format: "gridfm",
             message: format!("reading an entry of {}: {e}", dir.display()),
         })?;
@@ -1531,21 +1532,23 @@ fn resolve_raw_dir(dir: &Path) -> Result<PathBuf> {
     }
     match matches.len() {
         1 => Ok(matches.pop().expect("len checked")),
-        0 => Err(Error::FormatRead {
+        0 => Err(powerio::Error::FormatRead {
             format: "gridfm",
             message: format!(
                 "no gridfm dataset under {}; expected bus_data.parquet in the directory, a \
                  raw/ child, or a single <case>/raw/ child",
                 dir.display()
             ),
-        }),
-        n => Err(Error::FormatRead {
+        }
+        .into()),
+        n => Err(powerio::Error::FormatRead {
             format: "gridfm",
             message: format!(
                 "{n} gridfm datasets under {}; point at the specific <case>/raw directory",
                 dir.display()
             ),
-        }),
+        }
+        .into()),
     }
 }
 
@@ -1604,21 +1607,23 @@ fn read_meta(raw: &Path) -> (f64, String, Vec<String>) {
 /// Open a parquet file and collect every record batch (one for powerio-written
 /// data, possibly several for an externally-written prediction).
 fn read_parquet(path: &Path) -> Result<Vec<RecordBatch>> {
-    let file = std::fs::File::open(path).map_err(|e| Error::FormatRead {
+    let file = std::fs::File::open(path).map_err(|e| powerio::Error::FormatRead {
         format: "gridfm",
         message: format!("opening {}: {e}", path.display()),
     })?;
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)
         .and_then(ParquetRecordBatchReaderBuilder::build)
-        .map_err(|e| Error::FormatRead {
+        .map_err(|e| powerio::Error::FormatRead {
             format: "gridfm",
             message: format!("reading {}: {e}", path.display()),
         })?;
     reader
         .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| Error::FormatRead {
-            format: "gridfm",
-            message: format!("decoding {}: {e}", path.display()),
+        .map_err(|e| {
+            Error::Core(powerio::Error::FormatRead {
+                format: "gridfm",
+                message: format!("decoding {}: {e}", path.display()),
+            })
         })
 }
 
@@ -1641,21 +1646,22 @@ fn require_scenario_block(
     table: &str,
 ) -> Result<()> {
     if rows.is_empty() && !scen_col.is_empty() {
-        return Err(Error::FormatRead {
+        return Err(powerio::Error::FormatRead {
             format: "gridfm",
             message: format!(
                 "scenario {scenario} has no {table} rows, but the table holds {} row(s) for other \
                  scenarios — a partial or corrupt dataset",
                 scen_col.len()
             ),
-        });
+        }
+        .into());
     }
     Ok(())
 }
 
 /// A dense `[0, n)` parquet index → 1-based [`BusId`]. Errors on a negative index.
 fn dense_bus_id(v: i64) -> Result<BusId> {
-    let idx = usize::try_from(v).map_err(|_| Error::FormatRead {
+    let idx = usize::try_from(v).map_err(|_| powerio::Error::FormatRead {
         format: "gridfm",
         message: format!("negative dense bus index {v}"),
     })?;
@@ -1664,9 +1670,11 @@ fn dense_bus_id(v: i64) -> Result<BusId> {
 
 /// Look up a named column, erroring if absent.
 fn column<'a>(b: &'a RecordBatch, name: &str) -> Result<&'a ArrayRef> {
-    b.column_by_name(name).ok_or_else(|| Error::FormatRead {
-        format: "gridfm",
-        message: format!("missing column `{name}`"),
+    b.column_by_name(name).ok_or_else(|| {
+        Error::Core(powerio::Error::FormatRead {
+            format: "gridfm",
+            message: format!("missing column `{name}`"),
+        })
     })
 }
 
@@ -1675,18 +1683,18 @@ fn i64_col(batches: &[RecordBatch], name: &str) -> Result<Vec<i64>> {
     let mut out = Vec::with_capacity(batches.iter().map(RecordBatch::num_rows).sum());
     for b in batches {
         let arr = column(b, name)?;
-        let col = arr
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .ok_or_else(|| Error::FormatRead {
+        let col = arr.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+            powerio::Error::FormatRead {
                 format: "gridfm",
                 message: format!("column `{name}` is not Int64"),
-            })?;
+            }
+        })?;
         if col.null_count() > 0 {
-            return Err(Error::FormatRead {
+            return Err(powerio::Error::FormatRead {
                 format: "gridfm",
                 message: format!("column `{name}` has nulls"),
-            });
+            }
+            .into());
         }
         out.extend_from_slice(col.values());
     }
@@ -1698,18 +1706,18 @@ fn f64_col(batches: &[RecordBatch], name: &str) -> Result<Vec<f64>> {
     let mut out = Vec::with_capacity(batches.iter().map(RecordBatch::num_rows).sum());
     for b in batches {
         let arr = column(b, name)?;
-        let col = arr
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .ok_or_else(|| Error::FormatRead {
+        let col = arr.as_any().downcast_ref::<Float64Array>().ok_or_else(|| {
+            powerio::Error::FormatRead {
                 format: "gridfm",
                 message: format!("column `{name}` is not Float64"),
-            })?;
+            }
+        })?;
         if col.null_count() > 0 {
-            return Err(Error::FormatRead {
+            return Err(powerio::Error::FormatRead {
                 format: "gridfm",
                 message: format!("column `{name}` has nulls"),
-            });
+            }
+            .into());
         }
         out.extend_from_slice(col.values());
     }
@@ -2084,7 +2092,7 @@ mod tests {
         );
         let err = gridfm_record_batches(&net, 0, &GridfmOptions::default()).unwrap_err();
         assert!(
-            matches!(err, Error::ReferenceBusCount { .. }),
+            matches!(err, Error::Core(powerio::Error::ReferenceBusCount { .. })),
             "got {err:?}"
         );
     }
@@ -2877,10 +2885,10 @@ mod tests {
         assert!(
             matches!(
                 err,
-                Error::FormatRead {
+                Error::Core(powerio::Error::FormatRead {
                     format: "gridfm",
                     ..
-                }
+                })
             ),
             "got {err:?}"
         );
@@ -2894,10 +2902,10 @@ mod tests {
         assert!(
             matches!(
                 err,
-                Error::FormatRead {
+                Error::Core(powerio::Error::FormatRead {
                     format: "gridfm",
                     ..
-                }
+                })
             ),
             "got {err:?}"
         );
@@ -2907,10 +2915,10 @@ mod tests {
         assert!(
             matches!(
                 err,
-                Error::FormatRead {
+                Error::Core(powerio::Error::FormatRead {
                     format: "gridfm",
                     ..
-                }
+                })
             ),
             "got {err:?}"
         );
@@ -3091,10 +3099,10 @@ mod tests {
         assert!(
             matches!(
                 err,
-                Error::FormatRead {
+                Error::Core(powerio::Error::FormatRead {
                     format: "gridfm",
                     ..
-                }
+                })
             ),
             "got {err:?}"
         );

--- a/powerio-matrix/src/io/mod.rs
+++ b/powerio-matrix/src/io/mod.rs
@@ -32,7 +32,7 @@ pub fn read_dataset_dir(
     dir: impl AsRef<std::path::Path>,
     from: &str,
     scenario: i64,
-) -> powerio::Result<GridfmRead> {
+) -> crate::Result<GridfmRead> {
     require_dataset_format(from)?;
     read_gridfm_dataset(dir, scenario)
 }
@@ -47,7 +47,7 @@ pub fn read_dataset_dir(
 pub fn dataset_scenario_ids(
     dir: impl AsRef<std::path::Path>,
     from: &str,
-) -> powerio::Result<Vec<i64>> {
+) -> crate::Result<Vec<i64>> {
     require_dataset_format(from)?;
     gridfm::gridfm_scenario_ids(dir)
 }

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -29,24 +29,27 @@
 //! both carry phase shift injection. The full reference across every matrix is in
 //! [the matrix guide](https://eigenergy.github.io/powerio/guide/matrices.html).
 
-// Re-export the powerio data layer so one import covers model and matrix types, and so
-// the matrix modules' `crate::Error` / `crate::network` / `crate::format` paths
-// resolve unchanged after the split.
+// Re-export the powerio data layer so one import covers model and matrix types,
+// and so the matrix modules' `crate::network` / `crate::format` paths resolve
+// unchanged after the split. `Error` and `Result` are this crate's own: the
+// variants below are raised here and nowhere in the hub.
 pub use powerio::{
     Branch, Bus, BusId, BusType, ConnectivityReport, Conversion, DisplayData, DisplayFormat,
-    ElementCounts, Error, ErrorCategory, Extras, GenCost, GenCostPatch, GenCostPolicyReport,
-    Generator, Hvdc, IndexCore, IndexedNetwork, Load, MissingGenCostPolicy, Network,
-    NormalizeOptions, NormalizedNetwork, POWER_MODELS_ANGLE_BOUND_PAD, Parsed, PwdDisplay,
-    PwdSubstation, PypsaCsvOutputs, Result, ScenarioMismatch, Shunt, SourceFormat, Storage,
-    TargetFormat, WriteOptions, convert_file, convert_file_with_options, convert_str,
-    convert_str_with_options, display_format_from_name, error, format, gen_cost, geo, indexed,
-    network, parse_display_bytes, parse_display_file, parse_file, parse_gen_cost_csv,
+    ErrorCategory, Extras, GenCost, GenCostPatch, GenCostPolicyReport, Generator, Hvdc, IndexCore,
+    IndexedNetwork, Load, MissingGenCostPolicy, Network, NormalizeOptions, NormalizedNetwork,
+    POWER_MODELS_ANGLE_BOUND_PAD, Parsed, PwdDisplay, PwdSubstation, PypsaCsvOutputs, Shunt,
+    SourceFormat, Storage, TargetFormat, WriteOptions, convert_file, convert_file_with_options,
+    convert_str, convert_str_with_options, display_format_from_name, format, gen_cost, geo,
+    indexed, network, parse_display_bytes, parse_display_file, parse_file, parse_gen_cost_csv,
     parse_matpower, parse_matpower_file, parse_pandapower_json, parse_powermodels_json,
     parse_powerworld, parse_pslf, parse_psse, parse_str, parse_str_with_name,
     read_pypsa_csv_folder, target_format_from_name, write_as, write_as_with_options,
     write_egret_json, write_matpower, write_pandapower_json, write_powermodels_json,
     write_powerworld, write_psse, write_pypsa_csv_folder,
 };
+
+pub mod error;
+pub use error::{ElementCounts, Error, Result, ScenarioMismatch};
 
 /// Compressed sparse row matrix used by the projection builders.
 pub type SparseMatrix = sprs::CsMat<f64>;

--- a/powerio-matrix/src/lib.rs
+++ b/powerio-matrix/src/lib.rs
@@ -51,6 +51,9 @@ pub use powerio::{
 pub mod error;
 pub use error::{ElementCounts, Error, Result, ScenarioMismatch};
 
+/// The hub's error, so a binding can map both through one taxonomy.
+pub use powerio::Error as CoreError;
+
 /// Compressed sparse row matrix used by the projection builders.
 pub type SparseMatrix = sprs::CsMat<f64>;
 

--- a/powerio-matrix/src/matrix/adjacency.rs
+++ b/powerio-matrix/src/matrix/adjacency.rs
@@ -6,20 +6,20 @@ use std::collections::HashSet;
 
 use sprs::CsMat;
 
+use crate::Result;
 use crate::indexed::IndexedNetwork;
 use crate::matrix::triplet::CooBuilder;
-use crate::{Error, Result};
 
 /// Build the `n × n` 0/1 adjacency matrix.
 pub fn build_adjacency(case: &IndexedNetwork) -> Result<CsMat<f64>> {
     let n = case.n();
     let mut edges: HashSet<(usize, usize)> = HashSet::new();
     for (idx, br) in case.in_service_branches() {
-        let i = case.bus_index(br.from).ok_or(Error::UnknownBus {
+        let i = case.bus_index(br.from).ok_or(powerio::Error::UnknownBus {
             bus_id: br.from,
             element_index: idx,
         })?;
-        let j = case.bus_index(br.to).ok_or(Error::UnknownBus {
+        let j = case.bus_index(br.to).ok_or(powerio::Error::UnknownBus {
             bus_id: br.to,
             element_index: idx,
         })?;

--- a/powerio-matrix/src/matrix/incidence.rs
+++ b/powerio-matrix/src/matrix/incidence.rs
@@ -10,9 +10,9 @@ use sprs::CsMat;
 
 pub use powerio::DcConvention;
 
+use crate::Result;
 use crate::indexed::IndexedNetwork;
 use crate::matrix::triplet::CooBuilder;
-use crate::{Error, Result};
 
 use super::{BuildOptions, ZeroImpedanceSkips};
 
@@ -50,8 +50,8 @@ impl IncidenceParts {
 /// Self-loops (from == to) are dropped. A branch whose reactance is too small
 /// to divide by has no DC susceptance the Laplacian can carry; it is skipped
 /// when `opts.skip_zero_impedance` is true and rejected with
-/// [`Error::ZeroImpedance`] when it is false. A tap ratio under the same bound
-/// is [`Error::DegenerateTap`] either way, as it is in Y_bus.
+/// [`powerio::Error::ZeroImpedance`] when it is false. A tap ratio under the same bound
+/// is [`powerio::Error::DegenerateTap`] either way, as it is in Y_bus.
 pub fn build_incidence(
     case: &IndexedNetwork,
     conv: DcConvention,
@@ -63,11 +63,11 @@ pub fn build_incidence(
     let mut cols: Vec<Column> = Vec::new();
     let mut skipped_zero_impedance = Vec::new();
     for (idx, br) in case.in_service_branches() {
-        let i = case.bus_index(br.from).ok_or(Error::UnknownBus {
+        let i = case.bus_index(br.from).ok_or(powerio::Error::UnknownBus {
             bus_id: br.from,
             element_index: idx,
         })?;
-        let j = case.bus_index(br.to).ok_or(Error::UnknownBus {
+        let j = case.bus_index(br.to).ok_or(powerio::Error::UnknownBus {
             bus_id: br.to,
             element_index: idx,
         })?;
@@ -78,7 +78,7 @@ pub fn build_incidence(
         if i == j || degenerate_x {
             if i != j && degenerate_x {
                 if !opts.skip_zero_impedance {
-                    return Err(Error::ZeroImpedance { row: idx });
+                    return Err(powerio::Error::ZeroImpedance { row: idx }.into());
                 }
                 skipped_zero_impedance.push(idx);
             }
@@ -90,7 +90,7 @@ pub fn build_incidence(
         // A NaN reactance slips past the guard above and poisons the whole
         // Laplacian.
         if !b_e.is_finite() {
-            return Err(Error::NonFiniteSusceptance { row: idx });
+            return Err(powerio::Error::NonFiniteSusceptance { row: idx }.into());
         }
         // angle_radians, not to_radians: a normalized network's shift is
         // already in radians, so converting again would double-scale it.

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -515,7 +515,10 @@ fn bprime_rejects_nan_reactance() {
     net.branches[0].x = f64::NAN;
     let view = IndexedNetwork::new(&net);
     let err = build_bprime(&view, &BuildOptions::default()).unwrap_err();
-    assert!(matches!(err, crate::Error::NonFiniteSusceptance { .. }));
+    assert!(matches!(
+        err,
+        crate::Error::Core(powerio::Error::NonFiniteSusceptance { .. })
+    ));
 }
 
 #[test]
@@ -524,7 +527,10 @@ fn ybus_rejects_nan_reactance() {
     net.branches[0].x = f64::NAN;
     let view = IndexedNetwork::new(&net);
     let err = build_ybus(&view, &BuildOptions::default()).unwrap_err();
-    assert!(matches!(err, crate::Error::NonFiniteSusceptance { .. }));
+    assert!(matches!(
+        err,
+        crate::Error::Core(powerio::Error::NonFiniteSusceptance { .. })
+    ));
 }
 
 #[test]
@@ -558,11 +564,20 @@ fn zero_impedance_policy_can_error_instead_of_skipping() {
     };
 
     let bprime = build_bprime(&view, &opts).unwrap_err();
-    assert!(matches!(bprime, crate::Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        bprime,
+        crate::Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
     let ybus = build_ybus(&view, &opts).unwrap_err();
-    assert!(matches!(ybus, crate::Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        ybus,
+        crate::Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
     let inc = build_incidence(&view, DcConvention::ReactanceOnly, &opts).unwrap_err();
-    assert!(matches!(inc, crate::Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        inc,
+        crate::Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
 }
 
 #[test]
@@ -653,12 +668,18 @@ fn a_reactance_below_the_divisible_bound_is_zero_impedance() {
     };
     let err = build_incidence(&view, DcConvention::ReactanceOnly, &strict).unwrap_err();
     assert!(
-        matches!(err, crate::Error::ZeroImpedance { row: 0 }),
+        matches!(
+            err,
+            crate::Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+        ),
         "{err}"
     );
     let err = build_ybus(&view, &strict).unwrap_err();
     assert!(
-        matches!(err, crate::Error::ZeroImpedance { row: 0 }),
+        matches!(
+            err,
+            crate::Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+        ),
         "{err}"
     );
 }
@@ -702,13 +723,19 @@ fn a_tap_ratio_the_builders_cannot_divide_by_is_refused() {
         let view = IndexedNetwork::new(&net);
         let err = build_ybus(&view, &BuildOptions::default()).unwrap_err();
         assert!(
-            matches!(err, crate::Error::DegenerateTap { row: 0, .. }),
+            matches!(
+                err,
+                crate::Error::Core(powerio::Error::DegenerateTap { row: 0, .. })
+            ),
             "Ybus, tap {tap}: {err}"
         );
         let err =
             build_incidence(&view, DcConvention::Matpower, &BuildOptions::default()).unwrap_err();
         assert!(
-            matches!(err, crate::Error::DegenerateTap { row: 0, .. }),
+            matches!(
+                err,
+                crate::Error::Core(powerio::Error::DegenerateTap { row: 0, .. })
+            ),
             "incidence, tap {tap}: {err}"
         );
     }

--- a/powerio-matrix/src/matrix/ybus.rs
+++ b/powerio-matrix/src/matrix/ybus.rs
@@ -15,8 +15,8 @@
 use num_complex::Complex64;
 use sprs::CsMat;
 
+use crate::Result;
 use crate::indexed::IndexedNetwork;
-use crate::{Error, Result};
 
 use super::triplet::CooBuilder;
 
@@ -81,11 +81,11 @@ pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> 
     let mut b_coo = CooBuilder::with_capacity(n, 4 * case.branches().len() + n);
 
     for (row_idx, br) in case.in_service_branches() {
-        let i = case.bus_index(br.from).ok_or(Error::UnknownBus {
+        let i = case.bus_index(br.from).ok_or(powerio::Error::UnknownBus {
             bus_id: br.from,
             element_index: row_idx,
         })?;
-        let j = case.bus_index(br.to).ok_or(Error::UnknownBus {
+        let j = case.bus_index(br.to).ok_or(powerio::Error::UnknownBus {
             bus_id: br.to,
             element_index: row_idx,
         })?;
@@ -148,8 +148,8 @@ pub(crate) fn build_ybus_with_flags(case: &IndexedNetwork, flags: YbusFlags) -> 
 /// error.
 ///
 /// # Errors
-/// [`Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad value can't
-/// slip a NaN into Y_bus or a Parquet column. [`Error::DegenerateTap`] when the
+/// [`powerio::Error::NonFiniteSusceptance`] when `r`/`x` are NaN/Inf, so a bad value can't
+/// slip a NaN into Y_bus or a Parquet column. [`powerio::Error::DegenerateTap`] when the
 /// tap ratio is one the four admittances cannot be divided by.
 #[allow(clippy::many_single_char_names)]
 pub(crate) fn branch_admittance(
@@ -168,14 +168,14 @@ pub(crate) fn branch_admittance(
         if flags.skip_zero_impedance {
             return Ok(None);
         }
-        return Err(Error::ZeroImpedance { row });
+        return Err(powerio::Error::ZeroImpedance { row }.into());
     }
     let denom = r * r + x * x;
     // NaN leaves `hypot` NaN, which is not below the bound, so it arrives here
     // rather than reading as zero impedance. Either would write NaN into Y_bus
     // and silently break the downstream M-matrix/SDDM checks.
     if !denom.is_finite() {
-        return Err(Error::NonFiniteSusceptance { row });
+        return Err(powerio::Error::NonFiniteSusceptance { row }.into());
     }
     let y_series = Complex64::new(r / denom, -x / denom);
 
@@ -208,7 +208,7 @@ pub(crate) fn branch_admittance(
     // Each input is bounded on its own above; the products can still overflow
     // when several sit near their bound at once.
     if out.iter().any(|y| !y.re.is_finite() || !y.im.is_finite()) {
-        return Err(Error::NonFiniteSusceptance { row });
+        return Err(powerio::Error::NonFiniteSusceptance { row }.into());
     }
     Ok(Some(out))
 }

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -254,13 +254,13 @@ fn reference_bus_count_errors() {
     );
     assert!(matches!(
         IndexedNetwork::new(&two).reference_bus_index(),
-        Err(Error::ReferenceBusCount { found: 2 })
+        Err(powerio::Error::ReferenceBusCount { found: 2 })
     ));
     // Zero reference buses.
     let zero = net("no_ref", vec![bus(1, BusType::Pq)], vec![]);
     assert!(matches!(
         IndexedNetwork::new(&zero).reference_bus_index(),
-        Err(Error::ReferenceBusCount { found: 0 })
+        Err(powerio::Error::ReferenceBusCount { found: 0 })
     ));
 }
 
@@ -724,12 +724,18 @@ fn ungrounded_island_errors() {
     assert_eq!(view.n_connected_components(), 2);
     let p = build_ptdf(&view, DcConvention::ReactanceOnly).unwrap_err();
     assert!(
-        matches!(p, Error::UngroundedComponent { components: 1 }),
+        matches!(
+            p,
+            Error::Core(powerio::Error::UngroundedComponent { components: 1 })
+        ),
         "ptdf: {p:?}"
     );
     let l = build_lodf(&view, DcConvention::ReactanceOnly).unwrap_err();
     assert!(
-        matches!(l, Error::UngroundedComponent { components: 1 }),
+        matches!(
+            l,
+            Error::Core(powerio::Error::UngroundedComponent { components: 1 })
+        ),
         "lodf: {l:?}"
     );
 }

--- a/powerio-pkg/Cargo.toml
+++ b/powerio-pkg/Cargo.toml
@@ -21,6 +21,7 @@ schema = ["dep:schemars", "powerio/schema", "powerio-dist/schema"]
 [dependencies]
 num-complex = { workspace = true }
 powerio = { workspace = true }
+thiserror = "2"
 powerio-dist = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/powerio-pkg/src/error.rs
+++ b/powerio-pkg/src/error.rs
@@ -1,0 +1,101 @@
+//! Failures reading, writing, and transforming a `.pio.json` package.
+//!
+//! Every fallible entry point used to return `serde_json::Result`, so a
+//! version rejection, a `model_kind` inconsistency, and a genuine JSON syntax
+//! failure all arrived as one opaque `serde_json::Error` that a caller could
+//! only tell apart by matching on the message text. Each is its own variant
+//! here.
+
+use thiserror::Error as ThisError;
+
+/// A `.pio.json` failure.
+#[derive(Debug, ThisError)]
+#[non_exhaustive]
+pub enum Error {
+    /// The document is not well formed JSON, or does not have the shape the
+    /// envelope requires.
+    #[error("invalid .pio.json package envelope: {0}")]
+    Envelope(#[source] serde_json::Error),
+
+    /// The document comes from a powerio lineage this build does not read.
+    #[error("{0}")]
+    UnsupportedVersion(String),
+
+    /// The envelope's `model_kind` disagrees with the payload it carries.
+    #[error("model_kind does not match model.kind")]
+    ModelKindMismatch,
+
+    /// An operating point or study index that the document does not contain.
+    #[error("{0}")]
+    NoSuchIndex(String),
+
+    /// The payload could not be built, applied, or serialized.
+    #[error("{0}")]
+    Payload(String),
+
+    /// A failure from the balanced model, its readers, or its writers.
+    #[error(transparent)]
+    Core(#[from] powerio::Error),
+
+    /// A failure from the multiconductor model.
+    #[error(transparent)]
+    Multiconductor(#[from] powerio_dist::Error),
+
+    /// Serializing the package to JSON failed.
+    #[error("serializing .pio.json: {0}")]
+    Serialize(#[source] serde_json::Error),
+}
+
+impl From<serde_json::Error> for Error {
+    /// A `serde_json` failure raised inside this crate is a serialization
+    /// step, never a document the caller handed us: `from_json` names its own
+    /// failures through [`Error::Envelope`] before any of these can fire.
+    fn from(error: serde_json::Error) -> Self {
+        Error::Serialize(error)
+    }
+}
+
+impl Error {
+    /// Classify this error, using the hub's taxonomy.
+    #[must_use]
+    pub fn category(&self) -> powerio::ErrorCategory {
+        use powerio::ErrorCategory as C;
+        match self {
+            Error::Core(inner) => inner.category(),
+            Error::Envelope(_) | Error::UnsupportedVersion(_) | Error::Multiconductor(_) => {
+                C::Parse
+            }
+            Error::ModelKindMismatch | Error::NoSuchIndex(_) | Error::Payload(_) => C::Data,
+            Error::Serialize(_) => C::Output,
+        }
+    }
+}
+
+/// The result type every fallible entry point in this crate returns.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use powerio::ErrorCategory::{Data, Parse};
+
+    #[test]
+    fn a_version_rejection_is_not_a_syntax_failure() {
+        // The whole point of the split: both used to be one `serde_json::Error`
+        // that a caller could only tell apart by matching on message text.
+        let version = Error::UnsupportedVersion("stated 0.2.1".into());
+        assert_eq!(version.category(), Parse);
+        assert!(matches!(version, Error::UnsupportedVersion(_)));
+        assert!(matches!(Error::ModelKindMismatch, Error::ModelKindMismatch));
+        assert_eq!(Error::ModelKindMismatch.category(), Data);
+    }
+
+    #[test]
+    fn a_wrapped_hub_error_keeps_its_own_message() {
+        let wrapped: Error = powerio::Error::MissingField("bus").into();
+        assert_eq!(
+            wrapped.to_string(),
+            powerio::Error::MissingField("bus").to_string()
+        );
+    }
+}

--- a/powerio-pkg/src/lib.rs
+++ b/powerio-pkg/src/lib.rs
@@ -54,6 +54,9 @@ pub use lowering::{
     SequenceTransformConvention, check_multiconductor_to_balanced_lowering,
     lower_multiconductor_to_balanced,
 };
+pub mod error;
+pub use error::{Error, Result};
+
 pub use model::{ModelKind, ModelPayload};
 pub use operating::{ElementRef, ElementUpdate, OperatingPoint, OperatingPointSeries, TimeAxis};
 pub use package::{

--- a/powerio-pkg/src/operating.rs
+++ b/powerio-pkg/src/operating.rs
@@ -49,11 +49,11 @@ impl OperatingPointSeries {
     }
 
     /// Return the only point with `index`, rejecting duplicate period indices.
-    pub fn unique_point(&self, index: usize) -> serde_json::Result<Option<&OperatingPoint>> {
+    pub fn unique_point(&self, index: usize) -> crate::Result<Option<&OperatingPoint>> {
         let mut matches = self.points.iter().filter(|point| point.index == index);
         let first = matches.next();
         if matches.next().is_some() {
-            return Err(<serde_json::Error as serde::de::Error>::custom(format!(
+            return Err(crate::Error::Payload(format!(
                 "package has multiple operating points with index {index}"
             )));
         }
@@ -270,7 +270,7 @@ impl ElementUpdate {
 /// agnostic; GOC3 is the one document kind with a time series today.
 pub(crate) fn operating_points_from_document(
     document: &powerio::SourceDocument,
-) -> serde_json::Result<Option<OperatingPointSeries>> {
+) -> crate::Result<Option<OperatingPointSeries>> {
     match document {
         powerio::SourceDocument::Goc3(document) => goc3_operating_points(document),
         _ => Ok(None),
@@ -286,15 +286,13 @@ pub(crate) fn operating_points_drop_code(document: &powerio::SourceDocument) -> 
     }
 }
 
-fn goc3_operating_points(
-    document: &Goc3Document,
-) -> serde_json::Result<Option<OperatingPointSeries>> {
+fn goc3_operating_points(document: &Goc3Document) -> crate::Result<Option<OperatingPointSeries>> {
     let network = document
         .network()
-        .map_err(|error| json_error(error.to_string()))?;
+        .map_err(|error| crate::Error::Payload(error.to_string()))?;
     let time_series = document
         .time_series_input()
-        .map_err(|error| json_error(error.to_string()))?;
+        .map_err(|error| crate::Error::Payload(error.to_string()))?;
     let Some(general) = time_series.get("general").and_then(Value::as_object) else {
         return Ok(None);
     };
@@ -314,7 +312,7 @@ fn goc3_operating_points(
     let intervals = general.get("interval_duration").and_then(Value::as_array);
     let interval_len = intervals.map_or(0, Vec::len);
     if interval_len != periods {
-        return Err(json_error(format!(
+        return Err(crate::Error::Payload(format!(
             "time_series_input.general.time_periods ({periods}) does not match the \
              interval_duration length ({interval_len})"
         )));
@@ -325,7 +323,7 @@ fn goc3_operating_points(
     let device_ts = uid_map(
         document
             .time_series_input_records("simple_dispatchable_device")
-            .map_err(|error| json_error(error.to_string()))?,
+            .map_err(|error| crate::Error::Payload(error.to_string()))?,
     );
 
     let mut points = (0..periods).map(OperatingPoint::new).collect::<Vec<_>>();
@@ -341,7 +339,7 @@ fn goc3_operating_points(
     add_goc3_status_updates(document, "ac_line", "branches", 0, &mut points)?;
     let line_count = document
         .network_records("ac_line")
-        .map_err(|error| json_error(error.to_string()))?
+        .map_err(|error| crate::Error::Payload(error.to_string()))?
         .len();
     add_goc3_status_updates(
         document,
@@ -368,10 +366,10 @@ fn add_goc3_device_updates(
     device_ts: &HashMap<String, &Value>,
     base_mva: f64,
     points: &mut [OperatingPoint],
-) -> serde_json::Result<()> {
+) -> crate::Result<()> {
     for device in document
         .dispatchable_devices()
-        .map_err(|error| json_error(error.to_string()))?
+        .map_err(|error| crate::Error::Payload(error.to_string()))?
     {
         let Some(uid) = device.uid else {
             continue;
@@ -438,17 +436,17 @@ fn add_goc3_status_updates(
     target_table: &'static str,
     row_offset: usize,
     points: &mut [OperatingPoint],
-) -> serde_json::Result<()> {
+) -> crate::Result<()> {
     let source_items = document
         .network_records(source_section)
-        .map_err(|error| json_error(error.to_string()))?;
+        .map_err(|error| crate::Error::Payload(error.to_string()))?;
     if document.time_series_output().is_none() {
         return Ok(());
     }
     let status_by_uid = uid_map(
         document
             .time_series_output_records(source_section)
-            .map_err(|error| json_error(error.to_string()))?,
+            .map_err(|error| crate::Error::Payload(error.to_string()))?,
     );
     for (row, item) in source_items.iter().enumerate() {
         let Some(uid) = item.uid.as_ref() else {
@@ -527,10 +525,6 @@ fn per_period_metadata(obj: &Map<String, Value>, index: usize) -> BTreeMap<Strin
     metadata
 }
 
-pub(crate) fn json_error(message: impl Into<String>) -> serde_json::Error {
-    <serde_json::Error as serde::de::Error>::custom(message.into())
-}
-
 /// Apply one operating point to the payload and return the updated model plus
 /// the JSON Pointer paths of every field written, computed from the resolved
 /// rows so stale provenance cleanup follows identity resolution, never a stale
@@ -538,25 +532,23 @@ pub(crate) fn json_error(message: impl Into<String>) -> serde_json::Error {
 pub(crate) fn apply_operating_point_to_model(
     model: &ModelPayload,
     point: &OperatingPoint,
-) -> serde_json::Result<(ModelPayload, BTreeSet<String>)> {
+) -> crate::Result<(ModelPayload, BTreeSet<String>)> {
     let mut value = serde_json::to_value(model)?;
     let root = value.as_object_mut().ok_or_else(|| {
-        <serde_json::Error as serde::de::Error>::custom("model payload did not serialize to object")
+        crate::Error::Payload("model payload did not serialize to object".to_owned())
     })?;
     let payload_key = payload_key(model);
     let payload = root
         .get_mut(payload_key)
         .and_then(Value::as_object_mut)
         .ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "model payload missing `{payload_key}` object"
-            ))
+            crate::Error::Payload(format!("model payload missing `{payload_key}` object"))
         })?;
 
     let mut indexes = HashMap::new();
     let mut resolved_rows = Vec::with_capacity(point.updates.len());
     for update in &point.updates {
-        let row = resolve_update(payload, &mut indexes, update).map_err(json_error)?;
+        let row = resolve_update(payload, &mut indexes, update).map_err(crate::Error::Payload)?;
         apply_update_fields(payload, &update.element.table, row, &update.fields)?;
         resolved_rows.push(row);
     }
@@ -735,14 +727,14 @@ pub(crate) fn apply_update_fields(
     table_name: &str,
     row: usize,
     fields: &BTreeMap<String, Value>,
-) -> serde_json::Result<()> {
+) -> crate::Result<()> {
     let row_object = payload
         .get_mut(table_name)
         .and_then(Value::as_array_mut)
         .and_then(|table| table.get_mut(row))
         .and_then(Value::as_object_mut)
         .ok_or_else(|| {
-            json_error(format!(
+            crate::Error::Payload(format!(
                 "operating point table `{table_name}` has no object row {row}"
             ))
         })?;
@@ -756,19 +748,17 @@ pub(crate) fn validate_update_fields_survived(
     model: &ModelPayload,
     updates: &[ElementUpdate],
     resolved_rows: &[usize],
-) -> serde_json::Result<()> {
+) -> crate::Result<()> {
     let value = serde_json::to_value(model)?;
     let root = value.as_object().ok_or_else(|| {
-        <serde_json::Error as serde::de::Error>::custom("model payload did not serialize to object")
+        crate::Error::Payload("model payload did not serialize to object".to_owned())
     })?;
     let payload_key = payload_key(model);
     let payload = root
         .get(payload_key)
         .and_then(Value::as_object)
         .ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "model payload missing `{payload_key}` object"
-            ))
+            crate::Error::Payload(format!("model payload missing `{payload_key}` object"))
         })?;
 
     for (update, &resolved_row) in updates.iter().zip(resolved_rows) {
@@ -779,7 +769,7 @@ pub(crate) fn validate_update_fields_survived(
             .and_then(|table| table.get(resolved_row))
             .and_then(Value::as_object)
             .ok_or_else(|| {
-                json_error(format!(
+                crate::Error::Payload(format!(
                     "operating point table `{table_name}` has no object row {resolved_row} \
                      after typed materialization"
                 ))
@@ -787,7 +777,7 @@ pub(crate) fn validate_update_fields_survived(
 
         for field in update.fields.keys() {
             if !row.contains_key(field) {
-                return Err(json_error(format!(
+                return Err(crate::Error::Payload(format!(
                     "operating point field `{field}` is not present on table `{table_name}` \
                      row {resolved_row}"
                 )));

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -11,6 +11,7 @@ use powerio::{
 use powerio_dist::{DistSourceFormat, MulticonductorNetwork};
 
 use crate::diagnostics::{DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
+use crate::error::Error;
 use crate::lowering::{
     LoweringRecord, MulticonductorToBalancedError, MulticonductorToBalancedOptions,
     MulticonductorToBalancedReadiness, check_multiconductor_to_balanced_lowering,
@@ -468,15 +469,14 @@ impl NetworkPackage {
     /// The returned package has the same metadata and model kind, with its
     /// payload updated for `index`, `operating_points` cleared, and sane
     /// validation recomputed for the updated payload.
-    pub fn materialize_operating_point(&self, index: usize) -> serde_json::Result<Self> {
-        let series = self.operating_points.as_ref().ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom("package has no operating points")
-        })?;
-        let point = series.unique_point(index)?.ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "package has no operating point {index}"
-            ))
-        })?;
+    pub fn materialize_operating_point(&self, index: usize) -> crate::Result<Self> {
+        let series = self
+            .operating_points
+            .as_ref()
+            .ok_or_else(|| crate::Error::Payload("package has no operating points".to_owned()))?;
+        let point = series
+            .unique_point(index)?
+            .ok_or_else(|| Error::NoSuchIndex(format!("package has no operating point {index}")))?;
         // Applying resolves each update's row (identity first, stated row as
         // fallback), so the stale provenance paths come from the same
         // resolution rather than the stated row values.
@@ -543,7 +543,7 @@ impl NetworkPackage {
             package
                 .attach_normalized_solver_table_metadata()
                 .map_err(|err| {
-                    <serde_json::Error as serde::de::Error>::custom(format!(
+                    Error::Payload(format!(
                         "failed to recompute normalized solver table metadata: {err}"
                     ))
                 })?;
@@ -556,7 +556,7 @@ impl NetworkPackage {
     pub fn materialize_balanced_operating_point(
         &self,
         index: usize,
-    ) -> serde_json::Result<Option<BalancedNetwork>> {
+    ) -> crate::Result<Option<BalancedNetwork>> {
         Ok(self
             .materialize_operating_point(index)?
             .model
@@ -569,7 +569,7 @@ impl NetworkPackage {
     pub fn materialize_multiconductor_operating_point(
         &self,
         index: usize,
-    ) -> serde_json::Result<Option<MulticonductorNetwork>> {
+    ) -> crate::Result<Option<MulticonductorNetwork>> {
         Ok(self
             .materialize_operating_point(index)?
             .model
@@ -582,10 +582,11 @@ impl NetworkPackage {
     /// The returned package folds commits `0..=commit_index`, clears
     /// `operating_points` and `study`, and records the replay pass in
     /// `lowering_history`.
-    pub fn materialize_study_commit(&self, commit_index: usize) -> serde_json::Result<Self> {
-        let study = self.study.as_ref().ok_or_else(|| {
-            <serde_json::Error as serde::de::Error>::custom("package has no study block")
-        })?;
+    pub fn materialize_study_commit(&self, commit_index: usize) -> crate::Result<Self> {
+        let study = self
+            .study
+            .as_ref()
+            .ok_or_else(|| crate::Error::Payload("package has no study block".to_owned()))?;
         let base = if let Some(index) = study.base_operating_point {
             self.materialize_operating_point(index)?
         } else {
@@ -646,7 +647,7 @@ impl NetworkPackage {
             package
                 .attach_normalized_solver_table_metadata()
                 .map_err(|err| {
-                    <serde_json::Error as serde::de::Error>::custom(format!(
+                    Error::Payload(format!(
                         "failed to recompute normalized solver table metadata: {err}"
                     ))
                 })?;
@@ -658,7 +659,7 @@ impl NetworkPackage {
     pub fn materialize_balanced_study_commit(
         &self,
         commit_index: usize,
-    ) -> serde_json::Result<Option<BalancedNetwork>> {
+    ) -> crate::Result<Option<BalancedNetwork>> {
         Ok(self
             .materialize_study_commit(commit_index)?
             .model
@@ -667,36 +668,32 @@ impl NetworkPackage {
     }
 
     /// Serialize to compact `.pio.json`.
-    pub fn to_json(&self) -> serde_json::Result<String> {
-        serde_json::to_string(self)
+    pub fn to_json(&self) -> crate::Result<String> {
+        serde_json::to_string(self).map_err(Error::Serialize)
     }
 
     /// Serialize to pretty `.pio.json`.
-    pub fn to_json_pretty(&self) -> serde_json::Result<String> {
-        serde_json::to_string_pretty(self)
+    pub fn to_json_pretty(&self) -> crate::Result<String> {
+        serde_json::to_string_pretty(self).map_err(Error::Serialize)
     }
 
     /// Deserialize from `.pio.json`.
-    pub fn from_json(text: &str) -> serde_json::Result<Self> {
+    pub fn from_json(text: &str) -> crate::Result<Self> {
         // Tolerate a leading UTF-8 byte order mark, as the format readers do.
         // Name the format in the error: a document the JSON classifier calls a
         // package envelope (right `model_kind` and `model` markers) can still
         // fail here on a missing required field, and the bare serde message
         // ("missing field `producer`") does not say what it failed to be.
-        let pkg: Self = serde_json::from_str(text.trim_start_matches('\u{feff}')).map_err(|e| {
-            <serde_json::Error as serde::de::Error>::custom(format!(
-                "invalid .pio.json package envelope: {e}"
-            ))
-        })?;
+        let pkg: Self =
+            serde_json::from_str(text.trim_start_matches('\u{feff}')).map_err(Error::Envelope)?;
         if !powerio::version::supports(&pkg.powerio_version) {
-            return Err(<serde_json::Error as serde::de::Error>::custom(
-                powerio::version::reject(".pio.json", &pkg.powerio_version),
-            ));
+            return Err(Error::UnsupportedVersion(powerio::version::reject(
+                ".pio.json",
+                &pkg.powerio_version,
+            )));
         }
         if !pkg.kind_is_consistent() {
-            return Err(<serde_json::Error as serde::de::Error>::custom(
-                "model_kind does not match model.kind",
-            ));
+            return Err(Error::ModelKindMismatch);
         }
         Ok(pkg)
     }

--- a/powerio-pkg/src/study.rs
+++ b/powerio-pkg/src/study.rs
@@ -7,8 +7,8 @@ use serde_json::{Map, Value, json};
 
 use crate::model::ModelPayload;
 use crate::operating::{
-    ElementRef, ElementUpdate, IdentityIndex, apply_update_fields, json_error, payload_key,
-    resolve_update, resolve_update_row, validate_update_fields_survived,
+    ElementRef, ElementUpdate, IdentityIndex, apply_update_fields, payload_key, resolve_update,
+    resolve_update_row, validate_update_fields_survived,
 };
 
 /// Additive study block stored on a package envelope.
@@ -266,14 +266,14 @@ pub(crate) fn apply_study_to_model(
     model: &ModelPayload,
     study: &StudyBlock,
     commit_index: usize,
-) -> serde_json::Result<(ModelPayload, BTreeSet<String>)> {
+) -> crate::Result<(ModelPayload, BTreeSet<String>)> {
     if !matches!(model, ModelPayload::Balanced { .. }) {
-        return Err(json_error(
-            "STUDY.WRONG_MODEL_KIND: study materialization requires a balanced package",
+        return Err(crate::Error::Payload(
+            "STUDY.WRONG_MODEL_KIND: study materialization requires a balanced package".to_owned(),
         ));
     }
     if study.commits.get(commit_index).is_none() {
-        return Err(json_error(format!(
+        return Err(crate::Error::Payload(format!(
             "package has no study commit {commit_index}"
         )));
     }
@@ -284,7 +284,9 @@ pub(crate) fn apply_study_to_model(
         .as_object_mut()
         .and_then(|root| root.get_mut(payload_key))
         .and_then(Value::as_object_mut)
-        .ok_or_else(|| json_error(format!("model payload missing `{payload_key}` object")))?;
+        .ok_or_else(|| {
+            crate::Error::Payload(format!("model payload missing `{payload_key}` object"))
+        })?;
 
     let mut indexes = HashMap::new();
     let mut updated_paths = BTreeSet::new();
@@ -368,11 +370,11 @@ impl StudyApplyContext<'_> {
         edit: &StudyEdit,
         commit_pos: usize,
         edit_pos: usize,
-    ) -> serde_json::Result<()> {
+    ) -> crate::Result<()> {
         match edit {
             StudyEdit::DemandDelta { bus, p_mw, q_mvar } => {
-                let bus_row =
-                    resolve_update_row(self.payload, self.indexes, bus).map_err(json_error)?;
+                let bus_row = resolve_update_row(self.payload, self.indexes, bus)
+                    .map_err(crate::Error::Payload)?;
                 let touched = apply_demand_delta(self.payload, bus_row, *p_mw, *q_mvar)?;
                 for path in touched {
                     self.updated_paths
@@ -381,8 +383,8 @@ impl StudyApplyContext<'_> {
                 self.indexes.remove("loads");
             }
             StudyEdit::RatingDelta { branch, delta_mw } => {
-                let branch_row =
-                    resolve_update_row(self.payload, self.indexes, branch).map_err(json_error)?;
+                let branch_row = resolve_update_row(self.payload, self.indexes, branch)
+                    .map_err(crate::Error::Payload)?;
                 let branch = row_object_mut(self.payload, "branches", branch_row)?;
                 let old = number_field(branch, "rate_a", "branch", branch_row)?;
                 branch.insert("rate_a".to_owned(), json!(old + delta_mw));
@@ -392,7 +394,8 @@ impl StudyApplyContext<'_> {
                 ));
             }
             StudyEdit::SetFields { update } => {
-                let row = resolve_update(self.payload, self.indexes, update).map_err(json_error)?;
+                let row = resolve_update(self.payload, self.indexes, update)
+                    .map_err(crate::Error::Payload)?;
                 apply_update_fields(self.payload, &update.element.table, row, &update.fields)?;
                 for field in update.fields.keys() {
                     self.updated_paths.insert(format!(
@@ -404,7 +407,7 @@ impl StudyApplyContext<'_> {
                 self.set_field_rows.push(row);
             }
             StudyEdit::Unknown { kind, .. } => {
-                return Err(json_error(format!(
+                return Err(crate::Error::Payload(format!(
                     "STUDY.UNKNOWN_EDIT_KIND: study commit {commit_pos} edit {edit_pos} has unsupported kind `{kind}`"
                 )));
             }
@@ -418,13 +421,12 @@ fn apply_demand_delta(
     bus_row: usize,
     p_delta: f64,
     q_delta: Option<f64>,
-) -> serde_json::Result<Vec<String>> {
+) -> crate::Result<Vec<String>> {
     let (bus_id, bus_uid) = {
         let bus = row_object(payload, "buses", bus_row)?;
-        let bus_id = bus
-            .get("id")
-            .and_then(Value::as_u64)
-            .ok_or_else(|| json_error(format!("bus row {bus_row} has no numeric `id`")))?;
+        let bus_id = bus.get("id").and_then(Value::as_u64).ok_or_else(|| {
+            crate::Error::Payload(format!("bus row {bus_row} has no numeric `id`"))
+        })?;
         let bus_uid = bus
             .get("uid")
             .and_then(Value::as_str)
@@ -435,7 +437,7 @@ fn apply_demand_delta(
     let loads = payload
         .get_mut("loads")
         .and_then(Value::as_array_mut)
-        .ok_or_else(|| json_error("balanced payload has no `loads` array"))?;
+        .ok_or_else(|| crate::Error::Payload("balanced payload has no `loads` array".to_owned()))?;
     let mut rows = Vec::new();
     let mut total_p = 0.0;
     let mut total_q = 0.0;
@@ -493,7 +495,7 @@ fn apply_demand_delta(
         let load = loads
             .get_mut(row)
             .and_then(Value::as_object_mut)
-            .ok_or_else(|| json_error(format!("load row {row} disappeared")))?;
+            .ok_or_else(|| crate::Error::Payload(format!("load row {row} disappeared")))?;
         load.insert("p".to_owned(), json!(p + p_delta * p_share));
         load.insert("q".to_owned(), json!(q + q_delta * q_share));
         touched.push(format!("loads/{row}/p"));
@@ -506,26 +508,30 @@ fn row_object<'a>(
     payload: &'a Map<String, Value>,
     table_name: &str,
     row: usize,
-) -> serde_json::Result<&'a Map<String, Value>> {
+) -> crate::Result<&'a Map<String, Value>> {
     payload
         .get(table_name)
         .and_then(Value::as_array)
         .and_then(|table| table.get(row))
         .and_then(Value::as_object)
-        .ok_or_else(|| json_error(format!("table `{table_name}` has no object row {row}")))
+        .ok_or_else(|| {
+            crate::Error::Payload(format!("table `{table_name}` has no object row {row}"))
+        })
 }
 
 fn row_object_mut<'a>(
     payload: &'a mut Map<String, Value>,
     table_name: &str,
     row: usize,
-) -> serde_json::Result<&'a mut Map<String, Value>> {
+) -> crate::Result<&'a mut Map<String, Value>> {
     payload
         .get_mut(table_name)
         .and_then(Value::as_array_mut)
         .and_then(|table| table.get_mut(row))
         .and_then(Value::as_object_mut)
-        .ok_or_else(|| json_error(format!("table `{table_name}` has no object row {row}")))
+        .ok_or_else(|| {
+            crate::Error::Payload(format!("table `{table_name}` has no object row {row}"))
+        })
 }
 
 fn number_field(
@@ -533,9 +539,8 @@ fn number_field(
     field: &str,
     label: &str,
     row: usize,
-) -> serde_json::Result<f64> {
-    object
-        .get(field)
-        .and_then(Value::as_f64)
-        .ok_or_else(|| json_error(format!("{label} row {row} has no numeric `{field}` field")))
+) -> crate::Result<f64> {
+    object.get(field).and_then(Value::as_f64).ok_or_else(|| {
+        crate::Error::Payload(format!("{label} row {row} has no numeric `{field}` field"))
+    })
 }

--- a/powerio-prob/Cargo.toml
+++ b/powerio-prob/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 
 [dependencies]
 powerio.workspace = true
+thiserror = "2"
 powerio-matrix = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/powerio-prob/src/ac.rs
+++ b/powerio-prob/src/ac.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use powerio::{BusId, Error, IndexedNetwork, Result};
+use powerio::{BusId, IndexedNetwork};
+
+use crate::{Error, Result};
 
 use crate::{ReferenceBuses, Units, limits, nodal};
 
@@ -12,7 +14,7 @@ use crate::{ReferenceBuses, Units, limits, nodal};
 pub struct AcOpfOptions {
     pub units: Units,
     /// Skip non-self-loop branches with `r² + x² = 0`. If false, assembly
-    /// returns [`Error::ZeroImpedance`].
+    /// returns [`powerio::Error::ZeroImpedance`].
     pub skip_zero_impedance: bool,
     /// Give a branch with no thermal rating the bound
     /// [`Branch::synthesize_rate_a`](powerio::Branch::synthesize_rate_a)
@@ -257,13 +259,18 @@ pub fn build_ac_opf_instance(
     let mut vg = Vec::new();
 
     for (source_row, generator) in case.in_service_gens() {
-        let bus = case.bus_index(generator.bus).ok_or(Error::UnknownBus {
-            bus_id: generator.bus,
-            element_index: source_row,
-        })?;
-        let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
-            gen_index: source_row,
-        })?;
+        let bus = case
+            .bus_index(generator.bus)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: generator.bus,
+                element_index: source_row,
+            })?;
+        let cost = generator
+            .cost
+            .as_ref()
+            .ok_or(powerio::Error::MissingGenCost {
+                gen_index: source_row,
+            })?;
         let (q_raw, c_raw, c0_raw) = nodal::quadratic_terms(cost, source_row)?;
         bus_of_gen.push(bus);
         generator_rows.push(source_row);
@@ -305,20 +312,24 @@ pub fn build_ac_opf_instance(
     let network = case.network();
 
     for (source_row, branch) in case.in_service_branches() {
-        let from = case.bus_index(branch.from).ok_or(Error::UnknownBus {
-            bus_id: branch.from,
-            element_index: source_row,
-        })?;
-        let to = case.bus_index(branch.to).ok_or(Error::UnknownBus {
-            bus_id: branch.to,
-            element_index: source_row,
-        })?;
+        let from = case
+            .bus_index(branch.from)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: branch.from,
+                element_index: source_row,
+            })?;
+        let to = case
+            .bus_index(branch.to)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: branch.to,
+                element_index: source_row,
+            })?;
         let Some((series_g, series_b)) = branch.series_admittance(source_row)? else {
             if options.skip_zero_impedance {
                 skipped_zero_impedance.push(source_row);
                 continue;
             }
-            return Err(Error::ZeroImpedance { row: source_row });
+            return Err(powerio::Error::ZeroImpedance { row: source_row }.into());
         };
         let charging = branch.terminal_charging();
         if from == to {

--- a/powerio-prob/src/dc.rs
+++ b/powerio-prob/src/dc.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use powerio::{BusId, DcConvention, Error, IndexedNetwork, Result};
+use powerio::{BusId, DcConvention, IndexedNetwork};
+
+use crate::{Error, Result};
 
 use crate::{ReferenceBuses, limits, nodal};
 
@@ -58,7 +60,7 @@ pub struct DcOpfOptions {
     pub convention: DcConvention,
     pub units: Units,
     /// Skip non-self-loop branches with zero reactance. If false, assembly
-    /// returns [`Error::ZeroImpedance`].
+    /// returns [`powerio::Error::ZeroImpedance`].
     pub skip_zero_impedance: bool,
     /// Give a branch with no thermal rating the bound
     /// [`Branch::synthesize_rate_a`](powerio::Branch::synthesize_rate_a)
@@ -232,13 +234,18 @@ pub fn build_dc_opf_instance(
     let mut pmin = Vec::new();
 
     for (source_row, generator) in case.in_service_gens() {
-        let bus = case.bus_index(generator.bus).ok_or(Error::UnknownBus {
-            bus_id: generator.bus,
-            element_index: source_row,
-        })?;
-        let cost = generator.cost.as_ref().ok_or(Error::MissingGenCost {
-            gen_index: source_row,
-        })?;
+        let bus = case
+            .bus_index(generator.bus)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: generator.bus,
+                element_index: source_row,
+            })?;
+        let cost = generator
+            .cost
+            .as_ref()
+            .ok_or(powerio::Error::MissingGenCost {
+                gen_index: source_row,
+            })?;
         let (q_raw, c_raw, c0_raw) = nodal::quadratic_terms(cost, source_row)?;
         bus_of_gen.push(bus);
         generator_rows.push(source_row);
@@ -266,14 +273,18 @@ pub fn build_dc_opf_instance(
     let buses = &case.network().buses;
 
     for (source_row, branch) in case.in_service_branches() {
-        let from = case.bus_index(branch.from).ok_or(Error::UnknownBus {
-            bus_id: branch.from,
-            element_index: source_row,
-        })?;
-        let to = case.bus_index(branch.to).ok_or(Error::UnknownBus {
-            bus_id: branch.to,
-            element_index: source_row,
-        })?;
+        let from = case
+            .bus_index(branch.from)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: branch.from,
+                element_index: source_row,
+            })?;
+        let to = case
+            .bus_index(branch.to)
+            .ok_or(powerio::Error::UnknownBus {
+                bus_id: branch.to,
+                element_index: source_row,
+            })?;
         if from == to {
             // A self-loop carries no angle difference, so it contributes no
             // DC flow, and its shift injection cancels at its own bus.
@@ -287,7 +298,7 @@ pub fn build_dc_opf_instance(
                 skipped_zero_impedance.push(source_row);
                 continue;
             }
-            return Err(Error::ZeroImpedance { row: source_row });
+            return Err(powerio::Error::ZeroImpedance { row: source_row }.into());
         }
         let branch_b = options.convention.branch_susceptance(
             branch.r,
@@ -295,7 +306,7 @@ pub fn build_dc_opf_instance(
             branch.divisible_tap(source_row)?,
         ) * b_scale;
         if !branch_b.is_finite() {
-            return Err(Error::NonFiniteSusceptance { row: source_row });
+            return Err(powerio::Error::NonFiniteSusceptance { row: source_row }.into());
         }
         let shift_rad = if options.convention.includes_phase_shifts() {
             case.angle_radians(branch.shift)

--- a/powerio-prob/src/error.rs
+++ b/powerio-prob/src/error.rs
@@ -1,0 +1,90 @@
+//! Failures the problem instance builders raise.
+//!
+//! [`Error`] carries what this crate constructs and wraps the crates beneath
+//! it, so `?` moves a failure across the boundary without restating it. A
+//! caller that only wants the coarse split reads [`Error::category`], which is
+//! the same taxonomy every powerio surface uses.
+
+use thiserror::Error as ThisError;
+
+/// A problem instance failure.
+#[derive(Debug, ThisError)]
+#[non_exhaustive]
+pub enum Error {
+    /// A failure from the balanced model, its readers, or its writers.
+    #[error(transparent)]
+    Core(#[from] powerio::Error),
+
+    /// A failure from the matrix and dataset builders.
+    #[cfg(feature = "matrix")]
+    #[error(transparent)]
+    Matrix(#[from] powerio_matrix::Error),
+
+    /// An underlying I/O failure reading or writing a file.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("case has no generators; DC-OPF requires an `mpc.gen` block")]
+    NoGenerators,
+
+    #[error(
+        "generator {gen_index} has an unsupported cost model (model {model}, ncost {ncost}); need polynomial model 2 with degree ≤ 2"
+    )]
+    UnsupportedCostModel {
+        gen_index: usize,
+        model: u8,
+        ncost: usize,
+    },
+}
+
+impl Error {
+    /// Classify this error, using the hub's taxonomy.
+    ///
+    /// The match is exhaustive over the variant set, so a new variant must be
+    /// classified here before it compiles.
+    #[must_use]
+    pub fn category(&self) -> powerio::ErrorCategory {
+        use powerio::ErrorCategory as C;
+        match self {
+            Error::Core(inner) => inner.category(),
+            #[cfg(feature = "matrix")]
+            Error::Matrix(inner) => inner.category(),
+            Error::Io(_) => C::Io,
+            // A well-formed case that cannot satisfy a requested operation.
+            Error::NoGenerators | Error::UnsupportedCostModel { .. } => C::Data,
+        }
+    }
+}
+
+/// The result type every fallible entry point in this crate returns.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use powerio::ErrorCategory::{Data, Parse};
+
+    #[test]
+    fn category_pins_the_intended_buckets() {
+        assert_eq!(Error::NoGenerators.category(), Data);
+        assert_eq!(
+            Error::UnsupportedCostModel {
+                gen_index: 0,
+                model: 1,
+                ncost: 4
+            }
+            .category(),
+            Data
+        );
+    }
+
+    #[test]
+    fn a_wrapped_hub_error_keeps_its_own_category_and_message() {
+        let wrapped: Error = powerio::Error::MissingField("gen").into();
+        assert_eq!(wrapped.category(), Parse);
+        assert_eq!(
+            wrapped.to_string(),
+            powerio::Error::MissingField("gen").to_string()
+        );
+    }
+}

--- a/powerio-prob/src/lib.rs
+++ b/powerio-prob/src/lib.rs
@@ -23,7 +23,10 @@ pub use dc::{
     DcBranchData, DcGeneratorData, DcOpfInstance, DcOpfOptions, NodalGeneratorData, Units,
     build_dc_opf_instance,
 };
-pub use powerio::{DcConvention, Error, Result};
+pub use powerio::DcConvention;
+
+pub mod error;
+pub use error::{Error, Result};
 pub use reference::ReferenceBuses;
 pub use scopf::{
     ScopfDeviceClassLayout, ScopfError, ScopfInstance, ScopfResult, build_scopf_instance_from_str,

--- a/powerio-prob/src/matrix/bundle.rs
+++ b/powerio-prob/src/matrix/bundle.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
-use powerio::{GenCostPolicyReport, MissingGenCostPolicy, Result};
+use powerio::{GenCostPolicyReport, MissingGenCostPolicy};
+
+use crate::Result;
 use powerio_matrix::SparseMatrix;
 use powerio_matrix::io::{write_mtx, write_vector_mtx};
 use serde::Serialize;
@@ -245,7 +247,7 @@ pub fn write_dcopf_bundle(
     };
     let meta_path = dir.join("dcopf_meta.json");
     let json = serde_json::to_string_pretty(&meta)
-        .map_err(|error| powerio::Error::Mtx(error.to_string()))?;
+        .map_err(|error| powerio_matrix::Error::Mtx(error.to_string()))?;
     std::fs::write(&meta_path, json)?;
     files.push(meta_path);
 

--- a/powerio-prob/src/reference.rs
+++ b/powerio-prob/src/reference.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use powerio::{Error, Result};
+use powerio::Result;
 
 /// The reference (slack) buses of a problem instance, as dense bus indices in
 /// ascending order.
@@ -37,11 +37,11 @@ impl ReferenceBuses {
     /// The one reference bus.
     ///
     /// # Errors
-    /// [`Error::ReferenceBusCount`] unless the set holds exactly one bus.
+    /// [`powerio::Error::ReferenceBusCount`] unless the set holds exactly one bus.
     pub fn single(&self) -> Result<usize> {
         match self.0.as_slice() {
             [bus] => Ok(*bus),
-            other => Err(Error::ReferenceBusCount { found: other.len() }),
+            other => Err(powerio::Error::ReferenceBusCount { found: other.len() }),
         }
     }
 }

--- a/powerio-prob/tests/acopf.rs
+++ b/powerio-prob/tests/acopf.rs
@@ -1,8 +1,8 @@
 use powerio::{
-    Branch, BranchCharging, Bus, BusId, BusType, Error, GenCost, Generator, IndexedNetwork,
-    Network, parse_matpower_file,
+    Branch, BranchCharging, Bus, BusId, BusType, GenCost, Generator, IndexedNetwork, Network,
+    parse_matpower_file,
 };
-use powerio_prob::{AcOpfOptions, Units, build_ac_opf_instance};
+use powerio_prob::{AcOpfOptions, Error, Units, build_ac_opf_instance};
 
 fn case9() -> Network {
     parse_matpower_file("../tests/data/case9.m").expect("parse case9")
@@ -254,7 +254,10 @@ fn missing_and_unsupported_costs_are_distinct() {
     missing.generators[0].cost = None;
     let error = build_ac_opf_instance(&IndexedNetwork::new(&missing), &AcOpfOptions::default())
         .expect_err("missing cost");
-    assert!(matches!(error, Error::MissingGenCost { gen_index: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::MissingGenCost { gen_index: 0 })
+    ));
 
     let mut piecewise = small_network();
     piecewise.generators[0].cost = Some(GenCost::with_ncost(
@@ -293,7 +296,10 @@ fn zero_impedance_skip_or_reject() {
         },
     )
     .expect_err("reject");
-    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
 
     // Zero resistance with nonzero reactance is a valid series element.
     let mut inductive = small_network();
@@ -324,7 +330,10 @@ fn an_impedance_the_instance_cannot_divide_by_reads_as_zero_impedance() {
         },
     )
     .expect_err("reject");
-    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
 
     let mut small_x = small_network();
     small_x.branches[0].r = 0.0;
@@ -343,7 +352,10 @@ fn a_tap_the_instance_cannot_divide_by_is_refused() {
         let error = build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default())
             .expect_err("a tap the pi model divides by must be refused");
         assert!(
-            matches!(error, Error::DegenerateTap { row: 0, .. }),
+            matches!(
+                error,
+                Error::Core(powerio::Error::DegenerateTap { row: 0, .. })
+            ),
             "tap {tap}: {error}"
         );
     }
@@ -596,5 +608,8 @@ fn zero_base_mva_is_rejected() {
     net.base_mva = 0.0;
     let error = build_ac_opf_instance(&IndexedNetwork::new(&net), &AcOpfOptions::default())
         .expect_err("zero base");
-    assert!(matches!(error, Error::InvalidBaseMva { .. }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::InvalidBaseMva { .. })
+    ));
 }

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -1,8 +1,8 @@
 use powerio::{
-    Branch, Bus, BusId, BusType, DcConvention, Error, GenCost, Generator, IndexedNetwork, Network,
+    Branch, Bus, BusId, BusType, DcConvention, GenCost, Generator, IndexedNetwork, Network,
     parse_matpower_file,
 };
-use powerio_prob::{DcOpfOptions, Units, build_dc_opf_instance};
+use powerio_prob::{DcOpfOptions, Error, Units, build_dc_opf_instance};
 
 fn case9() -> Network {
     parse_matpower_file("../tests/data/case9.m").expect("parse case9")
@@ -212,7 +212,7 @@ fn a_network_of_two_islands_grounds_a_bus_in_each() {
     );
     assert!(matches!(
         problem.reference_buses.single(),
-        Err(Error::ReferenceBusCount { found: 2 })
+        Err(powerio::Error::ReferenceBusCount { found: 2 })
     ));
 
     // The set keeps its wire form as a plain array of dense bus indices.
@@ -357,7 +357,10 @@ fn missing_and_unsupported_costs_are_distinct() {
     missing.generators[0].cost = None;
     let error = build_dc_opf_instance(&IndexedNetwork::new(&missing), &DcOpfOptions::default())
         .expect_err("missing cost");
-    assert!(matches!(error, Error::MissingGenCost { gen_index: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::MissingGenCost { gen_index: 0 })
+    ));
 
     let mut piecewise = small_network();
     piecewise.generators[0].cost = Some(GenCost::with_ncost(
@@ -396,7 +399,10 @@ fn zero_reactance_can_be_skipped_or_rejected() {
         },
     )
     .expect_err("reject");
-    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
 }
 
 #[test]
@@ -417,7 +423,10 @@ fn a_reactance_the_instance_cannot_divide_by_reads_as_zero_impedance() {
         },
     )
     .expect_err("reject");
-    assert!(matches!(error, Error::ZeroImpedance { row: 0 }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::ZeroImpedance { row: 0 })
+    ));
 }
 
 #[test]
@@ -434,7 +443,10 @@ fn a_tap_the_instance_cannot_divide_by_is_refused() {
         )
         .expect_err("a tap the susceptance divides by must be refused");
         assert!(
-            matches!(error, Error::DegenerateTap { row: 0, .. }),
+            matches!(
+                error,
+                Error::Core(powerio::Error::DegenerateTap { row: 0, .. })
+            ),
             "tap {tap}: {error}"
         );
     }
@@ -462,7 +474,10 @@ fn zero_base_mva_is_rejected() {
     net.base_mva = 0.0;
     let error = build_dc_opf_instance(&IndexedNetwork::new(&net), &DcOpfOptions::default())
         .expect_err("zero base");
-    assert!(matches!(error, Error::InvalidBaseMva { .. }));
+    assert!(matches!(
+        error,
+        Error::Core(powerio::Error::InvalidBaseMva { .. })
+    ));
 }
 
 #[test]

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -83,9 +83,11 @@ fn to_pyerr(e: powerio_matrix::Error) -> PyErr {
     use powerio_matrix::{Error as E, ErrorCategory as C};
     // `Io` carries the underlying `std::io::Error`; hand it to PyO3 by value so
     // it picks the precise `OSError` subclass. (Returning here also keeps the
-    // `to_string()` below off the I/O path.)
-    if let E::Io(io) = e {
-        return io.into();
+    // `to_string()` below off the I/O path.) It arrives either raised here or
+    // raised by the hub and wrapped.
+    match e {
+        E::Io(io) | E::Core(powerio::Error::Io(io)) => return io.into(),
+        _ => {}
     }
     let msg = e.to_string();
     match e.category() {
@@ -266,7 +268,10 @@ fn write_options(
 }
 
 fn package_pyerr(e: serde_json::Error) -> PyErr {
-    PyValueError::new_err(format!("invalid .pio.json package: {e}"))
+    // A package failure is a PowerIOError like every other parse failure. It
+    // used to raise a bare `ValueError`, so `except powerio.PowerIOError` did
+    // not catch it.
+    PowerIOParseError::new_err(format!("invalid .pio.json package: {e}"))
 }
 
 fn package_to_json(pkg: &NetworkPackage) -> PyResult<String> {

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -79,23 +79,53 @@ pyo3::create_exception!(
 /// unmet operation precondition becomes [`PowerIODataError`]. Both subclass
 /// [`PowerIOError`], so existing `except PowerIOError` handlers keep working;
 /// output-side write failures fall back to the [`PowerIOError`] base.
-fn to_pyerr(e: powerio_matrix::Error) -> PyErr {
-    use powerio_matrix::{Error as E, ErrorCategory as C};
-    // `Io` carries the underlying `std::io::Error`; hand it to PyO3 by value so
-    // it picks the precise `OSError` subclass. (Returning here also keeps the
-    // `to_string()` below off the I/O path.) It arrives either raised here or
-    // raised by the hub and wrapped.
-    match e {
-        E::Io(io) | E::Core(powerio::Error::Io(io)) => return io.into(),
-        _ => {}
-    }
-    let msg = e.to_string();
-    match e.category() {
+/// Map a classified powerio failure onto the Python exception hierarchy.
+///
+/// Every crate's error carries the same `category()`, so one mapping serves
+/// all of them and the hierarchy cannot drift per surface.
+fn categorized_pyerr(category: powerio_matrix::ErrorCategory, msg: String) -> PyErr {
+    use powerio_matrix::ErrorCategory as C;
+    match category {
         C::UnknownFormat => PyValueError::new_err(msg),
         C::Parse => PowerIOParseError::new_err(msg),
         C::Data => PowerIODataError::new_err(msg),
-        // `Io` is handled above; `Output` (mtx/parquet) maps to the base.
+        // `Io` is unwrapped by the callers below when it still carries the
+        // original `std::io::Error`; `Output` (mtx/parquet) maps to the base.
         C::Io | C::Output => PowerIOError::new_err(msg),
+    }
+}
+
+fn core_pyerr(e: powerio_matrix::CoreError) -> PyErr {
+    // Hand I/O to PyO3 by value so it picks the precise `OSError` subclass.
+    if let powerio_matrix::CoreError::Io(io) = e {
+        return io.into();
+    }
+    let category = e.category();
+    categorized_pyerr(category, e.to_string())
+}
+
+fn to_pyerr(e: powerio_matrix::Error) -> PyErr {
+    use powerio_matrix::Error as E;
+    match e {
+        E::Io(io) => io.into(),
+        E::Core(inner) => core_pyerr(inner),
+        other => {
+            let category = other.category();
+            categorized_pyerr(category, other.to_string())
+        }
+    }
+}
+
+fn prob_pyerr(e: powerio_prob::Error) -> PyErr {
+    use powerio_prob::Error as E;
+    match e {
+        E::Io(io) => io.into(),
+        E::Core(inner) => core_pyerr(inner),
+        E::Matrix(inner) => to_pyerr(inner),
+        other => {
+            let category = other.category();
+            categorized_pyerr(category, other.to_string())
+        }
     }
 }
 
@@ -257,7 +287,7 @@ fn write_options(
             let text = std::fs::read_to_string(path).map_err(|e| {
                 PyValueError::new_err(format!("reading gen_cost_csv {path:?}: {e}"))
             })?;
-            powerio_matrix::parse_gen_cost_csv(&text).map_err(to_pyerr)?
+            powerio_matrix::parse_gen_cost_csv(&text).map_err(core_pyerr)?
         }
         None => Vec::new(),
     };
@@ -267,11 +297,15 @@ fn write_options(
     })
 }
 
-fn package_pyerr(e: serde_json::Error) -> PyErr {
-    // A package failure is a PowerIOError like every other parse failure. It
-    // used to raise a bare `ValueError`, so `except powerio.PowerIOError` did
-    // not catch it.
-    PowerIOParseError::new_err(format!("invalid .pio.json package: {e}"))
+fn package_pyerr(e: powerio_pkg::Error) -> PyErr {
+    // A package failure is a PowerIOError like every other failure. It used to
+    // raise a bare `ValueError` for everything, so `except powerio.PowerIOError`
+    // did not catch it, and every distinct cause read as one opaque string.
+    if let powerio_pkg::Error::Core(inner) = e {
+        return core_pyerr(inner);
+    }
+    let category = e.category();
+    categorized_pyerr(category, e.to_string())
 }
 
 fn package_to_json(pkg: &NetworkPackage) -> PyResult<String> {
@@ -488,7 +522,7 @@ fn build_package_from_path(
         return Ok(pkg);
     }
 
-    let parsed = powerio_matrix::parse_file(input, from_).map_err(to_pyerr)?;
+    let parsed = powerio_matrix::parse_file(input, from_).map_err(core_pyerr)?;
     let format = parsed.network.source_format.name();
     let retained_source = parsed.network.source.is_some();
     let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
@@ -539,7 +573,7 @@ fn build_package_from_str(text: &str, from_: Option<&str>) -> PyResult<NetworkPa
     }
 
     let parsed = powerio_matrix::parse_str(text, source_format.as_deref().unwrap_or("matpower"))
-        .map_err(to_pyerr)?;
+        .map_err(core_pyerr)?;
     let mut pkg = NetworkPackage::from_parsed_balanced(parsed);
     pkg.run_sane_validation();
     Ok(pkg)
@@ -716,7 +750,7 @@ impl PyNetwork {
     fn reference_bus_index(&self) -> PyResult<usize> {
         IndexedNetwork::with_core(&self.inner, &self.core)
             .reference_bus_index()
-            .map_err(to_pyerr)
+            .map_err(core_pyerr)
     }
 
     /// Dense `[0, n)` indices of every reference (slack) bus, ascending. May be
@@ -899,7 +933,7 @@ impl PyNetwork {
 
     /// Serialize this case to the JSON transport.
     fn to_json(&self) -> PyResult<String> {
-        self.inner.to_json().map_err(to_pyerr)
+        self.inner.to_json().map_err(core_pyerr)
     }
 
     /// Serialize this case to another format. Returns `(text, warnings)`.
@@ -913,7 +947,7 @@ impl PyNetwork {
     ) -> PyResult<(String, Vec<String>)> {
         let target = to
             .parse::<powerio_matrix::TargetFormat>()
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
         let opts = write_options(
             missing_gen_cost,
             default_gen_cost,
@@ -923,7 +957,7 @@ impl PyNetwork {
         let conv = self
             .inner
             .to_format_with_options(target, &opts)
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
         Ok((conv.text, conv.warnings))
     }
 
@@ -954,7 +988,7 @@ impl PyNetwork {
     /// canonicalized. The raw case is unchanged; the result carries no retained
     /// source, so writing it serializes the per-unit model rather than echoing.
     fn to_normalized(&self) -> PyResult<PyNetwork> {
-        let inner = self.inner.to_normalized().map_err(to_pyerr)?;
+        let inner = self.inner.to_normalized().map_err(core_pyerr)?;
         let core = IndexCore::build(&inner);
         Ok(PyNetwork {
             inner,
@@ -976,7 +1010,7 @@ impl PyNetwork {
         let normalized = self
             .inner
             .to_normalized_with_options(&options)
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
         let core = IndexCore::build(&normalized.network);
         let mut warnings = self.warnings.clone();
         warnings.extend(normalized.warnings);
@@ -1124,7 +1158,7 @@ impl PyNetwork {
                 ..AcOpfOptions::default()
             },
         )
-        .map_err(to_pyerr)?;
+        .map_err(prob_pyerr)?;
         serde_json::to_string(&instance).map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -1190,7 +1224,7 @@ impl PyNetwork {
         let mut policy_network = self.inner.clone();
         let cost_report = policy_network
             .apply_gen_cost_policy(&cost_opts.gen_cost_patches, cost_opts.missing_gen_cost)
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
         let view = IndexedNetwork::new(&policy_network);
         let instance = build_dc_opf_instance(
             &view,
@@ -1200,14 +1234,14 @@ impl PyNetwork {
                 ..DcOpfOptions::default()
             },
         )
-        .map_err(to_pyerr)?;
+        .map_err(prob_pyerr)?;
         let options = DcOpfBundleOptions {
             metadata: DcOpfBundleMetadata {
                 cost_policy: cost_opts.missing_gen_cost,
                 cost_report,
             },
         };
-        let outputs = write_bundle(&instance, out_dir, &options).map_err(to_pyerr)?;
+        let outputs = write_bundle(&instance, out_dir, &options).map_err(prob_pyerr)?;
         dir_files_dict(py, &outputs.dir, &outputs.files)
     }
 
@@ -1256,7 +1290,7 @@ impl PyNetwork {
         out_dir: &str,
     ) -> PyResult<Bound<'py, PyDict>> {
         let outputs =
-            powerio_matrix::write_pypsa_csv_folder(&self.inner, out_dir).map_err(to_pyerr)?;
+            powerio_matrix::write_pypsa_csv_folder(&self.inner, out_dir).map_err(core_pyerr)?;
         pypsa_outputs_to_dict(py, &outputs)
     }
 
@@ -1278,7 +1312,7 @@ impl PyNetwork {
 fn parse_file(path: &str, from_: Option<&str>) -> PyResult<PyNetwork> {
     powerio_matrix::parse_file(std::path::Path::new(path), from_)
         .map(case_from_parsed)
-        .map_err(to_pyerr)
+        .map_err(core_pyerr)
 }
 
 /// Parse a case from in-memory text in the named `format` (`matpower`,
@@ -1289,7 +1323,7 @@ fn parse_file(path: &str, from_: Option<&str>) -> PyResult<PyNetwork> {
 fn parse_str(text: &str, format: Option<&str>) -> PyResult<PyNetwork> {
     powerio_matrix::parse_str(text, format.unwrap_or("matpower"))
         .map(case_from_parsed)
-        .map_err(to_pyerr)
+        .map_err(core_pyerr)
 }
 
 /// Parse a display file from a path, inferring the format from the extension
@@ -1301,8 +1335,8 @@ fn parse_display_file<'py>(
     path: &str,
     from_: Option<&str>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let display =
-        powerio_matrix::parse_display_file(std::path::Path::new(path), from_).map_err(to_pyerr)?;
+    let display = powerio_matrix::parse_display_file(std::path::Path::new(path), from_)
+        .map_err(core_pyerr)?;
     display_data_to_py(py, display)
 }
 
@@ -1314,14 +1348,14 @@ fn parse_display_bytes<'py>(
     data: &[u8],
     format: &str,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let display = powerio_matrix::parse_display_bytes(data, format).map_err(to_pyerr)?;
+    let display = powerio_matrix::parse_display_bytes(data, format).map_err(core_pyerr)?;
     display_data_to_py(py, display)
 }
 
 /// Rebuild a case from JSON produced by `Network.to_json()`.
 #[pyfunction]
 fn from_json(text: &str) -> PyResult<PyNetwork> {
-    let inner = powerio_matrix::Network::from_json(text).map_err(to_pyerr)?;
+    let inner = powerio_matrix::Network::from_json(text).map_err(core_pyerr)?;
     let core = IndexCore::build(&inner);
     Ok(PyNetwork {
         inner,
@@ -1335,7 +1369,7 @@ fn from_json(text: &str) -> PyResult<PyNetwork> {
 fn read_pypsa_csv_folder(path: &str) -> PyResult<PyNetwork> {
     powerio_matrix::read_pypsa_csv_folder(std::path::Path::new(path))
         .map(case_from_parsed)
-        .map_err(to_pyerr)
+        .map_err(core_pyerr)
 }
 
 /// Convert a case file to another format through the network model. Returns
@@ -1358,7 +1392,7 @@ fn convert_file(
 ) -> PyResult<(String, Vec<String>)> {
     let target = to
         .parse::<powerio_matrix::TargetFormat>()
-        .map_err(to_pyerr)?;
+        .map_err(core_pyerr)?;
     let opts = write_options(
         missing_gen_cost,
         default_gen_cost,
@@ -1367,7 +1401,7 @@ fn convert_file(
     )?;
     let conv =
         powerio_matrix::convert_file_with_options(std::path::Path::new(path), target, from_, &opts)
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
     if let Some(out) = out {
         std::fs::write(out, &conv.text)
             .map_err(|e| PowerIOError::new_err(format!("writing {out}: {e}")))?;
@@ -1390,7 +1424,7 @@ fn convert_str(
 ) -> PyResult<(String, Vec<String>)> {
     let target = to
         .parse::<powerio_matrix::TargetFormat>()
-        .map_err(to_pyerr)?;
+        .map_err(core_pyerr)?;
     let opts = write_options(
         missing_gen_cost,
         default_gen_cost,
@@ -1399,7 +1433,7 @@ fn convert_str(
     )?;
     let conv =
         powerio_matrix::convert_str_with_options(text, target, format.unwrap_or("matpower"), &opts)
-            .map_err(to_pyerr)?;
+            .map_err(core_pyerr)?;
     Ok((conv.text, conv.warnings))
 }
 
@@ -1691,7 +1725,7 @@ impl PyPackage {
         );
         if include_solver_metadata {
             pkg.attach_normalized_solver_table_metadata()
-                .map_err(to_pyerr)?;
+                .map_err(core_pyerr)?;
         }
         Ok(Self { pkg })
     }
@@ -1730,14 +1764,15 @@ impl PyPackage {
 
     /// The operating point series as JSON, or `null` when absent.
     fn operating_points_json(&self) -> PyResult<String> {
-        serde_json::to_string(&self.pkg.operating_points).map_err(package_pyerr)
+        serde_json::to_string(&self.pkg.operating_points)
+            .map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))
     }
 
     /// Replace the operating point series from JSON and rerun validation.
     /// `null` or an empty series clears it.
     fn set_operating_points_json(&mut self, json: &str) -> PyResult<()> {
-        let series: Option<OperatingPointSeries> =
-            serde_json::from_str(json).map_err(package_pyerr)?;
+        let series: Option<OperatingPointSeries> = serde_json::from_str(json)
+            .map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))?;
         match series {
             Some(series) => self.pkg.set_operating_points(series),
             None => self.pkg.clear_operating_points(),
@@ -1748,7 +1783,8 @@ impl PyPackage {
 
     /// The study block as JSON, or `null` when absent.
     fn study_json(&self) -> PyResult<String> {
-        serde_json::to_string(&self.pkg.study).map_err(package_pyerr)
+        serde_json::to_string(&self.pkg.study)
+            .map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))
     }
 
     /// Materialize one operating point into a new static package handle.
@@ -1774,12 +1810,14 @@ impl PyPackage {
 
     /// The validation summary as JSON.
     fn validation_json(&self) -> PyResult<String> {
-        serde_json::to_string(&self.pkg.validation).map_err(package_pyerr)
+        serde_json::to_string(&self.pkg.validation)
+            .map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))
     }
 
     /// The structured diagnostics array as JSON.
     fn diagnostics_json(&self) -> PyResult<String> {
-        serde_json::to_string(&self.pkg.diagnostics).map_err(package_pyerr)
+        serde_json::to_string(&self.pkg.diagnostics)
+            .map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))
     }
 
     /// Readiness report for multiconductor to balanced lowering, as JSON.
@@ -1798,7 +1836,7 @@ impl PyPackage {
                 ..Default::default()
             },
         );
-        serde_json::to_string(&report).map_err(package_pyerr)
+        serde_json::to_string(&report).map_err(|e| package_pyerr(powerio_pkg::Error::Serialize(e)))
     }
 
     /// Lower a multiconductor package to a new balanced package handle.

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -50,8 +50,12 @@ use powerio_matrix::io::gridfm::{
 pyo3::create_exception!(
     _powerio,
     PowerIOError,
-    pyo3::exceptions::PyException,
-    "Base error raised by the powerio parser, converter, or matrix builders."
+    pyo3::exceptions::PyValueError,
+    "Base error raised by the powerio parser, converter, or matrix builders.\n\n\
+     Subclasses `ValueError`: every failure it covers is a statement about a \
+     value the caller supplied, and `except ValueError` was what callers wrote \
+     before the hierarchy existed. I/O failures do not reach it; they raise the \
+     matching `OSError` subclass by value."
 );
 
 pyo3::create_exception!(

--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -42,12 +42,6 @@ pub enum Error {
     #[error("branch row {row} has a tap ratio of {tap} that Y_bus cannot divide by")]
     DegenerateTap { row: usize, tap: f64 },
 
-    #[error("output dimension mismatch: matrix is {n}x{n} but RHS has length {b_len}")]
-    DimensionMismatch { n: usize, b_len: usize },
-
-    #[error("case has no generators; DC-OPF requires an `mpc.gen` block")]
-    NoGenerators,
-
     #[error("generator {gen_index} has no cost data")]
     MissingGenCost { gen_index: usize },
 
@@ -56,15 +50,6 @@ pub enum Error {
 
     #[error("invalid generator cost patch row {row}: {reason}")]
     InvalidGenCostPatch { row: usize, reason: String },
-
-    #[error(
-        "generator {gen_index} has an unsupported cost model (model {model}, ncost {ncost}); need polynomial model 2 with degree ≤ 2"
-    )]
-    UnsupportedCostModel {
-        gen_index: usize,
-        model: u8,
-        ncost: usize,
-    },
 
     #[error("`gen` has {gens} rows but `gencost` has {gencost}; expected {gens} (active only) or {} (active + reactive)", gens * 2)]
     GenCostCountMismatch { gens: usize, gencost: usize },
@@ -78,29 +63,6 @@ pub enum Error {
     #[error("invalid normalize option `{field}`: {value}")]
     InvalidNormalizeOption { field: &'static str, value: f64 },
 
-    #[error("dimension mismatch: `{what}` expected length {expected}, got {got}")]
-    ShapeMismatch {
-        what: &'static str,
-        expected: usize,
-        got: usize,
-    },
-
-    #[error(
-        "DC sensitivity solve failed: the reference-grounded Laplacian is singular even though every component is grounded"
-    )]
-    SingularNetwork,
-
-    #[error("invalid DC sensitivity option: {reason}")]
-    InvalidSensitivityOptions { reason: String },
-
-    #[error(
-        "DC sensitivity iterative solve did not converge after {iterations} iterations (relative residual {relative_residual:.3e})"
-    )]
-    SensitivitySolveDidNotConverge {
-        iterations: usize,
-        relative_residual: f64,
-    },
-
     #[error(
         "{components} connected component(s) have no reference (slack) bus to ground; DC sensitivities need at least one reference per island"
     )]
@@ -108,49 +70,6 @@ pub enum Error {
 
     #[error(transparent)]
     Io(#[from] std::io::Error),
-
-    #[error("matrix-market I/O: {0}")]
-    Mtx(String),
-
-    #[error("gridfm Parquet export: {0}")]
-    Parquet(String),
-
-    #[error("gridfm scenario batch is empty; provide at least one snapshot")]
-    EmptyScenarioBatch,
-
-    #[error("gridfm scenario id overflows i64 when numbering snapshot {index} from base {base}")]
-    ScenarioIdOverflow {
-        base: i64,
-        /// 0-based position of the snapshot whose `base + index` overflowed.
-        index: usize,
-    },
-
-    #[error(
-        "gridfm snapshot scenario {scenario} is normalized; gridfm export expects raw MW and degree fields"
-    )]
-    NormalizedGridfmSnapshot { scenario: i64 },
-
-    #[error(
-        "gridfm snapshot scenario {scenario} has non-finite {element} row {row} field `{field}`: {value}"
-    )]
-    NonFiniteGridfmValue {
-        scenario: i64,
-        element: &'static str,
-        row: usize,
-        field: &'static str,
-        value: f64,
-    },
-
-    #[error(
-        "gridfm snapshot {index} doesn't match the first snapshot's element set: {reason}; \
-         a scenario batch shares one base element set (same bus/branch/gen counts and bus-id order)"
-    )]
-    ScenarioShapeMismatch {
-        /// 0-based position of the offending snapshot in the batch (independent
-        /// of the snapshot's scenario id).
-        index: usize,
-        reason: ScenarioMismatch,
-    },
 
     #[error(
         "geo apply left {buses} bus(es) with no location and {branches} branch(es) with no route"
@@ -223,81 +142,15 @@ impl Error {
             | Error::ZeroImpedance { .. }
             | Error::NonFiniteSusceptance { .. }
             | Error::DegenerateTap { .. }
-            | Error::DimensionMismatch { .. }
-            | Error::NoGenerators
             | Error::MissingGenCost { .. }
             | Error::NonFiniteGenCost { .. }
             | Error::InvalidGenCostPatch { .. }
-            | Error::UnsupportedCostModel { .. }
             | Error::GenCostCountMismatch { .. }
             | Error::ReferenceBusCount { .. }
             | Error::InvalidBaseMva { .. }
             | Error::InvalidNormalizeOption { .. }
-            | Error::ShapeMismatch { .. }
-            | Error::SingularNetwork
-            | Error::InvalidSensitivityOptions { .. }
-            | Error::SensitivitySolveDidNotConverge { .. }
             | Error::UngroundedComponent { .. }
-            | Error::EmptyScenarioBatch
-            | Error::ScenarioIdOverflow { .. }
-            | Error::NormalizedGridfmSnapshot { .. }
-            | Error::NonFiniteGridfmValue { .. }
-            | Error::ScenarioShapeMismatch { .. }
             | Error::UnlocatedElements { .. } => C::Data,
-            // Output-side serialization write failures.
-            Error::Mtx(_) | Error::Parquet(_) => C::Output,
-        }
-    }
-}
-
-/// The element counts that define a scenario batch's shared base shape. Named
-/// (rather than a bare `(usize, usize, usize)`) so the three same-typed fields
-/// can't be transposed silently in an error message or a comparison.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ElementCounts {
-    pub buses: usize,
-    pub branches: usize,
-    pub gens: usize,
-}
-
-impl std::fmt::Display for ElementCounts {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} buses, {} branches, {} gens",
-            self.buses, self.branches, self.gens
-        )
-    }
-}
-
-/// Why a gridfm scenario snapshot doesn't line up with the first snapshot's
-/// base element set (the row-stack keeps every table schema-consistent by
-/// requiring the same element counts and bus-id ordering across snapshots).
-///
-/// This enum is `#[non_exhaustive]`; downstream matches must include a wildcard
-/// arm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ScenarioMismatch {
-    /// Element counts differ.
-    Counts {
-        expected: ElementCounts,
-        got: ElementCounts,
-    },
-    /// Counts match, but the buses are listed in a different order (so the dense
-    /// bus index wouldn't mean the same bus across snapshots).
-    BusOrder,
-}
-
-impl std::fmt::Display for ScenarioMismatch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Counts { expected, got } => {
-                write!(f, "got ({got}) vs the first snapshot's ({expected})")
-            }
-            Self::BusOrder => {
-                write!(f, "counts match but the bus ids are in a different order")
-            }
         }
     }
 }
@@ -308,7 +161,7 @@ mod tests {
 
     #[test]
     fn category_pins_the_intended_buckets() {
-        use ErrorCategory::*;
+        use ErrorCategory::{Data, Io, Parse, UnknownFormat};
         // The parser/format readers raise these.
         assert_eq!(Error::MissingField("bus").category(), Parse);
         assert_eq!(
@@ -320,9 +173,8 @@ mod tests {
             Parse
         );
         // An unmet operation precondition on an already-parsed case. UnknownBus
-        // and the scenario batch checks surface mid-build, not at parse time, so
-        // they are Data, not Parse — regression guard for that classification.
-        assert_eq!(Error::NoGenerators.category(), Data);
+        // surfaces mid-build, not at parse time, so it is Data, not Parse —
+        // regression guard for that classification.
         assert_eq!(Error::InvalidBaseMva { base: 0.0 }.category(), Data);
         assert_eq!(
             Error::UngroundedComponent { components: 1 }.category(),
@@ -336,18 +188,10 @@ mod tests {
             .category(),
             Data
         );
-        assert_eq!(Error::EmptyScenarioBatch.category(), Data);
-        assert_eq!(
-            Error::ScenarioShapeMismatch {
-                index: 1,
-                reason: ScenarioMismatch::BusOrder
-            }
-            .category(),
-            Data
-        );
-        // Format selection, output serialization, and underlying I/O.
+        // Format selection and underlying I/O. Output-side serialization
+        // failures belong to the crate that writes, so `Output` has no hub
+        // variant; `powerio_matrix::Error` carries it.
         assert_eq!(Error::UnknownFormat("xyz".into()).category(), UnknownFormat);
-        assert_eq!(Error::Mtx("write failed".into()).category(), Output);
         assert_eq!(
             Error::Io(std::io::Error::from(std::io::ErrorKind::NotFound)).category(),
             Io

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -51,7 +51,7 @@ pub mod solver_tables;
 pub mod version;
 
 pub use dc::DcConvention;
-pub use error::{ElementCounts, Error, ErrorCategory, Result, ScenarioMismatch};
+pub use error::{Error, ErrorCategory, Result};
 pub use format::{
     Conversion, DisplayData, DisplayFormat, Parsed, PwdDisplay, PwdSubstation, PypsaCsvOutputs,
     SourceDocument, TargetFormat, WriteOptions, convert_file, convert_file_with_options,

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -9,7 +9,7 @@ SensitivitySolver = Literal["auto", "dense", "iterative"]
 Units = Literal["perunit", "native"]
 GridfmOutputs = Dict[str, Any]
 
-class PowerIOError(Exception):
+class PowerIOError(ValueError):
     """Base error from the powerio parser, converter, or matrix builders."""
 
 class PowerIOParseError(PowerIOError):

--- a/python/powerio/_powerio.pyi
+++ b/python/powerio/_powerio.pyi
@@ -11,7 +11,7 @@ from typing import Any, Literal, Optional, Tuple
 __version__: str
 _has_gridfm: bool
 
-class PowerIOError(Exception):
+class PowerIOError(ValueError):
     """Base error from the powerio parser, converter, or matrix builders."""
 
 class PowerIOParseError(PowerIOError):

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -430,6 +430,9 @@ def test_error_subclasses_are_powerio_errors():
     # PowerIOError` keeps catching them (backward compatible).
     assert issubclass(powerio.PowerIOParseError, powerio.PowerIOError)
     assert issubclass(powerio.PowerIODataError, powerio.PowerIOError)
+    # And `ValueError`, so the handler callers wrote before the hierarchy
+    # existed still catches every failure it used to.
+    assert issubclass(powerio.PowerIOError, ValueError)
 
 
 def test_malformed_case_raises_parse_error():


### PR DESCRIPTION
`powerio::Error` had 35 variants and **15 of them were never constructed anywhere in `powerio`**. A caller reading the hub's error type saw gridfm Parquet failures, DC sensitivity convergence, and matrix-market I/O listed beside the MATPOWER parser, and `ErrorCategory::Output` existed for a serializer the hub does not contain.

**`powerio_matrix::Error` and `powerio_prob::Error` now carry what each crate raises.** `powerio-matrix` had no error type at all before this — it re-exported the hub's.

- to powerio-matrix: `Mtx`, `Parquet`, `EmptyScenarioBatch`, `ScenarioIdOverflow`, `NormalizedGridfmSnapshot`, `NonFiniteGridfmValue`, `ScenarioShapeMismatch` with `ScenarioMismatch` and `ElementCounts`, `DimensionMismatch`, `ShapeMismatch`, `SingularNetwork`, `InvalidSensitivityOptions`, `SensitivitySolveDidNotConverge`
- to powerio-prob: `NoGenerators`, `UnsupportedCostModel`

A variant several crates raise stays in the hub. `ZeroImpedance`, `UnknownBus`, `DegenerateTap` and their neighbours are shared vocabulary, not one crate's business.

**Each new type wraps the layer below through `#[error(transparent)]`, so a hub failure crossing the boundary keeps its `Display` text byte for byte.** That is load bearing rather than tidy: the C ABI reports errors as text and nothing else, so a wrapper that restated the message would change what every binding prints. A test pins it.

**powerio-pkg gets a real error type.** Every fallible entry point returned `serde_json::Result`, and seventeen sites reached for `serde::de::Error::custom` to smuggle a domain failure through it. `from_json` returned one opaque `serde_json::Error` for three unrelated things: malformed JSON, a document from a lineage this build does not read, and a `model_kind` that contradicts its payload. Those are now `Envelope`, `UnsupportedVersion` and `ModelKindMismatch`. Two sites used to wrap a whole `powerio::Error` into a serde string, destroying the variant and its category; they carry it now.

**One bug fixed.** `package_pyerr` mapped every `.pio.json` failure to a bare `ValueError`, so `except powerio.PowerIOError` did not catch a package failure although it caught every other parse failure. Package failures now subclass `PowerIOError` like everything else.

`ErrorCategory` keeps its five variants and stays non-`non_exhaustive`, deliberately. It is consumed in exactly one place workspace wide, and the Python layer now routes every crate through one `categorized_pyerr`, so the exception hierarchy cannot drift per surface.

**Surfaced, not fixed here:** `powerio-pkg/src/diagnostics.rs` and `powerio-dist/src/diagnostics.rs` are near-verbatim duplicates bridged by a hand-written remap that silently drops `source_ref`. With `powerio::Diagnostic` and `ValidationStatus` that is four names for two concepts. Worth an issue against 1.1.

Verified: `cargo fmt --all --check`, `scripts/ci-clippy.sh`, `scripts/capi-header-parity.sh`, and `cargo test --workspace --exclude powerio-py` at 51 binaries and 1274 tests, zero failures.

Ninth in the v0.9.0 stack, on top of #318.
