### PR TITLE
formats: declare the passthrough and area drops, and agree on one id rule

### DIFF
--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -1092,6 +1092,45 @@ pub(super) fn branch_rating_set_drop_warning(
     )
 }
 
+/// Warn once when elements carry passthrough extras `target`'s writer does not
+/// replay. `consumed` is the writer's own rule: the keys it reads back into a
+/// record. Everything else was retained by a reader because the source stated
+/// more than a rewrite would synthesize, so dropping it without saying so is
+/// an undeclared loss (#330). One line, a count and the reason, matching the
+/// granularity of the other writer warnings.
+pub(super) fn warn_dropped_extras(
+    target: &str,
+    net: &BalancedNetwork,
+    consumed: impl Fn(&str) -> bool,
+    warnings: &mut Vec<String>,
+) {
+    let carries = |extras: &crate::network::Extras| extras.keys().any(|k| !consumed(k));
+    let dropped = net.buses.iter().filter(|e| carries(&e.extras)).count()
+        + net.branches.iter().filter(|e| carries(&e.extras)).count()
+        + net.loads.iter().filter(|e| carries(&e.extras)).count()
+        + net.shunts.iter().filter(|e| carries(&e.extras)).count()
+        + net.switches.iter().filter(|e| carries(&e.extras)).count()
+        + net.storage.iter().filter(|e| carries(&e.extras)).count()
+        + net.hvdc.iter().filter(|e| carries(&e.extras)).count();
+    if dropped > 0 {
+        warnings.push(format!(
+            "{dropped} element(s) carry source-format passthrough fields (extras) the {target} \
+             writer does not replay; dropped"
+        ));
+    }
+}
+
+/// Warn when a writer drops the area table. Its own line rather than the
+/// extras count: `areas` is a typed field, not a passthrough (#330).
+pub(super) fn warn_dropped_areas(target: &str, net: &BalancedNetwork, warnings: &mut Vec<String>) {
+    if !net.areas.is_empty() {
+        warnings.push(format!(
+            "{} area record(s) dropped: the {target} writer emits no area table",
+            net.areas.len()
+        ));
+    }
+}
+
 pub(super) fn warn_extra_branch_rating_sets(
     target: &str,
     net: &BalancedNetwork,

--- a/powerio/src/format/powerworld/map.rs
+++ b/powerio/src/format/powerworld/map.rs
@@ -403,7 +403,13 @@ fn f_alias(r: &Row, keys: &[&str], default: f64) -> Result<f64> {
 /// (and padded ones — the comparison is verbatim) are kept as before.
 fn drop_default_id(extras: &mut Extras, keys: &[&str], default: &str) {
     for k in keys {
-        if extras.get(*k).and_then(serde_json::Value::as_str) == Some(default) {
+        // Trimmed: PowerWorld pads ids, and the padded default is still the
+        // default. The pwb reader applies the same rule.
+        if extras
+            .get(*k)
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|v| v.trim() == default)
+        {
             extras.remove(*k);
         }
     }
@@ -650,10 +656,13 @@ fn read_branch(
     // the writer derives on its own: the positional circuit for this bus pair,
     // or the Line/Transformer kind the tap already encodes. Exotic device
     // types (Breaker, Series Cap, ...) are always kept.
+    // Trim before comparing: PowerWorld pads circuit ids, so a real export
+    // spells the first circuit " 1", and the padded default is still the
+    // default (the pwb reader applies the same rule).
     if let Some(v) = r
         .get(LINE_CIRCUIT)
         .or_else(|| r.get("Circuit"))
-        .filter(|v| **v != nth.to_string())
+        .filter(|v| v.trim() != nth.to_string())
     {
         extras.insert(
             LINE_CIRCUIT.to_string(),
@@ -964,6 +973,17 @@ pub fn write_powerworld(net: &BalancedNetwork) -> Conversion {
         ));
     }
     warn_extra_branch_rating_sets("PowerWorld .aux", net, &mut warnings);
+    // The keys this writer replays: the two device ids, the branch circuit,
+    // and the device type. Anything else a reader retained — a foreign
+    // format's ids, ZIP components, LineLength — is dropped, and says so
+    // (#330).
+    super::super::warn_dropped_extras(
+        "PowerWorld .aux",
+        net,
+        |key| matches!(key, "LoadID" | "ShuntID" | "BranchDeviceType") || key == LINE_CIRCUIT,
+        &mut warnings,
+    );
+    super::super::warn_dropped_areas("PowerWorld .aux", net, &mut warnings);
     let branch_solutions = net.branches.iter().filter(|b| b.solution.is_some()).count();
     if branch_solutions > 0 {
         warnings.push(format!(

--- a/powerio/src/format/powerworld/pwb.rs
+++ b/powerio/src/format/powerworld/pwb.rs
@@ -571,12 +571,32 @@ fn gen_table_continues(
 fn checked_network(
     name_hint: Option<&str>,
     mut buses: Vec<Bus>,
-    loads: Vec<Load>,
-    shunts: Vec<Shunt>,
-    branches: Vec<Branch>,
+    mut loads: Vec<Load>,
+    mut shunts: Vec<Shunt>,
+    mut branches: Vec<Branch>,
     generators: Vec<Generator>,
 ) -> Result<BalancedNetwork> {
     derive_bus_kinds(&mut buses, &generators);
+    // A device id equal to the aux allocator's positional default (padding
+    // aside) restates what a rewrite re-derives; dropping it here is the same
+    // rule the aux reader applies, so the two PowerWorld readers agree on one
+    // case. Done over the final tables because a record probe does not know
+    // its position.
+    for (i, l) in loads.iter_mut().enumerate() {
+        drop_positional_id(&mut l.extras, "LoadID", i);
+    }
+    for (i, s) in shunts.iter_mut().enumerate() {
+        drop_positional_id(&mut s.extras, "ShuntID", i);
+    }
+    // Branch circuits use the aux reader's positional rule: the counter is per
+    // bus pair, so the second parallel branch's "2" is the default the
+    // allocator re-derives from order.
+    let mut parallel: HashMap<(BusId, BusId), usize> = HashMap::new();
+    for br in &mut branches {
+        let nth = parallel.entry((br.from, br.to)).or_insert(0);
+        *nth += 1;
+        drop_positional_id(&mut br.extras, LINE_CIRCUIT, *nth - 1);
+    }
     let net = BalancedNetwork {
         name: name_hint.unwrap_or("case").to_string(),
         base_mva: MVA_BASE,
@@ -597,6 +617,19 @@ fn checked_network(
         source: None,
     };
     net.check_references(FMT).map(|()| net)
+}
+
+/// Remove `key` when its trimmed value is the 1-based positional default the
+/// aux writer would allocate for element `index`.
+fn drop_positional_id(extras: &mut Extras, key: &str, index: usize) {
+    let default = (index + 1).to_string();
+    if extras
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|v| v.trim() == default)
+    {
+        extras.remove(key);
+    }
 }
 
 // ---- Cursor -----------------------------------------------------------------
@@ -1357,7 +1390,7 @@ fn read_load(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Load> {
     let mut extras = Extras::new();
     extras.insert(
         "LoadID".into(),
-        serde_json::Value::String(String::from_utf8_lossy(id).into_owned()),
+        serde_json::Value::String(String::from_utf8_lossy(id).trim().to_string()),
     );
     Ok(Load {
         bus,
@@ -1559,7 +1592,7 @@ fn read_shunt(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Shunt> {
     let mut extras = Extras::new();
     extras.insert(
         "ShuntID".into(),
-        serde_json::Value::String(String::from_utf8_lossy(id).into_owned()),
+        serde_json::Value::String(String::from_utf8_lossy(id).trim().to_string()),
     );
     Ok(Shunt {
         bus,
@@ -1766,13 +1799,19 @@ fn read_standard_branch_head(
         _ => return Err("branch tail tag not in the validated set"),
     };
     let mut extras = Extras::new();
-    extras.insert(
-        LINE_CIRCUIT.into(),
-        serde_json::Value::String(circuit.map_or_else(
-            || " 1".to_string(),
-            |s| String::from_utf8_lossy(s).into_owned(),
-        )),
-    );
+    // The padded default (" 1") restates what the aux writer's allocator hands
+    // the first branch of a pair; keeping it made the two PowerWorld readers
+    // disagree, and the pwb → aux leg reported the disagreement as a loss.
+    // Only a circuit beyond the default is data (the aux reader's rule).
+    if let Some(s) = circuit {
+        // Trimmed: the 2-byte field pads for display, and the aux tokenizer
+        // hands the same id back unpadded, so keeping the padding made the
+        // pwb → aux leg diff on whitespace.
+        let circuit = String::from_utf8_lossy(s).trim().to_string();
+        if circuit != "1" {
+            extras.insert(LINE_CIRCUIT.into(), serde_json::Value::String(circuit));
+        }
+    }
     // Line and Transformer restate what the tap already encodes (a pwb
     // transformer always reads a nonzero tap), and the aux writer re-derives
     // them; only an exotic device type would say more. Matches the aux
@@ -1869,8 +1908,9 @@ fn read_step_up_transformer_head(
     if to.0 == from {
         return Err("step up transformer has identical endpoints");
     }
-    let mut extras = Extras::new();
-    extras.insert(LINE_CIRCUIT.into(), serde_json::Value::String(" 1".into()));
+    // The step-up record carries no circuit of its own; the old hardcoded
+    // " 1" restated the aux allocator's default.
+    let extras = Extras::new();
     let br = Branch {
         from: BusId(from),
         to,

--- a/powerio/src/format/powerworld/tests.rs
+++ b/powerio/src/format/powerworld/tests.rs
@@ -363,11 +363,11 @@ fn real_export_field_names_map_gen_shunt_and_transformer() {
     assert_eq!((br.tap, br.shift), (0.9875, -2.5));
     assert_eq!((br.rate_a, br.rate_b, br.rate_c), (250.0, 260.0, 270.0));
     assert!(br.is_transformer());
-    assert_eq!(
-        br.extras.get("LineCircuit").and_then(|v| v.as_str()),
-        Some(" 1"),
-        "circuit ID kept verbatim, padding included"
-    );
+    // A padded " 1" is the allocator's default with PowerWorld's padding on
+    // it; both PowerWorld readers drop it (trim-insensitively) so the pwb and
+    // aux reads of one case agree. An explicit non-default circuit is kept
+    // verbatim, padding included.
+    assert_eq!(br.extras.get("LineCircuit"), None);
 }
 
 #[test]

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -1687,6 +1687,34 @@ pub fn write_pslf(net: &BalancedNetwork) -> Conversion {
         ));
     }
     warn_extra_branch_rating_sets("PSLF .epc", net, &mut warnings);
+    // The keys this writer replays, spelled out rather than `pslf_*`: the
+    // record tails (`pslf_lhs_extra`/`pslf_rhs_extra`) and the DC converter
+    // stash are retained by the reader and never written back, so a prefix
+    // rule would declare them replayed when they are not (#330).
+    super::warn_dropped_extras(
+        "PSLF .epc",
+        net,
+        |key| {
+            matches!(
+                key,
+                "id" | "pslf_circuit"
+                    | "pslf_section_id"
+                    | "pslf_tbase"
+                    | "pslf_mw"
+                    | "pslf_mvar"
+                    | "pslf_mw_i"
+                    | "pslf_mvar_i"
+                    | "pslf_mw_z"
+                    | "pslf_mvar_z"
+                    | "pslf_pu_mw"
+                    | "pslf_pu_mvar"
+                    | "pslf_pu_g"
+                    | "pslf_pu_b"
+            )
+        },
+        &mut warnings,
+    );
+    super::warn_dropped_areas("PSLF .epc", net, &mut warnings);
     let branch_solutions = net.branches.iter().filter(|b| b.solution.is_some()).count();
     if branch_solutions > 0 {
         warnings.push(format!(

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -770,6 +770,15 @@ pub fn write_psse_rev(net: &BalancedNetwork, rev: u32) -> Conversion {
     if !modern {
         warn_psse_extra_branch_ratings_dropped(net, &mut warnings);
     }
+    // This writer replays device ids and every `psse_*` key its reader
+    // retained; a foreign format's keys (LoadID, pslf_circuit, ...) have no
+    // record column and drop, declared once (#330).
+    super::warn_dropped_extras(
+        "PSS/E .raw",
+        net,
+        |key| key == "id" || key.starts_with("psse_"),
+        &mut warnings,
+    );
     let branch_solutions = net.branches.iter().filter(|b| b.solution.is_some()).count();
     if branch_solutions > 0 {
         warnings.push(format!(


### PR DESCRIPTION
Stacked on #334. Closes #330.

Each writer states its extras rule once — the keys it replays — and one warning carries the count of elements whose passthrough fields fall outside it. The area table gets its own line in the PowerWorld and PSLF writers: a typed field, not a passthrough. The remaining undeclared loss was the two PowerWorld readers disagreeing about default device ids: the pwb reader kept padded positional defaults the aux reader drops, so the pwb → aux leg diffed on whitespace and on the second parallel circuit. Both readers now share one rule — ids stored trimmed, a value equal to the writer allocator's positional default not retained.

The conversion matrix baselines do not move (the vendored fixtures' foreign ids are exactly the defaults no longer retained). Over icseg-corpus-enhanced, the pairwise `loss.undeclared` count for extras and area paths goes from 34 to 0. Warning categories for these are deliberately out of scope here; #335 carries that design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WiRGVwHaj2rm5ZUbd4zdNn
