### PR TITLE
ci: refuse to publish from a prerelease

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   publish:
     name: publish to crates.io
+    # crates.io has no unpublish, so a prerelease must never reach it through
+    # the release event. Dispatch stays open as the deliberate recovery path.
+    if: github.event_name != 'release' || github.event.release.prerelease == false
     runs-on: ubuntu-latest
     # Deployment protection (required reviewers, branch/tag rules) lives on the
     # crates-io environment in the repo settings, not in this file.

--- a/.github/workflows/notify-powerio-jl.yml
+++ b/.github/workflows/notify-powerio-jl.yml
@@ -18,6 +18,9 @@ permissions:
 
 jobs:
   dispatch:
+    # A prerelease tag is not a repin target: the receiving workflow only
+    # accepts a bare vX.Y.Z tag and would refuse it anyway.
+    if: github.event.release.prerelease == false
     runs-on: ubuntu-latest
     steps:
       - name: repository_dispatch powerio-release

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -210,8 +210,9 @@ jobs:
     # release-binaries.yml stages each release as a draft a human publishes, so
     # the release event fires with a user actor (events from a workflow's
     # GITHUB_TOKEN are swallowed by the recursion guard). Manual dispatch is the
-    # recovery path for a missed event.
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    # recovery path for a missed event. A prerelease still builds wheels and an
+    # sdist as run artifacts, but never uploads them to PyPI.
+    if: (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch'
     needs: [ lint, test, test-gridfm, wheels, sdist ]
     runs-on: ubuntu-latest
     # Deployment protection (required reviewers, tag rules) lives on the pypi


### PR DESCRIPTION
The three release triggered publish paths never read `github.event.release.prerelease`, so publishing a `vX.Y.Z-rc.N` release would `cargo publish` all six crates, upload wheels and an sdist to PyPI, and dispatch the repin to the Julia side exactly as a real release does. crates.io has no unpublish and PyPI filenames cannot be reused, so only the environment reviewer stood between an RC tag and two permanent index entries.

Guards the crates.io publish job, the PyPI publish job, and the notify dispatch. Manual dispatch stays open on the first two as the recovery path for a missed event. A prerelease still builds wheels and an sdist as run artifacts; only the upload is skipped.

`release-binaries.yml` is left alone: it fires on tag push, before a release object exists, and draft binaries for an RC tag are the point of tagging one.

GitHub runs release triggered workflows from the default branch's copy of the workflow file, so the guard takes effect once this merges, whatever the tag contains.

Checked with `actionlint` on the three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
