### PR TITLE
dist: document what the BMOPF writer parks under extras

### DIFF
--- a/powerio-dist/src/bmopf/mod.rs
+++ b/powerio-dist/src/bmopf/mod.rs
@@ -5,6 +5,58 @@
 //! `additionalProperties: false` on every element, so the strict writer
 //! drops what the schema cannot carry and says so per field; the dropped
 //! data stays in the model's `extras`, never in the emitted JSON.
+//!
+//! # What the writer parks under `extras`
+//!
+//! Some data has a physical meaning the schema cannot express in place but
+//! can carry in the free form `extras` object, and that data is relocated
+//! rather than dropped, with a warning per element. A consumer that reads the
+//! document and ignores `extras` gets a network that differs physically from
+//! the source and no error saying so: a tapped transformer reads as nominal
+//! tap, an impedance grounded neutral as solidly grounded, and the
+//! magnetizing branch disappears.
+//!
+//! ## Transformer fields
+//!
+//! Schema 0.1.0 has no slot for these nine fields in the `single_phase`,
+//! `center_tap`, `wye_delta`, and `delta_wye` subtype definitions, so a
+//! transformer carrying any of them emits them under
+//! `extras.transformer.<subtype>.<name>`, keyed by the same transformer name
+//! the subtype table uses:
+//!
+//! `tap`, `tap_min`, `tap_max`, `r_neutral_from`, `x_neutral_from`,
+//! `r_neutral_to`, `x_neutral_to`, `g_no_load`, `b_no_load`.
+//!
+//! The schema defines neither the `n_winding` subtype nor untyped
+//! `transformer.<subtype>` passthrough objects, so those keep every field in
+//! place and nothing moves. [`parse_bmopf_str`] folds the overlay back onto
+//! the subtype objects, so a powerio round trip is lossless; on a key
+//! collision the field already in the subtype object wins.
+//!
+//! ## Whole tables
+//!
+//! Schema 0.1.0 has no top level slot for these classes, so each emits at
+//! `extras.<class>.<name>` with the keying its top level table used:
+//!
+//! - `ibr` and `control_profile`, written from the typed model
+//! - `dc_bus`, `dc_line`, `dc_load`, `dc_source`, `time_series`, written from
+//!   untyped objects of that class
+//! - `capacitor`, only for a capacitor too malformed to type; a typed
+//!   capacitor goes to the strict top level `capacitor` table
+//!
+//! A source document's own `extras` object is stashed on read and re-emitted
+//! verbatim, so consumer keys beside these survive a round trip.
+//!
+//! # `terminal_conventions` goes stale on a rename
+//!
+//! The emitted `terminal_conventions` block is the source document's own
+//! block re-emitted verbatim, or, absent that, one authored from the terminal
+//! names in the model: a terminal named `n` in any case is a neutral, every
+//! other name is a phase. Either way the block describes the terminal naming
+//! of the document that carries it and nothing else. A consumer that renames
+//! terminals must delete the block and recompute it from the renamed
+//! terminals; carried across a rename it sorts names no bus has any more, and
+//! nothing else in the document contradicts it.
 
 mod read;
 mod write;

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -133,6 +133,11 @@ pub struct BmopfWriteOptions {
 /// Writes the strict BMOPF document. Every field the schema cannot carry
 /// is reported in the warnings.
 ///
+/// Transformer taps, neutral impedance, no load admittance, and the tables
+/// schema 0.1.0 dropped from the top level move under `extras` instead of
+/// being dropped; [the module docs](crate::bmopf) enumerate them, and state
+/// when the emitted `terminal_conventions` block stops being valid.
+///
 /// # Panics
 ///
 /// Never in practice: the document is maps, strings, and finite numbers,
@@ -141,7 +146,8 @@ pub fn write_bmopf_json(net: &MulticonductorNetwork) -> Conversion {
     write_bmopf_json_with_options(net, &BmopfWriteOptions::default())
 }
 
-/// Writes BMOPF JSON with explicit options.
+/// Writes BMOPF JSON with explicit options. Parks the same fields under
+/// `extras` as [`write_bmopf_json`].
 ///
 /// # Panics
 ///
@@ -1294,7 +1300,8 @@ impl Writer {
     /// `additionalProperties: false` subtype objects and into
     /// `extras.transformer.<subtype>.<name>`, warning per transformer.
     /// Subtypes the schema leaves undefined (`n_winding`, untyped
-    /// passthrough) are untouched.
+    /// passthrough) are untouched. The module docs enumerate the moved set
+    /// for consumers; extend both together.
     fn split_transformer_overflow(&mut self, by_subtype: &mut Map<String, Value>) {
         // The transformer fields the emitters still produce that lost their
         // subtype slots in schema 0.1.0. Listing the moved set (rather than


### PR DESCRIPTION
Documentation only. No behavior change, no schema change.

The strict BMOPF writer relocates data schema 0.1.0 cannot carry in place instead of dropping it, but the relocation was only visible in the per element warnings, so a consumer had to reverse engineer it. The module docs now enumerate what moves: nine transformer fields (`tap`, `tap_min`, `tap_max`, `r_neutral_from`, `x_neutral_from`, `r_neutral_to`, `x_neutral_to`, `g_no_load`, `b_no_load`) to `extras.transformer.<subtype>.<name>` for the four defined subtypes, and the classes with no top level slot (`ibr`, `control_profile`, `dc_bus`, `dc_line`, `dc_load`, `dc_source`, `time_series`, plus untyped `capacitor`) to `extras.<class>.<name>`. Reading past `extras` gives a tapped transformer at nominal tap, an impedance grounded neutral as solidly grounded, and no magnetizing branch, with no error, which the docs now say. `parse_bmopf_str` folds the transformer overlay back, so a powerio round trip stays lossless.

The emitted `terminal_conventions` block is either the source document's, re-emitted verbatim, or authored from the model's terminal names. Carried across a downstream terminal rename it describes names no bus has and nothing contradicts it, so the docs state that a renaming consumer must delete and recompute the block.

`split_transformer_overflow` carries a note pointing at the enumeration so the list and the code move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
