### PR TITLE
corpus: the report's own spellings are not corpus secrets

### DIFF
--- a/powerio-cli/src/corpus/mod.rs
+++ b/powerio-cli/src/corpus/mod.rs
@@ -698,6 +698,10 @@ fn dist_convert_leg(
             return out;
         }
     };
+    // The readback's own declarations count toward warning parity, exactly as
+    // the transmission leg counts them; without this a loss the reader states
+    // on re-parse was graded undeclared.
+    out.warnings.extend(parsed.warnings.iter().cloned());
     let before = invariants::distribution_core(source);
     let after = invariants::distribution_core(&parsed);
     if before != after {
@@ -724,7 +728,12 @@ fn dist_convert_leg(
 fn has_include(text: &str) -> bool {
     text.lines().any(|line| {
         let word = line.split_whitespace().next().unwrap_or("");
-        word.eq_ignore_ascii_case("redirect") || word.eq_ignore_ascii_case("compile")
+        word.eq_ignore_ascii_case("redirect")
+            || word.eq_ignore_ascii_case("compile")
+            // A `Buscoords` reference names a sidecar file the same way, so a
+            // string readback would lose every location and report it as a
+            // conversion loss that is really the harness's own limitation.
+            || word.eq_ignore_ascii_case("buscoords")
     })
 }
 

--- a/powerio-cli/src/corpus/mod.rs
+++ b/powerio-cli/src/corpus/mod.rs
@@ -47,7 +47,64 @@ const COMPARE_FILE: &str = "comparisons.json";
 /// vocabulary so the leak audit never mistakes the report's own schema for
 /// case data; keep it in step with [`Finding`], [`findings_for`] and
 /// [`walk_findings`].
-const SCHEMA_KEYS: [&str; 35] = [
+const SCHEMA_KEYS: [&str; 83] = [
+    // The summary's own prose, title case included: the audit matches exact
+    // tokens.
+    "Corpus",
+    "run",
+    "files",
+    "seen",
+    "unreadable",
+    "Buckets",
+    "siblings",
+    "Findings",
+    "count",
+    // JSON's own literals: a corpus value spelled "false" must not make the
+    // report's booleans unwritable.
+    "true",
+    "false",
+    "null",
+    // Every finding code. `allow` licenses each dot- and dash-separated
+    // component, so a corpus value spelled "terminal" cannot make
+    // `electrical.dc-terminal` unwritable.
+    "parse.panic",
+    "parse.failure",
+    "leg.panic",
+    "leg.failure",
+    "leg.unresolved-include",
+    "sibling.variant",
+    "sibling.status",
+    "sibling.ybus",
+    "electrical.unavailable",
+    "electrical.ybus",
+    "electrical.injection",
+    "electrical.dc-terminal",
+    "core.power",
+    "core.regrouped",
+    "loss.declared",
+    "loss.undeclared",
+    "warning.observed",
+    "walk.panic",
+    "walk.failure",
+    "walk.drift",
+    "walk.path-dependent",
+    "walk.resurrection",
+    "walk.absorbed",
+    // The remaining severities ("declared" is below with the schema keys).
+    "crash",
+    "silent-drop",
+    "silent-value-change",
+    "undeclared-loss",
+    // The `core_delta` labels.
+    "buses",
+    "branches",
+    "generators",
+    "loads",
+    "shunts",
+    "load",
+    "gen",
+    "base",
+    "mva",
     "hop",
     "hops",
     "path",

--- a/powerio-cli/src/corpus/walk.rs
+++ b/powerio-cli/src/corpus/walk.rs
@@ -415,7 +415,10 @@ impl Net {
                     return Err("written deck redirects to include files".to_string());
                 }
                 match catch_panic(|| powerio_dist::parse_str(&written.text, to)) {
-                    Ok(Ok(parsed)) => Ok(Self::Dist(parsed)),
+                    Ok(Ok(parsed)) => {
+                        warnings.extend(parsed.warnings.iter().cloned());
+                        Ok(Self::Dist(parsed))
+                    }
                     Ok(Err(err)) => Err(format!("readback: {err}")),
                     Err(message) => Err(format!("readback panicked: {message}")),
                 }


### PR DESCRIPTION
Two commits, both corpus harness correctness.

**The report's own spellings are not corpus secrets.** A corpus value spelled "false", "loads" or "terminal" taught the sanitizer a string the report itself must emit, and the audit then refused to write anything: JSON's boolean literals appear in every finding line, "loads -52" is a core delta label, and "terminal" is a component of the `electrical.dc-terminal` code. A Datasets-scale run hit 835 such collisions and could not produce a report at all. `SCHEMA_KEYS` now carries the JSON literals, every finding code (`allow()` licenses each dot and dash component), the remaining severities, the core delta labels, and the summary's own prose. Verified on a 1953 file corpus: 835, then 123, then 1 collision as each class surfaced; with the full vocabulary the report writes 12970 findings and the audit passes.

**Judge the dist readback honestly.** The dist compare leg discarded readback warnings from the declared judgment, so a loss the reader states on re-parse graded as undeclared; the transmission leg has always counted them, and the walk's dist arm now does too. A written deck referencing a `Buscoords` sidecar joins `Redirect` and `Compile` in the unresolved include class: a string readback cannot resolve it, and grading the lost locations as a conversion loss is a statement about the harness rather than about powerio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN