### PR TITLE
formats: carry areas through MATPOWER, read SetBusXY, declare every area drop

### DIFF
--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -625,10 +625,17 @@ const TRANSMISSION_FORMATS: [TransmissionFormat; 8] = [
 // PSLF; egret lands on zero). What remains on that row is genuine: costs the
 // targets cannot carry and the one-of-three cost set MATPOWER's
 // all-or-nothing gencost drops.
+// The MATPOWER reader reads `mpc.areas` and the writer emits it, so the one
+// case that states an area (PGLib 5) carries it into every payload built from
+// the .m file. MATPOWER and PSS/E hold the table (their cells do not move);
+// the six targets with no area table each declare the drop — +1 on the
+// MATPOWER and PSS/E source rows' PowerModels, PowerWorld, egret, pandapower,
+// Surge, and PSLF cells. The PowerModels row does not move: its reader reads
+// no areas, so its payloads carry none.
 const TRANSMISSION_WARNING_BASELINE: [[usize; 8]; 8] = [
+    [0, 1, 15, 15, 7, 15, 23, 14],
     [0, 0, 15, 14, 6, 14, 22, 13],
-    [0, 0, 15, 14, 6, 14, 22, 13],
-    [0, 0, 0, 1, 0, 2, 0, 1],
+    [0, 1, 0, 2, 1, 3, 1, 2],
     [0, 0, 0, 0, 0, 2, 0, 0],
     [0, 0, 9, 9, 0, 8, 1, 7],
     [1, 0, 7, 7, 0, 0, 0, 7],

--- a/powerio-dist/src/dss/raw.rs
+++ b/powerio-dist/src/dss/raw.rs
@@ -432,6 +432,7 @@ impl<L: Loader> Executor<'_, L> {
             Some("redirect") => self.do_redirect(scan, false, ctx),
             Some("compile") => self.do_redirect(scan, true, ctx),
             Some("buscoords") => self.do_buscoords(scan, ctx),
+            Some("setbusxy") => self.do_setbusxy(scan, ctx),
             Some("var") => self.do_var(scan),
             Some("clear" | "clearall") => self.raw.clear(),
             Some("//") => {}
@@ -863,6 +864,44 @@ impl<L: Loader> Executor<'_, L> {
                 }
             }
             Err(e) => self.warn_load_error("buscoords", &path, &e, ctx),
+        }
+    }
+
+    /// `SetBusXY bus=name x=.. y=..`, named or positional. The inline twin of
+    /// `Buscoords`: it states one bus's coordinates in the deck itself, so it
+    /// is the form that survives a single-document round trip.
+    fn do_setbusxy(&mut self, scan: &mut Scanner, ctx: &dyn Fn(String) -> String) {
+        let mut bus: Option<String> = None;
+        let mut x: Option<f64> = None;
+        let mut y: Option<f64> = None;
+        let mut position = 0usize;
+        while let Some(p) = scan.next_param() {
+            let slot = match p.name.as_deref().map(str::to_ascii_lowercase).as_deref() {
+                Some("bus") => 0,
+                Some("x") => 1,
+                Some("y") => 2,
+                Some(_) => continue,
+                None => {
+                    let slot = position;
+                    position += 1;
+                    slot
+                }
+            };
+            match slot {
+                0 => bus = Some(p.value.text),
+                1 => x = p.value.to_f64(None).ok(),
+                2 => y = p.value.to_f64(None).ok(),
+                _ => {}
+            }
+        }
+        match (bus, x, y) {
+            (Some(bus), Some(x), Some(y)) if !bus.is_empty() => {
+                self.raw.buscoords.push(BusCoord { bus, x, y });
+            }
+            _ => self.raw.warn(
+                &C::PARSE_DSS_SOURCE_MALFORMED,
+                ctx("setbusxy needs a bus and numeric x and y".into()),
+            ),
         }
     }
 

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -750,3 +750,37 @@ fn regcontrol_warns_and_keeps_taps() {
         .unwrap();
     assert_eq!(reg1.phases, 1);
 }
+
+#[test]
+fn setbusxy_promotes_to_locations_like_buscoords() {
+    let text = "\
+New Circuit.geo basekv=12.47 pu=1 phases=3 bus1=a
+New Line.l1 bus1=a.1.2.3 bus2=b.1.2.3 phases=3 r1=0.1 x1=0.2 length=1 units=km
+New Load.ld bus1=b.1.2.3 phases=3 conn=wye kv=7.2 kw=10 kvar=1
+SetBusXY bus=a x=-80 y=35
+SetBusXY b -80.5 35.25
+";
+    let net = powerio_dist::parse_str(text, "dss").unwrap();
+    let a = net.buses.iter().find(|b| b.id == "a").unwrap();
+    assert_eq!(a.location.unwrap().x.to_bits(), (-80.0f64).to_bits());
+    assert_eq!(a.location.unwrap().y.to_bits(), 35.0f64.to_bits());
+    let b = net.buses.iter().find(|b| b.id == "b").unwrap();
+    assert_eq!(b.location.unwrap().x.to_bits(), (-80.5f64).to_bits());
+    assert_eq!(b.location.unwrap().y.to_bits(), 35.25f64.to_bits());
+}
+
+#[test]
+fn a_short_setbusxy_is_a_declared_malformation() {
+    let text = "\
+New Circuit.geo basekv=12.47 pu=1 phases=3 bus1=a
+SetBusXY bus=a x=-80
+";
+    let net = powerio_dist::parse_str(text, "dss").unwrap();
+    assert!(
+        net.warnings
+            .iter()
+            .any(|w| w.contains("setbusxy needs a bus and numeric x and y")),
+        "{:?}",
+        net.warnings
+    );
+}

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -98,6 +98,7 @@ pub fn write_egret_json(net: &BalancedNetwork) -> Conversion {
 }
 
 fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
+    super::warn_dropped_areas(&F, "egret JSON", net, warnings);
     if !net.transformers_3w.is_empty() {
         warnings.push(
             &F.record_dropped,

--- a/powerio/src/format/matpower/mod.rs
+++ b/powerio/src/format/matpower/mod.rs
@@ -133,6 +133,7 @@ fn build_case<'a>(name: &str, get: impl Fn(&str) -> Option<&'a str>) -> Result<B
 
     let generators = parse_gens(&get)?;
     let storage = parse_optional(&get, "storage", rows::storage_row)?;
+    let areas = parse_optional(&get, "areas", rows::area_row)?;
     let mut hvdc = parse_optional(&get, "dcline", rows::hvdc_row)?;
     attach_dcline_costs(&get, &mut hvdc)?;
 
@@ -162,7 +163,7 @@ fn build_case<'a>(name: &str, get: impl Fn(&str) -> Option<&'a str>) -> Result<B
         storage,
         hvdc,
         transformers_3w: Vec::new(),
-        areas: Vec::new(),
+        areas,
         solver: None,
         source_format: SourceFormat::Matpower,
         source: None,

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -6,8 +6,8 @@
 //! demand and shunts onto the bus row; the hub keeps them first-class).
 
 use crate::network::{
-    Branch, Bus, BusId, BusType, Extras, GEN_EXTRA_KEYS, GenCaps, GenCost, Generator, Hvdc, Load,
-    Shunt, Storage,
+    Area, Branch, Bus, BusId, BusType, Extras, GEN_EXTRA_KEYS, GenCaps, GenCost, Generator, Hvdc,
+    Load, Shunt, Storage,
 };
 use crate::{Error, Result};
 
@@ -326,5 +326,18 @@ pub(super) fn hvdc_row(row: &[f64], i: usize) -> Result<Hvdc> {
         cost: None,
         uid: None,
         extras: Extras::new(),
+    })
+}
+
+/// `mpc.areas` row: `[area, refbus]`. The table is legacy in MATPOWER itself
+/// but documented, and it is the only place this format can state an area, so
+/// the two columns carry the area number and its reference bus. A `refbus` of
+/// 0 reads as no reference bus, mirroring what the writer emits for one.
+pub(super) fn area_row(row: &[f64], i: usize) -> Result<Area> {
+    require("areas", row, i, 2)?;
+    let refbus = row[1] as usize;
+    Ok(Area {
+        slack_bus: (refbus > 0).then_some(BusId(refbus)),
+        ..Area::new(row[0] as usize)
     })
 }

--- a/powerio/src/format/matpower/tests.rs
+++ b/powerio/src/format/matpower/tests.rs
@@ -467,3 +467,46 @@ fn an_out_of_service_load_does_not_become_live_demand() {
         conversion.warnings
     );
 }
+
+#[test]
+fn areas_survive_the_canonical_round_trip() {
+    let mut net = parse_mpc(CASE_TINY).unwrap();
+    net.source = None;
+    net.source_format = SourceFormat::InMemory;
+    net.areas.push(crate::network::Area {
+        slack_bus: Some(BusId(1)),
+        ..crate::network::Area::new(7)
+    });
+    net.areas.push(crate::network::Area::new(9));
+
+    let text = write_matpower(&net);
+    assert!(text.contains("mpc.areas"), "areas block missing:\n{text}");
+    let back = parse_mpc(&text).unwrap();
+    assert_eq!(back.areas.len(), 2);
+    assert_eq!(back.areas[0].number, 7);
+    assert_eq!(back.areas[0].slack_bus, Some(BusId(1)));
+    assert_eq!(back.areas[1].number, 9);
+    assert_eq!(back.areas[1].slack_bus, None, "refbus 0 reads as none");
+}
+
+#[test]
+fn an_area_name_or_interchange_is_a_declared_drop() {
+    let mut net = parse_mpc(CASE_TINY).unwrap();
+    net.source = None;
+    net.source_format = SourceFormat::InMemory;
+    net.areas.push(crate::network::Area {
+        name: Some("west".into()),
+        net_interchange: 12.5,
+        ..crate::network::Area::new(1)
+    });
+
+    let conversion = crate::format::write_as(&net, crate::format::TargetFormat::Matpower).unwrap();
+    assert!(
+        conversion
+            .warnings
+            .iter()
+            .any(|w| w.contains("area record(s) carry a name or interchange data")),
+        "the fields mpc.areas cannot hold must be declared: {:?}",
+        conversion.warnings
+    );
+}

--- a/powerio/src/format/matpower/writer.rs
+++ b/powerio/src/format/matpower/writer.rs
@@ -195,6 +195,18 @@ fn canonical_warnings(net: &BalancedNetwork) -> Diagnostics {
     // one. This is the same helper the PSS/E, PSLF and PowerWorld writers use;
     // the hand-rolled version here reported a bare yes/no.
     crate::format::warn_dropped_extras(&F, "canonical MATPOWER .m", net, |_| false, &mut warnings);
+    // `mpc.areas` carries the area number and reference bus and nothing else.
+    let lossy_areas = net
+        .areas
+        .iter()
+        .filter(|a| a.name.is_some() || a.net_interchange != 0.0 || a.tolerance != 0.0)
+        .count();
+    if lossy_areas > 0 {
+        warnings.push(&F.field_dropped, format!(
+            "{lossy_areas} of {} area record(s) carry a name or interchange data: `mpc.areas` holds only the area number and reference bus",
+            net.areas.len()
+        ));
+    }
     warnings
 }
 
@@ -286,6 +298,16 @@ fn canonical(net: &BalancedNetwork) -> String {
         );
     }
     let _ = writeln!(s, "];");
+
+    if !net.areas.is_empty() {
+        // `mpc.areas` is `[area, refbus]` and the reader reads it back. An
+        // area with no reference bus writes 0, which reads back as none.
+        let _ = writeln!(s, "mpc.areas = [");
+        for a in &net.areas {
+            let _ = writeln!(s, "\t{}\t{};", a.number, a.slack_bus.map_or(0, |b| b.0));
+        }
+        let _ = writeln!(s, "];");
+    }
 
     if !net.generators.is_empty() {
         // The 21-column layout (Pc1..APF) is standard MATPOWER and the reader

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -983,6 +983,7 @@ fn warn_pandapower_branch_losses(net: &BalancedNetwork, warnings: &mut Diagnosti
         ));
     }
     warn_extra_branch_rating_sets(&F, "pandapower JSON", net, warnings);
+    super::warn_dropped_areas(&F, "pandapower JSON", net, warnings);
     let branch_solutions = net.branches.iter().filter(|b| b.solution.is_some()).count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(

--- a/powerio/src/format/powermodels.rs
+++ b/powerio/src/format/powermodels.rs
@@ -97,6 +97,7 @@ pub fn write_powermodels_json(net: &BalancedNetwork) -> Conversion {
             net.transformers_3w.len()
         ));
     }
+    super::warn_dropped_areas(&F, "PowerModels JSON", net, &mut warnings);
     let voltage_loads = net
         .loads
         .iter()

--- a/powerio/src/format/pypsa.rs
+++ b/powerio/src/format/pypsa.rs
@@ -580,6 +580,7 @@ pub fn write_pypsa_csv_folder(
         ));
     }
     warn_extra_branch_rating_sets(&F, "PyPSA CSV", net, &mut warnings);
+    super::warn_dropped_areas(&F, "PyPSA CSV", net, &mut warnings);
     let branch_solutions = net.branches.iter().filter(|b| b.solution.is_some()).count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -93,6 +93,7 @@ pub fn write_surge_json(net: &BalancedNetwork) -> Conversion {
     root.insert("network".into(), Value::Object(network));
 
     warn_extra_branch_rating_sets(&F, FMT, net, &mut warnings);
+    super::warn_dropped_areas(&F, FMT, net, &mut warnings);
     finish(&F, root, warnings)
 }
 

--- a/powerio/tests/common/mod.rs
+++ b/powerio/tests/common/mod.rs
@@ -60,13 +60,27 @@ pub fn rts_gmlc_fetched(name: &str) -> Option<PathBuf> {
 /// Branch circuit identity: the trimmed `LineCircuit` extra, `"1"` (the
 /// PowerWorld default) when absent.
 #[allow(dead_code)]
-pub fn ckt(b: &powerio::Branch) -> String {
-    b.extras
-        .get("LineCircuit")
-        .and_then(|v| v.as_str())
-        .unwrap_or("1")
-        .trim()
-        .to_string()
+/// Branch keys under the one id rule (#330): the retained circuit where the
+/// file stated one the writer would not re-derive, else the per-pair ordinal
+/// the readers dropped as a positional default. Aligned with `branches`, so
+/// zip the result back onto the slice.
+pub fn branch_keys(branches: &[powerio::Branch]) -> Vec<(usize, usize, String)> {
+    let mut nth: std::collections::BTreeMap<(usize, usize), usize> =
+        std::collections::BTreeMap::new();
+    branches
+        .iter()
+        .map(|b| {
+            let pair = (b.from.0, b.to.0);
+            let n = nth.entry(pair).or_insert(0);
+            *n += 1;
+            let ckt = b
+                .extras
+                .get("LineCircuit")
+                .and_then(|v| v.as_str())
+                .map_or_else(|| n.to_string(), |v| v.trim().to_string());
+            (pair.0, pair.1, ckt)
+        })
+        .collect()
 }
 
 /// The path a label resolves to in the gitignored local corpus manifest

--- a/powerio/tests/powerworld_parity.rs
+++ b/powerio/tests/powerworld_parity.rs
@@ -23,14 +23,11 @@ use powerio::network::{BalancedNetwork, BusId};
 use powerio::parse_file;
 
 mod common;
-use common::{activsg2000_fetched as fetched, ckt, powerworld_vendored as vendored};
+use common::{activsg2000_fetched as fetched, branch_keys, powerworld_vendored as vendored};
 
-/// Branch identity: from, to, trimmed circuit ID.
+/// Branch identity: from, to, circuit under the one id rule.
 fn branch_ids(net: &BalancedNetwork) -> BTreeSet<(usize, usize, String)> {
-    net.branches
-        .iter()
-        .map(|b| (b.from.0, b.to.0, ckt(b)))
-        .collect()
+    branch_keys(&net.branches).into_iter().collect()
 }
 
 #[test]
@@ -72,10 +69,9 @@ fn activsg200_aux_vs_matpower_structural() {
 
     // Impedance, charging, and tap agree on every matched branch to the .m
     // file's print precision.
-    let by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = aux
-        .branches
-        .iter()
-        .map(|b| ((b.from.0, b.to.0, ckt(b)), b))
+    let by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = branch_keys(&aux.branches)
+        .into_iter()
+        .zip(&aux.branches)
         .collect();
     for mb in &m.branches {
         let key = (mb.from.0, mb.to.0, "1".to_string());

--- a/powerio/tests/powerworld_pwb.rs
+++ b/powerio/tests/powerworld_pwb.rs
@@ -11,7 +11,7 @@ use powerio::network::BalancedNetwork;
 use powerio::parse_file;
 
 mod common;
-use common::{activsg2000_fetched as fetched, ckt, powerworld_vendored as vendored};
+use common::{activsg2000_fetched as fetched, branch_keys, powerworld_vendored as vendored};
 
 fn read_pwb(path: &Path) -> BalancedNetwork {
     let bytes = std::fs::read(path).unwrap();
@@ -152,12 +152,11 @@ fn activsg200_pwb_matches_its_aux_sibling() {
     // Branches: identity (including the default circuit on the one record
     // that omits it), impedances, ratings, taps, device kind.
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
     let mut transformers = 0;
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -359,12 +358,11 @@ fn texas2000_june2016_pwb_matches_its_aux_sibling() {
     }
 
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
     let mut transformers = 0;
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -886,11 +884,10 @@ fn activsg2000_current_era_pwb_matches_its_aux_sibling() {
         );
     }
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -1014,11 +1011,10 @@ fn activsg500_pwb_matches_its_aux_sibling() {
         );
     }
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -1139,11 +1135,10 @@ fn hawaii40_pwb_matches_its_aux_sibling() {
         );
     }
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -1382,11 +1377,10 @@ fn texas7k_pwb_matches_its_aux_and_matpower_siblings() {
 
     // Branches against the aux by full identity (endpoints + circuit).
     let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-    for b in &aux.branches {
-        aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+    for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+        aux_by_id.insert(key, b);
     }
-    for p in &pwb.branches {
-        let key = (p.from.0, p.to.0, ckt(p));
+    for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
         let a = aux_by_id
             .remove(&key)
             .unwrap_or_else(|| panic!("{key:?} not in aux"));
@@ -1551,11 +1545,10 @@ fn texas7k_resaves_match_the_2022_aux() {
             "{label}"
         );
         let mut aux_by_id: BTreeMap<(usize, usize, String), &powerio::Branch> = BTreeMap::default();
-        for b in &aux.branches {
-            aux_by_id.insert((b.from.0, b.to.0, ckt(b)), b);
+        for (key, b) in branch_keys(&aux.branches).into_iter().zip(&aux.branches) {
+            aux_by_id.insert(key, b);
         }
-        for p in &pwb.branches {
-            let key = (p.from.0, p.to.0, ckt(p));
+        for (key, p) in branch_keys(&pwb.branches).into_iter().zip(&pwb.branches) {
             let a = aux_by_id
                 .remove(&key)
                 .unwrap_or_else(|| panic!("{label}: {key:?} not in aux"));


### PR DESCRIPTION
The corpus walk's two undeclared loss findings, resolved by retention where the format can hold the data and declaration where it cannot.

**Areas through MATPOWER.** The reader reads `mpc.areas` (`[area, refbus]`, refbus 0 as none) and the writer emits it, so the area number and reference bus survive MATPOWER round trips; a name or interchange data the two columns cannot hold is a declared drop. With areas actually flowing from .m files, six writers were exposed dropping them silently: PowerModels, egret, Surge, pandapower, and PyPSA now declare through `warn_dropped_areas` like PSLF and PowerWorld already did. They get declaration rather than retention because none of their schemas is verified to carry an area table, and powerio authors no foreign format fields.

**SetBusXY.** The dss reader gains `SetBusXY` (named or positional), feeding the same typed locations as `Buscoords`. Inline coordinates in real decks were dropped entirely before, and the inline form is the one that survives a single-document round trip. The piecewise pandapower cost mapping the same walk pointed at is #360.

**Conversion matrix.** Twelve cells move by exactly one declared warning (the PGLib 5 fixture states an area); the matpower and psse cells hold, since both formats carry the table, and every "claims lossless" violation the change surfaced is resolved by declaration.

**Local test repair** (second commit). Six local-data pwb/aux tests kept a `ckt` helper with a static "1" fallback from before the one id rule (#330): the positional circuit counter is per bus pair, so the second parallel branch's "2" is as much a default as the first's "1", and both parallel Texas7k branches fell back to "1" and collided. `branch_keys` re-derives the per-pair ordinal exactly as `drop_positional_id` drops it. These tests read local datasets and never run in CI, which is how the stale helper survived the rule change; all thirteen pass again.

Full ci-mirror green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN