### PR TITLE
json: spell a nonfinite float as a string on every document powerio authors

### DIFF
--- a/docs/schema/pio-package/0.9/schema.json
+++ b/docs/schema/pio-package/0.9/schema.json
@@ -25,9 +25,21 @@
           ]
         },
         "net_interchange": {
-          "description": "Scheduled net interchange (MW); positive is export out of the area.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Scheduled net interchange (MW); positive is export out of the area."
         },
         "number": {
           "format": "uint",
@@ -46,9 +58,21 @@
           "description": "The area swing (slack) bus, or `None` when unset."
         },
         "tolerance": {
-          "description": "Interchange tolerance bandwidth (MW).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Interchange tolerance bandwidth (MW)."
         }
       },
       "required": [
@@ -59,7 +83,7 @@
       "type": "object"
     },
     "BalancedNetwork": {
-      "description": "A balanced network with stable source bus IDs and separate element tables.",
+      "description": "A balanced network with stable source bus IDs and separate element tables.\n\n`remote = \"Self\"` turns the derived serde impls into inherent functions;\nthe trait impls beneath the struct route them through [`crate::nonfinite`],\nso a nonfinite float spells as a string on every JSON route.",
       "properties": {
         "areas": {
           "default": [],
@@ -70,14 +94,38 @@
           "type": "array"
         },
         "base_frequency": {
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
           "default": 60.0,
-          "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field.",
-          "format": "double",
-          "type": "number"
+          "description": "System base frequency in hertz (50 or 60). Threaded through the formats\nthat record it (PSS/E `BASFRQ`, pandapower `f_hz`) and defaulted to\n[`DEFAULT_BASE_FREQUENCY`] for the rest. Load-bearing for any\nreactance↔henry conversion (pandapower line charging) and reported as a\nfidelity loss when a non-default value writes to a format with no\nfrequency field."
         },
         "base_mva": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "branches": {
           "items": {
@@ -182,17 +230,53 @@
     "Branch": {
       "properties": {
         "angmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "angmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "b": {
-          "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "MATPOWER compatible total line charging susceptance (p.u.). This is the\nlegacy total projection; when [`charging`](Branch::charging) is present,\nper terminal admittance is canonical and this field is compatibility data."
         },
         "charging": {
           "anyOf": [
@@ -241,21 +325,69 @@
           "type": "boolean"
         },
         "r": {
-          "description": "Series resistance (p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Series resistance (p.u.)."
         },
         "rate_a": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "rate_b": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "rate_c": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "rating_sets": {
           "default": [],
@@ -276,9 +408,21 @@
           ]
         },
         "shift": {
-          "description": "Phase shift (degrees).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Phase shift (degrees)."
         },
         "solution": {
           "anyOf": [
@@ -293,9 +437,21 @@
           "description": "Solved branch flow values, when present in a case snapshot."
         },
         "tap": {
-          "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Tap ratio, MATPOWER convention: 0 means \"no tap\" (a line), treated as 1."
         },
         "to": {
           "$ref": "#/$defs/BusId"
@@ -308,9 +464,21 @@
           ]
         },
         "x": {
-          "description": "Series reactance (p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Series reactance (p.u.)."
         }
       },
       "required": [
@@ -335,20 +503,68 @@
       "description": "Per terminal branch shunt admittance in p.u. This is the canonical\nphysical branch shunt model when present.",
       "properties": {
         "b_fr": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "b_to": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "g_fr": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "g_to": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -363,16 +579,52 @@
       "description": "Current limits for a branch, in source units.",
       "properties": {
         "c_rating_a": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "c_rating_b": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "c_rating_c": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -389,8 +641,20 @@
           "type": "string"
         },
         "rate_mva": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -403,20 +667,68 @@
       "description": "Solved branch terminal flows in MW/MVAr.",
       "properties": {
         "pf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -435,25 +747,61 @@
           "type": "integer"
         },
         "base_kv": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "evhi": {
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
           "default": null,
-          "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "description": "Emergency (short-term) voltage band, set only when the source states one\ndistinct from the normal [`vmax`](Bus::vmax)/[`vmin`](Bus::vmin) band (PSS/E\n`EVHI`/`EVLO`). `None` means the emergency band equals the normal band, so\nread `evhi.unwrap_or(vmax)` / `evlo.unwrap_or(vmin)`. `#[serde(default)]` so\nJSON written before the fields existed still deserializes."
         },
         "evlo": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "extras": {
           "additionalProperties": true,
@@ -491,22 +839,70 @@
           ]
         },
         "va": {
-          "description": "Voltage angle (degrees).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Voltage angle (degrees)."
         },
         "vm": {
-          "description": "Voltage magnitude (p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Voltage magnitude (p.u.)."
         },
         "vmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "vmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "zone": {
           "format": "uint",
@@ -548,10 +944,22 @@
       "description": "Diagram canvas metadata.",
       "properties": {
         "height": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "units": {
@@ -561,10 +969,22 @@
           ]
         },
         "width": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         }
       },
@@ -574,10 +994,22 @@
       "description": "Diagram canvas metadata.",
       "properties": {
         "height": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "units": {
@@ -587,10 +1019,22 @@
           ]
         },
         "width": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         }
       },
@@ -753,38 +1197,98 @@
           "type": "array"
         },
         "v_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "v_min": {
-          "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0).",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0)."
         },
         "vn_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "vneg_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "vpn_max": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": [
             "array",
@@ -793,8 +1297,20 @@
         },
         "vpn_min": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": [
             "array",
@@ -802,23 +1318,59 @@
           ]
         },
         "vpos_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "vpos_min": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "vpp_max": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": [
             "array",
@@ -827,8 +1379,20 @@
         },
         "vpp_min": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": [
             "array",
@@ -836,10 +1400,22 @@
           ]
         },
         "vzero_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         }
       },
@@ -868,12 +1444,24 @@
           "type": "string"
         },
         "q_rated": {
-          "description": "Nameplate rated reactive power of the whole bank, vars.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Nameplate rated reactive power of the whole bank, vars."
         },
         "terminal_map": {
           "items": {
@@ -882,12 +1470,24 @@
           "type": "array"
         },
         "v_nom": {
-          "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Nameplate nominal voltage, volts: line to line for the three phase\nconfigurations, across the terminals for SINGLE_PHASE."
         }
       },
       "required": [
@@ -956,12 +1556,24 @@
           "$ref": "#/$defs/Configuration"
         },
         "cost": {
-          "description": "$/kWh; no OpenDSS equivalent, so it is None until a format supplies it.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "$/kWh; no OpenDSS equivalent, so it is None until a format supplies it."
         },
         "extras": {
           "additionalProperties": true,
@@ -969,10 +1581,22 @@
         },
         "i_max": {
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -986,10 +1610,22 @@
         "p_max": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1001,10 +1637,22 @@
           "default": null,
           "description": "Bounds per phase. A `null` element reads as -Inf in a lower bound\nand +Inf in an upper bound: the PMD unbounded spelling (#268).",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1015,18 +1663,42 @@
         "p_nom": {
           "description": "Setpoint, watts per phase.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "q_max": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1037,10 +1709,22 @@
         "q_min": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1050,18 +1734,42 @@
         },
         "q_nom": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "s_max": {
           "description": "Per-conductor apparent power and current limits, VA and amps (BMOPF\ngenerator fields, alongside the p/q bounds).",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1106,10 +1814,22 @@
           "default": null,
           "description": "Per conductor current limits, amperes.",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1121,20 +1841,44 @@
           "type": "string"
         },
         "p_avail": {
-          "description": "Available active power, watts.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Available active power, watts."
         },
         "p_max": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1145,10 +1889,22 @@
         "p_min": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1162,10 +1918,22 @@
         "q_max": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1176,10 +1944,22 @@
         "q_min": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1190,10 +1970,22 @@
         "s_max": {
           "description": "Per phase apparent power nameplate ratings, volt amperes.",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": "array"
@@ -1244,10 +2036,22 @@
         "i_max": {
           "description": "Per-conductor ampacity and apparent power limits, amps and VA\n(BMOPF schema 0.1.0 line fields, alongside the linecode's own).\nA `null` element reads as +Inf (#268).",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1256,12 +2060,24 @@
           ]
         },
         "length": {
-          "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268).",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Meters. A `null` reads as NaN: a BMOPF line without a length (#268)."
         },
         "linecode": {
           "type": "string"
@@ -1281,10 +2097,22 @@
         },
         "s_max": {
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1322,8 +2150,20 @@
         "b_from": {
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1332,8 +2172,20 @@
         "b_to": {
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1347,8 +2199,20 @@
           "description": "Shunt admittance halves at each end, S per meter.",
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1357,8 +2221,20 @@
         "g_to": {
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1368,10 +2244,22 @@
           "default": null,
           "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1391,8 +2279,20 @@
           "description": "Series impedance, ohm per meter.",
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1401,10 +2301,22 @@
         "s_max": {
           "default": null,
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1422,8 +2334,20 @@
         "x_series": {
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1461,16 +2385,40 @@
         "p_nom": {
           "description": "Watts per phase.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "q_nom": {
           "description": "Vars per phase.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -1507,8 +2455,20 @@
             },
             "v_nom": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             }
@@ -1528,8 +2488,20 @@
             },
             "v_nom": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             }
@@ -1549,8 +2521,20 @@
             },
             "v_nom": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             }
@@ -1566,43 +2550,115 @@
           "properties": {
             "alpha_i": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "alpha_p": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "alpha_z": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "beta_i": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "beta_p": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "beta_z": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
@@ -1612,8 +2668,20 @@
             },
             "v_nom": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             }
@@ -1635,15 +2703,39 @@
           "properties": {
             "gamma_p": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
             "gamma_q": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             },
@@ -1653,8 +2745,20 @@
             },
             "v_nom": {
               "items": {
-                "format": "double",
-                "type": "number"
+                "anyOf": [
+                  {
+                    "format": "double",
+                    "type": "number"
+                  },
+                  {
+                    "enum": [
+                      "Infinity",
+                      "-Infinity",
+                      "NaN"
+                    ],
+                    "type": "string"
+                  }
+                ]
               },
               "type": "array"
             }
@@ -1674,8 +2778,20 @@
         "b": {
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1692,8 +2808,20 @@
           "description": "Total siemens in conductor order.",
           "items": {
             "items": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "type": "array"
           },
@@ -1744,10 +2872,22 @@
           "default": null,
           "description": "Ampacity per conductor. A `null` element reads as +Inf (#268).",
           "items": {
-            "format": "double",
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
             ]
           },
           "type": [
@@ -1808,8 +2948,20 @@
         "xsc_pct": {
           "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         }
@@ -1905,8 +3057,20 @@
         "coeffs": {
           "description": "Raw coefficients, highest order first for the polynomial model:\n`[c_{k-1}, …, c1, c0]`.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -1924,12 +3088,36 @@
           "type": "integer"
         },
         "shutdown": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "startup": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -1948,8 +3136,20 @@
         },
         "caps": {
           "additionalProperties": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "default": {},
           "description": "The MATPOWER gen capability / ramp columns past `PMIN`, aligned to\n`GEN_EXTRA_KEYS` by index (`None` for a column the source omitted).\nA fixed array, not an [`Extras`] map: a string-keyed map per generator\ncosts 11 heap allocations each, which dominates the parse of a large\ngenerator-heavy case. Surfaced into formats that name them (PowerModels).\nOn the JSON snapshot it is a name-keyed object (see `caps_serde`) so the\nschema stays additive when `GEN_EXTRA_KEYS` grows; `#[serde(default)]` so a\nsnapshot that omits it deserializes to the empty set.",
@@ -1969,34 +3169,118 @@
           "type": "boolean"
         },
         "mbase": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pg": {
-          "description": "Real power set point (MW).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Real power set point (MW)."
         },
         "pmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qg": {
-          "description": "Reactive power set point (MVAr).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Reactive power set point (MVAr)."
         },
         "qmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "regulated_bus": {
           "anyOf": [
@@ -2018,9 +3302,21 @@
           ]
         },
         "vg": {
-          "description": "Voltage set point (p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Voltage set point (p.u.)."
         }
       },
       "required": [
@@ -2248,52 +3544,196 @@
           "type": "boolean"
         },
         "loss0": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "loss1": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "pt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmaxf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmaxt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qminf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmint": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "to": {
           "$ref": "#/$defs/BusId"
@@ -2306,12 +3746,36 @@
           ]
         },
         "vf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "vt": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -2365,16 +3829,52 @@
       "description": "A series impedance with the MVA base it is expressed on. Used pairwise by\n[`Transformer3W`]; a self-contained unit so the base travels with the value\ninstead of being implied by position.\n\n`r`/`x` are per unit on the *system* base (the same `CZ = 1` convention as\n[`Branch::r`]/[`Branch::x`], so the matrix math needs no rebasing); `base_mva`\nrecords the winding-pair MVA base the source file declared (PSS/E `SBASE1-2`\nand friends), kept so a write-back reproduces it and so a future `CZ = 2`\nreader has somewhere to put the winding base it must rebase from. Room to grow\n(winding voltage base, turns-ratio units) as the transformer control work\nlands without reshaping the [`Transformer3W::z`] array.",
       "properties": {
         "base_mva": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "r": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "x": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -2397,14 +3897,38 @@
           "type": "boolean"
         },
         "p": {
-          "description": "Active demand (MW).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Active demand (MW)."
         },
         "q": {
-          "description": "Reactive demand (MVAr).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Reactive demand (MVAr)."
         },
         "uid": {
           "description": "Stable row identity; see [`Bus::uid`].",
@@ -2468,45 +3992,141 @@
               ]
             },
             "p_constant_current": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "p_constant_impedance": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "p_constant_power": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "q_constant_current": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "q_constant_impedance": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "q_constant_power": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "scaling": {
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ],
               "default": null,
-              "description": "Source scaling factor, when a format has one.",
-              "format": "double",
-              "type": [
-                "number",
-                "null"
-              ]
+              "description": "Source scaling factor, when a format has one."
             },
             "v_nom": {
-              "default": null,
-              "format": "double",
-              "type": [
-                "number",
-                "null"
-              ]
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "default": null
             }
           },
           "required": [
@@ -2524,32 +4144,92 @@
           "description": "Exponential voltage model: `P = p * (V / v_nom)^gamma_p`,\n`Q = q * (V / v_nom)^gamma_q`.",
           "properties": {
             "gamma_p": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "gamma_q": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "kind": {
               "const": "exponential",
               "type": "string"
             },
             "p": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "q": {
-              "format": "double",
-              "type": "number"
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": "number"
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ]
             },
             "v_nom": {
-              "default": null,
-              "format": "double",
-              "type": [
-                "number",
-                "null"
-              ]
+              "anyOf": [
+                {
+                  "format": "double",
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                {
+                  "enum": [
+                    "Infinity",
+                    "-Infinity",
+                    "NaN"
+                  ],
+                  "type": "string"
+                }
+              ],
+              "default": null
             }
           },
           "required": [
@@ -2578,14 +4258,38 @@
           "description": "Per point provenance when it differs from the network default."
         },
         "x": {
-          "description": "X coordinate. In geographic space this is longitude.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "X coordinate. In geographic space this is longitude."
         },
         "y": {
-          "description": "Y coordinate. In geographic space this is latitude.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Y coordinate. In geographic space this is latitude."
         }
       },
       "required": [
@@ -2609,14 +4313,38 @@
           "description": "Per point provenance when it differs from the network default."
         },
         "x": {
-          "description": "X coordinate. In geographic space this is longitude.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "X coordinate. In geographic space this is longitude."
         },
         "y": {
-          "description": "Y coordinate. In geographic space this is latitude.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Y coordinate. In geographic space this is latitude."
         }
       },
       "required": [
@@ -2787,9 +4515,21 @@
       "description": "A multiconductor distribution network.\n\n`source` retains the original text for the byte exact echo tier;\n`defaulted` records, per element (`\"class.name\"` key), the fields the\nreader materialized from format defaults rather than the source text.",
       "properties": {
         "base_frequency": {
-          "description": "Hz.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Hz."
         },
         "buses": {
           "items": {
@@ -3257,10 +4997,22 @@
           ]
         },
         "base_mva": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "power": {
@@ -3481,8 +5233,20 @@
     "PowerFactorControl": {
       "properties": {
         "pf": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -3535,9 +5299,21 @@
     "Shunt": {
       "properties": {
         "b": {
-          "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Shunt susceptance (MVAr at V = 1 p.u.). For a switched shunt this is the\ninitial (steady-state) value within the [`control`](Shunt::control) blocks."
         },
         "bus": {
           "$ref": "#/$defs/BusId"
@@ -3559,9 +5335,21 @@
           "type": "object"
         },
         "g": {
-          "description": "Shunt conductance (MW at V = 1 p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Shunt conductance (MW at V = 1 p.u.)."
         },
         "in_service": {
           "type": "boolean"
@@ -3587,9 +5375,21 @@
       "description": "One block of a switched shunt: `steps` equal increments of susceptance `b`.",
       "properties": {
         "b": {
-          "description": "Susceptance increment per step (MVAr at V = 1 p.u.).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Susceptance increment per step (MVAr at V = 1 p.u.)."
         },
         "steps": {
           "format": "uint32",
@@ -3651,20 +5451,44 @@
           ]
         },
         "newton_tolerance": {
-          "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`).",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Newton power flow mismatch tolerance (`NEWTON TOLN`)."
         },
         "zero_impedance_threshold": {
-          "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`).",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Branches with `|x|` below this are treated as zero impedance (`GENERAL THRSHZ`)."
         }
       },
       "type": "object"
@@ -3885,36 +5709,120 @@
           "$ref": "#/$defs/BusId"
         },
         "charge_efficiency": {
-          "format": "double",
-          "type": "number"
-        },
-        "charge_rating": {
-          "format": "double",
-          "type": "number"
-        },
-        "current_rating": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
+        "charge_rating": {
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
+        },
+        "current_rating": {
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
+        },
         "discharge_efficiency": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "discharge_rating": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "energy": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "energy_rating": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "extras": {
           "additionalProperties": true,
@@ -3924,36 +5832,132 @@
           "type": "boolean"
         },
         "p_loss": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "ps": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "q_loss": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmax": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qmin": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "qs": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "r": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "thermal_rating": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "uid": {
           "description": "Stable row identity; see [`Bus::uid`].",
@@ -3963,8 +5967,20 @@
           ]
         },
         "x": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -4216,12 +6232,24 @@
           "type": "boolean"
         },
         "current_rating": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "extras": {
           "additionalProperties": true,
@@ -4231,44 +6259,104 @@
           "$ref": "#/$defs/BusId"
         },
         "pf": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "pt": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "qf": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "qt": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "thermal_rating": {
-          "default": null,
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "default": null
         },
         "to": {
           "$ref": "#/$defs/BusId"
@@ -4313,18 +6401,54 @@
           "$ref": "#/$defs/SwitchedShuntMode"
         },
         "rmpct": {
-          "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Percent of the controlled device's reactive range to apply (PSS/E `RMPCT`)."
         },
         "vhigh": {
-          "description": "Regulated voltage band (per unit).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Regulated voltage band (per unit)."
         },
         "vlow": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -4362,8 +6486,20 @@
         "duration_hours": {
           "description": "Optional duration per period, in hours.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -4397,13 +6533,37 @@
           "type": "boolean"
         },
         "mag_b": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "mag_g": {
-          "description": "Magnetizing shunt referred to the star point (p.u. on the system base).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Magnetizing shunt referred to the star point (p.u. on the system base)."
         },
         "name": {
           "type": [
@@ -4412,13 +6572,37 @@
           ]
         },
         "star_va": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "star_vm": {
-          "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Star-point voltage magnitude (p.u.) and angle (degrees), as solved."
         },
         "uid": {
           "description": "Stable row identity; see [`Bus::uid`].",
@@ -4462,12 +6646,36 @@
       "description": "Automatic-control data for a regulating transformer ([`Branch::control`]).\n\nThe limits carry whatever the [`mode`](TransformerControl::mode) regulates:\n`tap_min`/`tap_max` bound the tap ratio (or the phase angle, for\n[`ActiveFlow`](TransformerControlMode::ActiveFlow)), and `band_min`/`band_max`\nbound the controlled quantity (the regulated voltage band, or the\nscheduled MW/MVAr). `ntp` is the number of discrete tap positions and\n`controlled_bus` is the regulated bus (`None` = the transformer's own\nterminal). `mva_base` is the winding MVA base the impedance is referred to.",
       "properties": {
         "band_max": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "band_min": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "controlled_bus": {
           "anyOf": [
@@ -4483,8 +6691,20 @@
           "$ref": "#/$defs/TransformerControlMode"
         },
         "mva_base": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "ntp": {
           "format": "uint32",
@@ -4492,12 +6712,36 @@
           "type": "integer"
         },
         "tap_max": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "tap_min": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         }
       },
       "required": [
@@ -4661,29 +6905,77 @@
       "properties": {
         "breakpoints": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "p_min_for_q": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "p_min_for_q_max": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "q_limits": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -4728,15 +7020,39 @@
       "properties": {
         "breakpoints": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "p_limits": {
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
@@ -4798,16 +7114,40 @@
         "v_angle": {
           "description": "Radians per terminal.",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         },
         "v_magnitude": {
           "description": "Volts per terminal (0.0 on grounded terminals).",
           "items": {
-            "format": "double",
-            "type": "number"
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
           },
           "type": "array"
         }
@@ -4829,31 +7169,103 @@
           "$ref": "#/$defs/BusId"
         },
         "nominal_kv": {
-          "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Winding nominal voltage (kV); 0 defers to the terminal bus base kV."
         },
         "rate_a": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "rate_b": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "rate_c": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "shift": {
-          "description": "Phase shift (degrees).",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Phase shift (degrees)."
         },
         "tap": {
-          "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`.",
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Off-nominal turns ratio (1.0 = nominal); the PSS/E `WINDV`, `CW = 1`."
         }
       },
       "required": [
@@ -4876,31 +7288,79 @@
           "$ref": "#/$defs/WindingConn"
         },
         "r_neutral": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         },
         "r_pct": {
-          "description": "Winding resistance, percent of the winding base.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Winding resistance, percent of the winding base."
         },
         "s_rating": {
-          "description": "Volt amperes.",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Volt amperes."
         },
         "tap": {
-          "format": "double",
-          "type": "number"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": "number"
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ]
         },
         "terminal_map": {
           "items": {
@@ -4909,18 +7369,42 @@
           "type": "array"
         },
         "v_ref": {
-          "description": "Rated winding voltage, volts (line to line for 2 and 3 phase).",
-          "format": "double",
-          "type": [
-            "number",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
+          ],
+          "description": "Rated winding voltage, volts (line to line for 2 and 3 phase)."
         },
         "x_neutral": {
-          "format": "double",
-          "type": [
-            "number",
-            "null"
+          "anyOf": [
+            {
+              "format": "double",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            {
+              "enum": [
+                "Infinity",
+                "-Infinity",
+                "NaN"
+              ],
+              "type": "string"
+            }
           ]
         }
       },

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -110,6 +110,20 @@ Schema is derived from the serde models and checked in CI against the committed
 and the balanced payload's serialized form is additionally held to a committed
 golden file by `powerio/tests/snapshot_schema.rs`.
 
+### Nonfinite numbers {#nonfinite}
+
+JSON has no `Inf`/`NaN` literal, and readers legitimately produce nonfinite
+values: an absent reactive limit reads as `Inf` from MATPOWER, PowerModels,
+pandapower, and PyPSA. Every float position in a `.pio.json` document —
+envelope and both payloads — writes a nonfinite value as the string
+`"Infinity"`, `"-Infinity"`, or `"NaN"`, and reads back either a number or one
+of those spellings, so every document powerio writes reads back. The generated
+schema states this as the string arm on every float position. The
+multiconductor bound fields additionally accept the `null` a pre-0.9 writer
+emitted, restored by field role: unbounded above in an upper bound, unbounded
+below in a lower bound, not known in a length. At any other float position a
+`null` is refused with a message naming this change.
+
 ### The balanced model JSON {#pio-payload-balanced}
 
 `model.balanced_network` is the serde form of `powerio::BalancedNetwork`, stamped when

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -2255,7 +2255,8 @@ mod tests {
     }
 
     #[test]
-    fn package_rejects_non_finite_payload_before_writing() {
+    #[allow(clippy::float_cmp)]
+    fn package_carries_a_nonfinite_payload_as_string_spellings() {
         let stamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -2279,13 +2280,16 @@ mpc.branch = [
         )
         .unwrap();
 
-        let err = run_package(&input, Some(&output), None, 0).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("validating .pio.json package readback"),
-            "{err}"
-        );
-        assert!(!output.exists());
+        run_package(&input, Some(&output), None, 0).unwrap();
+        let text = std::fs::read_to_string(&output).unwrap();
+        assert!(text.contains("\"angmin\": \"NaN\""), "{text}");
+        assert!(text.contains("\"angmax\": \"Infinity\""), "{text}");
+        let pkg = powerio_pkg::NetworkPackage::from_json(&text).unwrap();
+        let powerio_pkg::ModelPayload::Balanced { balanced_network } = &pkg.model else {
+            panic!("balanced payload expected");
+        };
+        assert!(balanced_network.branches[0].angmin.is_nan());
+        assert_eq!(balanced_network.branches[0].angmax, f64::INFINITY);
 
         let _ = std::fs::remove_file(input);
         let _ = std::fs::remove_file(output);

--- a/powerio-diag/src/lib.rs
+++ b/powerio-diag/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod category;
 pub mod code;
 pub mod collect;
+pub mod nonfinite;
 pub mod record;
 pub mod registry;
 pub mod render;

--- a/powerio-diag/src/nonfinite.rs
+++ b/powerio-diag/src/nonfinite.rs
@@ -1,0 +1,765 @@
+//! JSON spellings for nonfinite floats, one convention for every document
+//! powerio authors.
+//!
+//! JSON has no `Inf`/`NaN` literal. A nonfinite `f64` is written as one of
+//! three strings — `"Infinity"`, `"-Infinity"`, `"NaN"` — and a float
+//! position reads back either a number or one of those spellings, so every
+//! value the library holds round trips through model JSON and the
+//! `.pio.json` document. Readers legitimately produce nonfinite values (an
+//! absent reactive limit is `Inf` in MATPOWER, PowerModels, pandapower, and
+//! PyPSA), so the transport must carry them or refuse real cases. The
+//! multiconductor bound fields additionally accept the `null` a pre-0.9
+//! writer emitted, restored by field role (see `powerio-dist`'s `nonfinite`
+//! module); that leniency is read side only — writes spell strings
+//! everywhere.
+//!
+//! The mechanism is a pair of forwarding wrappers threaded through serde:
+//! [`NonFiniteSer`] intercepts `serialize_f64`/`serialize_f32`, and
+//! [`NonFiniteDe`] intercepts `deserialize_f64`/`deserialize_f32`, each
+//! forwarding everything else — including `extras` maps, whose string values
+//! pass through untouched because interception is keyed on the *type* being
+//! an `f64`, never on a string's content. `BalancedNetwork`'s `Serialize`
+//! and `Deserialize` impls route through the wrappers, so the spelling holds
+//! on every serialization route (model JSON, the `.pio.json` payload, the C
+//! ABI), including serde's internal buffering for tagged enums. Interception
+//! applies only to human readable formats: a binary serializer receives the
+//! plain `f64`.
+
+use core::fmt;
+
+use serde::de::{self, DeserializeSeed, EnumAccess, MapAccess, SeqAccess, VariantAccess, Visitor};
+use serde::ser::{
+    SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+    SerializeTupleStruct, SerializeTupleVariant,
+};
+use serde::{Deserializer, Serialize, Serializer};
+
+/// The spelling of `f64::INFINITY` in model JSON.
+pub const INFINITY: &str = "Infinity";
+/// The spelling of `f64::NEG_INFINITY` in model JSON.
+pub const NEG_INFINITY: &str = "-Infinity";
+/// The spelling of `f64::NAN` in model JSON.
+pub const NAN: &str = "NaN";
+
+fn spell(v: f64) -> &'static str {
+    if v.is_nan() {
+        NAN
+    } else if v > 0.0 {
+        INFINITY
+    } else {
+        NEG_INFINITY
+    }
+}
+
+fn unspell(s: &str) -> Option<f64> {
+    match s {
+        INFINITY => Some(f64::INFINITY),
+        NEG_INFINITY => Some(f64::NEG_INFINITY),
+        NAN => Some(f64::NAN),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Serialization: forward everything, spell a nonfinite float as a string.
+// ---------------------------------------------------------------------------
+
+/// Wraps any [`Serializer`], writing nonfinite floats as their string
+/// spellings on human readable formats and forwarding everything else.
+pub struct NonFiniteSer<S>(pub S);
+
+/// Re-enters the wrapper for a nested value, so the interception threads
+/// through sequences, maps, and struct fields.
+struct Adapt<'a, T: ?Sized>(&'a T);
+
+impl<T: Serialize + ?Sized> Serialize for Adapt<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(NonFiniteSer(serializer))
+    }
+}
+
+impl<S: Serializer> Serializer for NonFiniteSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    type SerializeSeq = SeqSer<S::SerializeSeq>;
+    type SerializeTuple = TupleSer<S::SerializeTuple>;
+    type SerializeTupleStruct = TupleStructSer<S::SerializeTupleStruct>;
+    type SerializeTupleVariant = TupleVariantSer<S::SerializeTupleVariant>;
+    type SerializeMap = MapSer<S::SerializeMap>;
+    type SerializeStruct = StructSer<S::SerializeStruct>;
+    type SerializeStructVariant = StructVariantSer<S::SerializeStructVariant>;
+
+    fn serialize_f32(self, v: f32) -> Result<S::Ok, S::Error> {
+        if v.is_finite() || !self.0.is_human_readable() {
+            self.0.serialize_f32(v)
+        } else {
+            self.0.serialize_str(spell(f64::from(v)))
+        }
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<S::Ok, S::Error> {
+        if v.is_finite() || !self.0.is_human_readable() {
+            self.0.serialize_f64(v)
+        } else {
+            self.0.serialize_str(spell(v))
+        }
+    }
+
+    fn serialize_bool(self, v: bool) -> Result<S::Ok, S::Error> {
+        self.0.serialize_bool(v)
+    }
+    fn serialize_i8(self, v: i8) -> Result<S::Ok, S::Error> {
+        self.0.serialize_i8(v)
+    }
+    fn serialize_i16(self, v: i16) -> Result<S::Ok, S::Error> {
+        self.0.serialize_i16(v)
+    }
+    fn serialize_i32(self, v: i32) -> Result<S::Ok, S::Error> {
+        self.0.serialize_i32(v)
+    }
+    fn serialize_i64(self, v: i64) -> Result<S::Ok, S::Error> {
+        self.0.serialize_i64(v)
+    }
+    fn serialize_i128(self, v: i128) -> Result<S::Ok, S::Error> {
+        self.0.serialize_i128(v)
+    }
+    fn serialize_u8(self, v: u8) -> Result<S::Ok, S::Error> {
+        self.0.serialize_u8(v)
+    }
+    fn serialize_u16(self, v: u16) -> Result<S::Ok, S::Error> {
+        self.0.serialize_u16(v)
+    }
+    fn serialize_u32(self, v: u32) -> Result<S::Ok, S::Error> {
+        self.0.serialize_u32(v)
+    }
+    fn serialize_u64(self, v: u64) -> Result<S::Ok, S::Error> {
+        self.0.serialize_u64(v)
+    }
+    fn serialize_u128(self, v: u128) -> Result<S::Ok, S::Error> {
+        self.0.serialize_u128(v)
+    }
+    fn serialize_char(self, v: char) -> Result<S::Ok, S::Error> {
+        self.0.serialize_char(v)
+    }
+    fn serialize_str(self, v: &str) -> Result<S::Ok, S::Error> {
+        self.0.serialize_str(v)
+    }
+    fn serialize_bytes(self, v: &[u8]) -> Result<S::Ok, S::Error> {
+        self.0.serialize_bytes(v)
+    }
+    fn serialize_none(self) -> Result<S::Ok, S::Error> {
+        self.0.serialize_none()
+    }
+    fn serialize_some<T: Serialize + ?Sized>(self, value: &T) -> Result<S::Ok, S::Error> {
+        self.0.serialize_some(&Adapt(value))
+    }
+    fn serialize_unit(self) -> Result<S::Ok, S::Error> {
+        self.0.serialize_unit()
+    }
+    fn serialize_unit_struct(self, name: &'static str) -> Result<S::Ok, S::Error> {
+        self.0.serialize_unit_struct(name)
+    }
+    fn serialize_unit_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+    ) -> Result<S::Ok, S::Error> {
+        self.0.serialize_unit_variant(name, variant_index, variant)
+    }
+    fn serialize_newtype_struct<T: Serialize + ?Sized>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<S::Ok, S::Error> {
+        self.0.serialize_newtype_struct(name, &Adapt(value))
+    }
+    fn serialize_newtype_variant<T: Serialize + ?Sized>(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<S::Ok, S::Error> {
+        self.0
+            .serialize_newtype_variant(name, variant_index, variant, &Adapt(value))
+    }
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, S::Error> {
+        self.0.serialize_seq(len).map(SeqSer)
+    }
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, S::Error> {
+        self.0.serialize_tuple(len).map(TupleSer)
+    }
+    fn serialize_tuple_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, S::Error> {
+        self.0.serialize_tuple_struct(name, len).map(TupleStructSer)
+    }
+    fn serialize_tuple_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, S::Error> {
+        self.0
+            .serialize_tuple_variant(name, variant_index, variant, len)
+            .map(TupleVariantSer)
+    }
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, S::Error> {
+        self.0.serialize_map(len).map(MapSer)
+    }
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, S::Error> {
+        self.0.serialize_struct(name, len).map(StructSer)
+    }
+    fn serialize_struct_variant(
+        self,
+        name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStructVariant, S::Error> {
+        self.0
+            .serialize_struct_variant(name, variant_index, variant, len)
+            .map(StructVariantSer)
+    }
+    fn collect_str<T: fmt::Display + ?Sized>(self, value: &T) -> Result<S::Ok, S::Error> {
+        self.0.collect_str(value)
+    }
+    fn is_human_readable(&self) -> bool {
+        self.0.is_human_readable()
+    }
+}
+
+#[doc(hidden)]
+pub struct SeqSer<S>(S);
+impl<S: SerializeSeq> SerializeSeq for SeqSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_element(&Adapt(value))
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct TupleSer<S>(S);
+impl<S: SerializeTuple> SerializeTuple for TupleSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_element<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_element(&Adapt(value))
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct TupleStructSer<S>(S);
+impl<S: SerializeTupleStruct> SerializeTupleStruct for TupleStructSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_field(&Adapt(value))
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct TupleVariantSer<S>(S);
+impl<S: SerializeTupleVariant> SerializeTupleVariant for TupleVariantSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_field<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_field(&Adapt(value))
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct MapSer<S>(S);
+impl<S: SerializeMap> SerializeMap for MapSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    // Keys forward unwrapped: a nonfinite float key stays the error it is
+    // today rather than silently becoming a string key.
+    fn serialize_key<T: Serialize + ?Sized>(&mut self, key: &T) -> Result<(), S::Error> {
+        self.0.serialize_key(key)
+    }
+    fn serialize_value<T: Serialize + ?Sized>(&mut self, value: &T) -> Result<(), S::Error> {
+        self.0.serialize_value(&Adapt(value))
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct StructSer<S>(S);
+impl<S: SerializeStruct> SerializeStruct for StructSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), S::Error> {
+        self.0.serialize_field(key, &Adapt(value))
+    }
+    fn skip_field(&mut self, key: &'static str) -> Result<(), S::Error> {
+        self.0.skip_field(key)
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+#[doc(hidden)]
+pub struct StructVariantSer<S>(S);
+impl<S: SerializeStructVariant> SerializeStructVariant for StructVariantSer<S> {
+    type Ok = S::Ok;
+    type Error = S::Error;
+    fn serialize_field<T: Serialize + ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), S::Error> {
+        self.0.serialize_field(key, &Adapt(value))
+    }
+    fn skip_field(&mut self, key: &'static str) -> Result<(), S::Error> {
+        self.0.skip_field(key)
+    }
+    fn end(self) -> Result<S::Ok, S::Error> {
+        self.0.end()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deserialization: forward everything, read the string spellings back at
+// float positions.
+// ---------------------------------------------------------------------------
+
+/// Wraps any [`Deserializer`], accepting the string spellings wherever an
+/// `f64`/`f32` is expected on human readable formats and forwarding
+/// everything else.
+pub struct NonFiniteDe<D>(pub D);
+
+macro_rules! forward_deserialize {
+    ($($method:ident)*) => {
+        $(
+            fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, D::Error> {
+                self.0.$method(Wrap(visitor))
+            }
+        )*
+    };
+}
+
+impl<'de, D: Deserializer<'de>> Deserializer<'de> for NonFiniteDe<D> {
+    type Error = D::Error;
+
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, D::Error> {
+        if self.0.is_human_readable() {
+            self.0.deserialize_any(NumOrSpelling(visitor))
+        } else {
+            self.0.deserialize_f32(visitor)
+        }
+    }
+
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, D::Error> {
+        if self.0.is_human_readable() {
+            self.0.deserialize_any(NumOrSpelling(visitor))
+        } else {
+            self.0.deserialize_f64(visitor)
+        }
+    }
+
+    forward_deserialize! {
+        deserialize_any deserialize_bool
+        deserialize_i8 deserialize_i16 deserialize_i32 deserialize_i64 deserialize_i128
+        deserialize_u8 deserialize_u16 deserialize_u32 deserialize_u64 deserialize_u128
+        deserialize_char deserialize_str deserialize_string
+        deserialize_bytes deserialize_byte_buf
+        deserialize_option deserialize_unit
+        deserialize_seq deserialize_map deserialize_identifier deserialize_ignored_any
+    }
+
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_unit_struct(name, Wrap(visitor))
+    }
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_newtype_struct(name, Wrap(visitor))
+    }
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_tuple(len, Wrap(visitor))
+    }
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_tuple_struct(name, len, Wrap(visitor))
+    }
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_struct(name, fields, Wrap(visitor))
+    }
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, D::Error> {
+        self.0.deserialize_enum(name, variants, Wrap(visitor))
+    }
+    fn is_human_readable(&self) -> bool {
+        self.0.is_human_readable()
+    }
+}
+
+/// At a float position: numbers forward, the three spellings convert, and
+/// `null` gets the message that names the pre-0.9 spelling.
+struct NumOrSpelling<V>(V);
+
+impl<'de, V: Visitor<'de>> Visitor<'de> for NumOrSpelling<V> {
+    type Value = V::Value;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a number or one of \"Infinity\", \"-Infinity\", \"NaN\"")
+    }
+
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<V::Value, E> {
+        self.0.visit_i64(v)
+    }
+    fn visit_i128<E: de::Error>(self, v: i128) -> Result<V::Value, E> {
+        self.0.visit_i128(v)
+    }
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<V::Value, E> {
+        self.0.visit_u64(v)
+    }
+    fn visit_u128<E: de::Error>(self, v: u128) -> Result<V::Value, E> {
+        self.0.visit_u128(v)
+    }
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<V::Value, E> {
+        self.0.visit_f64(v)
+    }
+
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<V::Value, E> {
+        match unspell(s) {
+            Some(v) => self.0.visit_f64(v),
+            None => Err(de::Error::invalid_value(de::Unexpected::Str(s), &self)),
+        }
+    }
+
+    fn visit_unit<E: de::Error>(self) -> Result<V::Value, E> {
+        Err(de::Error::custom(
+            "a number is null; powerio 0.9.0 spells a nonfinite value \"Infinity\", \
+             \"-Infinity\", or \"NaN\", and a document written before 0.9.0 spelled it null \
+             — regenerate the document",
+        ))
+    }
+
+    fn visit_bool<E: de::Error>(self, v: bool) -> Result<V::Value, E> {
+        self.0.visit_bool(v)
+    }
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<V::Value, A::Error> {
+        self.0.visit_map(map)
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<V::Value, A::Error> {
+        self.0.visit_seq(seq)
+    }
+}
+
+/// Generic forwarding visitor: threads the wrapper into nested access types
+/// so a float anywhere in the tree is intercepted, and forwards every scalar
+/// verbatim — a string only converts at a float position, never here.
+struct Wrap<V>(V);
+
+impl<'de, V: Visitor<'de>> Visitor<'de> for Wrap<V> {
+    type Value = V::Value;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.expecting(f)
+    }
+
+    fn visit_bool<E: de::Error>(self, v: bool) -> Result<V::Value, E> {
+        self.0.visit_bool(v)
+    }
+    fn visit_i8<E: de::Error>(self, v: i8) -> Result<V::Value, E> {
+        self.0.visit_i8(v)
+    }
+    fn visit_i16<E: de::Error>(self, v: i16) -> Result<V::Value, E> {
+        self.0.visit_i16(v)
+    }
+    fn visit_i32<E: de::Error>(self, v: i32) -> Result<V::Value, E> {
+        self.0.visit_i32(v)
+    }
+    fn visit_i64<E: de::Error>(self, v: i64) -> Result<V::Value, E> {
+        self.0.visit_i64(v)
+    }
+    fn visit_i128<E: de::Error>(self, v: i128) -> Result<V::Value, E> {
+        self.0.visit_i128(v)
+    }
+    fn visit_u8<E: de::Error>(self, v: u8) -> Result<V::Value, E> {
+        self.0.visit_u8(v)
+    }
+    fn visit_u16<E: de::Error>(self, v: u16) -> Result<V::Value, E> {
+        self.0.visit_u16(v)
+    }
+    fn visit_u32<E: de::Error>(self, v: u32) -> Result<V::Value, E> {
+        self.0.visit_u32(v)
+    }
+    fn visit_u64<E: de::Error>(self, v: u64) -> Result<V::Value, E> {
+        self.0.visit_u64(v)
+    }
+    fn visit_u128<E: de::Error>(self, v: u128) -> Result<V::Value, E> {
+        self.0.visit_u128(v)
+    }
+    fn visit_f32<E: de::Error>(self, v: f32) -> Result<V::Value, E> {
+        self.0.visit_f32(v)
+    }
+    fn visit_f64<E: de::Error>(self, v: f64) -> Result<V::Value, E> {
+        self.0.visit_f64(v)
+    }
+    fn visit_char<E: de::Error>(self, v: char) -> Result<V::Value, E> {
+        self.0.visit_char(v)
+    }
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<V::Value, E> {
+        self.0.visit_str(v)
+    }
+    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<V::Value, E> {
+        self.0.visit_borrowed_str(v)
+    }
+    fn visit_string<E: de::Error>(self, v: String) -> Result<V::Value, E> {
+        self.0.visit_string(v)
+    }
+    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<V::Value, E> {
+        self.0.visit_bytes(v)
+    }
+    fn visit_borrowed_bytes<E: de::Error>(self, v: &'de [u8]) -> Result<V::Value, E> {
+        self.0.visit_borrowed_bytes(v)
+    }
+    fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<V::Value, E> {
+        self.0.visit_byte_buf(v)
+    }
+    fn visit_none<E: de::Error>(self) -> Result<V::Value, E> {
+        self.0.visit_none()
+    }
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<V::Value, D::Error> {
+        self.0.visit_some(NonFiniteDe(deserializer))
+    }
+    fn visit_unit<E: de::Error>(self) -> Result<V::Value, E> {
+        self.0.visit_unit()
+    }
+    fn visit_newtype_struct<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<V::Value, D::Error> {
+        self.0.visit_newtype_struct(NonFiniteDe(deserializer))
+    }
+    fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<V::Value, A::Error> {
+        self.0.visit_seq(SeqDe(seq))
+    }
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<V::Value, A::Error> {
+        self.0.visit_map(MapDe(map))
+    }
+    fn visit_enum<A: EnumAccess<'de>>(self, data: A) -> Result<V::Value, A::Error> {
+        self.0.visit_enum(EnumDe(data))
+    }
+}
+
+struct SeqDe<A>(A);
+impl<'de, A: SeqAccess<'de>> SeqAccess<'de> for SeqDe<A> {
+    type Error = A::Error;
+    fn next_element_seed<T: DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>, A::Error> {
+        self.0.next_element_seed(SeedDe(seed))
+    }
+    fn size_hint(&self) -> Option<usize> {
+        self.0.size_hint()
+    }
+}
+
+struct MapDe<A>(A);
+impl<'de, A: MapAccess<'de>> MapAccess<'de> for MapDe<A> {
+    type Error = A::Error;
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, A::Error> {
+        self.0.next_key_seed(SeedDe(seed))
+    }
+    fn next_value_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<T::Value, A::Error> {
+        self.0.next_value_seed(SeedDe(seed))
+    }
+    fn size_hint(&self) -> Option<usize> {
+        self.0.size_hint()
+    }
+}
+
+struct EnumDe<A>(A);
+impl<'de, A: EnumAccess<'de>> EnumAccess<'de> for EnumDe<A> {
+    type Error = A::Error;
+    type Variant = VariantDe<A::Variant>;
+    fn variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        seed: T,
+    ) -> Result<(T::Value, Self::Variant), A::Error> {
+        self.0
+            .variant_seed(SeedDe(seed))
+            .map(|(value, variant)| (value, VariantDe(variant)))
+    }
+}
+
+struct VariantDe<A>(A);
+impl<'de, A: VariantAccess<'de>> VariantAccess<'de> for VariantDe<A> {
+    type Error = A::Error;
+    fn unit_variant(self) -> Result<(), A::Error> {
+        self.0.unit_variant()
+    }
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, seed: T) -> Result<T::Value, A::Error> {
+        self.0.newtype_variant_seed(SeedDe(seed))
+    }
+    fn tuple_variant<V: Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value, A::Error> {
+        self.0.tuple_variant(len, Wrap(visitor))
+    }
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, A::Error> {
+        self.0.struct_variant(fields, Wrap(visitor))
+    }
+}
+
+struct SeedDe<S>(S);
+impl<'de, S: DeserializeSeed<'de>> DeserializeSeed<'de> for SeedDe<S> {
+    type Value = S::Value;
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<S::Value, D::Error> {
+        self.0.deserialize(NonFiniteDe(deserializer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    struct Probe {
+        qmax: f64,
+        qmin: f64,
+        opt: Option<f64>,
+        list: Vec<f64>,
+        name: String,
+        extras: serde_json::Value,
+    }
+
+    fn to_json(p: &Probe) -> String {
+        let mut out = Vec::new();
+        let mut ser = serde_json::Serializer::new(&mut out);
+        Serialize::serialize(p, super::NonFiniteSer(&mut ser)).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    fn from_json(text: &str) -> Result<Probe, serde_json::Error> {
+        let mut de = serde_json::Deserializer::from_str(text);
+        Deserialize::deserialize(super::NonFiniteDe(&mut de))
+    }
+
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn nonfinite_floats_spell_as_strings_and_read_back() {
+        let p = Probe {
+            qmax: f64::INFINITY,
+            qmin: f64::NEG_INFINITY,
+            opt: Some(f64::NAN),
+            list: vec![1.5, f64::INFINITY],
+            name: "g1".into(),
+            extras: serde_json::json!({"note": "Infinity"}),
+        };
+        let text = to_json(&p);
+        assert!(text.contains("\"qmax\":\"Infinity\""), "{text}");
+        assert!(text.contains("\"qmin\":\"-Infinity\""), "{text}");
+        assert!(text.contains("\"opt\":\"NaN\""), "{text}");
+        assert!(text.contains("[1.5,\"Infinity\"]"), "{text}");
+        // The extras string is untouched: interception is by type, never by
+        // a string's content.
+        assert!(text.contains("\"note\":\"Infinity\""), "{text}");
+
+        let back = from_json(&text).unwrap();
+        assert_eq!(back.qmax, f64::INFINITY);
+        assert_eq!(back.qmin, f64::NEG_INFINITY);
+        assert!(back.opt.unwrap().is_nan());
+        assert_eq!(back.list[1], f64::INFINITY);
+        assert_eq!(back.extras["note"], "Infinity");
+
+        // Second write is byte stable.
+        assert_eq!(to_json(&back), text);
+    }
+
+    #[test]
+    fn finite_values_serialize_as_numbers() {
+        let p = Probe {
+            qmax: 9900.0,
+            qmin: -9900.0,
+            opt: None,
+            list: vec![],
+            name: String::new(),
+            extras: serde_json::Value::Null,
+        };
+        let text = to_json(&p);
+        assert!(text.contains("\"qmax\":9900.0"), "{text}");
+        assert!(!text.contains("Infinity"), "{text}");
+    }
+
+    #[test]
+    fn an_unknown_string_at_a_float_position_is_refused() {
+        let err = from_json(
+            r#"{"qmax":"unbounded","qmin":0.0,"opt":null,"list":[],"name":"","extras":null}"#,
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Infinity"), "{msg}");
+        assert!(msg.contains("unbounded"), "{msg}");
+    }
+
+    #[test]
+    fn a_null_at_a_float_position_names_the_old_spelling() {
+        let err =
+            from_json(r#"{"qmax":null,"qmin":0.0,"opt":null,"list":[],"name":"","extras":null}"#)
+                .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("before 0.9.0"), "{msg}");
+    }
+}

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -896,6 +896,7 @@ impl UntypedObject {
 /// reader materialized from format defaults rather than the source text.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct MulticonductorNetwork {
     pub name: Option<String>,
@@ -950,6 +951,23 @@ pub struct MulticonductorNetwork {
     pub source: Option<Arc<String>>,
     pub source_format: Option<DistSourceFormat>,
     pub extras: Extras,
+}
+
+// `remote = "Self"` turns the derived serde impls into inherent functions;
+// routing them through `powerio_diag::nonfinite` spells a nonfinite float as
+// `"Infinity"`/`"-Infinity"`/`"NaN"` on every JSON route, the same convention
+// as the balanced model. The bound fields' `with` modules keep accepting the
+// `null` a pre-0.9 writer emitted (read side only).
+impl serde::Serialize for MulticonductorNetwork {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        MulticonductorNetwork::serialize(self, powerio_diag::nonfinite::NonFiniteSer(serializer))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for MulticonductorNetwork {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        MulticonductorNetwork::deserialize(powerio_diag::nonfinite::NonFiniteDe(deserializer))
+    }
 }
 
 impl MulticonductorNetwork {

--- a/powerio-dist/src/nonfinite.rs
+++ b/powerio-dist/src/nonfinite.rs
@@ -1,16 +1,19 @@
-//! Payload spellings for nonfinite floats.
+//! Read side leniency for `null` at the bound fields.
 //!
-//! serde_json writes a nonfinite `f64` as JSON `null`. These modules read
-//! that `null` back, so a payload the library wrote always reads back
-//! (#268). A `null` element in an upper bound means unbounded above
-//! (+Inf); in a lower bound, unbounded below (-Inf); in a length, not
-//! known (NaN). This is the PMD convention.
+//! The multiconductor model writes a nonfinite `f64` as `"Infinity"`,
+//! `"-Infinity"`, or `"NaN"` like every powerio document
+//! (`powerio_diag::nonfinite`, threaded through the model's serde impls).
+//! Before 0.9.0 serde_json wrote it as JSON `null`, and these modules keep
+//! reading that `null` back by field role, so a payload an earlier writer
+//! emitted still reads (#268): a `null` element in an upper bound means
+//! unbounded above (+Inf); in a lower bound, unbounded below (-Inf); in a
+//! length, not known (NaN). The role defaults are the PMD convention.
 //!
 //! serde `with` modules receive `&T`, so the serialize signatures take
 //! references the lints would otherwise refuse.
 //!
-//! An `Option<f64>` field needs no module: a nonfinite writes as `null` and
-//! reads back as `None`, which is the same statement the bound made.
+//! An `Option<f64>` field needs no module: a nonfinite value spells itself
+//! as a string and round trips, and a pre-0.9 `null` reads back as `None`.
 #![allow(
     clippy::ref_option,
     clippy::trivially_copy_pass_by_ref,
@@ -160,6 +163,33 @@ mod tests {
         v.as_object_mut().unwrap().remove("i_max");
         let back: DistSwitch = serde_json::from_value(v).expect("omitted bound must parse");
         assert!(back.i_max.is_none());
+    }
+
+    /// The network type spells a nonfinite value as a string on every JSON
+    /// route (the unified powerio convention), and the bound modules keep
+    /// reading a pre-0.9 `null` element by field role.
+    #[test]
+    #[allow(clippy::float_cmp)]
+    fn network_spells_nonfinite_as_strings_and_reads_legacy_null() {
+        use crate::model::{DistLineCode, MulticonductorNetwork};
+
+        let mut net = MulticonductorNetwork::named("nf");
+        let mut code = DistLineCode::new("lc", vec![vec![0.1]], vec![vec![0.2]]);
+        code.i_max = Some(vec![f64::INFINITY, 400.0]);
+        net.linecodes.push(code);
+
+        let text = serde_json::to_string(&net).unwrap();
+        assert!(text.contains(r#""i_max":["Infinity",400.0]"#), "{text}");
+
+        let back: MulticonductorNetwork = serde_json::from_str(&text).unwrap();
+        assert_eq!(back.linecodes[0].i_max, Some(vec![f64::INFINITY, 400.0]));
+        assert_eq!(serde_json::to_string(&back).unwrap(), text);
+
+        // A pre-0.9 writer spelled the element `null`; the role default
+        // (+Inf for an ampacity) still applies on read.
+        let legacy = text.replace(r#""i_max":["Infinity",400.0]"#, r#""i_max":[null,400.0]"#);
+        let back: MulticonductorNetwork = serde_json::from_str(&legacy).unwrap();
+        assert_eq!(back.linecodes[0].i_max, Some(vec![f64::INFINITY, 400.0]));
     }
 
     /// A required field spelled `null` for a nonfinite value is still required:

--- a/powerio-pkg/examples/generate_schemas.rs
+++ b/powerio-pkg/examples/generate_schemas.rs
@@ -52,6 +52,7 @@ mod generate {
         also_required: &[&str],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut schema = serde_json::to_value(schema_for!(T))?;
+        spell_nonfinite_floats(&mut schema)?;
         let root = schema
             .as_object_mut()
             .ok_or("schemars returned a non-object schema root")?;
@@ -85,6 +86,59 @@ mod generate {
         let mut text = serde_json::to_string_pretty(&schema)?;
         text.push('\n');
         fs::write(path, text)?;
+        Ok(())
+    }
+
+    /// Every document powerio authors spells a nonfinite float as
+    /// `"Infinity"`, `"-Infinity"`, or `"NaN"` (`powerio_diag::nonfinite`),
+    /// so every float position in the schema accepts a string spelling
+    /// beside the number. Fields whose number arm already admits `null`
+    /// (the multiconductor bounds) keep it: that is the read side leniency
+    /// for documents a pre-0.9 writer emitted.
+    fn spell_nonfinite_floats(
+        schema: &mut serde_json::Value,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use serde_json::Value;
+
+        fn spell(node: &mut Value) {
+            match node {
+                Value::Object(map) => {
+                    let is_double = map.get("format") == Some(&Value::String("double".into()));
+                    let takes_number = match map.get("type") {
+                        Some(Value::String(t)) => t == "number",
+                        Some(Value::Array(ts)) => ts.iter().any(|t| t == "number"),
+                        _ => false,
+                    };
+                    if is_double && takes_number {
+                        let mut number_arm = serde_json::Map::new();
+                        number_arm.insert("type".into(), map.remove("type").unwrap());
+                        number_arm.insert("format".into(), map.remove("format").unwrap());
+                        map.insert(
+                            "anyOf".into(),
+                            serde_json::json!([
+                                number_arm,
+                                { "type": "string", "enum": ["Infinity", "-Infinity", "NaN"] }
+                            ]),
+                        );
+                    } else {
+                        for v in map.values_mut() {
+                            spell(v);
+                        }
+                    }
+                }
+                Value::Array(items) => {
+                    for v in items {
+                        spell(v);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if schema.get("$defs").is_none() {
+            return Err("schema has no $defs".into());
+        }
+        spell(schema);
         Ok(())
     }
 }

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -146,6 +146,7 @@ impl From<&NormalizedSolverTables> for NormalizedSolverTableMetadata {
 /// newer producer.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct NetworkPackage {
     /// The powerio version that wrote this document; see
@@ -194,6 +195,21 @@ pub struct NetworkPackage {
     pub lowering_history: Vec<LoweringRecord>,
     #[serde(default, skip_serializing_if = "DerivedMetadata::is_empty")]
     pub derived: DerivedMetadata,
+}
+
+// Same mechanism as the two network models: the whole document — envelope
+// fields, operating point series, both payload kinds — spells a nonfinite
+// float as a string, so no `.pio.json` powerio writes refuses to read back.
+impl serde::Serialize for NetworkPackage {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        NetworkPackage::serialize(self, powerio_diag::nonfinite::NonFiniteSer(serializer))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for NetworkPackage {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        NetworkPackage::deserialize(powerio_diag::nonfinite::NonFiniteDe(deserializer))
+    }
 }
 
 impl NetworkPackage {

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -85,6 +85,7 @@ pub use normalize::{
     NormalizeOptions, NormalizeSourceRows, NormalizedNetwork, POWER_MODELS_ANGLE_BOUND_PAD,
 };
 pub use operations::Selector;
+pub use powerio_diag::nonfinite;
 pub use solver_tables::{
     NORMALIZED_SOLVER_TABLES_PASS, NormalizedSolverTables, SolverArcRow, SolverArcTerminal,
     SolverBranchRow, SolverBusRow, SolverCostRow, SolverGeneratorRow, SolverHvdcRow, SolverLoadRow,

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -309,8 +309,13 @@ impl SourceFormat {
 }
 
 /// A balanced network with stable source bus IDs and separate element tables.
+///
+/// `remote = "Self"` turns the derived serde impls into inherent functions;
+/// the trait impls beneath the struct route them through [`crate::nonfinite`],
+/// so a nonfinite float spells as a string on every JSON route.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(remote = "Self")]
 #[non_exhaustive]
 pub struct BalancedNetwork {
     pub name: String,
@@ -367,6 +372,23 @@ pub struct BalancedNetwork {
     /// `from_json` round-trip returns this as `None`.
     #[serde(skip)]
     pub source: Option<Arc<String>>,
+}
+
+impl Serialize for BalancedNetwork {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        BalancedNetwork::serialize(self, crate::nonfinite::NonFiniteSer(serializer))
+    }
+}
+
+impl<'de> Deserialize<'de> for BalancedNetwork {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        BalancedNetwork::deserialize(crate::nonfinite::NonFiniteDe(deserializer))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1722,13 +1744,13 @@ impl BalancedNetwork {
     /// stays on the same-format write path; a [`from_json`](BalancedNetwork::from_json)
     /// round-trip reproduces every field except `source`, which returns `None`.
     ///
-    /// JSON has no `Inf`/`NaN`: `serde_json` writes a non-finite field as
-    /// `null`, which [`from_json`](BalancedNetwork::from_json) rejects on the way back
-    /// (`null` is not an `f64`). The write stays total, the bindings
-    /// materialize every parsed network through this transport, and readers
-    /// legitimately produce `Inf` limits, but such a document does not round
-    /// trip; [`to_json_with_diagnostics`](BalancedNetwork::to_json_with_diagnostics)
-    /// reports the degradation as a fidelity record naming the field.
+    /// JSON has no `Inf`/`NaN` literal: a nonfinite field is written as
+    /// `"Infinity"`, `"-Infinity"`, or `"NaN"` (see [`crate::nonfinite`]) and
+    /// [`from_json`](BalancedNetwork::from_json) reads either a number or one
+    /// of those spellings back, so every network round trips — readers
+    /// legitimately produce `Inf` limits, and a document written before
+    /// 0.9.0 spelled them `null`, which still refuses with a message naming
+    /// the change.
     ///
     /// # Errors
     /// A `serde_json` serialization failure (none arise from this model today).
@@ -1739,336 +1761,17 @@ impl BalancedNetwork {
         })
     }
 
-    /// [`to_json`](BalancedNetwork::to_json) plus the records the write
-    /// produced: one per non-finite field, since serde writes each as a `null`
-    /// that [`from_json`](BalancedNetwork::from_json) then refuses. A caller
-    /// that needs to know whether the document reads back takes this form; a
-    /// caller that only needs the text takes `to_json`.
+    /// [`to_json`](BalancedNetwork::to_json) plus the fidelity records the
+    /// write produced. The write is faithful today — a nonfinite value spells
+    /// itself as a string and reads back — so the record list is empty; the
+    /// channel stays because it is the shape a write-side finding arrives
+    /// through, and a caller wired to it needs no change when one appears.
     ///
     /// # Errors
     /// A `serde_json` serialization failure (none arise from this model today).
     pub fn to_json_with_diagnostics(&self) -> crate::Result<(String, Diagnostics)> {
         let text = self.to_json()?;
-        let mut diagnostics = Diagnostics::new();
-        for path in self.non_finite_fields() {
-            diagnostics.push(
-                &crate::diagnostics::codes::EMIT_PIO_JSON.not_a_number,
-                format!(
-                    "{path} is not finite; JSON has no Inf/NaN, so it is written as null \
-                     and this document will not read back through from_json"
-                ),
-            );
-        }
-        Ok((text, diagnostics))
-    }
-
-    /// The paths of every non-finite numeric field, empty when all values are
-    /// finite. Drives the snapshot writer's degradation warning (see
-    /// [`to_json`](BalancedNetwork::to_json)): serde writes EVERY non-finite `f64` as
-    /// `null`, so the warning must name them all, not just the first, or the
-    /// caller fixes one field and the snapshot still fails to read back.
-    /// `extras` maps hold `serde_json::Value`, which cannot carry a non-finite
-    /// number, so only the typed `f64` fields need scanning. Every struct is
-    /// destructured exhaustively: adding an `f64` field without classifying it
-    /// here is a compile error, not a silently unguarded value.
-    // The length IS the exhaustive field walk; splitting it would only scatter
-    // the per-struct lists the compile-time check exists to keep in one place.
-    #[allow(clippy::too_many_lines)]
-    pub(crate) fn non_finite_fields(&self) -> Vec<String> {
-        fn bad<'a>(
-            fields: impl IntoIterator<Item = (&'a str, f64)>,
-        ) -> impl Iterator<Item = &'a str> {
-            fields
-                .into_iter()
-                .filter_map(|(name, v)| (!v.is_finite()).then_some(name))
-        }
-        let mut out = Vec::new();
-        if !self.base_mva.is_finite() {
-            out.push("base_mva".into());
-        }
-        if !self.base_frequency.is_finite() {
-            out.push("base_frequency".into());
-        }
-        for (i, b) in self.buses.iter().enumerate() {
-            #[rustfmt::skip]
-            let Bus { id: _, kind: _, vm, va, base_kv, vmax, vmin, evhi: _, evlo: _, area: _, zone: _, name: _, uid: _, location, extras: _ } = b;
-            let fields = [
-                ("vm", *vm),
-                ("va", *va),
-                ("base_kv", *base_kv),
-                ("vmax", *vmax),
-                ("vmin", *vmin),
-            ];
-            out.extend(bad(fields).map(|f| format!("buses[{i}].{f}")));
-            if let Some(location) = location {
-                let fields = [("location.x", location.x), ("location.y", location.y)];
-                out.extend(bad(fields).map(|f| format!("buses[{i}].{f}")));
-            }
-        }
-        for (i, l) in self.loads.iter().enumerate() {
-            let Load {
-                bus: _,
-                p,
-                q,
-                voltage_model,
-                in_service: _,
-                uid: _,
-                extras: _,
-            } = l;
-            out.extend(bad([("p", *p), ("q", *q)]).map(|f| format!("loads[{i}].{f}")));
-            if let Some(model) = voltage_model {
-                match model {
-                    LoadVoltageModel::ConstantPower => {}
-                    LoadVoltageModel::Zip {
-                        p_constant_power,
-                        q_constant_power,
-                        p_constant_current,
-                        q_constant_current,
-                        p_constant_impedance,
-                        q_constant_impedance,
-                        v_nom,
-                        load_type: _,
-                        scaling,
-                    } => {
-                        let fields = [
-                            ("p_constant_power", *p_constant_power),
-                            ("q_constant_power", *q_constant_power),
-                            ("p_constant_current", *p_constant_current),
-                            ("q_constant_current", *q_constant_current),
-                            ("p_constant_impedance", *p_constant_impedance),
-                            ("q_constant_impedance", *q_constant_impedance),
-                        ];
-                        out.extend(bad(fields).map(|f| format!("loads[{i}].voltage_model.{f}")));
-                        if matches!(v_nom, Some(v) if !v.is_finite()) {
-                            out.push(format!("loads[{i}].voltage_model.v_nom"));
-                        }
-                        if matches!(scaling, Some(v) if !v.is_finite()) {
-                            out.push(format!("loads[{i}].voltage_model.scaling"));
-                        }
-                    }
-                    LoadVoltageModel::Exponential {
-                        p,
-                        q,
-                        v_nom,
-                        gamma_p,
-                        gamma_q,
-                    } => {
-                        out.extend(
-                            bad([
-                                ("p", *p),
-                                ("q", *q),
-                                ("gamma_p", *gamma_p),
-                                ("gamma_q", *gamma_q),
-                            ])
-                            .map(|f| format!("loads[{i}].voltage_model.{f}")),
-                        );
-                        if matches!(v_nom, Some(v) if !v.is_finite()) {
-                            out.push(format!("loads[{i}].voltage_model.v_nom"));
-                        }
-                    }
-                }
-            }
-        }
-        for (i, s) in self.shunts.iter().enumerate() {
-            let Shunt {
-                bus: _,
-                g,
-                b,
-                in_service: _,
-                control: _,
-                uid: _,
-                extras: _,
-            } = s;
-            out.extend(bad([("g", *g), ("b", *b)]).map(|f| format!("shunts[{i}].{f}")));
-        }
-        for (i, br) in self.branches.iter().enumerate() {
-            #[rustfmt::skip]
-            let Branch { from: _, to: _, r, x, b, charging, rate_a, rate_b, rate_c, rating_sets, current_ratings, tap, shift, in_service: _, angmin, angmax, control: _, solution, uid: _, route: _, extras: _ } = br;
-            let fields = [
-                ("r", *r),
-                ("x", *x),
-                ("b", *b),
-                ("rate_a", *rate_a),
-                ("rate_b", *rate_b),
-                ("rate_c", *rate_c),
-                ("tap", *tap),
-                ("shift", *shift),
-                ("angmin", *angmin),
-                ("angmax", *angmax),
-            ];
-            out.extend(bad(fields).map(|f| format!("branches[{i}].{f}")));
-            out.extend(
-                rating_sets
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, r)| !r.rate_mva.is_finite())
-                    .map(|(j, _)| format!("branches[{i}].rating_sets[{j}].rate_mva")),
-            );
-            if let Some(charging) = charging {
-                let BranchCharging {
-                    g_fr,
-                    b_fr,
-                    g_to,
-                    b_to,
-                } = charging;
-                let fields = [
-                    ("g_fr", *g_fr),
-                    ("b_fr", *b_fr),
-                    ("g_to", *g_to),
-                    ("b_to", *b_to),
-                ];
-                out.extend(bad(fields).map(|f| format!("branches[{i}].charging.{f}")));
-            }
-            if let Some(current) = current_ratings {
-                let BranchCurrentRatings {
-                    c_rating_a,
-                    c_rating_b,
-                    c_rating_c,
-                } = current;
-                let fields = [
-                    ("c_rating_a", *c_rating_a),
-                    ("c_rating_b", *c_rating_b),
-                    ("c_rating_c", *c_rating_c),
-                ];
-                out.extend(bad(fields).map(|f| format!("branches[{i}].current_ratings.{f}")));
-            }
-            if let Some(solution) = solution {
-                let BranchSolution { pf, qf, pt, qt } = solution;
-                out.extend(
-                    bad([("pf", *pf), ("qf", *qf), ("pt", *pt), ("qt", *qt)])
-                        .map(|f| format!("branches[{i}].solution.{f}")),
-                );
-            }
-        }
-        for (i, sw) in self.switches.iter().enumerate() {
-            let Switch {
-                from: _,
-                to: _,
-                closed: _,
-                thermal_rating,
-                current_rating,
-                pf,
-                qf,
-                pt,
-                qt,
-                uid: _,
-                extras: _,
-            } = sw;
-            for (field, value) in [
-                ("thermal_rating", *thermal_rating),
-                ("current_rating", *current_rating),
-                ("pf", *pf),
-                ("qf", *qf),
-                ("pt", *pt),
-                ("qt", *qt),
-            ] {
-                if matches!(value, Some(v) if !v.is_finite()) {
-                    out.push(format!("switches[{i}].{field}"));
-                }
-            }
-        }
-        for (i, g) in self.generators.iter().enumerate() {
-            #[rustfmt::skip]
-            let Generator { bus: _, pg, qg, pmax, pmin, qmax, qmin, vg, mbase, in_service: _, cost, caps, regulated_bus: _, uid: _ } = g;
-            let fields = [
-                ("pg", *pg),
-                ("qg", *qg),
-                ("pmax", *pmax),
-                ("pmin", *pmin),
-                ("qmax", *qmax),
-                ("qmin", *qmin),
-                ("vg", *vg),
-                ("mbase", *mbase),
-            ];
-            out.extend(bad(fields).map(|f| format!("generators[{i}].{f}")));
-            if let Some(GenCost {
-                model: _,
-                startup,
-                shutdown,
-                ncost: _,
-                coeffs,
-            }) = cost
-            {
-                out.extend(
-                    bad([("startup", *startup), ("shutdown", *shutdown)])
-                        .map(|f| format!("generators[{i}].cost.{f}")),
-                );
-                if coeffs.iter().any(|c| !c.is_finite()) {
-                    out.push(format!("generators[{i}].cost.coeffs"));
-                }
-            }
-            // Name the exact cap key (caps serializes as a name-keyed object, so
-            // the null lands at generators[i].caps.<key>, e.g. ramp_30), matching
-            // the key-level precision of every other field.
-            for (key, slot) in GEN_EXTRA_KEYS.iter().zip(caps.iter()) {
-                if matches!(slot, Some(v) if !v.is_finite()) {
-                    out.push(format!("generators[{i}].caps.{key}"));
-                }
-            }
-        }
-        for (i, s) in self.storage.iter().enumerate() {
-            #[rustfmt::skip]
-            let Storage { bus: _, ps, qs, energy, energy_rating, charge_rating, discharge_rating, charge_efficiency, discharge_efficiency, thermal_rating, current_rating, qmin, qmax, r, x, p_loss, q_loss, in_service: _, uid: _, extras: _ } = s;
-            let fields = [
-                ("ps", *ps),
-                ("qs", *qs),
-                ("energy", *energy),
-                ("energy_rating", *energy_rating),
-                ("charge_rating", *charge_rating),
-                ("discharge_rating", *discharge_rating),
-                ("charge_efficiency", *charge_efficiency),
-                ("discharge_efficiency", *discharge_efficiency),
-                ("thermal_rating", *thermal_rating),
-                ("qmin", *qmin),
-                ("qmax", *qmax),
-                ("r", *r),
-                ("x", *x),
-                ("p_loss", *p_loss),
-                ("q_loss", *q_loss),
-            ];
-            out.extend(bad(fields).map(|f| format!("storage[{i}].{f}")));
-            if matches!(current_rating, Some(v) if !v.is_finite()) {
-                out.push(format!("storage[{i}].current_rating"));
-            }
-        }
-        for (i, h) in self.hvdc.iter().enumerate() {
-            #[rustfmt::skip]
-            let Hvdc { from: _, to: _, in_service: _, pf, pt, qf, qt, vf, vt, pmin, pmax, qminf, qmaxf, qmint, qmaxt, loss0, loss1, cost, uid: _, extras: _ } = h;
-            let fields = [
-                ("pf", *pf),
-                ("pt", *pt),
-                ("qf", *qf),
-                ("qt", *qt),
-                ("vf", *vf),
-                ("vt", *vt),
-                ("pmin", *pmin),
-                ("pmax", *pmax),
-                ("qminf", *qminf),
-                ("qmaxf", *qmaxf),
-                ("qmint", *qmint),
-                ("qmaxt", *qmaxt),
-                ("loss0", *loss0),
-                ("loss1", *loss1),
-            ];
-            out.extend(bad(fields).map(|f| format!("hvdc[{i}].{f}")));
-            if let Some(GenCost {
-                model: _,
-                startup,
-                shutdown,
-                ncost: _,
-                coeffs,
-            }) = cost
-            {
-                out.extend(
-                    bad([("startup", *startup), ("shutdown", *shutdown)])
-                        .map(|f| format!("hvdc[{i}].cost.{f}")),
-                );
-                if coeffs.iter().any(|c| !c.is_finite()) {
-                    out.push(format!("hvdc[{i}].cost.coeffs"));
-                }
-            }
-        }
-        out
+        Ok((text, Diagnostics::new()))
     }
 
     /// Serialize this network to `format`, preserving the retained source text
@@ -2102,6 +1805,9 @@ impl BalancedNetwork {
     }
 
     /// Rebuild a `BalancedNetwork` from JSON produced by [`to_json`](BalancedNetwork::to_json).
+    ///
+    /// A float position accepts a number or the nonfinite spellings
+    /// `"Infinity"`, `"-Infinity"`, `"NaN"` (see [`crate::nonfinite`]).
     ///
     /// Validates the result (no buses, unique bus ids, no dangling references)
     /// before returning, so the JSON transport (the C ABI and Julia bridge ride
@@ -2928,7 +2634,8 @@ mod tests {
     }
 
     #[test]
-    fn non_finite_fields_lists_every_offender_not_just_the_first() {
+    #[allow(clippy::float_cmp)]
+    fn nonfinite_values_round_trip_through_model_json() {
         let bus = |id, vm| Bus {
             id: BusId(id),
             kind: BusType::Pq,
@@ -2988,8 +2695,9 @@ mod tests {
             uid: None,
         };
         g.caps[8] = Some(f64::INFINITY); // ramp_30
-        // Three distinct non-finite fields: a bus vm (NaN), a branch x (Inf), and
-        // a generator ramp_30 cap (Inf).
+        // Three nonfinite values at three nesting depths: a bus vm (NaN, a
+        // struct field in a table), a branch x (Inf), and a generator ramp_30
+        // cap (Inf, inside the name-keyed caps object).
         let mut net = BalancedNetwork::in_memory(
             "nf",
             100.0,
@@ -2997,18 +2705,34 @@ mod tests {
             vec![branch],
         );
         net.generators.push(g);
-        let fields = net.non_finite_fields();
-        assert!(fields.contains(&"buses[0].vm".to_string()), "{fields:?}");
-        assert!(fields.contains(&"branches[0].x".to_string()), "{fields:?}");
-        assert!(
-            fields.contains(&"generators[0].caps.ramp_30".to_string()),
-            "caps reported at key precision: {fields:?}"
-        );
-        assert_eq!(
-            fields.len(),
-            3,
-            "exactly the three offenders, no more: {fields:?}"
-        );
+
+        let text = net.to_json().unwrap();
+        assert!(text.contains(r#""vm":"NaN""#), "{text}");
+        assert!(text.contains(r#""x":"Infinity""#), "{text}");
+        assert!(text.contains(r#""ramp_30":"Infinity""#), "{text}");
+
+        let back = BalancedNetwork::from_json(&text).unwrap();
+        assert!(back.buses[0].vm.is_nan());
+        assert_eq!(back.branches[0].x, f64::INFINITY);
+        assert_eq!(back.generators[0].caps[8], Some(f64::INFINITY));
+
+        // Second write is byte stable, and the empty diagnostics channel
+        // reflects that nothing was dropped.
+        assert_eq!(back.to_json().unwrap(), text);
+        let (_, diagnostics) = net.to_json_with_diagnostics().unwrap();
+        assert!(diagnostics.lines().is_empty());
+    }
+
+    #[test]
+    fn a_null_at_a_float_position_names_the_pre_090_spelling() {
+        let net = BalancedNetwork::in_memory("nf", 100.0, vec![bus(1), bus(2)], Vec::new());
+        let text = net
+            .to_json()
+            .unwrap()
+            .replacen("\"vm\":1.0", "\"vm\":null", 1);
+        assert!(text.contains("\"vm\":null"), "fixture edit failed: {text}");
+        let err = BalancedNetwork::from_json(&text).unwrap_err().to_string();
+        assert!(err.contains("before 0.9.0"), "{err}");
     }
 
     #[test]

--- a/powerio/tests/convert.rs
+++ b/powerio/tests/convert.rs
@@ -2204,45 +2204,33 @@ fn slackless_network_conversion_warns_for_power_flow_targets() {
 }
 
 #[test]
-fn model_json_warns_on_non_finite_and_does_not_read_back() {
-    // JSON has no Inf/NaN: serde writes them as `null`, which the validating
-    // reader rejects. Readers legitimately produce Inf limits and the bindings
-    // materialize every network through model JSON, so the write stays total,
-    // but it must SAY what degraded (naming the field), and the no-read-back
-    // consequence is pinned here so a change to either side surfaces.
+#[allow(clippy::float_cmp)]
+fn model_json_carries_non_finite_values_as_string_spellings() {
+    // JSON has no Inf/NaN literal: powerio spells them "Infinity",
+    // "-Infinity", "NaN" and reads either a number or a spelling back, so a
+    // network with legitimate Inf limits round trips instead of degrading to
+    // null. Pinned on a real case so a change to either side surfaces.
     let mut net = parse_matpower_file(data("case9.m")).unwrap();
     net.branches[2].angmax = f64::INFINITY;
+    net.buses[0].vm = f64::NAN;
     let (text, diagnostics) = net.to_json_with_diagnostics().unwrap();
-    let warnings = diagnostics.lines();
     assert!(
-        warnings.iter().any(|w| w.contains("branches[2].angmax")),
-        "the degradation warning should name the field: {warnings:?}"
+        diagnostics.lines().is_empty(),
+        "a faithful write reports nothing: {:?}",
+        diagnostics.lines()
     );
-    let err =
-        BalancedNetwork::from_json(&text).expect_err("a null-degraded document must not validate");
-    assert!(err.to_string().contains("null"), "got: {err}");
+    assert!(text.contains(r#""angmax":"Infinity""#), "{text}");
+    assert!(text.contains(r#""vm":"NaN""#), "{text}");
 
-    // A NaN bus voltage warns the same way.
-    let mut net = parse_matpower_file(data("case9.m")).unwrap();
-    net.buses[0].vm = f64::NAN;
-    let warnings = net.to_json_with_diagnostics().unwrap().1.lines();
-    assert!(
-        warnings.iter().any(|w| w.contains("buses[0].vm")),
-        "got: {warnings:?}"
-    );
+    let back = BalancedNetwork::from_json(&text).expect("string spellings read back");
+    assert_eq!(back.branches[2].angmax, f64::INFINITY);
+    assert!(back.buses[0].vm.is_nan());
 
-    // EVERY non-finite field is named, not just the first: serde writes them all
-    // as null, so a caller fixing only the first-reported field would re-export
-    // and still fail to read back. Both offenders must appear in one write.
-    let mut net = parse_matpower_file(data("case9.m")).unwrap();
-    net.buses[0].vm = f64::NAN;
-    net.branches[2].angmax = f64::INFINITY;
-    let warnings = net.to_json_with_diagnostics().unwrap().1.lines();
-    assert!(
-        warnings.iter().any(|w| w.contains("buses[0].vm"))
-            && warnings.iter().any(|w| w.contains("branches[2].angmax")),
-        "both non-finite fields must be named in one write: {warnings:?}"
-    );
+    // A document from a pre-0.9 writer spelled these null; the refusal names
+    // the change rather than reporting a bare type error.
+    let legacy = text.replace(r#""angmax":"Infinity""#, r#""angmax":null"#);
+    let err = BalancedNetwork::from_json(&legacy).expect_err("null must still refuse");
+    assert!(err.to_string().contains("before 0.9.0"), "got: {err}");
 }
 
 #[test]


### PR DESCRIPTION
A network with an unbounded reactive limit could be parsed but its model JSON could not be read back: serde_json writes a nonfinite f64 as null and the reader refuses null, so powerio package refused stock case9241pegase and case2869pegase, and every consumer that moves a parsed network as JSON (the C ABI, the Julia and Python bindings, a browser holding a study) hit the same wall. Both the tellegen and ExaModelsPower integration briefs found it independently, and 0.9.0 is the last release where the spelling can change.

A float position now writes "Infinity", "-Infinity", or "NaN" and reads back either a number or one of those spellings, one convention across the balanced model, the multiconductor model, and the .pio.json envelope. The mechanism is a forwarding serializer and deserializer pair in powerio-diag (the one crate below both models): interception is keyed on the value's type, so extras strings pass through verbatim, and it applies only to human readable formats. Each document type routes its serde impls through the pair with serde(remote = "Self"), which also threads the spelling through serde's internal buffering for the internally tagged payload enum.

The multiconductor bound fields keep reading the null a pre-0.9 writer emitted, restored by field role as before (#268); everywhere else a null is refused with a message naming the 0.9.0 spelling change. The nonfinite field walk and its degradation record are gone, since nothing degrades; to_json_with_diagnostics stays as the channel a future write-side finding arrives through. The generated schema gains the string arm on every float position, and the schema generator refuses to run if the document ever loses its $defs shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN