### PR TITLE
api: byte entry points for dist and packages, classifier at the crate root

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -29,3 +29,7 @@ reader can retire a lineage; the published document stays.
 The generator never removes files. Keep these documents byte for byte; do
 not regenerate or reformat them. The `frozen_schemas` test in powerio-pkg
 pins them.
+
+## Recognizing a document
+
+Two rules classify a bare JSON document. A package is a top level `model_kind` of `"balanced"` or `"multiconductor"` beside a `model` key; model JSON is `buses` beside another network key (the case formats spell it `bus`). `powerio::classify_json_text` is the reference implementation, and `powerio::JSON_CLASSES` carries the permanent family spellings; a consumer classifying a dropped file in TypeScript, Python, or Julia restates this rule.

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -371,6 +371,25 @@ pub fn parse_str(text: &str, format: &str) -> crate::Result<MulticonductorNetwor
     parse_text(text, format.parse::<DistTargetFormat>()?)
 }
 
+/// Parses in-memory case `bytes` of the named `format`. The bytes decode as
+/// UTF-8 and take the [`parse_str`] path from there.
+///
+/// A caller that already holds the file's bytes — an upload, an archive
+/// member — parses them here rather than staging a temporary file for
+/// [`parse_file`]. Without this entry point a browser caller decodes through
+/// JS `File.text()`, which silently replaces every invalid byte with U+FFFD.
+///
+/// # Errors
+/// [`Error::FormatRead`](crate::Error::FormatRead) if the bytes are not
+/// UTF-8; otherwise as [`parse_str`].
+pub fn parse_bytes(bytes: &[u8], format: &str) -> crate::Result<MulticonductorNetwork> {
+    let text = std::str::from_utf8(bytes).map_err(|e| crate::Error::FormatRead {
+        format: "case text",
+        message: format!("not valid UTF-8: {e}"),
+    })?;
+    parse_str(text, format)
+}
+
 /// Parses `path`, taking the format from `from` when given, the `.dss`
 /// extension otherwise, and for `.json` the shared distribution classifier.
 pub fn parse_file(
@@ -744,6 +763,29 @@ mod tests {
                 .as_ref()
                 .is_some_and(|s| !s.starts_with('\u{feff}'))
         );
+    }
+
+    #[test]
+    fn parse_bytes_matches_parse_str_on_a_dss_fixture() {
+        let bytes = std::fs::read(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../tests/data/dist/micro/onephase_zip_load.dss"
+        ))
+        .unwrap();
+        let from_bytes = parse_bytes(&bytes, "dss").unwrap();
+        let from_str = parse_str(std::str::from_utf8(&bytes).unwrap(), "dss").unwrap();
+        assert_eq!(from_bytes.buses.len(), from_str.buses.len());
+        assert_eq!(from_bytes.loads.len(), from_str.loads.len());
+        assert_eq!(from_bytes.source, from_str.source);
+    }
+
+    #[test]
+    fn parse_bytes_refuses_non_utf8_and_names_the_encoding() {
+        // 0xE9 is CP1252 é, the classic single byte a Windows editor leaves.
+        let bytes = b"clear\nnew circuit.caf\xE9 basekv=12.47 bus1=src\n";
+        let err = parse_bytes(bytes, "dss").unwrap_err();
+        assert!(matches!(err, crate::Error::FormatRead { .. }), "{err}");
+        assert!(err.to_string().contains("UTF-8"), "{err}");
     }
 
     #[test]

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -23,6 +23,8 @@ pub mod codes {
             "a dss command, object spec, or property assignment does not parse";
         PARSE_DIST_MALFORMED = "PARSE.DIST.MALFORMED", Fatal,
             "a distribution document is not valid JSON for its format", category = Parse;
+        PARSE_DIST_SOURCE_MALFORMED = "PARSE.DIST.SOURCE_MALFORMED", Fatal,
+            "a distribution reader refused the source it was given", category = Parse;
 
         // READ.DSS: decoded, but not representable in the multiconductor model.
         /// A `Redirect`/`Compile`/`Buscoords` include the reader refused

--- a/powerio-dist/src/error.rs
+++ b/powerio-dist/src/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
         message: String,
     },
 
+    #[error("{format} read error: {message}")]
+    FormatRead {
+        format: &'static str,
+        message: String,
+    },
+
     #[error("unknown distribution format `{0}` (expected dss, bmopf, or pmd)")]
     UnknownFormat(String),
 }
@@ -33,6 +39,7 @@ impl Error {
         match self {
             Error::Io { .. } => &codes::READ_DIST_IO_FAILED,
             Error::Json { .. } => &codes::PARSE_DIST_MALFORMED,
+            Error::FormatRead { .. } => &codes::PARSE_DIST_SOURCE_MALFORMED,
             Error::UnknownFormat(_) => &codes::REQUEST_DIST_FORMAT_UNKNOWN,
         }
     }
@@ -42,7 +49,7 @@ impl Error {
     pub fn category(&self) -> ErrorCategory {
         match self {
             Error::Io { .. } => ErrorCategory::Io,
-            Error::Json { .. } => ErrorCategory::Parse,
+            Error::Json { .. } | Error::FormatRead { .. } => ErrorCategory::Parse,
             Error::UnknownFormat(_) => ErrorCategory::UnknownFormat,
         }
     }
@@ -62,6 +69,10 @@ mod tests {
             Error::Json {
                 format: "BMOPF",
                 message: "top level is not an object".into(),
+            },
+            Error::FormatRead {
+                format: "case text",
+                message: "not valid UTF-8".into(),
             },
             Error::UnknownFormat("xyz".into()),
         ];

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -56,7 +56,7 @@ pub use bmopf::{
 };
 pub use convert::{
     Conversion, ConversionSidecar, DistTargetFormat, classify_distribution_json, convert_file,
-    convert_str, dist_target_from_name, parse_file, parse_str,
+    convert_str, dist_target_from_name, parse_bytes, parse_file, parse_str,
 };
 pub use diagnostics::{DiagnosticCode, DiagnosticSeverity, DiagnosticStage, StructuredDiagnostic};
 pub use dss::{

--- a/powerio-pkg/src/package.rs
+++ b/powerio-pkg/src/package.rs
@@ -640,6 +640,16 @@ impl NetworkPackage {
         Ok(pkg)
     }
 
+    /// Deserialize from `.pio.json` held as bytes, for a caller that never
+    /// stages the text — an upload, an archive member. The bytes must decode
+    /// as UTF-8; a leading byte order mark is tolerated as in [`Self::from_json`].
+    pub fn from_json_bytes(bytes: &[u8]) -> crate::Result<Self> {
+        let text = std::str::from_utf8(bytes).map_err(|e| {
+            Error::Malformed(serde::de::Error::custom(format!("not valid UTF-8: {e}")))
+        })?;
+        Self::from_json(text)
+    }
+
     #[must_use]
     pub fn with_origin(mut self, origin: Origin) -> Self {
         self.origin = origin;

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -280,6 +280,22 @@ fn powerio_version_is_present_and_required() {
 }
 
 #[test]
+fn from_json_bytes_tolerates_a_byte_order_mark_and_refuses_non_utf8() {
+    let json = balanced_package().to_json().unwrap();
+    NetworkPackage::from_json_bytes(json.as_bytes()).expect("plain bytes load");
+
+    let mut with_bom = b"\xEF\xBB\xBF".to_vec();
+    with_bom.extend_from_slice(json.as_bytes());
+    NetworkPackage::from_json_bytes(&with_bom).expect("byte order mark is tolerated");
+
+    // 0xE9 is CP1252 e-acute, the classic single byte a Windows editor leaves.
+    let err = NetworkPackage::from_json_bytes(b"{\"powerio_version\xE9\": 1}").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("UTF-8"), "got: {msg}");
+    assert!(msg.contains(".pio.json"), "got: {msg}");
+}
+
+#[test]
 fn version_gate_rejects_other_lineages_and_says_regenerate() {
     let pkg = balanced_package();
     let mut v = serde_json::to_value(&pkg).unwrap();

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -52,8 +52,11 @@ pub mod solver_tables;
 pub mod version;
 
 pub use dc::DcConvention;
-pub use diagnostics::{Diagnostics, EmitFamily, StructuredDiagnostic};
+pub use diagnostics::{
+    DiagnosticCode, DiagnosticSeverity, Diagnostics, EmitFamily, StructuredDiagnostic,
+};
 pub use error::{Error, ErrorCategory, Result};
+pub use format::routing::{Detection, JSON_CLASSES, JsonClass, classify_json_text};
 pub use format::{
     Conversion, DisplayData, DisplayFormat, Parsed, PwdDisplay, PwdSubstation, PypsaCsvOutputs,
     SourceDocument, TargetFormat, WriteOptions, convert_file, convert_file_with_options,

--- a/powerio/tests/classify_corpus.rs
+++ b/powerio/tests/classify_corpus.rs
@@ -131,3 +131,21 @@ fn every_json_fixture_classifies_as_stated() {
         );
     }
 }
+
+/// The classifier and the diagnostic vocabulary are crate root exports, so a
+/// consumer reaches them without spelling the module tree. This compiles only
+/// while those paths stay public.
+#[test]
+fn classifier_and_diagnostic_types_are_crate_root_exports() {
+    let class = powerio::classify_json_text(r#"{"model_kind":"balanced","model":{}}"#);
+    assert!(matches!(class, powerio::JsonClass::Package));
+    assert!(matches!(
+        powerio::classify_json_text("not json"),
+        powerio::JsonClass::Case(powerio::Detection::Unknown)
+    ));
+    assert_eq!(powerio::JSON_CLASSES.len(), 6);
+    let severity = powerio::DiagnosticSeverity::Warning;
+    assert!(severity < powerio::DiagnosticSeverity::Fatal);
+    let code_of: fn(&powerio::StructuredDiagnostic) -> &powerio::DiagnosticCode = |d| &d.code;
+    let _ = code_of;
+}


### PR DESCRIPTION
powerio_dist::parse_bytes and NetworkPackage::from_json_bytes parse bytes a caller already holds (a browser upload, an archive member) without staging a temporary file or decoding through JS File.text(), which silently replaces every invalid byte with U+FFFD. Both refuse non UTF-8 input with an error naming the encoding: the dist failure is the new Error::FormatRead variant, coded PARSE.DIST.SOURCE_MALFORMED, and the package failure keeps the invalid .pio.json package voice. from_json_bytes shares from_json's byte order mark handling.

The powerio crate root now exports Detection, JsonClass, JSON_CLASSES, classify_json_text, DiagnosticCode, and DiagnosticSeverity; powerio::format::JsonClass used to fail E0603 because format/mod.rs only imported routing privately. docs/schema/README.md states the two sentence JSON recognition rule and names classify_json_text as the reference implementation, for consumers classifying dropped files in TypeScript, Python, or Julia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN