### PR TITLE
formats: refuse an id a reader cannot represent instead of saturating

### DIFF
--- a/powerio/src/error.rs
+++ b/powerio/src/error.rs
@@ -28,6 +28,13 @@ pub enum Error {
         value: String,
     },
 
+    #[error("malformed MATPOWER `{field}` row {row}: {message}")]
+    BadId {
+        field: &'static str,
+        row: usize,
+        message: String,
+    },
+
     #[error("unbalanced brackets in MATPOWER `{0}` matrix")]
     UnbalancedBrackets(&'static str),
 
@@ -147,6 +154,7 @@ impl Error {
             Error::MissingField(_)
             | Error::ShortRow { .. }
             | Error::BadFloat { .. }
+            | Error::BadId { .. }
             | Error::UnbalancedBrackets(_) => &codes::PARSE_MATPOWER_MALFORMED,
             Error::FormatRead { .. } => &codes::PARSE_SOURCE_MALFORMED,
             Error::Io(_) => &codes::READ_IO_FAILED,
@@ -185,6 +193,7 @@ impl Error {
             Error::MissingField(_)
             | Error::ShortRow { .. }
             | Error::BadFloat { .. }
+            | Error::BadId { .. }
             | Error::UnbalancedBrackets(_)
             | Error::FormatRead { .. } => C::Parse,
             // A well-formed case that can't satisfy a requested operation. These
@@ -230,6 +239,11 @@ mod tests {
                 field: "bus",
                 row: 1,
                 value: "x".into(),
+            },
+            Error::BadId {
+                field: "bus",
+                row: 1,
+                message: "`BUS_I` value 1e300 is outside the id range 0..2^63".into(),
             },
             Error::UnbalancedBrackets("bus"),
             Error::FormatRead {

--- a/powerio/src/format/egret.rs
+++ b/powerio/src/format/egret.rs
@@ -491,30 +491,32 @@ fn num_key(k: &str) -> i64 {
     k[start..].parse::<i64>().unwrap_or(i64::MAX)
 }
 
-/// A non-negative integer bus id from an f64 (egret writes some ids as numbers).
-/// Rejects negative, fractional, or out-of-range values rather than truncating or
-/// wrapping them onto the wrong bus.
-fn id_from_f64(x: f64) -> Option<usize> {
-    // Strict `<`: `usize::MAX as f64` rounds up to 2^64, so values in the gap just
-    // below it would pass `<=` and then saturate on the `as usize` cast.
-    (x >= 0.0 && x.fract() == 0.0 && x < usize::MAX as f64).then_some(x as usize)
+/// A non-negative integral id from an f64 (egret writes some ids as numbers).
+/// Fractional values are refused here; the range bound is the shared
+/// [`crate::format::id_from_f64`] policy.
+fn integral_id(x: f64) -> Option<usize> {
+    (x.fract() == 0.0)
+        .then(|| crate::format::id_from_f64(x, "id").ok())
+        .flatten()
 }
 
 /// A bus id from a JSON value: a numeric string (egret's convention) or a bare
-/// number. `None` for a non-integer, negative, or non-numeric value (named buses
-/// aren't representable in the integer `BusId` space).
+/// number. `None` for a non-integer, negative, out-of-range, or non-numeric
+/// value (named buses aren't representable in the integer `BusId` space).
 fn parse_id(v: &Value) -> Option<usize> {
     match v {
         Value::String(s) => {
             let s = s.trim();
             s.parse::<usize>()
                 .ok()
-                .or_else(|| s.parse::<f64>().ok().and_then(id_from_f64))
+                .filter(|&x| x <= BusId::MAX.0)
+                .or_else(|| s.parse::<f64>().ok().and_then(integral_id))
         }
         Value::Number(n) => n
             .as_u64()
+            .filter(|&x| x <= BusId::MAX.0 as u64)
             .map(|x| x as usize)
-            .or_else(|| n.as_f64().and_then(id_from_f64)),
+            .or_else(|| n.as_f64().and_then(integral_id)),
         _ => None,
     }
 }

--- a/powerio/src/format/matpower/rows.rs
+++ b/powerio/src/format/matpower/rows.rs
@@ -137,13 +137,23 @@ fn require(field: &'static str, row: &[f64], i: usize, expected: usize) -> Resul
     Ok(())
 }
 
+/// An id column through [`crate::format::id_from_f64`]; a refusal carries the
+/// matrix name and row position into [`Error::BadId`].
+fn id_col(field: &'static str, row: &[f64], i: usize, col: usize, name: &str) -> Result<usize> {
+    crate::format::id_from_f64(row[col], name).map_err(|message| Error::BadId {
+        field,
+        row: i,
+        message,
+    })
+}
+
 /// Parse a bus row into a [`Bus`] plus an optional [`Load`] and [`Shunt`].
 /// A load/shunt is emitted only when its values are nonzero, matching MATPOWER:
 /// a bus with `Pd = Qd = 0` carries no load. `in_service` follows the bus type
 /// (an isolated bus is out of service).
 pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Option<Shunt>)> {
     require("bus", row, i, bus_col::REQUIRED)?;
-    let id = BusId(row[bus_col::BUS_I] as usize);
+    let id = BusId(id_col("bus", row, i, bus_col::BUS_I, "BUS_I")?);
     let kind = BusType::from_f64(row[bus_col::BUS_TYPE]);
     let in_service = kind != BusType::Isolated;
     let bus = Bus {
@@ -156,8 +166,8 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
         vmin: row[bus_col::VMIN],
         evhi: None,
         evlo: None,
-        area: row[bus_col::BUS_AREA] as usize,
-        zone: row[bus_col::ZONE] as usize,
+        area: id_col("bus", row, i, bus_col::BUS_AREA, "BUS_AREA")?,
+        zone: id_col("bus", row, i, bus_col::ZONE, "ZONE")?,
         name: None,
         uid: None,
         location: None,
@@ -189,8 +199,8 @@ pub(super) fn bus_row(row: &[f64], i: usize) -> Result<(Bus, Option<Load>, Optio
 pub(super) fn branch_row(row: &[f64], i: usize) -> Result<Branch> {
     require("branch", row, i, branch_col::REQUIRED)?;
     Ok(Branch {
-        from: BusId(row[branch_col::F_BUS] as usize),
-        to: BusId(row[branch_col::T_BUS] as usize),
+        from: BusId(id_col("branch", row, i, branch_col::F_BUS, "F_BUS")?),
+        to: BusId(id_col("branch", row, i, branch_col::T_BUS, "T_BUS")?),
         r: row[branch_col::BR_R],
         x: row[branch_col::BR_X],
         b: row[branch_col::BR_B],
@@ -228,7 +238,7 @@ pub(super) fn gen_row(row: &[f64], i: usize) -> Result<Generator> {
         *slot = Some(v);
     }
     Ok(Generator {
-        bus: BusId(row[gen_col::GEN_BUS] as usize),
+        bus: BusId(id_col("gen", row, i, gen_col::GEN_BUS, "GEN_BUS")?),
         pg: row[gen_col::PG],
         qg: row[gen_col::QG],
         qmax: row[gen_col::QMAX],
@@ -280,7 +290,13 @@ pub(super) fn gencost_row(row: &[f64], i: usize) -> Result<GenCost> {
 pub(super) fn storage_row(row: &[f64], i: usize) -> Result<Storage> {
     require("storage", row, i, storage_col::REQUIRED)?;
     Ok(Storage {
-        bus: BusId(row[storage_col::STORAGE_BUS] as usize),
+        bus: BusId(id_col(
+            "storage",
+            row,
+            i,
+            storage_col::STORAGE_BUS,
+            "STORAGE_BUS",
+        )?),
         ps: row[storage_col::PS],
         qs: row[storage_col::QS],
         energy: row[storage_col::ENERGY],
@@ -306,8 +322,8 @@ pub(super) fn storage_row(row: &[f64], i: usize) -> Result<Storage> {
 pub(super) fn hvdc_row(row: &[f64], i: usize) -> Result<Hvdc> {
     require("dcline", row, i, dcline_col::REQUIRED)?;
     Ok(Hvdc {
-        from: BusId(row[dcline_col::F_BUS] as usize),
-        to: BusId(row[dcline_col::T_BUS] as usize),
+        from: BusId(id_col("dcline", row, i, dcline_col::F_BUS, "F_BUS")?),
+        to: BusId(id_col("dcline", row, i, dcline_col::T_BUS, "T_BUS")?),
         in_service: is_in_service(row[dcline_col::BR_STATUS]),
         pf: row[dcline_col::PF],
         pt: row[dcline_col::PT],
@@ -335,9 +351,9 @@ pub(super) fn hvdc_row(row: &[f64], i: usize) -> Result<Hvdc> {
 /// 0 reads as no reference bus, mirroring what the writer emits for one.
 pub(super) fn area_row(row: &[f64], i: usize) -> Result<Area> {
     require("areas", row, i, 2)?;
-    let refbus = row[1] as usize;
+    let refbus = id_col("areas", row, i, 1, "refbus")?;
     Ok(Area {
         slack_bus: (refbus > 0).then_some(BusId(refbus)),
-        ..Area::new(row[0] as usize)
+        ..Area::new(id_col("areas", row, i, 0, "area")?)
     })
 }

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -593,6 +593,28 @@ pub(crate) fn geographic_meta(buses: &[Bus]) -> Option<crate::geo::GeoMeta> {
     })
 }
 
+/// A source id from an f64: an in range value truncates the way the readers
+/// always have; a negative, non-finite, or over-ceiling value is refused with
+/// a message naming `column`, instead of letting the `as usize` cast saturate.
+/// The ceiling is [`crate::network::BusId::MAX`] (`i64::MAX`, the C ABI id
+/// bound), applied to every id column so a non-bus id gets the same policy.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub(crate) fn id_from_f64(
+    value: f64,
+    column: impl std::fmt::Display,
+) -> std::result::Result<usize, String> {
+    // Strict `<`: `i64::MAX as f64` rounds up to 2^63, so `<=` would admit
+    // values the cast saturates past `BusId::MAX`.
+    if value >= 0.0 && value < i64::MAX as f64 {
+        Ok(value as usize)
+    } else {
+        // Debug keeps the shortest float form ("1e300", never 301 digits).
+        Err(format!(
+            "`{column}` value {value:?} is outside the id range 0..2^63"
+        ))
+    }
+}
+
 /// A case with no buses is content-free for every consumer. Most readers
 /// already reject it on a missing required table, but a JSON carrying only
 /// `baseMVA` would otherwise parse to a hollow network; reject it in the

--- a/powerio/src/format/pandapower.rs
+++ b/powerio/src/format/pandapower.rs
@@ -1822,21 +1822,20 @@ struct Row<'a> {
 
 impl Row<'_> {
     /// The pandas index value as a non-negative integer; pandapower element
-    /// ids live in the index, so a bad value is an error, not a default.
-    /// Values at or above `usize::MAX` are rejected so the float cast is exact
-    /// and the bus loop's `+ 1` cannot overflow.
+    /// ids live in the index, so a bad value is an error, never a default.
+    /// The shared id ceiling keeps the float cast exact and lets the bus
+    /// loop's `+ 1` never overflow.
     fn index_usize(&self) -> Result<usize> {
         let v = &self.frame.index[self.i];
         value_usize(v)
             .or_else(|| {
                 v.as_f64()
-                    .filter(|f| f.fract() == 0.0 && *f >= 0.0 && *f < usize::MAX as f64)
-                    .map(|f| f as usize)
+                    .filter(|f| f.fract() == 0.0)
+                    .and_then(|f| crate::format::id_from_f64(f, "index").ok())
             })
-            .filter(|&i| i < usize::MAX)
             .ok_or_else(|| {
                 bad(format!(
-                    "`{}` row at position {}: index is not a non-negative integer (`{}`)",
+                    "`{}` row at position {}: index `{}` is not a non-negative integer in the id range 0..2^63",
                     self.frame.name,
                     self.i,
                     value_repr(v)
@@ -2060,13 +2059,13 @@ fn read_poly_costs(
             .and_then(|v| {
                 value_usize(v).or_else(|| {
                     v.as_f64()
-                        .filter(|f| f.fract() == 0.0 && *f >= 0.0 && *f < usize::MAX as f64)
-                        .map(|f| f as usize)
+                        .filter(|f| f.fract() == 0.0)
+                        .and_then(|f| crate::format::id_from_f64(f, "element").ok())
                 })
             })
             .ok_or_else(|| {
                 bad(format!(
-                    "`poly_cost` row {}: required column `element` is missing or not a non-negative integer",
+                    "`poly_cost` row {}: required column `element` is missing or not a non-negative integer in the id range 0..2^63",
                     row.label()
                 ))
             })?;
@@ -2141,6 +2140,10 @@ fn bus_ref(
             "`{table}` row {label}: bus reference `{key}` is not an integer (`{}`)",
             value_repr(cell)
         )),
+        BusRefError::OutOfRange => bad(format!(
+            "`{table}` row {label}: bus reference `{key}` is outside the id range 0..2^63 ({})",
+            value_repr(cell)
+        )),
     })?;
     bus_of_pp.get(&idx).copied().ok_or_else(|| {
         bad(format!(
@@ -2152,6 +2155,7 @@ fn bus_ref(
 enum BusRefError {
     Negative,
     NotInteger,
+    OutOfRange,
 }
 
 fn decode_bus_index(v: &Value) -> std::result::Result<usize, BusRefError> {
@@ -2161,13 +2165,20 @@ fn decode_bus_index(v: &Value) -> std::result::Result<usize, BusRefError> {
         } else if f < 0.0 {
             Err(BusRefError::Negative)
         } else {
-            Ok(f as usize)
+            crate::format::id_from_f64(f, "bus").map_err(|_| BusRefError::OutOfRange)
+        }
+    }
+    fn from_u64(u: u64) -> std::result::Result<usize, BusRefError> {
+        if u <= BusId::MAX.0 as u64 {
+            Ok(u as usize)
+        } else {
+            Err(BusRefError::OutOfRange)
         }
     }
     match v {
         Value::Number(n) => {
             if let Some(u) = n.as_u64() {
-                Ok(u as usize)
+                from_u64(u)
             } else if n.as_i64().is_some() {
                 // as_u64 failed, so the integer is negative.
                 Err(BusRefError::Negative)
@@ -2178,7 +2189,7 @@ fn decode_bus_index(v: &Value) -> std::result::Result<usize, BusRefError> {
         Value::String(s) => {
             let s = s.trim();
             if let Ok(u) = s.parse::<u64>() {
-                Ok(u as usize)
+                from_u64(u)
             } else if s.parse::<i64>().is_ok() {
                 Err(BusRefError::Negative)
             } else {
@@ -2218,10 +2229,16 @@ fn value_f64(v: &Value) -> Option<f64> {
     }
 }
 
+/// Every caller reads an id column (pandas index, `zone`, cost `element`), so
+/// integer input gets the same [`BusId::MAX`] ceiling the float paths get from
+/// [`crate::format::id_from_f64`].
 fn value_usize(v: &Value) -> Option<usize> {
     match v {
-        Value::Number(_) => v.as_u64().map(|x| x as usize),
-        Value::String(s) => s.parse().ok(),
+        Value::Number(_) => v
+            .as_u64()
+            .filter(|&x| x <= BusId::MAX.0 as u64)
+            .map(|x| x as usize),
+        Value::String(s) => s.parse().ok().filter(|&x: &usize| x <= BusId::MAX.0),
         _ => None,
     }
 }
@@ -2412,7 +2429,9 @@ mod tests {
     fn bus_index_must_be_non_negative_integer() {
         let msg = err(&pp_net(vec![bus_table(json!(["x"]))]));
         assert!(
-            msg.contains("`bus` row at position 0: index is not a non-negative integer (`x`)"),
+            msg.contains(
+                "`bus` row at position 0: index `x` is not a non-negative integer in the id range"
+            ),
             "{msg}"
         );
     }

--- a/powerio/src/format/pslf.rs
+++ b/powerio/src/format/pslf.rs
@@ -1160,25 +1160,27 @@ fn id_at(tokens: &[String], i: usize, default: usize, field: &str, rec: &Record)
 
 /// Read a required nonnegative numeric identifier.
 fn req_id(tokens: &[String], i: usize, field: &str, rec: &Record) -> Result<usize> {
-    tokens
-        .get(i)
-        .and_then(|tok| parse_id(tok))
-        .ok_or_else(|| Error::FormatRead {
+    match tokens.get(i) {
+        Some(tok) => parse_id(tok).ok_or_else(|| bad_field(field, i, tok, rec)),
+        None => Err(Error::FormatRead {
             format: FMT,
-            message: format!("{field} missing or invalid at line {}", rec.line_no),
-        })
+            message: format!("{field} missing at line {}", rec.line_no),
+        }),
+    }
 }
 
 /// Parse PSLF numeric identifiers, including integer-valued floating text.
+/// Fractional values are refused here; the range bound is the shared
+/// [`crate::format::id_from_f64`] policy.
 fn parse_id(tok: &str) -> Option<usize> {
     if let Ok(value) = tok.parse::<usize>() {
-        return Some(value);
+        return (value <= BusId::MAX.0).then_some(value);
     }
     let value = tok.parse::<f64>().ok()?;
-    if !value.is_finite() || value < 0.0 || value.fract() != 0.0 || value > usize::MAX as f64 {
+    if value.fract() != 0.0 {
         return None;
     }
-    Some(value as usize)
+    crate::format::id_from_f64(value, "id").ok()
 }
 
 /// Read a numeric status field as an in service boolean.

--- a/powerio/src/format/psse.rs
+++ b/powerio/src/format/psse.rs
@@ -1675,15 +1675,20 @@ fn num_at(f: &[String], i: usize, default: f64) -> Result<f64> {
         Some(s) => s.parse().map_err(|_| bad_field(i, s)),
     }
 }
-/// Field `i` as a bus id (parsed as f64 then truncated, the PSS/E convention).
+/// Field `i` as a bus id (parsed as f64 then truncated, the PSS/E convention);
+/// the range policy is [`crate::format::id_from_f64`].
 fn id_at(f: &[String], i: usize, default: usize) -> Result<usize> {
     match f.get(i).map(String::as_str) {
         None | Some("") => Ok(default),
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        Some(s) => s
-            .parse::<f64>()
-            .map(|v| v as usize)
-            .map_err(|_| bad_field(i, s)),
+        Some(s) => {
+            let v: f64 = s.parse().map_err(|_| bad_field(i, s))?;
+            crate::format::id_from_f64(v, format_args!("field {i}")).map_err(|message| {
+                Error::FormatRead {
+                    format: FMT,
+                    message,
+                }
+            })
+        }
     }
 }
 /// Field `i` as a status flag (nonzero = in service).
@@ -1730,7 +1735,12 @@ fn read_bus(f: &[String]) -> Result<Bus> {
         .ok_or_else(|| Error::FormatRead {
             format: FMT,
             message: "bus record missing numeric id (field I)".into(),
-        })? as usize;
+        })?;
+    let id =
+        crate::format::id_from_f64(id, "bus field I").map_err(|message| Error::FormatRead {
+            format: FMT,
+            message,
+        })?;
     let name = f
         .get(1)
         .filter(|n| !n.is_empty())
@@ -4650,10 +4660,10 @@ Q
 
     #[test]
     fn a_bus_id_past_the_int64_ceiling_is_refused() {
-        // The id column is read as f64 and cast, and the cast saturates: two
-        // distinct ids above the ceiling both land on usize::MAX-ish values
-        // that the C ABI reports as the same int64. Refuse them at the reader
-        // boundary instead of collapsing two buses onto one reported id.
+        // The id column is read as f64, and an unchecked cast would saturate:
+        // two distinct ids above the ceiling would collapse onto one reported
+        // int64 id at the C ABI. The shared range policy refuses them at the
+        // reader boundary.
         let raw = r"0, 100.00, 33, 0, 0, 60.00 / synthetic out-of-range export
 CASE
 COMMENT
@@ -4665,8 +4675,9 @@ Q
 
         let err = parse_psse(raw).unwrap_err();
 
+        let text = err.to_string();
         assert!(
-            err.to_string().contains("outside the int64 id space"),
+            text.contains("bus field I") && text.contains("outside the id range"),
             "an out-of-range bus id should be refused: {err}"
         );
     }

--- a/powerio/src/format/surge.rs
+++ b/powerio/src/format/surge.rs
@@ -1449,33 +1449,36 @@ fn value_to_usize(value: &Value, key: &str) -> Result<usize> {
     match value {
         Value::Number(number) => {
             if let Some(value) = number.as_u64() {
-                usize::try_from(value)
-                    .map_err(|_| format_error(format!("`{key}` integer is too large")))
-            } else if let Some(value) = number.as_i64() {
-                if value >= 0 {
-                    usize::try_from(value as u64)
-                        .map_err(|_| format_error(format!("`{key}` integer is too large")))
-                } else {
-                    Err(format_error(format!("`{key}` must be nonnegative")))
-                }
-            } else if let Some(value) = number.as_f64() {
-                // Mirror the integer branches' "too large" rejection: a float
-                // beyond usize would otherwise saturate to usize::MAX and read
-                // as a confusing unknown-bus reference later.
-                if value >= 0.0 && value.fract() == 0.0 && value < usize::MAX as f64 {
+                if value <= BusId::MAX.0 as u64 {
                     Ok(value as usize)
-                } else if value >= usize::MAX as f64 {
-                    Err(format_error(format!("`{key}` integer is too large")))
                 } else {
+                    Err(format_error(format!("`{key}` integer is too large")))
+                }
+            } else if number.as_i64().is_some() {
+                // as_u64 failed, so the integer is negative.
+                Err(format_error(format!("`{key}` must be nonnegative")))
+            } else if let Some(value) = number.as_f64() {
+                if value.is_finite() && value.fract() != 0.0 {
                     Err(format_error(format!("`{key}` must be an integer")))
+                } else {
+                    // The shared range policy: a float beyond the id ceiling
+                    // must not saturate into a confusing unknown-bus reference.
+                    crate::format::id_from_f64(value, key).map_err(format_error)
                 }
             } else {
                 Err(format_error(format!("`{key}` is not an integer")))
             }
         }
-        Value::String(value) => value
-            .parse::<usize>()
-            .map_err(|_| format_error(format!("`{key}` string is not an integer"))),
+        Value::String(value) => {
+            let parsed = value
+                .parse::<usize>()
+                .map_err(|_| format_error(format!("`{key}` string is not an integer")))?;
+            if parsed <= BusId::MAX.0 {
+                Ok(parsed)
+            } else {
+                Err(format_error(format!("`{key}` integer is too large")))
+            }
+        }
         _ => Err(format_error(format!("`{key}` is not an integer"))),
     }
 }
@@ -1522,12 +1525,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn float_index_beyond_usize_is_rejected() {
+    fn float_index_beyond_the_id_ceiling_is_rejected() {
         // 1e20 backs into the f64 branch (too large for as_u64) and would
-        // saturate to usize::MAX under `as usize`; it must get the same "too
-        // large" rejection the integer branches give.
+        // saturate under `as usize`; the shared range policy refuses it with
+        // the column name.
         let err = value_to_usize(&serde_json::json!(1e20), "from_bus").unwrap_err();
-        assert!(err.to_string().contains("too large"), "got: {err}");
+        let text = err.to_string();
+        assert!(
+            text.contains("`from_bus`") && text.contains("outside the id range"),
+            "got: {err}"
+        );
         assert_eq!(
             value_to_usize(&serde_json::json!(3.0), "from_bus").unwrap(),
             3

--- a/powerio/tests/convert.rs
+++ b/powerio/tests/convert.rs
@@ -2100,7 +2100,7 @@ fn parse_str_rejects_malformed_pandapower_frames() {
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("index is not a non-negative integer"),
+            err.contains("is not a non-negative integer in the id range"),
             "index {huge}: {err}"
         );
     }

--- a/powerio/tests/id_range.rs
+++ b/powerio/tests/id_range.rs
@@ -1,0 +1,182 @@
+//! Readers refuse an id column value the id space cannot represent (issue
+//! #341): `1e300` or a negative id must produce a read error naming the
+//! column, never a saturated `usize` id.
+
+use std::path::PathBuf;
+
+use powerio::parse_file;
+
+fn temp_path(name: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "powerio-id-range-test-{}-{name}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos())
+    ));
+    path
+}
+
+fn read_error(name: &str, text: &str) -> String {
+    let path = temp_path(name);
+    std::fs::write(&path, text).unwrap();
+    let err = parse_file(&path, None).expect_err("out-of-range id must not parse");
+    std::fs::remove_file(&path).ok();
+    let message = err.to_string();
+    // The refusal must carry the source value, never the saturated cast.
+    assert!(
+        !message.contains("18446744073709551615"),
+        "saturated id leaked into: {message}"
+    );
+    message
+}
+
+#[test]
+fn matpower_refuses_a_huge_branch_bus_id() {
+    let err = read_error(
+        "huge.m",
+        r"function mpc = huge
+mpc.baseMVA = 100;
+mpc.bus = [
+    1  3  0  0  0  0  1  1.0  0  345  1  1.1  0.9;
+    2  1  10 5  0  0  1  1.0  0  345  1  1.1  0.9;
+];
+mpc.branch = [
+    1e300  2  0.01  0.05  0.02  0  0  0  0  0  1  -360  360;
+];
+",
+    );
+    assert!(
+        err.contains("F_BUS") && err.contains("outside the id range"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn matpower_refuses_a_negative_bus_id() {
+    let err = read_error(
+        "negative.m",
+        r"function mpc = negative
+mpc.baseMVA = 100;
+mpc.bus = [
+    -1  3  0  0  0  0  1  1.0  0  345  1  1.1  0.9;
+];
+mpc.branch = [
+    1  1  0.01  0.05  0.02  0  0  0  0  0  1  -360  360;
+];
+",
+    );
+    assert!(
+        err.contains("BUS_I") && err.contains("outside the id range"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn psse_refuses_out_of_range_bus_ids() {
+    let case5 = std::fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../tests/data/psse/case5.raw"),
+    )
+    .unwrap();
+    for (name, poison) in [("huge.raw", "1e300"), ("negative.raw", "-1")] {
+        let text = case5.replace(
+            "   10,'10          '",
+            &format!("   {poison},'10          '"),
+        );
+        let err = read_error(name, &text);
+        assert!(
+            err.contains("bus field I") && err.contains("outside the id range"),
+            "got: {err}"
+        );
+    }
+}
+
+#[test]
+fn pslf_refuses_out_of_range_bus_ids() {
+    let epc = |id: &str| {
+        format!(
+            r#"title
+two bus
+!
+solution parameters
+sbase 100.0000
+!
+bus data  [2] ty vsched volt angle ar zone vmax vmin date_in date_out pid L own st
+1 "Slack       " 230.0000 : 0 1.0000 1.0000 0.0 1 1 1.1 0.9 400101 391231 0 0 1 0
+{id} "Load        " 230.0000 : 1 1.0000 1.0000 -1.0 1 1 1.1 0.9 400101 391231 0 0 1 0
+end
+"#
+        )
+    };
+    for (name, poison) in [("huge.epc", "1e300"), ("negative.epc", "-2")] {
+        let err = read_error(name, &epc(poison));
+        assert!(err.contains("bus id") && err.contains(poison), "got: {err}");
+    }
+}
+
+#[test]
+fn surge_refuses_out_of_range_bus_numbers() {
+    let doc = |number: &str| {
+        format!(
+            r#"{{"format":"surge-json","schema_version":"0.1.0","meta":{{}},"network":{{"buses":[{{"number":{number}}}]}}}}"#
+        )
+    };
+    let err = read_error("huge.surge.json", &doc("1e300"));
+    assert!(
+        err.contains("`number`") && err.contains("outside the id range"),
+        "got: {err}"
+    );
+    // A negative integer keeps the dedicated nonnegative refusal.
+    let err = read_error("negative.surge.json", &doc("-1"));
+    assert!(err.contains("`number`"), "got: {err}");
+}
+
+#[test]
+fn pandapower_refuses_out_of_range_bus_indices() {
+    let doc = |index: &str| {
+        format!(
+            r#"{{
+  "_module": "pandapower.auxiliary",
+  "_class": "pandapowerNet",
+  "_object": {{
+    "bus": {{
+      "_module": "pandas.core.frame",
+      "_class": "DataFrame",
+      "_object": "{{\"columns\":[\"name\",\"vn_kv\"],\"index\":[{index}],\"data\":[[\"b1\",110.0]]}}",
+      "orient": "split",
+      "is_multiindex": false,
+      "is_multicolumn": false
+    }}
+  }}
+}}"#
+        )
+    };
+    // serde_json renders the huge float back as `1e+300`.
+    for (name, poison, shown) in [
+        ("huge.pp.json", "1e300", "1e+300"),
+        ("negative.pp.json", "-1", "-1"),
+    ] {
+        let err = read_error(name, &doc(poison));
+        assert!(
+            err.contains("`bus`") && err.contains("index") && err.contains(shown),
+            "got: {err}"
+        );
+    }
+}
+
+#[test]
+fn egret_refuses_out_of_range_load_bus_references() {
+    let doc = |bus: &str| {
+        format!(
+            r#"{{"system":{{"baseMVA":100.0}},"elements":{{"bus":{{"1":{{"matpower_bustype":"ref"}}}},"load":{{"load_1":{{"bus":{bus},"p_load":1.0}}}}}}}}"#
+        )
+    };
+    // serde_json renders the huge float back as `1e+300`.
+    for (name, poison, shown) in [
+        ("huge.egret.json", "1e300", "1e+300"),
+        ("negative.egret.json", "-1", "-1"),
+    ] {
+        let err = read_error(name, &doc(poison));
+        assert!(err.contains("`bus`") && err.contains(shown), "got: {err}");
+    }
+}

--- a/powerio/tests/pslf.rs
+++ b/powerio/tests/pslf.rs
@@ -378,10 +378,7 @@ fn malformed_pslf_input_returns_errors_without_panics() {
     for (text, expected) in [
         ("", "no buses"),
         ("title\nunterminated\n", "no buses"),
-        (
-            "bus data [1]\nnot-a-bus\nend\n",
-            "bus id missing or invalid",
-        ),
+        ("bus data [1]\nnot-a-bus\nend\n", "bus id field 0 value"),
         (
             "bus data [1]\n1 \"A\" 230 : bad 1 1 0 1 1 1.1 0.9\nend\n",
             "bus type field 0 value",


### PR DESCRIPTION
Most readers parsed an id column through `s.parse::<f64>()` and an `as usize` cast, which saturates: `1e300` in an id column silently became `usize::MAX`. A shared helper, `format::id_from_f64`, now states the policy once: an in range value truncates as before, and a negative, non-finite, or too large value is a read error naming the column and the offending value. The ceiling is `BusId::MAX` (`i64::MAX`), the same bound `check_references` enforces for bus ids, so every id column gets it whether or not it is a bus id.

Migrated: the MATPOWER row readers (bus, branch, gen, storage, dcline, areas — through the new `Error::BadId` in the existing PARSE.MATPOWER.MALFORMED family), PSS/E `id_at` and the bus record id, PSLF `parse_id`, Surge `value_to_usize`, pandapower's index, cost element, and bus reference decoding plus `value_usize`, and egret's `parse_id`, whose local range test the helper generalizes. Integer input paths on the same columns get the same ceiling, so one lexical form cannot accept what another refuses. The PowerWorld aux reader keeps its stricter u32 bound from #271 and is untouched.

Closes #341.

Closes #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN