### PR TITLE
dist: classify dss regulator banks into the BMOPF subtypes and write them

### DIFF
--- a/powerio-dist/src/bmopf/mod.rs
+++ b/powerio-dist/src/bmopf/mod.rs
@@ -47,6 +47,21 @@
 //! A source document's own `extras` object is stashed on read and re-emitted
 //! verbatim, so consumer keys beside these survive a round trip.
 //!
+//! # Regulator subtypes track the BMOPFTools schema extension
+//!
+//! Schema 0.1.0 defines no regulator subtype; the BMOPF authors' BMOPFTools
+//! toolchain extends the schema with `single_phase_autotransformer` and
+//! `open_delta_regulator`, and this writer emits both as deliberate interop
+//! with that toolchain, the same standing as the `voltage_source.cost`
+//! passthrough, pending an upstream schema proposal. An OpenDSS transformer
+//! a RegControl targets emits as `transformer.single_phase_autotransformer`
+//! when it reads as a series regulator (one phase, two windings of equal
+//! connection, voltage, and rating on distinct buses), and two identical
+//! line to line legs spelling one open delta connection (ABBC/BCAC/CABA)
+//! merge into one `transformer.open_delta_regulator` object named after the
+//! first leg. A BMOPF document that already carries either subtype
+//! re-emits it verbatim.
+//!
 //! # `terminal_conventions` goes stale on a rename
 //!
 //! The emitted `terminal_conventions` block is the source document's own

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -19,7 +19,8 @@ use crate::model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference,
     DistControlProfile, DistGenerator, DistIbr, DistLoadVoltageModel, DistTransformer, Extras, Mat,
     MulticonductorNetwork, ReactivePowerReference, ReactivePowerUnit, VoltVarControl,
-    VoltWattControl, VoltageSource, Winding, WindingConn, n_winding_impedance_base, pair_keys,
+    VoltWattControl, VoltageSource, Winding, WindingConn, n_winding_impedance_base,
+    open_delta_connection, open_delta_pairable, pair_keys, winding_phase_pair,
 };
 
 /// The `$id` of the BMOPF schema this writer targets, and the value it
@@ -1214,7 +1215,11 @@ impl Writer {
                 .expect("subtype maps are objects")
                 .insert(name, v);
         };
+        let merged = self.open_delta_pairs(net, &mut by_subtype);
         for t in &net.transformers {
+            if merged.contains(&t.name) {
+                continue;
+            }
             self.warn_nonuniform_per_phase_taps(t);
             match classify(t) {
                 Kind::SinglePhase => {
@@ -1252,6 +1257,21 @@ impl Writer {
                     let v = self.two_winding(t, &t.windings[0], &t.windings[1], 1.0, true, true);
                     insert(sub, t.name.clone(), v, &mut by_subtype);
                 }
+                kind @ (Kind::Autotransformer | Kind::OpenDeltaLeg) => {
+                    // A lone Kind::OpenDeltaLeg is a leg whose partner is
+                    // missing or no longer identical: still a single phase
+                    // autotransformer on its own.
+                    if matches!(kind, Kind::OpenDeltaLeg) {
+                        self.warn_unpaired_open_delta_leg(t);
+                    }
+                    let v = self.autotransformer(t);
+                    insert(
+                        "single_phase_autotransformer",
+                        t.name.clone(),
+                        v,
+                        &mut by_subtype,
+                    );
+                }
                 Kind::CenterTap => {
                     let v = self.center_tap(t);
                     insert("center_tap", t.name.clone(), v, &mut by_subtype);
@@ -1282,7 +1302,7 @@ impl Writer {
                         t,
                         &C::EMIT_BMOPF_TRANSFORMER_UNSUPPORTED,
                         format!(
-                            "transformer {}: {why}; not representable in the four BMOPF \
+                            "transformer {}: {why}; not representable in the BMOPF transformer \
                              subtypes, dropped from the output",
                             t.name
                         ),
@@ -1355,6 +1375,199 @@ impl Writer {
                     .insert(name.clone(), Value::Object(overflow));
             }
         }
+    }
+
+    fn warn_unpaired_open_delta_leg(&mut self, t: &DistTransformer) {
+        self.transformer_diagnostic(
+            t,
+            &C::EMIT_BMOPF_VALUE_SUBSTITUTED,
+            format!(
+                "transformer {}: open delta leg has no matching partner leg; \
+                 emitted as single_phase_autotransformer",
+                t.name
+            ),
+            Map::new(),
+        );
+    }
+
+    /// Merges classified open delta leg pairs into single
+    /// `open_delta_regulator` objects and returns the merged transformer
+    /// names. Legs are paired by shared bus pair; the pair must spell one of
+    /// the three connections and stay electrically identical, else each leg
+    /// falls back to `single_phase_autotransformer` in the main loop.
+    fn open_delta_pairs(
+        &mut self,
+        net: &MulticonductorNetwork,
+        by_subtype: &mut Map<String, Value>,
+    ) -> BTreeSet<String> {
+        let mut merged = BTreeSet::new();
+        let mut groups: BTreeMap<(String, String), Vec<&DistTransformer>> = BTreeMap::new();
+        for t in &net.transformers {
+            if !matches!(classify(t), Kind::OpenDeltaLeg) {
+                continue;
+            }
+            let key = (
+                t.windings[0].bus.to_ascii_lowercase(),
+                t.windings[1].bus.to_ascii_lowercase(),
+            );
+            groups.entry(key).or_default().push(t);
+        }
+        for legs in groups.into_values() {
+            let [a, b] = legs[..] else { continue };
+            let pair = |t: &DistTransformer| winding_phase_pair(&t.windings[0]);
+            let (Some(pa), Some(pb)) = (pair(a), pair(b)) else {
+                continue;
+            };
+            let Some((connection, swapped)) = open_delta_connection(pa, pb) else {
+                continue;
+            };
+            if !open_delta_pairable(a, b) {
+                continue;
+            }
+            let (first, second) = if swapped { (b, a) } else { (a, b) };
+            self.warn_nonuniform_per_phase_taps(first);
+            self.warn_nonuniform_per_phase_taps(second);
+            let mut details = Map::new();
+            details.insert("merged_leg".into(), json!(&second.name));
+            details.insert("connection".into(), json!(connection));
+            self.transformer_diagnostic(
+                first,
+                &C::EMIT_BMOPF_TRANSFORMER_OPEN_DELTA_MERGED,
+                format!(
+                    "transformer {}: legs {} and {} emitted as one open_delta_regulator \
+                     `{}` (connection {connection})",
+                    first.name, first.name, second.name, first.name
+                ),
+                details,
+            );
+            let v = self.open_delta_regulator(first, second, connection);
+            by_subtype
+                .entry("open_delta_regulator".to_string())
+                .or_insert_with(|| Value::Object(Map::new()))
+                .as_object_mut()
+                .expect("subtype maps are objects")
+                .insert(first.name.clone(), v);
+            merged.insert(first.name.clone());
+            merged.insert(second.name.clone());
+        }
+        merged
+    }
+
+    /// The `single_phase_autotransformer` shape of the BMOPFTools schema
+    /// extension: a step voltage regulator as series plus common winding.
+    /// No `v_nom` fields; the ratio is `tap_ratio` (regulated over source).
+    fn autotransformer(&mut self, t: &DistTransformer) -> Value {
+        let from = &t.windings[0];
+        let to = &t.windings[1];
+        let mut o = self.regulator_fields(t, from, to);
+        o.insert("terminal_map_from".into(), json!(from.terminal_map));
+        o.insert("terminal_map_to".into(), json!(to.terminal_map));
+        if let Some(ratio) = self.regulator_tap_ratio(t, from, to)
+            && (ratio - 1.0).abs() > 1e-12
+        {
+            o.insert("tap_ratio".into(), self.num(ratio, "transformer tap_ratio"));
+        }
+        self.warn_unrepresented_neutral_fields(t, "single_phase_autotransformer");
+        self.transformer_extras_dropped(t, &TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS);
+        o.into()
+    }
+
+    /// The `open_delta_regulator` shape of the BMOPFTools schema extension:
+    /// two identical line to line regulating legs stated once, with the
+    /// phase pairing carried by `connection` and per leg `tap_ratio` entries.
+    fn open_delta_regulator(
+        &mut self,
+        first: &DistTransformer,
+        second: &DistTransformer,
+        connection: &'static str,
+    ) -> Value {
+        let from = &first.windings[0];
+        let to = &first.windings[1];
+        let mut o = self.regulator_fields(first, from, to);
+        // The pairing check pins the legs to phases {1, 2, 3}; the object
+        // spans the whole phase set on both sides.
+        o.insert("terminal_map_from".into(), json!(["1", "2", "3"]));
+        o.insert("terminal_map_to".into(), json!(["1", "2", "3"]));
+        o.insert("connection".into(), json!(connection));
+        let a1 = self.regulator_tap_ratio(first, from, to);
+        let a2 = self.regulator_tap_ratio(second, &second.windings[0], &second.windings[1]);
+        if let (Some(a1), Some(a2)) = (a1, a2)
+            && ((a1 - 1.0).abs() > 1e-12 || (a2 - 1.0).abs() > 1e-12)
+        {
+            o.insert(
+                "tap_ratio".into(),
+                self.nums(&[a1, a2], "transformer tap_ratio"),
+            );
+        }
+        for t in [first, second] {
+            self.warn_unrepresented_neutral_fields(t, "open_delta_regulator");
+            self.transformer_extras_dropped(t, &TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS);
+        }
+        o.into()
+    }
+
+    /// The fields the two regulator subtypes share: buses, rating, and the
+    /// series impedance in referred ohms, leakage on the from side.
+    fn regulator_fields(
+        &mut self,
+        t: &DistTransformer,
+        from: &Winding,
+        to: &Winding,
+    ) -> Map<String, Value> {
+        let s = from.s_rating;
+        let zb_from = base_impedance(from.v_ref, s);
+        let zb_to = base_impedance(to.v_ref, s);
+        let mut o = Map::new();
+        o.insert("bus_from".into(), json!(from.bus));
+        o.insert("bus_to".into(), json!(to.bus));
+        o.insert("s_rating".into(), self.num(s, "transformer s_rating"));
+        self.referred_ohms(&mut o, "r_series_from", from.r_pct, zb_from, t, "from");
+        self.referred_ohms(&mut o, "r_series_to", to.r_pct, zb_to, t, "to");
+        if t.xsc_pct.is_empty() {
+            self.transformer_diagnostic(
+                t,
+                &C::EMIT_BMOPF_TRANSFORMER_MISSING_XSC,
+                format!(
+                    "transformer {}: xsc_pct is empty; emitted x_series_from=0",
+                    t.name
+                ),
+                Map::new(),
+            );
+        }
+        let xhl = t.xsc_pct.first().copied().unwrap_or(0.0);
+        self.referred_ohms(&mut o, "x_series_from", xhl, zb_from, t, "from");
+        o.insert("x_series_to".into(), json!(0.0));
+        self.transformer_no_load_fields(&mut o, t, from, s);
+        o
+    }
+
+    /// The regulation ratio (regulated over source): the to side tap over
+    /// the from side tap. `None` (with a warning) when the taps cannot form
+    /// a nonnegative finite ratio.
+    fn regulator_tap_ratio(
+        &mut self,
+        t: &DistTransformer,
+        from: &Winding,
+        to: &Winding,
+    ) -> Option<f64> {
+        let ratio = to.tap / from.tap;
+        if ratio.is_finite() && ratio >= 0.0 {
+            return Some(ratio);
+        }
+        let mut details = Map::new();
+        details.insert("from_tap".into(), json!(from.tap));
+        details.insert("to_tap".into(), json!(to.tap));
+        self.transformer_diagnostic(
+            t,
+            &C::EMIT_BMOPF_TRANSFORMER_TAP_DROPPED,
+            format!(
+                "transformer {}: taps ({}, {}) cannot form a nonnegative finite \
+                 BMOPF tap_ratio; dropped",
+                t.name, from.tap, to.tap
+            ),
+            details,
+        );
+        None
     }
 
     /// Shared single_phase / center_tap shape. `to_scale` rescales the to
@@ -2461,6 +2674,13 @@ enum Kind {
     /// Two windings already in the shared single_phase/center_tap shape,
     /// emitted under the named subtype.
     SinglePhaseShape(&'static str),
+    /// A dss classified step voltage regulator, emitted under the
+    /// `single_phase_autotransformer` subtype of the BMOPFTools schema
+    /// extension.
+    Autotransformer,
+    /// One line to line leg of a dss classified open delta regulator bank;
+    /// two legs merge into one `open_delta_regulator` object.
+    OpenDeltaLeg,
     CenterTap,
     WyeDelta,
     DeltaWye,
@@ -2481,6 +2701,8 @@ fn classify(t: &DistTransformer) -> Kind {
                 "center_tap" => return Kind::SinglePhaseShape("center_tap"),
                 "wye_delta" => return Kind::WyeDelta,
                 "delta_wye" => return Kind::DeltaWye,
+                "single_phase_autotransformer" => return Kind::Autotransformer,
+                "open_delta_regulator" => return Kind::OpenDeltaLeg,
                 _ => {}
             }
         }
@@ -2490,16 +2712,19 @@ fn classify(t: &DistTransformer) -> Kind {
     }
     let conns: Vec<WindingConn> = t.windings.iter().map(|w| w.conn).collect();
     match (t.phases, conns.as_slice()) {
-        // single_phase covers the plain 1-phase wye-wye unit and both open
-        // wye / open delta leg orientations (one delta winding wired line to
-        // line). The single_phase shape holds the delta side: it carries two
-        // phase terminals, no conn discriminator, and its line to line v_ref
-        // makes the per winding impedance base v^2/s already right. The
-        // pattern reads as the three pairs wye-wye, delta-wye, wye-delta.
+        // single_phase covers the plain 1-phase unit in every conn pairing:
+        // a delta winding here is one wired line to line (an open wye or
+        // open delta leg, or both legs of a fixed tap open delta bank). The
+        // single_phase shape holds it: two phase terminals, no conn
+        // discriminator, and the line to line v_ref makes the per winding
+        // impedance base v^2/s already right — which reads the same for one
+        // delta winding or two.
         (
             1,
-            [WindingConn::Wye | WindingConn::Delta, WindingConn::Wye]
-            | [WindingConn::Wye, WindingConn::Delta],
+            [
+                WindingConn::Wye | WindingConn::Delta,
+                WindingConn::Wye | WindingConn::Delta,
+            ],
         ) => Kind::SinglePhase,
         (1, [WindingConn::Wye, WindingConn::Wye, WindingConn::Wye]) => Kind::CenterTap,
         (3, [WindingConn::Wye, WindingConn::Delta]) => Kind::WyeDelta,

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -144,8 +144,8 @@ pub mod codes {
             "the BMOPF formulation expects exactly one voltage source";
 
 
-        // EMIT.BMOPF: the nineteen codes the writer already publishes, now
-        // registered entries rather than loose string literals.
+        // EMIT.BMOPF: the writer's element specific codes, registered
+        // entries rather than loose string literals.
         EMIT_BMOPF_AUTOTRANSFORMER_DROPPED = "EMIT.BMOPF.AUTOTRANSFORMER_DROPPED", Warning,
             "an autotransformer the BMOPF schema cannot state was dropped";
         EMIT_BMOPF_BUS_LOCATION_DROPPED = "EMIT.BMOPF.BUS_LOCATION_DROPPED", Warning,
@@ -181,6 +181,8 @@ pub mod codes {
         EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_UNCONVERTIBLE =
             "EMIT.BMOPF.TRANSFORMER_NO_LOAD_SHUNT_UNCONVERTIBLE", Warning,
             "a transformer no load shunt could not be converted to the BMOPF form";
+        EMIT_BMOPF_TRANSFORMER_OPEN_DELTA_MERGED = "EMIT.BMOPF.TRANSFORMER_OPEN_DELTA_MERGED",
+            Warning, "two regulator legs merged into one open_delta_regulator object";
         EMIT_BMOPF_TRANSFORMER_PER_PHASE_TAP_COLLAPSED =
             "EMIT.BMOPF.TRANSFORMER_PER_PHASE_TAP_COLLAPSED", Warning,
             "a transformer's per phase taps were collapsed to one BMOPF tap";

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -11,7 +11,7 @@
 //! `max(4, highest node + 1)` to match PowerModelsDistribution and the
 //! public BMOPF examples.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -31,7 +31,8 @@ use crate::model::{
     DistLoadVoltageModel, DistShunt, DistSourceFormat, DistSwitch, DistTransformer, Extras,
     IbrPrimeMover, IbrTopology, Mat, MulticonductorNetwork, PowerFactorControl,
     ReactivePowerReference, ReactivePowerUnit, UntypedObject, VoltVarControl, VoltWattControl,
-    VoltageSource, Winding, WindingConn, pair_keys, square_from_rows,
+    VoltageSource, Winding, WindingConn, open_delta_connection, open_delta_pairable, pair_keys,
+    square_from_rows, winding_phase_pair,
 };
 
 /// Upper bound on any count property (`phases`, conductors, `windings`, tap
@@ -172,6 +173,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> MulticonductorNetw
         linecode_units: BTreeMap::new(),
         linecode_nconds: BTreeMap::new(),
         xycurves: BTreeMap::new(),
+        regulated: BTreeSet::new(),
         vars: &raw.vars,
     };
 
@@ -230,6 +232,7 @@ pub fn network_from_raw(raw: &RawDss, source: Arc<String>) -> MulticonductorNetw
     for obj in raw.of_class("regcontrol") {
         rd.regcontrol(obj);
     }
+    rd.classify_regulators();
     for obj in &raw.objects {
         if !TYPED_DSS_CLASSES.contains(&obj.class.as_str()) {
             rd.net.untyped.push(UntypedObject::from(obj));
@@ -404,6 +407,9 @@ struct Reader<'a> {
     /// (Line.cpp FetchLineCode), exactly like `phases=`.
     linecode_nconds: BTreeMap<String, usize>,
     xycurves: BTreeMap<String, XyCurveRaw>,
+    /// Transformer names (lowercase) a regcontrol targets, for the BMOPF
+    /// regulator subtype classification pass.
+    regulated: BTreeSet<String>,
     vars: &'a VarMap,
 }
 
@@ -2229,8 +2235,90 @@ impl Reader<'_> {
             "regcontrol {}: voltage regulation is ignored; transformer `{target}` keeps its written taps",
             obj.name
         ));
+        if !target.is_empty() {
+            self.regulated.insert(target.to_ascii_lowercase());
+        }
         self.net.untyped.push(UntypedObject::from(obj));
     }
+
+    /// Marks regcontrol targeted transformers with the BMOPF regulator
+    /// subtype the writer emits (`bmopf_subtype` in extras), tracking the
+    /// BMOPFTools schema extension. Only the unambiguous shapes classify: a
+    /// series single phase unit with equal winding voltages and ratings, and
+    /// a pair of identical line to line legs spelling one of the three open
+    /// delta connections. Anything else keeps today's typing.
+    fn classify_regulators(&mut self) {
+        let regulated = std::mem::take(&mut self.regulated);
+        if regulated.is_empty() {
+            return;
+        }
+        let mut legs: Vec<usize> = Vec::new();
+        for (idx, t) in self.net.transformers.iter_mut().enumerate() {
+            if !regulated.contains(&t.name.to_ascii_lowercase()) || !is_series_regulator(t) {
+                continue;
+            }
+            t.extras.insert(
+                "bmopf_subtype".into(),
+                "single_phase_autotransformer".into(),
+            );
+            if winding_phase_pair(&t.windings[0]).is_some() {
+                legs.push(idx);
+            }
+        }
+        let mut groups: BTreeMap<(String, String), Vec<usize>> = BTreeMap::new();
+        for &idx in &legs {
+            let t = &self.net.transformers[idx];
+            let key = (
+                t.windings[0].bus.to_ascii_lowercase(),
+                t.windings[1].bus.to_ascii_lowercase(),
+            );
+            groups.entry(key).or_default().push(idx);
+        }
+        for idxs in groups.into_values() {
+            let [a, b] = idxs[..] else { continue };
+            let (ta, tb) = (&self.net.transformers[a], &self.net.transformers[b]);
+            let pair = |t: &DistTransformer| winding_phase_pair(&t.windings[0]);
+            let (Some(pa), Some(pb)) = (pair(ta), pair(tb)) else {
+                continue;
+            };
+            if open_delta_connection(pa, pb).is_none() || !open_delta_pairable(ta, tb) {
+                continue;
+            }
+            for idx in [a, b] {
+                self.net.transformers[idx]
+                    .extras
+                    .insert("bmopf_subtype".into(), "open_delta_regulator".into());
+            }
+        }
+    }
+}
+
+/// A regcontrol target that reads as a series regulator: one phase, two
+/// windings of the same connection, voltage, and rating, on distinct buses,
+/// spanning the same phase conductors on both sides.
+fn is_series_regulator(t: &DistTransformer) -> bool {
+    let [a, b] = t.windings.as_slice() else {
+        return false;
+    };
+    let positive = |v: f64| v.is_finite() && v > 0.0;
+    let phase_terms = |w: &Winding| -> Vec<String> {
+        w.terminal_map
+            .iter()
+            .filter(|t| *t != "0")
+            .cloned()
+            .collect()
+    };
+    let phases = phase_terms(a);
+    t.phases == 1
+        && a.conn == b.conn
+        && a.v_ref.to_bits() == b.v_ref.to_bits()
+        && positive(a.v_ref)
+        && a.s_rating.to_bits() == b.s_rating.to_bits()
+        && positive(a.s_rating)
+        && !a.bus.eq_ignore_ascii_case(&b.bus)
+        && phases == phase_terms(b)
+        && matches!(phases.len(), 1 | 2)
+        && (phases.len() < 2 || phases[0] != phases[1])
 }
 
 /// Every entry times `k`.

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -1205,6 +1205,55 @@ pub(crate) fn n_winding_impedance_base(phases: usize, v_nom: f64, s: f64) -> Opt
         .then_some(phases * v_nom * v_nom / s)
 }
 
+/// The two phase conductors of a line to line regulating winding: exactly
+/// two terminals, both named 1..=3, distinct, in terminal map order.
+pub(crate) fn winding_phase_pair(winding: &Winding) -> Option<(u8, u8)> {
+    let [first, second] = winding.terminal_map.as_slice() else {
+        return None;
+    };
+    let phase = |term: &String| term.parse::<u8>().ok().filter(|n| (1..=3).contains(n));
+    match (phase(first), phase(second)) {
+        (Some(lead), Some(lag)) if lead != lag => Some((lead, lag)),
+        _ => None,
+    }
+}
+
+/// The GridLAB-D open delta connection two ordered line to line phase pairs
+/// spell (the naming the BMOPFTools schema extension uses), and whether the
+/// legs arrived in the swapped order. Any other orientation is `None`.
+pub(crate) fn open_delta_connection(a: (u8, u8), b: (u8, u8)) -> Option<(&'static str, bool)> {
+    match (a, b) {
+        ((1, 2), (2, 3)) => Some(("ABBC", false)),
+        ((2, 3), (1, 2)) => Some(("ABBC", true)),
+        ((2, 3), (1, 3)) => Some(("BCAC", false)),
+        ((1, 3), (2, 3)) => Some(("BCAC", true)),
+        ((3, 1), (2, 1)) => Some(("CABA", false)),
+        ((2, 1), (3, 1)) => Some(("CABA", true)),
+        _ => None,
+    }
+}
+
+/// Whether two single phase regulator legs are electrically identical, so
+/// one BMOPF `open_delta_regulator` object (which states one per regulator
+/// impedance and rating) can carry both without collapsing anything.
+pub(crate) fn open_delta_pairable(a: &DistTransformer, b: &DistTransformer) -> bool {
+    let ([a0, a1], [b0, b1]) = (a.windings.as_slice(), b.windings.as_slice()) else {
+        return false;
+    };
+    let eq = |x: f64, y: f64| x.to_bits() == y.to_bits();
+    eq(a0.v_ref, b0.v_ref)
+        && eq(a1.v_ref, b1.v_ref)
+        && eq(a0.s_rating, b0.s_rating)
+        && eq(a1.s_rating, b1.s_rating)
+        && eq(a0.r_pct, b0.r_pct)
+        && eq(a1.r_pct, b1.r_pct)
+        && a.xsc_pct.len() == b.xsc_pct.len()
+        && a.xsc_pct.iter().zip(&b.xsc_pct).all(|(x, y)| eq(*x, *y))
+        && ["%noloadloss", "%imag", "g_no_load", "b_no_load"]
+            .iter()
+            .all(|k| a.extras.get(*k) == b.extras.get(*k))
+}
+
 /// Upper triangular `(i, j)` winding index pairs for `n` windings, the order
 /// short circuit test pairs (`x_sc`/`xsc_pct`) are keyed by.
 pub(crate) fn pair_keys(n: usize) -> Vec<(usize, usize)> {

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -3246,3 +3246,293 @@ fn consumer_extras_are_not_read_as_schema_fields() {
         net.parse_diagnostics
     );
 }
+
+// ----- regulator subtypes (BMOPFTools schema extension) -------------------
+
+#[test]
+fn dss_single_phase_regulator_emits_the_autotransformer_subtype() {
+    let v = schema_validator();
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.regcase basekv=2.4 bus1=650.1.2.3\n\
+         New Transformer.vreg phases=1 windings=2 buses=(650.1 rg60.1) \
+         kvs=(2.4 2.4) kvas=(1666 1666) xhl=0.01 %loadloss=0.01 taps=(1.0 1.05)\n\
+         New RegControl.cvreg transformer=vreg winding=2 vreg=122 band=2 ptratio=20",
+    );
+    let t = &net.transformers[0];
+    assert_eq!(
+        t.extras.get("bmopf_subtype"),
+        Some(&serde_json::json!("single_phase_autotransformer"))
+    );
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let reg = &doc["transformer"]["single_phase_autotransformer"]["vreg"];
+    assert_eq!(reg["bus_from"], "650");
+    assert_eq!(reg["bus_to"], "rg60");
+    assert_eq!(reg["s_rating"], serde_json::json!(1_666_000.0));
+    // %loadloss 0.01 splits into 0.005% per winding on zb = 2400^2/1666000.
+    let zb = 2400.0 * 2400.0 / 1_666_000.0;
+    assert!((reg["r_series_from"].as_f64().unwrap() - 0.005 / 100.0 * zb).abs() < 1e-15);
+    assert!((reg["x_series_from"].as_f64().unwrap() - 0.01 / 100.0 * zb).abs() < 1e-15);
+    assert_eq!(reg["x_series_to"], serde_json::json!(0.0));
+    assert_eq!(reg["tap_ratio"], serde_json::json!(1.05));
+    // The subtype has no voltage fields; the ratio is tap_ratio alone.
+    assert!(reg.get("v_nom_from").is_none(), "{reg}");
+    assert!(reg.get("v_nom_to").is_none(), "{reg}");
+
+    // The classification marker is converter bookkeeping; the dss echo
+    // neither prints it nor warns about it.
+    let dss_out = write_dss(&net);
+    assert!(!dss_out.text.contains("bmopf_subtype"), "{}", dss_out.text);
+    assert!(
+        dss_out
+            .warnings
+            .iter()
+            .all(|w| !w.contains("bmopf_subtype")),
+        "{:?}",
+        dss_out.warnings
+    );
+}
+
+#[test]
+fn dss_open_delta_regulator_pair_merges_into_one_object() {
+    let v = schema_validator();
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.odcase basekv=4.16 bus1=busa.1.2.3\n\
+         New Transformer.rega phases=1 windings=2 buses=(busa.1.2 busb.1.2) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=1 %loadloss=0.2 taps=(1.0 1.03)\n\
+         New RegControl.crega transformer=rega winding=2 vreg=120 band=2 ptratio=34.7\n\
+         New Transformer.regb phases=1 windings=2 buses=(busa.2.3 busb.2.3) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=1 %loadloss=0.2 taps=(1.0 1.06)\n\
+         New RegControl.cregb transformer=regb winding=2 vreg=120 band=2 ptratio=34.7",
+    );
+    for t in &net.transformers {
+        assert_eq!(
+            t.extras.get("bmopf_subtype"),
+            Some(&serde_json::json!("open_delta_regulator")),
+            "{}",
+            t.name
+        );
+    }
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let table = doc["transformer"]["open_delta_regulator"]
+        .as_object()
+        .unwrap();
+    assert_eq!(table.keys().collect::<Vec<_>>(), ["rega"]);
+    let reg = &table["rega"];
+    assert_eq!(reg["connection"], "ABBC");
+    assert_eq!(reg["bus_from"], "busa");
+    assert_eq!(reg["bus_to"], "busb");
+    assert_eq!(reg["terminal_map_from"], serde_json::json!(["1", "2", "3"]));
+    assert_eq!(reg["terminal_map_to"], serde_json::json!(["1", "2", "3"]));
+    assert_eq!(reg["tap_ratio"], serde_json::json!([1.03, 1.06]));
+    let zb = 4160.0 * 4160.0 / 1_000_000.0;
+    assert!((reg["r_series_from"].as_f64().unwrap() - 0.1 / 100.0 * zb).abs() < 1e-12);
+    assert!((reg["x_series_from"].as_f64().unwrap() - 1.0 / 100.0 * zb).abs() < 1e-12);
+    let merge = diagnostic(
+        &out,
+        "EMIT.BMOPF.TRANSFORMER_OPEN_DELTA_MERGED",
+        "transformer rega",
+    );
+    assert_eq!(merge.details["merged_leg"], serde_json::json!("regb"));
+
+    // The emitted document reads back untyped and re-emits byte identical.
+    let again = parse_bmopf_str(&out.text).unwrap();
+    let twice = write_bmopf_json(&again);
+    assert_eq!(out.text, twice.text);
+}
+
+#[test]
+fn unregulated_and_mismatched_transformers_keep_their_subtype() {
+    // No regcontrol: a plain two winding unit stays single_phase.
+    let plain = parse_dss_str(
+        "Clear\n\
+         New Circuit.plaincase basekv=2.4 bus1=650.1.2.3\n\
+         New Transformer.t1 phases=1 windings=2 buses=(650.1 651.1) \
+         kvs=(2.4 2.4) kvas=(100 100) xhl=2",
+    );
+    assert!(!plain.transformers[0].extras.contains_key("bmopf_subtype"));
+    let doc: serde_json::Value = serde_json::from_str(&write_bmopf_json(&plain).text).unwrap();
+    assert!(doc["transformer"]["single_phase"].get("t1").is_some());
+    assert!(
+        doc["transformer"]
+            .get("single_phase_autotransformer")
+            .is_none()
+    );
+
+    // A regcontrol on a voltage changing transformer is an LTC, and its
+    // winding voltages rule the series regulator reading out.
+    let ltc = parse_dss_str(
+        "Clear\n\
+         New Circuit.ltccase basekv=2.4 bus1=650.1.2.3\n\
+         New Transformer.t2 phases=1 windings=2 buses=(650.1 lv.1) \
+         kvs=(2.4 0.24) kvas=(100 100) xhl=2\n\
+         New RegControl.ct2 transformer=t2 winding=2 vreg=122 band=2 ptratio=20",
+    );
+    assert!(!ltc.transformers[0].extras.contains_key("bmopf_subtype"));
+    let doc: serde_json::Value = serde_json::from_str(&write_bmopf_json(&ltc).text).unwrap();
+    assert!(doc["transformer"]["single_phase"].get("t2").is_some());
+}
+
+#[test]
+fn open_delta_legs_with_different_impedance_stay_single_units() {
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.odcase basekv=4.16 bus1=busa.1.2.3\n\
+         New Transformer.rega phases=1 windings=2 buses=(busa.1.2 busb.1.2) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=1\n\
+         New RegControl.crega transformer=rega winding=2 vreg=120 band=2 ptratio=34.7\n\
+         New Transformer.regb phases=1 windings=2 buses=(busa.2.3 busb.2.3) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=2\n\
+         New RegControl.cregb transformer=regb winding=2 vreg=120 band=2 ptratio=34.7",
+    );
+    for t in &net.transformers {
+        assert_eq!(
+            t.extras.get("bmopf_subtype"),
+            Some(&serde_json::json!("single_phase_autotransformer")),
+            "{}",
+            t.name
+        );
+    }
+    let doc: serde_json::Value = serde_json::from_str(&write_bmopf_json(&net).text).unwrap();
+    let table = doc["transformer"]["single_phase_autotransformer"]
+        .as_object()
+        .unwrap();
+    assert_eq!(table.len(), 2);
+    assert!(doc["transformer"].get("open_delta_regulator").is_none());
+}
+
+#[test]
+fn open_delta_leg_without_its_partner_falls_back_to_a_single_unit() {
+    let mut net = parse_dss_str(
+        "Clear\n\
+         New Circuit.odcase basekv=4.16 bus1=busa.1.2.3\n\
+         New Transformer.rega phases=1 windings=2 buses=(busa.1.2 busb.1.2) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=1\n\
+         New RegControl.crega transformer=rega winding=2 vreg=120 band=2 ptratio=34.7\n\
+         New Transformer.regb phases=1 windings=2 buses=(busa.2.3 busb.2.3) \
+         kvs=(4.16 4.16) kvas=(1000 1000) xhl=1\n\
+         New RegControl.cregb transformer=regb winding=2 vreg=120 band=2 ptratio=34.7",
+    );
+    net.transformers.retain(|t| t.name == "rega");
+    let out = write_bmopf_json(&net);
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    assert!(
+        doc["transformer"]["single_phase_autotransformer"]
+            .get("rega")
+            .is_some()
+    );
+    assert!(doc["transformer"].get("open_delta_regulator").is_none());
+    assert!(
+        out.warnings
+            .iter()
+            .any(|w| w.contains("rega") && w.contains("no matching partner")),
+        "{:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn bmopf_regulator_subtypes_round_trip_verbatim() {
+    let v = schema_validator();
+    let text = r#"{
+        "bus": {
+            "b1": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]},
+            "b2": {"terminal_names": ["1", "2", "3", "n"], "perfectly_grounded_terminals": ["n"]}
+        },
+        "voltage_source": {"src": {"bus": "b1", "terminal_map": ["1", "n"],
+            "v_magnitude": [2400.0], "v_angle": [0.0]}},
+        "transformer": {
+            "single_phase_autotransformer": {
+                "svr": {
+                    "bus_from": "b1", "bus_to": "b2",
+                    "terminal_map_from": ["1", "n"], "terminal_map_to": ["1", "n"],
+                    "s_rating": 1666000.0,
+                    "r_series_from": 0.001, "x_series_from": 0.002,
+                    "r_series_to": 0.001, "x_series_to": 0.0,
+                    "g_no_load": 0.0001, "b_no_load": -0.0002,
+                    "tap_ratio": 1.05, "tap_ratio_min": 0.9, "tap_ratio_max": 1.1,
+                    "regulator_type": "B",
+                    "i_max_from": [668.0], "i_max_to": [668.0]
+                }
+            },
+            "open_delta_regulator": {
+                "odr": {
+                    "bus_from": "b1", "bus_to": "b2",
+                    "terminal_map_from": ["1", "2", "3"], "terminal_map_to": ["1", "2", "3"],
+                    "s_rating": 1000000.0,
+                    "r_series_from": 0.01, "x_series_from": 0.02,
+                    "connection": "BCAC",
+                    "tap_ratio": [1.03, 1.06],
+                    "regulator_type": "A"
+                }
+            }
+        }
+    }"#;
+    let net = parse_bmopf_str(text).unwrap();
+    assert!(
+        net.untyped
+            .iter()
+            .any(|u| u.class == "transformer.single_phase_autotransformer" && u.name == "svr")
+    );
+    assert!(
+        net.untyped
+            .iter()
+            .any(|u| u.class == "transformer.open_delta_regulator" && u.name == "odr")
+    );
+
+    let out = write_bmopf_json(&net);
+    assert_eq!(errors(&v, &out.text), Vec::<String>::new());
+    let source: serde_json::Value = serde_json::from_str(text).unwrap();
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    assert_eq!(
+        doc["transformer"]["single_phase_autotransformer"]["svr"],
+        source["transformer"]["single_phase_autotransformer"]["svr"]
+    );
+    assert_eq!(
+        doc["transformer"]["open_delta_regulator"]["odr"],
+        source["transformer"]["open_delta_regulator"]["odr"]
+    );
+    let again = parse_bmopf_str(&out.text).unwrap();
+    let twice = write_bmopf_json(&again);
+    assert_eq!(out.text, twice.text);
+}
+
+#[test]
+fn a_fixed_tap_open_delta_bank_emits_two_single_phase_units() {
+    // Two 1 phase Delta/Delta legs across A-B and B-C between one bus pair: a
+    // fixed tap open delta bank with no RegControl. Each leg is a line to
+    // line unit the single_phase shape holds; through 0.9.0 the [Delta,
+    // Delta] pairing had no classify arm and both legs dropped silently.
+    let net = parse_dss_str(
+        "Clear\n\
+         New Circuit.odb basekv=12.47 bus1=sourcebus.1.2.3\n\
+         New Transformer.leg_ab phases=1 windings=2 buses=(sourcebus.1.2, loadbus.1.2) \
+         conns=(delta delta) kvs=(12.47 12.47) kvas=(100 100) xhl=1\n\
+         New Transformer.leg_bc phases=1 windings=2 buses=(sourcebus.2.3, loadbus.2.3) \
+         conns=(delta delta) kvs=(12.47 12.47) kvas=(100 100) xhl=1\n",
+    );
+    assert_eq!(net.transformers.len(), 2, "{:?}", net.transformers);
+
+    let out = write_bmopf_json(&net);
+    assert!(
+        !out.warnings
+            .iter()
+            .any(|w| w.contains("EMIT.BMOPF.TRANSFORMER_UNSUPPORTED")),
+        "the bank must not drop: {:?}",
+        out.warnings
+    );
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    let single_phase = &doc["transformer"]["single_phase"];
+    assert!(
+        single_phase.get("leg_ab").is_some() && single_phase.get("leg_bc").is_some(),
+        "both legs emit as single_phase: {}",
+        doc["transformer"]
+    );
+}


### PR DESCRIPTION
A BMOPF document carrying single_phase_autotransformer or open_delta_regulator already round tripped verbatim through the untyped passthrough; the loss was on the OpenDSS side, where a RegControl targeted regulator emitted as a plain single_phase transformer and an autotransformer dropped with a diagnostic. The dss reader now classifies a single phase series regulator into the autotransformer subtype and two line to line legs spelling ABBC, BCAC or CABA into one open delta regulator, the writer emits both subtypes with the field grammar BMOPFTools defines (EMIT.BMOPF.TRANSFORMER_OPEN_DELTA_MERGED names the absorbed leg), and every ambiguous pattern keeps today's typing, since a wrong classification is worse than a drop. The subtypes are a schema extension the BMOPF task force has not yet absorbed; the writer documentation says so next to voltage_source.cost, which has the same standing.

A consumer integration run over the branch found the adjacent hole: a fixed tap open delta bank, two one phase Delta/Delta legs with no RegControl, an ordinary deck, had no classify arm at all and both legs dropped silently. The one phase arm now takes every conn pairing, since a line to line delta winding reads the same on either side, and the drop message stops counting subtypes.

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN