### PR TITLE
capi: charge and discharge efficiency on solver_storage

### DIFF
--- a/docs/src/abi-v5.md
+++ b/docs/src/abi-v5.md
@@ -221,4 +221,4 @@ The star-lowered space required no binding edit at all, which is the point worth
 
 ## What did not change
 
-Every ABI 4 Arrow table id and its column order. Two cost tables append at 21 and 22 and `solver_bus` gains `area` and `zone` at the end of its columns, so a consumer addressing columns by name sees nothing shift. Every case format token except the three retired above. The opaque handle design. The panic guard on every entry point. `errbuf` and `errlen` last. `pio_abi_version`, `pio_version` and `pio_has_feature`.
+Every ABI 4 Arrow table id and its column order. Two cost tables append at 21 and 22, `solver_bus` gains `area` and `zone` at the end of its columns, and `solver_storage` gains `charge_efficiency` and `discharge_efficiency` the same way, so a consumer addressing columns by name sees nothing shift. Every case format token except the three retired above. The opaque handle design. The panic guard on every entry point. `errbuf` and `errlen` last. `pio_abi_version`, `pio_version` and `pio_has_feature`.

--- a/docs/src/capi-arrow.md
+++ b/docs/src/capi-arrow.md
@@ -68,7 +68,7 @@ powerio.group_axis    # table 22 only, "solver_gen"
 powerio.group_column  # table 22 only, "gen_index"
 ```
 
-`solver_bus` (table 6) gained `area` and `zone` at the end of its column list in the same release, so an area or zone keyed consumer does not have to fall back to the JSON snapshot for two integers per bus.
+`solver_bus` (table 6) gained `area` and `zone` at the end of its column list in the same release, so an area or zone keyed consumer does not have to fall back to the JSON snapshot for two integers per bus. `solver_storage` (table 13) gained `charge_efficiency` and `discharge_efficiency` the same way, so a storage constraint that prices conversion losses reads them from the table it already decodes.
 
 ## Arrow catalog JSON
 

--- a/powerio-capi/src/arrow_export.rs
+++ b/powerio-capi/src/arrow_export.rs
@@ -274,6 +274,7 @@ fn catalog_value() -> serde_json::Value {
                 ("discharge_rating", "float64"), ("thermal_rating", "float64"),
                 ("qmin", "float64"), ("qmax", "float64"), ("r", "float64"),
                 ("x", "float64"), ("p_loss", "float64"), ("q_loss", "float64"),
+                ("charge_efficiency", "float64"), ("discharge_efficiency", "float64"),
             ]),
             table_spec(PIO_ARROW_TABLE_SOLVER_HVDC, "solver_hvdc", "record_batch", &["arrow"], true, Some("solver_hvdc"), None, units_solver(), &[
                 ("index", "int64"), ("source_row", "int64"), ("from_bus_index", "int64"),
@@ -934,6 +935,14 @@ fn solver_storage_batch(t: &NormalizedSolverTables) -> Result<RecordBatch, Arrow
         ("x", f64s(t.storage.iter().map(|x| x.x).collect())),
         ("p_loss", f64s(t.storage.iter().map(|x| x.p_loss).collect())),
         ("q_loss", f64s(t.storage.iter().map(|x| x.q_loss).collect())),
+        (
+            "charge_efficiency",
+            f64s(t.storage.iter().map(|x| x.charge_efficiency).collect()),
+        ),
+        (
+            "discharge_efficiency",
+            f64s(t.storage.iter().map(|x| x.discharge_efficiency).collect()),
+        ),
     ])
 }
 
@@ -1918,6 +1927,16 @@ mod tests {
         assert_eq!(solver_bus["columns"][14]["name"], "is_reference");
         assert_eq!(solver_bus["columns"][15]["name"], "area");
         assert_eq!(solver_bus["columns"][16]["name"], "zone");
+
+        // solver_storage grew the two efficiencies at the end; same rule.
+        let solver_storage = find("solver_storage");
+        assert_eq!(solver_storage["columns"][0]["name"], "index");
+        assert_eq!(solver_storage["columns"][15]["name"], "q_loss");
+        assert_eq!(solver_storage["columns"][16]["name"], "charge_efficiency");
+        assert_eq!(
+            solver_storage["columns"][17]["name"],
+            "discharge_efficiency"
+        );
     }
 
     fn gen_cost_net() -> BalancedNetwork {
@@ -2131,6 +2150,79 @@ mod tests {
         assert_eq!(names[names.len() - 2..], ["area", "zone"]);
         assert_eq!(names[0], "index");
         assert_eq!(names[14], "is_reference");
+    }
+
+    fn storage_net() -> BalancedNetwork {
+        use powerio::{Bus, BusId, BusType, Generator, Storage};
+
+        let mut net = BalancedNetwork::in_memory(
+            "storage",
+            100.0,
+            vec![
+                Bus::new(BusId(1), BusType::Ref, 230.0),
+                Bus::new(BusId(2), BusType::Pq, 230.0),
+            ],
+            Vec::new(),
+        );
+        let mut generator = Generator::new(BusId(1));
+        generator.pmax = 100.0;
+        net.generators = vec![generator];
+        // Every field distinct, so a column fed from the wrong field fails.
+        let mut storage = Storage::new(BusId(2));
+        storage.ps = 30.0;
+        storage.qs = -10.0;
+        storage.energy = 50.0;
+        storage.energy_rating = 90.0;
+        storage.charge_rating = 20.0;
+        storage.discharge_rating = 25.0;
+        storage.charge_efficiency = 0.9;
+        storage.discharge_efficiency = 0.85;
+        storage.thermal_rating = 40.0;
+        storage.qmin = -15.0;
+        storage.qmax = 15.0;
+        storage.r = 0.01;
+        storage.x = 0.02;
+        storage.p_loss = 2.0;
+        storage.q_loss = 1.0;
+        net.storage = vec![storage];
+        net
+    }
+
+    #[test]
+    fn solver_storage_exports_charge_and_discharge_efficiency() {
+        let n = storage_net();
+        let tables = n.to_normalized_solver_tables().unwrap();
+        let sa = round_trip(&n, PIO_ARROW_TABLE_SOLVER_STORAGE);
+        assert_eq!(sa.len(), tables.storage.len());
+        let expected: Vec<f64> = tables.storage.iter().map(|s| s.charge_efficiency).collect();
+        assert_eq!(
+            f64_col(&sa, "charge_efficiency").values(),
+            expected.as_slice()
+        );
+        let expected: Vec<f64> = tables
+            .storage
+            .iter()
+            .map(|s| s.discharge_efficiency)
+            .collect();
+        assert_eq!(
+            f64_col(&sa, "discharge_efficiency").values(),
+            expected.as_slice()
+        );
+        // Pin the source values so the two columns cannot trade places.
+        assert_eq!(f64_col(&sa, "charge_efficiency").value(0), 0.9);
+        assert_eq!(f64_col(&sa, "discharge_efficiency").value(0), 0.85);
+        // The appended columns sit after the frozen prefix.
+        let names: Vec<&str> = sa
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names[names.len() - 2..],
+            ["charge_efficiency", "discharge_efficiency"]
+        );
+        assert_eq!(names[0], "index");
+        assert_eq!(names[15], "q_loss");
     }
 
     fn gen_cost_golden_json(case_file: &str) -> serde_json::Value {


### PR DESCRIPTION
SolverStorageRow has carried both efficiencies since the row existed, but Arrow table 13 dropped them, so a consumer whose storage constraint prices conversion losses had to materialize the JSON snapshot for two floats per row. They append after the frozen prefix the way solver_bus gained area and zone: catalog spec, batch builder, a catalog assertion that the frozen prefix stays put, and an export test over a storage network whose fields are pairwise distinct so a column fed from the wrong field or a swapped pair fails. The ABI 5 census and the Arrow policy page now name the appended pair beside solver_bus's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN