### PR TITLE
mcp: fix transport text handling, contain folder writers, expose diagnostic codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ pip install 'powerio[mcp]'
 powerio-mcp
 ```
 
+`python -m powerio.mcp` and the `powerio-mcp` console script are consumer entry points and do not move without a version bump.
+
 MCP clients can keep a case in `.pio.json` document JSON through the `package`
 transport:
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -202,6 +202,8 @@ diagnostics(pkg)
 document JSON passed through the legacy `json` argument. The document
 metadata's `model_kind` routes balanced and multiconductor model JSON.
 
+`python -m powerio.mcp` and the `powerio-mcp` console script are consumer entry points and do not move without a version bump.
+
 The optional MCP server accepts local filesystem paths and `file://` URIs for
 `path` and `out_path` arguments. Remote URI schemes are rejected. Deployments
 that need filesystem containment can set `POWERIO_MCP_ALLOWED_ROOTS` to an
@@ -220,6 +222,6 @@ out = checked_path(arg, purpose="out_path", for_write=True)
 `checked_path` decodes the argument (local path or `file://` URI), refuses
 remote schemes, resolves symlinks — including a dangling final component under
 `for_write`, so a link inside a root cannot redirect a write out of it — and
-raises `ValueError` when the result lands outside the roots. Its parts,
-`allowed_roots`, `decode_local_path`, and `check_allowed_path`, are public
-too.
+raises `PathNotAllowed` (a `ValueError` subclass) when the result lands
+outside the roots. Its parts, `allowed_roots`, `decode_local_path`, and
+`check_allowed_path`, are public too, as is `PathNotAllowed`.

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -54,7 +54,8 @@ pyo3::create_exception!(
      Subclasses `ValueError`: every failure it covers is a statement about a \
      value the caller supplied, and `except ValueError` was what callers wrote \
      before the hierarchy existed. I/O failures do not reach it; they raise the \
-     matching `OSError` subclass by value."
+     matching `OSError` subclass by value. Failures mapped from the Rust core \
+     carry the diagnostic code string as a `.code` attribute."
 );
 
 pyo3::create_exception!(
@@ -86,16 +87,30 @@ pyo3::create_exception!(
 ///
 /// Every crate's error carries the same `category()`, so one mapping serves
 /// all of them and the hierarchy cannot drift per surface.
-fn categorized_pyerr(category: powerio_matrix::ErrorCategory, msg: String) -> PyErr {
+fn categorized_pyerr(
+    category: powerio_matrix::ErrorCategory,
+    code: &'static str,
+    msg: String,
+) -> PyErr {
     use powerio_matrix::ErrorCategory as C;
-    match category {
+    let err = match category {
         C::UnknownFormat => PyValueError::new_err(msg),
         C::Parse => PowerIOParseError::new_err(msg),
         C::Data => PowerIODataError::new_err(msg),
         // `Io` is unwrapped by the callers below when it still carries the
         // original `std::io::Error`; `Output` (mtx/parquet) maps to the base.
         C::Io | C::Output => PowerIOError::new_err(msg),
-    }
+    };
+    with_code(err, code)
+}
+
+/// Attach the diagnostic code as a `.code` attribute on the exception value,
+/// the Python counterpart of `Error::code()`.
+fn with_code(err: PyErr, code: &'static str) -> PyErr {
+    Python::attach(|py| {
+        let _ = err.value(py).setattr("code", code);
+    });
+    err
 }
 
 fn core_pyerr(e: powerio_matrix::CoreError) -> PyErr {
@@ -104,7 +119,8 @@ fn core_pyerr(e: powerio_matrix::CoreError) -> PyErr {
         return io.into();
     }
     let category = e.category();
-    categorized_pyerr(category, e.to_string())
+    let code = e.code().code;
+    categorized_pyerr(category, code, e.to_string())
 }
 
 fn to_pyerr(e: powerio_matrix::Error) -> PyErr {
@@ -114,7 +130,8 @@ fn to_pyerr(e: powerio_matrix::Error) -> PyErr {
         E::Core(inner) => core_pyerr(inner),
         other => {
             let category = other.category();
-            categorized_pyerr(category, other.to_string())
+            let code = other.code().code;
+            categorized_pyerr(category, code, other.to_string())
         }
     }
 }
@@ -127,7 +144,8 @@ fn prob_pyerr(e: powerio_prob::Error) -> PyErr {
         E::Matrix(inner) => to_pyerr(inner),
         other => {
             let category = other.category();
-            categorized_pyerr(category, other.to_string())
+            let code = other.code().code;
+            categorized_pyerr(category, code, other.to_string())
         }
     }
 }
@@ -315,7 +333,7 @@ fn package_pyerr(e: powerio_pkg::Error) -> PyErr {
     match e {
         powerio_pkg::Error::Core(inner) => core_pyerr(inner),
         powerio_pkg::Error::Multiconductor(inner) => dist_to_pyerr(inner),
-        other => categorized_pyerr(other.category(), other.to_string()),
+        other => categorized_pyerr(other.category(), other.code().code, other.to_string()),
     }
 }
 
@@ -1571,17 +1589,18 @@ fn write_with_sidecars(
 fn dist_to_pyerr(e: powerio_dist::Error) -> PyErr {
     use powerio_dist::Error as E;
     let msg = e.to_string();
+    let code = e.code().code;
     match e {
         // OSError(errno, strerror, filename) lets CPython pick the precise
         // subclass (FileNotFoundError etc.) while keeping the path on
         // e.filename, which a bare io::Error conversion would drop.
         E::Io { path, source } => match source.raw_os_error() {
             Some(errno) => pyo3::exceptions::PyOSError::new_err((errno, source.to_string(), path)),
-            None => PowerIOError::new_err(msg),
+            None => with_code(PowerIOError::new_err(msg), code),
         },
         E::UnknownFormat(_) => PyValueError::new_err(msg),
-        E::Json { .. } => PowerIOParseError::new_err(msg),
-        _ => PowerIOError::new_err(msg),
+        E::Json { .. } => with_code(PowerIOParseError::new_err(msg), code),
+        _ => with_code(PowerIOError::new_err(msg), code),
     }
 }
 

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -9,7 +9,13 @@ Units = Literal["perunit", "native"]
 GridfmOutputs = Dict[str, Any]
 
 class PowerIOError(ValueError):
-    """Base error from the powerio parser, converter, or matrix builders."""
+    """Base error from the powerio parser, converter, or matrix builders.
+
+    Failures mapped from the Rust core carry the diagnostic code string as
+    ``code``; it is set at raise time, so it is instance-only.
+    """
+
+    code: str
 
 class PowerIOParseError(PowerIOError):
     """A case file is malformed or unparseable."""

--- a/python/powerio/_powerio.pyi
+++ b/python/powerio/_powerio.pyi
@@ -12,7 +12,13 @@ __version__: str
 _has_gridfm: bool
 
 class PowerIOError(ValueError):
-    """Base error from the powerio parser, converter, or matrix builders."""
+    """Base error from the powerio parser, converter, or matrix builders.
+
+    Failures mapped from the Rust core carry the diagnostic code string as
+    ``code``; it is set at raise time, so it is instance-only.
+    """
+
+    code: str
 
 class PowerIOParseError(PowerIOError):
     """A case file is malformed or unparseable."""

--- a/python/powerio/mcp/sandbox.py
+++ b/python/powerio/mcp/sandbox.py
@@ -35,11 +35,20 @@ LEGACY_ROOT_ENVS = ("POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT")
 __all__ = [
     "ALLOWED_ROOTS_ENV",
     "LEGACY_ROOT_ENVS",
+    "PathNotAllowed",
     "allowed_roots",
     "check_allowed_path",
     "checked_path",
     "decode_local_path",
 ]
+
+
+class PathNotAllowed(ValueError):
+    """The containment policy refused a path.
+
+    Subclasses :class:`ValueError`, which is what
+    :func:`check_allowed_path` raised before this type existed.
+    """
 
 
 def allowed_roots() -> tuple[Path, ...]:
@@ -110,7 +119,7 @@ def _path_for_policy(path: Path, *, for_write: bool) -> Path:
 def check_allowed_path(
     path: Path, *, for_write: bool = False, purpose: str = "path"
 ) -> None:
-    """Raise :class:`ValueError` when ``path`` resolves outside the roots.
+    """Raise :class:`PathNotAllowed` when ``path`` resolves outside the roots.
 
     Symlinks are resolved first, including a dangling final component under
     ``for_write``, so a link inside a root cannot redirect a write out of it.
@@ -121,14 +130,14 @@ def check_allowed_path(
     try:
         resolved = _path_for_policy(path, for_write=for_write)
     except OSError as exc:
-        raise ValueError(
+        raise PathNotAllowed(
             f"cannot resolve `{purpose}` against allowed MCP roots: {exc}"
         ) from exc
     for root in roots:
         if resolved == root or root in resolved.parents:
             return
     root_list = ", ".join(str(root) for root in roots)
-    raise ValueError(f"`{purpose}` is outside allowed MCP roots: {root_list}")
+    raise PathNotAllowed(f"`{purpose}` is outside allowed MCP roots: {root_list}")
 
 
 def checked_path(

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -20,11 +20,14 @@ from __future__ import annotations
 
 import json as jsonlib
 import os
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Annotated, Any, Callable, Dict, Optional, TypeAlias
 
 from mcp.server.mcpserver import MCPServer
+from pydantic import Field
 
 import powerio
 from powerio import dist
@@ -84,6 +87,34 @@ _MATRIX_HELP = (
     "laplacian, lacpf"
 )
 
+# JSON schema `enum` entries the tool surface advertises. `json_schema_extra`
+# documents without validating, so the historical aliases stay accepted.
+_JsonFormatArg: TypeAlias = Optional[
+    Annotated[
+        str,
+        Field(json_schema_extra={"enum": ["package", "model-json", "bmopf-json"]}),
+    ]
+]
+# A FieldInfo constant rather than an `Annotated[str, ...]` alias: stubtest
+# probes a str-aliased Annotated differently across python versions. The
+# enum list is Any-typed for pydantic's invariant JsonValue list.
+_MATRIX_KIND_ENUM: "list[Any]" = sorted(_MATRIX_KIND_ALIASES)
+_MATRIX_KIND_FIELD = Field(json_schema_extra={"enum": _MATRIX_KIND_ENUM})
+
+# Tool description prose for the open ended format name sets.
+_SOURCE_FORMAT_HELP = (
+    "Accepted `from_format` names — transmission: matpower, powermodels-json, "
+    "egret-json, pandapower-json, psse, powerworld, pslf, goc3-json, "
+    "surge-json, opfdata-json, pypsa-csv, gridfm; distribution: dss, pmd-json, "
+    "bmopf-json. Omit it to infer from the file extension or JSON markers."
+)
+_TARGET_FORMAT_HELP = (
+    "Accepted `to_format` names — transmission: matpower, psse, "
+    "powermodels-json, egret-json, pandapower-json, powerworld, pslf; "
+    "distribution: dss, pmd-json, bmopf-json. The folder targets pypsa-csv "
+    "and gridfm go through `save`."
+)
+
 
 @dataclass
 class _Loaded:
@@ -106,6 +137,15 @@ def _opts(options: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 def _one_input(path: Optional[str], content: Optional[str]) -> None:
     if (path is None) == (content is None):
         raise ValueError("provide exactly one of `path` or `content`")
+
+
+def _coded_error(prefix: str, exc: Exception) -> ValueError:
+    """Lead with the diagnostic code when the failure carries one, so a
+    consumer that splits on the first colon reads a code, never prose."""
+    code = getattr(exc, "code", None)
+    if code:
+        return ValueError(f"{code}: {exc}")
+    return ValueError(f"{prefix}: {exc}")
 
 
 def _required(value: Optional[str], name: str) -> str:
@@ -388,7 +428,7 @@ def _load_package(package_json: str) -> _Loaded:
             package_json=package_json,
         )
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except (ValueError, KeyError, TypeError) as exc:
         raise ValueError(f"parse failed: {exc}") from exc
 
@@ -427,7 +467,7 @@ def _package_json_from_input(
             raise ValueError("content is not a .pio.json package")
         return powerio.Package.from_str(text, from_format).to_json()
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
     except ImportError as exc:
@@ -462,7 +502,7 @@ def _parse_transmission(
                 _required(content, "content"), format or "matpower"
             )
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
     except ImportError as exc:
@@ -492,7 +532,7 @@ def _parse_distribution(
                 _required(content, "content"), _required(format, "from_format")
             )
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
     except OSError as exc:
@@ -560,7 +600,7 @@ def _load_transport(text: str, json_format: Optional[str]) -> _Loaded:
     try:
         net = powerio.from_json(text)
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except (ValueError, KeyError, TypeError) as exc:
         raise ValueError(f"parse failed: {exc}") from exc
     return _Loaded("transmission", net, list(net.read_warnings), "model-json")
@@ -575,6 +615,10 @@ def _load_any(
     json_format: Optional[str],
     options: Optional[Dict[str, Any]] = None,
 ) -> _Loaded:
+    # The tools spell an unset text argument as "" (a bare `str` annotation
+    # keeps the SDK from re-parsing JSON text before validation); empty
+    # transport text is invalid anyway, so "" means absent here.
+    content, transport, package_json = content or None, transport or None, package_json or None
     _one_network_input(path, content, transport, package_json)
     if package_json is not None:
         return _load_package(package_json)
@@ -676,6 +720,72 @@ def _write_text(
     }
 
 
+def _install_dir_tree(tmp_dir: str, out_path: str, overwrite: bool) -> None:
+    """Move a directory writer's staged output into place.
+
+    Every target runs through the same containment resolution as a single
+    file write, and `overwrite=False` refuses before anything has moved.
+    """
+    if not os.path.lexists(out_path):
+        os.rename(tmp_dir, out_path)
+        return
+    tmp = Path(tmp_dir)
+    files = [p for p in sorted(tmp.rglob("*")) if p.is_file()]
+    targets = [Path(out_path) / p.relative_to(tmp) for p in files]
+    if not overwrite:
+        for target in targets:
+            if os.path.lexists(target):
+                raise ValueError(
+                    f"refusing to overwrite existing file: {target}; pass overwrite=true"
+                )
+    for target in targets:
+        sandbox.check_allowed_path(target.parent, purpose="out_path")
+        os.makedirs(target.parent, exist_ok=True)
+        sandbox.check_allowed_path(target, for_write=True, purpose="out_path")
+    for source, target in zip(files, targets):
+        os.replace(source, target)
+
+
+def _rebase_result_paths(
+    result: Dict[str, Any], tmp_dir: str, out_path: str
+) -> Dict[str, Any]:
+    """Rewrite writer-reported paths from the staging directory to the
+    installed location."""
+
+    def rebase(value: Any) -> Any:
+        if isinstance(value, str) and value.startswith(tmp_dir):
+            return out_path + value[len(tmp_dir) :]
+        return value
+
+    rebased = dict(result)
+    if "dir" in rebased:
+        rebased["dir"] = rebase(rebased["dir"])
+    if "files" in rebased:
+        rebased["files"] = [rebase(item) for item in rebased["files"]]
+    return rebased
+
+
+def _staged_dir_write(
+    out_path: str, overwrite: bool, write: Callable[[str], Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Run a directory writer against a fresh staging directory, then install.
+
+    The writers create children unchecked, so they never see `out_path`;
+    installation applies the containment policy and `overwrite` per file.
+    """
+    parent = os.path.dirname(os.path.abspath(out_path)) or os.curdir
+    os.makedirs(parent, exist_ok=True)
+    tmp_dir = tempfile.mkdtemp(prefix=Path(out_path).name + ".", dir=parent)
+    # mkdtemp creates 0o700; the installed directory is ordinary output.
+    os.chmod(tmp_dir, 0o755)
+    try:
+        result = write(tmp_dir)
+        _install_dir_tree(tmp_dir, out_path, overwrite)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    return _rebase_result_paths(result, tmp_dir, out_path)
+
+
 def _choose_from_format(
     from_format: Optional[str] = None,
     *,
@@ -771,7 +881,7 @@ def _convert_impl(
             conv = loaded.network.to_format(to_format)
             warnings = loaded.warnings + list(conv.warnings)
     except powerio.PowerIOError as exc:
-        raise ValueError(f"conversion failed: {exc}") from exc
+        raise _coded_error("conversion failed", exc) from exc
     return {"text": conv.text, "warnings": warnings}
 
 
@@ -798,20 +908,24 @@ def _save_impl(
     if _is_gridfm_format(to_l):
         if loaded.domain != "transmission":
             raise ValueError("gridfm export needs a transmission network")
-        try:
+
+        def write_gridfm(staging: str) -> Dict[str, Any]:
             return dict(
                 loaded.network.write_gridfm(
-                    out_path,
+                    staging,
                     scenario=int(opts.get("scenario", 0)),
                     include_y_bus=bool(opts.get("include_y_bus", True)),
                     include_taps=bool(opts.get("include_taps", True)),
                     include_shifts=bool(opts.get("include_shifts", True)),
                 )
             )
+
+        try:
+            return _staged_dir_write(out_path, overwrite, write_gridfm)
         except ImportError as exc:
             raise ValueError(str(exc)) from exc
         except powerio.PowerIOError as exc:
-            raise ValueError(f"conversion failed: {exc}") from exc
+            raise _coded_error("conversion failed", exc) from exc
         except OSError as exc:
             raise ValueError(f"write failed: {exc}") from exc
 
@@ -819,9 +933,13 @@ def _save_impl(
         if loaded.domain != "transmission":
             raise ValueError("pypsa-csv export needs a transmission network")
         try:
-            result = loaded.network.write_pypsa_csv_folder(out_path)
+            result = _staged_dir_write(
+                out_path,
+                overwrite,
+                lambda staging: dict(loaded.network.write_pypsa_csv_folder(staging)),
+            )
         except powerio.PowerIOError as exc:
-            raise ValueError(f"conversion failed: {exc}") from exc
+            raise _coded_error("conversion failed", exc) from exc
         except OSError as exc:
             raise ValueError(f"write failed: {exc}") from exc
         return {
@@ -836,7 +954,7 @@ def _save_impl(
         try:
             conv = loaded.network.to_format(target)
         except powerio.PowerIOError as exc:
-            raise ValueError(f"conversion failed: {exc}") from exc
+            raise _coded_error("conversion failed", exc) from exc
         return _write_text(out_path, conv.text, loaded.warnings + list(conv.warnings), overwrite)
 
     if loaded.domain != "transmission":
@@ -844,7 +962,7 @@ def _save_impl(
     try:
         conv = loaded.network.to_format(target)
     except powerio.PowerIOError as exc:
-        raise ValueError(f"conversion failed: {exc}") from exc
+        raise _coded_error("conversion failed", exc) from exc
     return _write_text(out_path, conv.text, loaded.warnings + list(conv.warnings), overwrite)
 
 
@@ -869,6 +987,8 @@ def _parse_impl(
     options: Optional[Dict[str, Any]] = None,
     transport: str = "json",
 ) -> dict:
+    # "" means absent, as in `_load_any`.
+    content = content or None
     transport_l = _fmt(transport or "json")
     if transport_l in _PACKAGE_JSON_FORMATS:
         package_json = _package_json_from_input(path, content, from_format, options)
@@ -925,7 +1045,7 @@ def _normalize_impl(
     try:
         norm = loaded.network.to_normalized()
     except powerio.PowerIOError as exc:
-        raise ValueError(f"normalization failed: {exc}") from exc
+        raise _coded_error("normalization failed", exc) from exc
     normalized = _Loaded("transmission", norm, list(norm.read_warnings), "model-json")
     summary = _summary(normalized)
     return {
@@ -984,7 +1104,7 @@ def _matrix_impl(
     except ImportError as exc:
         raise ValueError(str(exc)) from exc
     except powerio.PowerIOError as exc:
-        raise ValueError(f"matrix build failed: {exc}") from exc
+        raise _coded_error("matrix build failed", exc) from exc
     coo = mat.tocoo()
     return {
         **_header("powerio.matrix"),
@@ -1008,7 +1128,7 @@ def _display_impl(path: str, from_format: Optional[str] = None) -> dict:
     try:
         data = powerio.parse_display_file(path, from_format)
     except powerio.PowerIOError as exc:
-        raise ValueError(f"parse failed: {exc}") from exc
+        raise _coded_error("parse failed", exc) from exc
     except FileNotFoundError as exc:
         raise ValueError(f"file not found: {exc}") from exc
     except OSError as exc:
@@ -1033,18 +1153,27 @@ def _display_impl(path: str, from_format: Optional[str] = None) -> dict:
     }
 
 
-@mcp.tool(name="convert")
+# The tool text arguments that can carry JSON (`content`, `json`,
+# `package_json`) are annotated bare `str`: under any other annotation the
+# SDK re-parses a string that reads as JSON, destroying the text. "" means
+# unset.
+@mcp.tool(
+    name="convert",
+    description="Convert a network to a single text format. "
+    + _TARGET_FORMAT_HELP
+    + " "
+    + _SOURCE_FORMAT_HELP,
+)
 def _convert_tool(
     to_format: str,
     path: Optional[str] = None,
-    content: Optional[str] = None,
-    json: Optional[str] = None,
-    package_json: Optional[str] = None,
+    content: str = "",
+    json: str = "",
+    package_json: str = "",
     from_format: Optional[str] = None,
-    json_format: Optional[str] = None,
+    json_format: _JsonFormatArg = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Convert a network to a single text format."""
     return _convert_impl(
         to_format,
         path=path,
@@ -1057,20 +1186,25 @@ def _convert_tool(
     )
 
 
-@mcp.tool(name="save")
+@mcp.tool(
+    name="save",
+    description="Write a converted network to disk. "
+    + _TARGET_FORMAT_HELP
+    + " "
+    + _SOURCE_FORMAT_HELP,
+)
 def _save_tool(
     out_path: str,
     path: Optional[str] = None,
-    content: Optional[str] = None,
-    json: Optional[str] = None,
-    package_json: Optional[str] = None,
+    content: str = "",
+    json: str = "",
+    package_json: str = "",
     to_format: Optional[str] = None,
     from_format: Optional[str] = None,
-    json_format: Optional[str] = None,
+    json_format: _JsonFormatArg = None,
     options: Optional[Dict[str, Any]] = None,
     overwrite: bool = False,
 ) -> dict:
-    """Write a converted network to disk."""
     return _save_impl(
         out_path,
         path=path,
@@ -1085,64 +1219,76 @@ def _save_tool(
     )
 
 
-@mcp.tool(name="summary")
+@mcp.tool(
+    name="summary",
+    description="Return canonical summary JSON for a balanced or "
+    "multiconductor model. " + _SOURCE_FORMAT_HELP,
+)
 def _summary_tool(
     path: Optional[str] = None,
-    content: Optional[str] = None,
-    json: Optional[str] = None,
-    package_json: Optional[str] = None,
+    content: str = "",
+    json: str = "",
+    package_json: str = "",
     from_format: Optional[str] = None,
-    json_format: Optional[str] = None,
+    json_format: _JsonFormatArg = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Return canonical summary JSON for a balanced or multiconductor model."""
     return _summary_impl(
         path, content, json, package_json, from_format, json_format, options
     )
 
 
-@mcp.tool(name="parse")
+@mcp.tool(
+    name="parse",
+    description="Parse a model and return legacy JSON or a `.pio.json` "
+    "package. " + _SOURCE_FORMAT_HELP,
+)
 def _parse_tool(
     path: Optional[str] = None,
-    content: Optional[str] = None,
+    content: str = "",
     from_format: Optional[str] = None,
     options: Optional[Dict[str, Any]] = None,
     transport: str = "json",
 ) -> dict:
-    """Parse a model and return legacy JSON or a `.pio.json` package."""
     return _parse_impl(path, content, from_format, options, transport)
 
 
-@mcp.tool(name="normalize")
+@mcp.tool(
+    name="normalize",
+    description="Normalize a transmission network and return the powerio "
+    "JSON transport. " + _SOURCE_FORMAT_HELP,
+)
 def _normalize_tool(
     path: Optional[str] = None,
-    content: Optional[str] = None,
-    json: Optional[str] = None,
-    package_json: Optional[str] = None,
+    content: str = "",
+    json: str = "",
+    package_json: str = "",
     from_format: Optional[str] = None,
-    json_format: Optional[str] = None,
+    json_format: _JsonFormatArg = None,
     options: Optional[Dict[str, Any]] = None,
 ) -> dict:
-    """Normalize a transmission network and return the powerio JSON transport."""
     return _normalize_impl(
         path, content, json, package_json, from_format, json_format, options
     )
 
 
-@mcp.tool(name="matrix")
+@mcp.tool(
+    name="matrix",
+    description="Build a transmission matrix output in COO form. "
+    + _SOURCE_FORMAT_HELP,
+)
 def _matrix_tool(
-    kind: str,
+    kind: Annotated[str, _MATRIX_KIND_FIELD],
     path: Optional[str] = None,
-    content: Optional[str] = None,
-    json: Optional[str] = None,
-    package_json: Optional[str] = None,
+    content: str = "",
+    json: str = "",
+    package_json: str = "",
     from_format: Optional[str] = None,
-    json_format: Optional[str] = None,
+    json_format: _JsonFormatArg = None,
     options: Optional[Dict[str, Any]] = None,
     scheme: str = "bx",
     convention: str = "series",
 ) -> dict:
-    """Build a transmission matrix output in COO form."""
     return _matrix_impl(
         kind,
         path=path,

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -56,6 +56,25 @@ def test_tool_surface_is_semantic():
     # The SDK 2.0 model field is snake_case `input_schema`; the wire format is
     # still the protocol's camelCase `inputSchema`.
     assert "inputSchema" in tools["save"].model_dump(by_alias=True)
+    # Transport text arguments are bare `str` with "" meaning unset: under any
+    # other annotation the SDK re-parses JSON text before validation and the
+    # tool receives an object instead of the document.
+    for name in ("convert", "save", "summary", "normalize", "matrix"):
+        props = tools[name].input_schema["properties"]
+        for arg in ("content", "json", "package_json"):
+            assert props[arg]["type"] == "string"
+            assert props[arg]["default"] == ""
+    parse_content = tools["parse"].input_schema["properties"]["content"]
+    assert parse_content["type"] == "string" and parse_content["default"] == ""
+    # The closed sets are advertised as enums; the impls keep accepting aliases.
+    kind = tools["matrix"].input_schema["properties"]["kind"]
+    assert kind["enum"] == sorted(server._MATRIX_KIND_ALIASES)
+    json_format = tools["summary"].input_schema["properties"]["json_format"]
+    assert json_format["anyOf"][0]["enum"] == ["package", "model-json", "bmopf-json"]
+    # The open ended format name sets are prose in the descriptions.
+    assert "matpower" in tools["convert"].description
+    assert "bmopf-json" in tools["save"].description
+    assert "matpower" in tools["parse"].description
 
 
 def test_summary_transmission_schema():
@@ -311,10 +330,25 @@ def test_matrix_kinds_aliases_and_errors():
         server.matrix("b", path=str(DSS))
 
 
-def test_bad_json_transport_maps_cleanly():
+def test_bad_json_transport_leads_with_the_diagnostic_code():
     for bad in ("{}", "[]", "null", '{"buses": "nope"}'):
-        with pytest.raises(ValueError, match="parse failed"):
+        with pytest.raises(ValueError, match=r"^PARSE\.SOURCE\.MALFORMED: "):
             server.matrix("bprime", json=bad, json_format="model-json")
+
+
+def test_parse_failures_carry_the_code_and_the_tools_lead_with_it():
+    with pytest.raises(powerio.PowerIOError) as native:
+        powerio.parse_str("mpc.bus = [", "matpower")
+    assert native.value.code == "PARSE.MATPOWER.MALFORMED"
+    with pytest.raises(ValueError) as mapped:
+        server.summary(content="mpc.bus = [", from_format="matpower")
+    assert str(mapped.value).startswith("PARSE.MATPOWER.MALFORMED: ")
+
+
+def test_empty_transport_text_means_unset():
+    with pytest.raises(ValueError, match="provide exactly one"):
+        server._summary_tool()
+    assert server._summary_tool(path=str(DATA / "case9.m"))["elements"]["buses"] == 9
 
 
 def test_save_text_folder_and_overwrite(tmp_path):
@@ -436,6 +470,66 @@ def test_mcp_write_refuses_symlink_escape_from_allowed_root(monkeypatch, tmp_pat
         to_format="bmopf-json", out_path=str(root / "ok.json"), json=MINIMAL_BMOPF
     )
     assert (root / "ok.json").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_directory_save_refuses_symlink_escape_at_a_child_name(monkeypatch, tmp_path):
+    # The folder writers create children the single file containment check
+    # never saw; every installed file must pass the same `for_write` resolution.
+    root = tmp_path / "allowed"
+    out = root / "pypsa"
+    out.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside / "leaked.csv", out / "buses.csv")
+    case = root / "case9.m"
+    case.write_text((DATA / "case9.m").read_text())
+    monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(root))
+
+    with pytest.raises(ValueError, match="outside allowed MCP roots"):
+        server.save(
+            to_format="pypsa-csv", out_path=str(out), path=str(case), overwrite=True
+        )
+    assert not (outside / "leaked.csv").exists()
+    # Refusal happens before anything is installed.
+    assert not (out / "network.csv").exists()
+
+
+def test_directory_save_honours_overwrite(tmp_path):
+    folder = tmp_path / "pypsa"
+    server.save(to_format="pypsa-csv", out_path=str(folder), path=str(DATA / "case9.m"))
+    assert (folder / "buses.csv").exists()
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        server.save(
+            to_format="pypsa-csv", out_path=str(folder), path=str(DATA / "case9.m")
+        )
+    r = server.save(
+        to_format="pypsa-csv",
+        out_path=str(folder),
+        path=str(DATA / "case9.m"),
+        overwrite=True,
+    )
+    # Writer-reported paths are the installed location, never the staging dir.
+    assert r["dir"] == str(folder)
+    assert all(f.startswith(str(folder)) for f in r["files"])
+    assert not [p for p in folder.parent.iterdir() if p.name.startswith("pypsa.")]
+
+
+@gridfm_only
+def test_gridfm_save_honours_overwrite(tmp_path):
+    out_dir = tmp_path / "gfm"
+    first = server.save(
+        to_format="gridfm", out_path=str(out_dir), path=str(DATA / "case9.m")
+    )
+    assert first["files"] and all(f.startswith(str(out_dir)) for f in first["files"])
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        server.save(to_format="gridfm", out_path=str(out_dir), path=str(DATA / "case9.m"))
+    server.save(
+        to_format="gridfm",
+        out_path=str(out_dir),
+        path=str(DATA / "case9.m"),
+        overwrite=True,
+    )
 
 
 def test_display_decodes_powerworld_pwd():

--- a/python/tests/test_mcp_sandbox.py
+++ b/python/tests/test_mcp_sandbox.py
@@ -141,3 +141,18 @@ def test_a_write_into_a_missing_directory_raises(monkeypatch, tmp_path):
         sandbox.checked_path(
             str(tmp_path / "nope" / "out.json"), purpose="out_path", for_write=True
         )
+
+
+def test_refusals_raise_the_exported_type(monkeypatch, tmp_path):
+    # Consumers match on the type; the prose is free to change.
+    assert "PathNotAllowed" in sandbox.__all__
+    assert issubclass(sandbox.PathNotAllowed, ValueError)
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setenv(sandbox.ALLOWED_ROOTS_ENV, str(root))
+    with pytest.raises(sandbox.PathNotAllowed):
+        sandbox.checked_path(str(tmp_path / "elsewhere.m"))
+    with pytest.raises(sandbox.PathNotAllowed):
+        sandbox.checked_path(
+            str(root / "nope" / "out.json"), purpose="out_path", for_write=True
+        )

--- a/python/tests/test_mcp_transport.py
+++ b/python/tests/test_mcp_transport.py
@@ -1,0 +1,104 @@
+"""The MCP server driven over a real stdio transport.
+
+The other MCP tests call the tool functions in process, which skips the SDK's
+argument handling entirely. That gap hid a real defect: unless the annotation
+is exactly ``str``, the SDK re-parses a string argument whose text reads as
+JSON into an object before validation, so every transport argument carrying
+JSON was destroyed before the tool saw it. These tests spawn
+``python -m powerio.mcp`` and speak the protocol.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="powerio[mcp] not installed (needs Python 3.10+)")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
+
+# The SDK waits forever by default; a server that starts and then blocks
+# would hang the suite with nothing to fail it.
+TIMEOUT = 60.0
+
+# A payload the JSON reader must receive byte intact: a non-ASCII bus name
+# and a float a decode and re-encode cycle is prone to mangle.
+BMOPF_MALMO = '{"bus":{"Malmö":{"terminal_names":["1"],"v_max":[1e21]}}}'
+
+
+def _run(steps):
+    """Drive one stdio session; ``steps`` is an async callable on the session."""
+
+    async def go():
+        params = StdioServerParameters(
+            command=sys.executable, args=["-m", "powerio.mcp"], env=dict(os.environ)
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(
+                read, write, read_timeout_seconds=TIMEOUT
+            ) as session:
+                await asyncio.wait_for(session.initialize(), TIMEOUT)
+                return await steps(session)
+
+    return asyncio.run(go())
+
+
+def _payload(result):
+    assert not result.is_error, result.content[0].text
+    return json.loads(result.content[0].text)
+
+
+def test_the_json_transport_round_trips_over_stdio():
+    async def steps(session):
+        parsed = _payload(await session.call_tool("parse", {"path": str(DATA / "case9.m")}))
+        assert parsed["json_format"] == "model-json"
+        return _payload(await session.call_tool("summary", {"json": parsed["json"]}))
+
+    assert _run(steps)["elements"]["buses"] == 9
+
+
+def test_the_package_transport_round_trips_over_stdio():
+    async def steps(session):
+        parsed = _payload(
+            await session.call_tool(
+                "parse", {"path": str(DATA / "case9.m"), "transport": "package"}
+            )
+        )
+        package = parsed["package_json"]
+        diag = _payload(await session.call_tool("diagnostics", {"package_json": package}))
+        assert diag["schema"] == "powerio.diagnostics"
+        return _payload(await session.call_tool("summary", {"package_json": package}))
+
+    assert _run(steps)["elements"]["buses"] == 9
+
+
+def test_non_json_content_survives_the_transport():
+    async def steps(session):
+        return _payload(
+            await session.call_tool(
+                "convert",
+                {
+                    "to_format": "psse",
+                    "content": (DATA / "case9.m").read_text(),
+                    "from_format": "matpower",
+                },
+            )
+        )
+
+    assert _run(steps)["text"].lstrip().startswith("0,")
+
+
+def test_json_content_reaches_the_reader_byte_intact():
+    async def steps(session):
+        return _payload(await session.call_tool("parse", {"content": BMOPF_MALMO}))
+
+    parsed = _run(steps)
+    assert parsed["domain"] == "distribution"
+    doc = json.loads(parsed["json"])
+    assert doc["bus"]["Malmö"]["v_max"] == [1e21]


### PR DESCRIPTION
Driven over a real stdio transport, every tool except `diagnostics` refused its own output: the mcp 2.0 SDK re-parses a string argument whose text reads as JSON into an object before validation unless the annotation is exactly `str`, so the `content`/`json`/`package_json` arguments arrived as objects and validation rejected them. Those arguments are now bare `str = ""` in the tool schemas, with "" meaning unset; the impls normalize, and the compatibility callables keep `None`.

The folder targets (`pypsa-csv`, `gridfm`) checked only the output directory: children were created without the containment resolution the single file path applies, and `overwrite=False` was ignored. The writers now fill a fresh staging directory and every installed file passes the same `for_write` resolution; `overwrite=False` refuses before anything moves, and writer-reported paths are rebased to the installed location.

`powerio.mcp.sandbox` exports `PathNotAllowed`, a `ValueError` subclass raised by `check_allowed_path`, so consumers match a type instead of prose.

The extension attaches `Error::code()` as a `.code` attribute on the powerio exceptions, and the server's tool errors lead with the code when one is present, so a consumer that splits on the first colon reads a code, never an English phrase.

Tool schemas advertise the closed sets as enums (`json_format`, matrix `kind`) without narrowing what the impls accept; the open ended `from_format`/`to_format` names are prose in the tool descriptions. Docs state that `python -m powerio.mcp` and the `powerio-mcp` console script are consumer entry points and do not move without a version bump.

A new suite spawns `python -m powerio.mcp` and speaks the protocol: model json and package round trips, case text as content, and a payload with `Malmö` and `1e21` reaching the JSON reader byte intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN