### PR TITLE
prob: refuse a concave generator cost row before bus count decides (#342)

### DIFF
--- a/powerio-prob/src/diagnostics.rs
+++ b/powerio-prob/src/diagnostics.rs
@@ -2,7 +2,7 @@
 //!
 //! The record, the code grammar, and the severity ladder live in
 //! `powerio-diag`. This crate raises failures only: a wrapped hub or matrix
-//! failure keeps its own code, so the entries here are the two an instance
+//! failure keeps its own code, so the entries here are the three an instance
 //! build raises itself.
 
 pub use powerio_diag::{DiagnosticInfo, DiagnosticSeverity, check_registry};
@@ -13,6 +13,8 @@ pub mod codes {
             "the case has no generator for the problem to dispatch", category = Data;
         BUILD_INSTANCE_UNSUPPORTED_COST_MODEL = "BUILD.INSTANCE.UNSUPPORTED_COST_MODEL", Fatal,
             "a generator cost model the instance builder cannot state", category = Data;
+        BUILD_INSTANCE_CONCAVE_COST = "BUILD.INSTANCE.CONCAVE_COST", Fatal,
+            "a generator cost row states a concave curve", category = Data;
         READ_INSTANCE_IO_FAILED = "READ.INSTANCE.IO_FAILED", Fatal,
             "an instance file could not be read", category = Io;
         PARSE_SCOPF_MALFORMED = "PARSE.SCOPF.MALFORMED", Fatal,

--- a/powerio-prob/src/error.rs
+++ b/powerio-prob/src/error.rs
@@ -38,6 +38,11 @@ pub enum Error {
         model: u8,
         ncost: usize,
     },
+
+    #[error(
+        "generator {gen_index} has a concave cost row (c2 = {c2}); need a nonnegative quadratic coefficient"
+    )]
+    ConcaveCost { gen_index: usize, c2: f64 },
 }
 
 impl Error {
@@ -52,6 +57,7 @@ impl Error {
             Error::Io(_) => &codes::READ_INSTANCE_IO_FAILED,
             Error::NoGenerators => &codes::BUILD_INSTANCE_NO_GENERATORS,
             Error::UnsupportedCostModel { .. } => &codes::BUILD_INSTANCE_UNSUPPORTED_COST_MODEL,
+            Error::ConcaveCost { .. } => &codes::BUILD_INSTANCE_CONCAVE_COST,
         }
     }
 
@@ -68,7 +74,9 @@ impl Error {
             Error::Matrix(inner) => inner.category(),
             Error::Io(_) => C::Io,
             // A well-formed case that cannot satisfy a requested operation.
-            Error::NoGenerators | Error::UnsupportedCostModel { .. } => C::Data,
+            Error::NoGenerators
+            | Error::UnsupportedCostModel { .. }
+            | Error::ConcaveCost { .. } => C::Data,
         }
     }
 }
@@ -93,6 +101,14 @@ mod tests {
             .category(),
             Data
         );
+        assert_eq!(
+            Error::ConcaveCost {
+                gen_index: 0,
+                c2: -0.5
+            }
+            .category(),
+            Data
+        );
     }
 
     // Every error is a diagnostic that ended the operation, so the code's
@@ -107,6 +123,10 @@ mod tests {
                 gen_index: 0,
                 model: 1,
                 ncost: 4,
+            },
+            Error::ConcaveCost {
+                gen_index: 0,
+                c2: -0.5,
             },
         ];
         for error in &every {

--- a/powerio-prob/src/nodal.rs
+++ b/powerio-prob/src/nodal.rs
@@ -19,7 +19,9 @@ use crate::{Error, Result};
 /// quadratic gives `1/q` near 1e17 wherever the curvature is inverted.
 ///
 /// # Errors
-/// [`Error::UnsupportedCostModel`] for a row that states no quadratic curve.
+/// [`Error::UnsupportedCostModel`] for a row that states no quadratic curve;
+/// [`Error::ConcaveCost`] for a negative quadratic coefficient, which the
+/// least cost split in [`combine_costs`] cannot price.
 pub(crate) fn quadratic_terms(cost: &GenCost, gen_index: usize) -> Result<(f64, f64, f64)> {
     // One rule, stated once on the hub type. Rolling it again here diverged
     // twice: the threshold applied to `2*c2` rather than to the source
@@ -32,6 +34,15 @@ pub(crate) fn quadratic_terms(cost: &GenCost, gen_index: usize) -> Result<(f64, 
             model: cost.model,
             ncost: cost.ncost,
         })?;
+    // The readers keep a concave row; the convexity assumption is this
+    // crate's, so the instance builders refuse it here, before bus count
+    // decides whether the row passes through or joins a merge.
+    if q < 0.0 {
+        return Err(Error::ConcaveCost {
+            gen_index,
+            c2: q / 2.0,
+        });
+    }
     Ok((q, c, c0))
 }
 
@@ -134,6 +145,9 @@ impl Default for BusCost {
 
 impl BusCost {
     fn add(&mut self, q: f64, c: f64, c0: f64) {
+        // `quadratic_terms` refuses a negative `q`, so the flat arm below only
+        // ever takes `q == 0` rows.
+        debug_assert!(q >= 0.0, "concave cost row reached combine_costs: q = {q}");
         self.count += 1;
         if self.count == 1 {
             self.only = (q, c, c0);
@@ -201,6 +215,28 @@ mod tests {
         let costs = combine_costs(1, &[0, 0], &[q, 0.2], &[c, 5.0], &[c0, 0.0]);
         assert_eq!(costs.q, vec![0.0]);
         assert_eq!(costs.c, vec![3.0], "the cheaper linear term sets the bus");
+    }
+
+    #[test]
+    fn a_concave_row_is_refused_with_its_source_coefficient() {
+        let concave = GenCost::new(2, 0.0, 0.0, vec![-0.5, 5.0, 0.0]);
+        let error = quadratic_terms(&concave, 3).expect_err("a concave row");
+        match error {
+            Error::ConcaveCost { gen_index, c2 } => {
+                assert_eq!(gen_index, 3);
+                assert_eq!(c2.to_bits(), (-0.5_f64).to_bits());
+            }
+            other => panic!("wrong error: {other}"),
+        }
+    }
+
+    /// A negative coefficient within the artifact tolerance is the same
+    /// rounding artifact as a positive one: the row reads flat, no refusal.
+    #[test]
+    fn a_tiny_negative_artifact_still_reads_as_a_linear_curve() {
+        let artifact = GenCost::new(2, 0.0, 0.0, vec![-1e-17, 3.0, 0.0]);
+        let (q, c, c0) = quadratic_terms(&artifact, 0).expect("a model 2 row");
+        assert_eq!((q, c, c0), (0.0, 3.0, 0.0));
     }
 
     #[test]

--- a/powerio-prob/tests/acopf.rs
+++ b/powerio-prob/tests/acopf.rs
@@ -279,6 +279,33 @@ fn missing_and_unsupported_costs_are_distinct() {
     ));
 }
 
+/// #342: the AC builder shares `quadratic_terms`, so a concave cost row is
+/// refused with the same code whether the generator is alone at its bus or not.
+#[test]
+fn a_concave_cost_row_is_refused() {
+    let mut lone = small_network();
+    lone.generators[0].cost = Some(GenCost::new(2, 0.0, 0.0, vec![-0.5, 5.0, 0.0]));
+    let error = build_ac_opf_instance(&IndexedNetwork::new(&lone), &AcOpfOptions::default())
+        .expect_err("a lone concave row");
+    assert!(
+        matches!(error, Error::ConcaveCost { gen_index: 0, c2 } if c2.to_bits() == (-0.5f64).to_bits()),
+        "{error}"
+    );
+    assert_eq!(error.code().code, "BUILD.INSTANCE.CONCAVE_COST");
+
+    let mut shared = small_network();
+    let mut concave = generator(10, -0.5, 5.0, 0.0);
+    concave.uid = Some("concave".to_owned());
+    shared.generators.push(concave);
+    let error = build_ac_opf_instance(&IndexedNetwork::new(&shared), &AcOpfOptions::default())
+        .expect_err("a concave row in a merge");
+    assert!(
+        matches!(error, Error::ConcaveCost { gen_index: 1, c2 } if c2.to_bits() == (-0.5f64).to_bits()),
+        "{error}"
+    );
+    assert_eq!(error.code().code, "BUILD.INSTANCE.CONCAVE_COST");
+}
+
 #[test]
 fn zero_impedance_skip_or_reject() {
     let mut net = small_network();

--- a/powerio-prob/tests/dcopf.rs
+++ b/powerio-prob/tests/dcopf.rs
@@ -39,6 +39,34 @@ fn small_network() -> BalancedNetwork {
     network
 }
 
+/// A two bus MATPOWER case text, one generator at bus 1 per `(c2, c1)` row,
+/// written to a tempdir and read back through the MATPOWER reader.
+fn case_from_text(cost_rows: &[(f64, f64)]) -> BalancedNetwork {
+    use std::fmt::Write as _;
+    let mut gens = String::new();
+    let mut costs = String::new();
+    for &(c2, c1) in cost_rows {
+        gens.push_str("1 0 0 30 -30 1 100 1 100 10 0 0 0 0 0 0 0 0 0 0 0;\n");
+        writeln!(costs, "2 0 0 3 {c2} {c1} 0;").expect("write cost row");
+    }
+    let text = format!(
+        "function mpc = concave\n\
+         mpc.version = '2';\n\
+         mpc.baseMVA = 100;\n\
+         mpc.bus = [\n\
+         1 3 0 0 0 0 1 1 0 230 1 1.1 0.9;\n\
+         2 1 10 0 0 0 1 1 0 230 1 1.1 0.9;\n\
+         ];\n\
+         mpc.gen = [\n{gens}];\n\
+         mpc.branch = [\n1 2 0 0.2 0 0 0 0 0 0 1 -360 360;\n];\n\
+         mpc.gencost = [\n{costs}];\n"
+    );
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("concave.m");
+    std::fs::write(&path, text).expect("write case");
+    parse_matpower_file(&path).expect("parse case text")
+}
+
 fn two_island_network() -> BalancedNetwork {
     let mut network = BalancedNetwork::in_memory(
         "islands",
@@ -519,6 +547,49 @@ fn a_cost_rounding_artifact_reaches_neither_space() {
         problem.nodal_generator_data().q[0].to_bits(),
         0.0_f64.to_bits()
     );
+}
+
+/// #342: `BusCost` read a negative quadratic coefficient two ways, quadratic
+/// for a lone generator and flat inside a shared bus merge. The build now
+/// refuses the row before bus count can decide.
+#[test]
+fn a_concave_cost_row_is_refused_however_many_generators_share_the_bus() {
+    let lone = case_from_text(&[(-0.5, 5.0)]);
+    let error = build_dc_opf_instance(&IndexedNetwork::new(&lone), &DcOpfOptions::default())
+        .expect_err("a lone concave row");
+    assert!(
+        matches!(error, Error::ConcaveCost { gen_index: 0, c2 } if c2.to_bits() == (-0.5f64).to_bits()),
+        "{error}"
+    );
+    assert_eq!(error.code().code, "BUILD.INSTANCE.CONCAVE_COST");
+
+    let shared = case_from_text(&[(0.04, 20.0), (-0.5, 5.0)]);
+    let error = build_dc_opf_instance(&IndexedNetwork::new(&shared), &DcOpfOptions::default())
+        .expect_err("a concave row in a merge");
+    assert!(
+        matches!(error, Error::ConcaveCost { gen_index: 1, c2 } if c2.to_bits() == (-0.5f64).to_bits()),
+        "{error}"
+    );
+    assert_eq!(error.code().code, "BUILD.INSTANCE.CONCAVE_COST");
+}
+
+#[test]
+fn a_flat_row_and_a_convex_row_still_build() {
+    // `c2 == 0` keeps the deliberate flat arm: the flat rate is the bus
+    // marginal. Coefficients are per unit scaled, `c` by base.
+    let flat = case_from_text(&[(2.0, 1.0), (0.0, 3.0)]);
+    let problem =
+        build_dc_opf_instance(&IndexedNetwork::new(&flat), &DcOpfOptions::default()).expect("flat");
+    let nodal = problem.nodal_generator_data();
+    let bus = problem.generators.bus_of_gen[0];
+    assert_eq!(nodal.q[bus].to_bits(), 0.0_f64.to_bits());
+    assert_close(nodal.c[bus], 3.0 * 100.0);
+
+    // A convex row keeps its curve, `q = 2 c2` scaled by base².
+    let convex = case_from_text(&[(0.11, 5.0)]);
+    let problem = build_dc_opf_instance(&IndexedNetwork::new(&convex), &DcOpfOptions::default())
+        .expect("convex");
+    assert_close(problem.generators.q[0], 2.0 * 0.11 * 100.0 * 100.0);
 }
 
 #[test]


### PR DESCRIPTION
A gencost row with a negative quadratic coefficient read two ways: a lone generator passed it through to the instance, while a shared bus merge dropped it into the flat arm of BusCost::add and let it pin the bus marginal. The readers keep the row untouched; the convexity assumption belongs to powerio-prob, so quadratic_terms now refuses it with Error::ConcaveCost under BUILD.INSTANCE.CONCAVE_COST before either builder reaches combine_costs, naming the generator and its source coefficient. A coefficient within the artifact tolerance still reads flat, and q == 0 rows keep the deliberate flat arm.

Closes #342

Closes #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN