### PR TITLE
corpus: derive the anonymizer's vocabulary from the model schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,7 @@ dependencies = [
  "powerio-pkg",
  "powerio-prob",
  "ratatui",
+ "schemars",
  "serde",
  "serde_json",
  "sprs",

--- a/powerio-cli/Cargo.toml
+++ b/powerio-cli/Cargo.toml
@@ -28,12 +28,15 @@ doc = false
 [dependencies]
 # The hub crate directly, for `powerio::version`: the CLI authors a summary
 # document and must stamp it with the same key every other one carries.
-powerio.workspace = true
+# `schema`: the corpus anonymizer derives its field name vocabulary from the
+# model's own JSON schema, so it stays complete without a hand-kept list.
+powerio = { workspace = true, features = ["schema"] }
 powerio-matrix = { workspace = true, features = ["gridfm"] }
 powerio-prob = { workspace = true, features = ["matrix"] }
 # Unconditional: the CLI always ships the distribution surface (`convert
 # --to dss/pmd-json/bmopf-json`); only the C ABI gates it behind a feature.
-powerio-dist.workspace = true
+powerio-dist = { workspace = true, features = ["schema"] }
+schemars.workspace = true
 powerio-pkg.workspace = true
 sprs.workspace = true
 anyhow = "1"

--- a/powerio-cli/src/corpus/anonymize.rs
+++ b/powerio-cli/src/corpus/anonymize.rs
@@ -208,39 +208,113 @@ impl Sanitizer {
 }
 
 /// Every string powerio itself writes into a serialized network that is not
-/// case data: enum spellings, format tokens, unit names.
+/// case data: field names, enum spellings, format tokens, unit names.
 ///
-/// Derived by serializing a network built here, whose every name is chosen
-/// here, rather than from a hand-kept list — a new enum variant joins the
-/// vocabulary the day the model gains it. A real case whose element is named
-/// after one of these spellings is exempt from the audit; the tradeoff runs
-/// the safe way, since a spurious failure would stop a run cold while this
-/// costs one masked token.
+/// Derived from the model itself rather than from a hand-kept list, twice
+/// over. The JSON schemas of both network types name every field and every
+/// enum spelling, populated or not, so a new field joins the vocabulary the
+/// day the model gains it; a reference network built here adds the spellings
+/// custom serializers write past the schema, such as the generator capability
+/// map's column names. A real case whose element is named after one of these
+/// spellings is exempt from the audit; the tradeoff runs the safe way, since a
+/// spurious failure would stop a run cold while this costs one unmasked token.
 ///
-/// Built once. It depends on nothing but the model's own field names, and
-/// `identifying()` runs per emitted message and per audited line, so rebuilding
-/// a network and serializing it there dominated both.
-fn vocabulary() -> &'static BTreeSet<String> {
+/// The completeness gate lives in `super::tests`: the union of every
+/// fixture's serde keys must sit inside this set.
+///
+/// Built once. `identifying()` runs per emitted message and per audited line,
+/// so rebuilding the schemas and the network there would dominate both.
+pub(crate) fn vocabulary() -> &'static BTreeSet<String> {
     static VOCABULARY: std::sync::OnceLock<BTreeSet<String>> = std::sync::OnceLock::new();
     VOCABULARY.get_or_init(build_vocabulary)
 }
 
 fn build_vocabulary() -> BTreeSet<String> {
     use powerio_matrix::{BalancedNetwork, Branch, Bus, BusId, BusType, Generator, Load, Shunt};
+    let mut out = BTreeSet::new();
+    // Field names and enum spellings of both models, from the same derives
+    // that generate the published schema documents.
+    for value in [
+        serde_json::to_value(schemars::schema_for!(BalancedNetwork)),
+        serde_json::to_value(schemars::schema_for!(powerio_dist::MulticonductorNetwork)),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        collect_schema_words(&value, &mut out);
+    }
     let mut net = BalancedNetwork::new("", 100.0);
     net.buses.push(Bus::new(BusId(1), BusType::Ref, 1.0));
     net.buses.push(Bus::new(BusId(2), BusType::Pv, 1.0));
     net.buses.push(Bus::new(BusId(3), BusType::Pq, 1.0));
     net.buses.push(Bus::new(BusId(4), BusType::Isolated, 1.0));
     net.branches.push(Branch::new(BusId(1), BusId(2), 0.0, 1.0));
-    net.generators.push(Generator::new(BusId(1)));
+    // Filled so `caps_serde` writes its column names, which the schema
+    // states as a plain string map.
+    let mut generator = Generator::new(BusId(1));
+    for slot in &mut generator.caps {
+        *slot = Some(0.0);
+    }
+    net.generators.push(generator);
     net.loads.push(Load::new(BusId(1), 0.0, 0.0));
     net.shunts.push(Shunt::new(BusId(1), 0.0, 0.0));
-    let mut out = BTreeSet::new();
     if let Ok(value) = serde_json::to_value(&net) {
-        collect_strings(&value, &mut out);
+        collect_words(&value, &mut out);
     }
     out
+}
+
+/// Keys and string values of a document powerio built itself, where every
+/// spelling is powerio's own. Never run on anything a corpus touched.
+fn collect_words(value: &serde_json::Value, out: &mut BTreeSet<String>) {
+    match value {
+        serde_json::Value::String(s) if !s.is_empty() => {
+            out.insert(s.clone());
+        }
+        serde_json::Value::Array(xs) => {
+            for x in xs {
+                collect_words(x, out);
+            }
+        }
+        serde_json::Value::Object(xs) => {
+            for (key, x) in xs {
+                out.insert(key.clone());
+                collect_words(x, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Property names and enum spellings of a JSON schema. Nothing else: a
+/// schema's description sentences are not spellings the report writes.
+fn collect_schema_words(value: &serde_json::Value, out: &mut BTreeSet<String>) {
+    match value {
+        serde_json::Value::Array(xs) => {
+            for x in xs {
+                collect_schema_words(x, out);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(serde_json::Value::Object(props)) = map.get("properties") {
+                out.extend(props.keys().cloned());
+            }
+            if let Some(serde_json::Value::Array(spellings)) = map.get("enum") {
+                out.extend(
+                    spellings
+                        .iter()
+                        .filter_map(|s| s.as_str().map(str::to_string)),
+                );
+            }
+            if let Some(spelling) = map.get("const").and_then(serde_json::Value::as_str) {
+                out.insert(spelling.to_string());
+            }
+            for x in map.values() {
+                collect_schema_words(x, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// `after / before`, to three significant digits, or `None` when `before` is

--- a/powerio-cli/src/corpus/mod.rs
+++ b/powerio-cli/src/corpus/mod.rs
@@ -1415,3 +1415,70 @@ fn render_summary(ingest: &Ingest, findings: &[Finding]) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::path::Path;
+
+    use super::{Case, read_case};
+
+    /// Every serde key of `value` outside its `extras` subtrees, where keys
+    /// are powerio's own field names rather than case data.
+    fn model_keys(value: &serde_json::Value, in_extras: bool, out: &mut BTreeSet<String>) {
+        match value {
+            serde_json::Value::Array(xs) => {
+                for x in xs {
+                    model_keys(x, in_extras, out);
+                }
+            }
+            serde_json::Value::Object(xs) => {
+                for (key, x) in xs {
+                    if !in_extras {
+                        out.insert(key.clone());
+                    }
+                    model_keys(x, in_extras || key == "extras", out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// The vocabulary's completeness gate: parse every fixture the readers
+    /// accept, union their serde keys, and require every one to be
+    /// vocabulary. A field name outside it masks as a corpus secret the day
+    /// a real corpus teaches the same spelling.
+    #[test]
+    fn every_fixture_field_name_is_vocabulary() {
+        let data = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("tests/data");
+        let mut keys = BTreeSet::new();
+        let mut parsed = 0usize;
+        for entry in walkdir::WalkDir::new(&data)
+            .into_iter()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_type().is_file())
+        {
+            let Ok(case) = read_case(entry.path()) else {
+                continue;
+            };
+            let value = match case {
+                Case::Balanced(net, _) => serde_json::to_value(&*net),
+                Case::Multiconductor(net) => serde_json::to_value(&*net),
+            }
+            .expect("a parsed fixture serializes");
+            model_keys(&value, false, &mut keys);
+            parsed += 1;
+        }
+        assert!(parsed >= 18, "only {parsed} fixtures parsed");
+        let vocabulary = super::anonymize::vocabulary();
+        let missing: Vec<&String> = keys.iter().filter(|k| !vocabulary.contains(*k)).collect();
+        assert!(
+            missing.is_empty(),
+            "{} fixture field name(s) outside the vocabulary would mask as corpus secrets: {missing:?}",
+            missing.len()
+        );
+    }
+}

--- a/powerio-cli/tests/corpus_harness.rs
+++ b/powerio-cli/tests/corpus_harness.rs
@@ -230,6 +230,27 @@ fn an_extras_key_is_learned_like_any_other_name() {
     assert_eq!(sanitizer.template(".loads[#].p"), ".loads[#].p");
 }
 
+/// A corpus string spelled like a powerio field name is vocabulary, so the
+/// field stays reportable. Before #340 the vocabulary held only what the
+/// reference network populated, and a finding about `charging.g_fr` read
+/// `charging.<name>` the day a corpus taught the same spelling.
+#[test]
+fn a_field_name_the_corpus_also_spells_stays_reportable() {
+    let mut sanitizer = anonymize::Sanitizer::new();
+    sanitizer.learn_network(&serde_json::json!({
+        "branches": [{ "extras": { "g_fr": 1.0, "band_min": 2.0 } }]
+    }));
+    assert_eq!(
+        sanitizer.template(".branches[#].charging.g_fr"),
+        ".branches[#].charging.g_fr"
+    );
+    assert!(
+        sanitizer
+            .audit(".transformers[#].bands[#].band_min")
+            .is_ok()
+    );
+}
+
 /// A corpus may hold a symlink whose name sits under the root and whose target
 /// does not. The walk does not descend symlinked directories, but it still
 /// hands over symlinked files, and reading one reads its target.


### PR DESCRIPTION
The vocabulary was built by serializing a reference network whose ::new constructors leave every Option sub-struct empty, and its walker collected string values only, so it held five enum spellings and none of the model's field names: a corpus string that happened to spell one (an extras key like g_fr, a file stem like voltage) became a secret, masked that field out of every serde path in the report, and could stop a run at the audit. The vocabulary now also collects every property name and enum spelling from the JSON schemas of BalancedNetwork and MulticonductorNetwork, the same schemars derives that generate the published schema documents, so a new field or variant joins the day the model gains it and the distribution model is covered for the first time. The reference network stays for what custom serializers write past the schema: its generator's capability slots are filled so caps_serde emits the column names the schema states as a plain string map. A completeness gate parses every fixture under tests/data, unions the serde keys outside extras subtrees, and fails on any key missing from the vocabulary; it covers 206 keys from 52 fixtures, of which the old set held zero.

Closes #340.

Closes #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN