### PR TITLE
rust: keep the 0.8 names alive for one release behind deprecation warnings

### DIFF
--- a/docs/src/abi-v5.md
+++ b/docs/src/abi-v5.md
@@ -219,6 +219,12 @@ PowerIO.jl is the one binding powerio owns, and its ABI 5 change is the honest e
 
 The star-lowered space required no binding edit at all, which is the point worth carrying away: the numbers changed and the code did not. A binding that sizes buffers from one extractor and fills them from another was already correct or already broken; ABI 5 decides which. Assert the closure and find out.
 
+## Coming from 0.8.x in Rust
+
+The C ABI cannot bridge — the binding gates on `pio_abi_version` by equality, so a library and a binding move together — but the Rust surface keeps the 0.8 names alive for exactly one release, each behind a deprecation warning that names its successor. `powerio::Network` is `BalancedNetwork`, `powerio_dist::DistNetwork` is `MulticonductorNetwork`, `build_scopf_instance_from_str` is `parse_scopf_str`, `Branch::legacy_total_charging_b` is `total_charging_b`, and `DcConvention::PaperPure` is an associated constant equal to `DcConvention::ReactanceOnly`, usable in expression and pattern position alike. Python carries the same bridge: `powerio.Network` and `powerio.dist.DistNetwork` resolve with a `DeprecationWarning` naming the successor. A 0.8 consumer compiles against 0.9 with warnings, fixes them by renaming, and is untouched by 1.0.0, which deletes the whole set; `scripts/deprecated-inventory.sh` lists it, and its `--assert-empty` run is the 1.0.0 gate. Passing the retired `powerio-json` format token fails as before, and the error now says where model JSON went instead of listing the accepted names.
+
+Two 0.8 behaviors have no alias because the successor is a different statement, and both fail loudly with a message naming the change: a nonfinite float in a powerio document is the string `"Infinity"`, `"-Infinity"`, or `"NaN"` where 0.8 wrote an unreadable `null`, and error variants that moved to the crates that construct them are a compile error whose fix is the new path. The changelog's 0.9.0 section is the complete rename table.
+
 ## What did not change
 
 Every ABI 4 Arrow table id and its column order. Two cost tables append at 21 and 22, `solver_bus` gains `area` and `zone` at the end of its columns, and `solver_storage` gains `charge_efficiency` and `discharge_efficiency` the same way, so a consumer addressing columns by name sees nothing shift. Every case format token except the three retired above. The opaque handle design. The panic guard on every entry point. `errbuf` and `errlen` last. `pio_abi_version`, `pio_version` and `pio_has_feature`.

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -70,6 +70,8 @@ pub use graph::{
     DistGraph, DistGraphAttachment, DistGraphAttachmentKind, DistGraphBus, DistGraphEdge,
     DistGraphEdgeKind,
 };
+#[allow(deprecated)]
+pub use model::DistNetwork;
 pub use model::{
     ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
     DistCapacitor, DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -1292,6 +1292,13 @@ pub(crate) fn square_from_rows(rows: &[Vec<f64>], n: usize) -> Option<Mat> {
     Some(m)
 }
 
+/// The 0.8 spelling of [`MulticonductorNetwork`]. The alias goes away at 1.0.0.
+#[deprecated(
+    since = "0.9.0",
+    note = "renamed to MulticonductorNetwork in 0.9.0; the alias goes away at 1.0.0"
+)]
+pub type DistNetwork = MulticonductorNetwork;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1320,5 +1327,15 @@ mod tests {
     fn wrong_shape_is_rejected() {
         assert!(square_from_rows(&[vec![1.0], vec![2.0]], 2).is_none());
         assert!(square_from_rows(&[vec![1.0, 2.0]], 2).is_none());
+    }
+}
+
+#[cfg(test)]
+mod deprecation_shim_tests {
+    #[test]
+    #[allow(deprecated)]
+    fn the_08_type_name_still_compiles() {
+        let net: crate::DistNetwork = crate::MulticonductorNetwork::named("shim");
+        assert_eq!(net.name.as_deref(), Some("shim"));
     }
 }

--- a/powerio-prob/src/lib.rs
+++ b/powerio-prob/src/lib.rs
@@ -29,4 +29,6 @@ pub mod diagnostics;
 pub mod error;
 pub use error::{Error, Result};
 pub use reference::ReferenceBuses;
+#[allow(deprecated)]
+pub use scopf::build_scopf_instance_from_str;
 pub use scopf::{ScopfDeviceClassLayout, ScopfError, ScopfInstance, ScopfResult, parse_scopf_str};

--- a/powerio-prob/src/scopf/mod.rs
+++ b/powerio-prob/src/scopf/mod.rs
@@ -5,5 +5,7 @@ mod projection;
 mod types;
 
 pub use error::{ScopfError, ScopfResult};
+#[allow(deprecated)]
+pub use projection::build_scopf_instance_from_str;
 pub use projection::parse_scopf_str;
 pub use types::*;

--- a/powerio-prob/src/scopf/projection.rs
+++ b/powerio-prob/src/scopf/projection.rs
@@ -1087,6 +1087,15 @@ fn build_scopf_instance(document: &Goc3Document) -> Result<ScopfInstance> {
 }
 
 /// Parse source text and build its SCOPF instance.
+/// The 0.8 spelling of [`parse_scopf_str`]. The alias goes away at 1.0.0.
+#[deprecated(
+    since = "0.9.0",
+    note = "renamed to parse_scopf_str in 0.9.0; the alias goes away at 1.0.0"
+)]
+pub fn build_scopf_instance_from_str(text: &str, from: &str) -> Result<ScopfInstance> {
+    parse_scopf_str(text, from)
+}
+
 pub fn parse_scopf_str(text: &str, from: &str) -> Result<ScopfInstance> {
     if from != "goc3-json" {
         return Err(ScopfError::UnsupportedFormat(from.to_owned()));

--- a/powerio-prob/tests/scopf.rs
+++ b/powerio-prob/tests/scopf.rs
@@ -557,3 +557,12 @@ fn the_validation_case_indexes_every_row_in_document_order() {
         }
     );
 }
+
+#[test]
+#[allow(deprecated)]
+fn the_08_scopf_entry_point_still_answers() {
+    let old = powerio_prob::build_scopf_instance_from_str(SMALL, "goc3-json")
+        .expect("the 0.8 alias builds");
+    let new = parse_scopf_str(SMALL, "goc3-json").expect("build small SCOPF instance");
+    assert_eq!(old.lengths, new.lengths);
+}

--- a/powerio/src/dc.rs
+++ b/powerio/src/dc.rs
@@ -62,6 +62,15 @@ pub enum DcConvention {
 }
 
 impl DcConvention {
+    /// The 0.8 spelling of [`DcConvention::ReactanceOnly`]. Works in
+    /// expression and pattern position; goes away at 1.0.0.
+    #[allow(non_upper_case_globals)]
+    #[deprecated(
+        since = "0.9.0",
+        note = "renamed to DcConvention::ReactanceOnly in 0.9.0; the alias goes away at 1.0.0"
+    )]
+    pub const PaperPure: DcConvention = DcConvention::ReactanceOnly;
+
     /// The branch susceptance from resistance, reactance, and effective tap.
     /// Only [`Self::Matpower`] reads the tap, and only
     /// [`Self::SeriesImpedance`] reads the resistance.

--- a/powerio/src/format/mod.rs
+++ b/powerio/src/format/mod.rs
@@ -672,6 +672,12 @@ pub const SOURCE_FORMAT_NAMES: &str = "matpower/m, powermodels-json/powermodels/
 /// surface instead of echoing the token: this parser reads only balanced
 /// transmission formats. Otherwise the refusal enumerates the accepted names.
 fn unknown_source_format(name: &str) -> Error {
+    if name.eq_ignore_ascii_case("powerio-json") {
+        return Error::UnknownFormat(
+            "the `powerio-json` token was retired in 0.9.0: model JSON is not a case format              or a conversion target; write it with `to_json` (`pio_to_json` in C, `json_format              model-json` on the MCP server), package the case as `.pio.json`, and classify a              JSON document with `classify_json_text` (family `model-json`)"
+                .into(),
+        );
+    }
     if let Some(dist) = routing::distribution_format_from_name(name) {
         return Error::UnknownFormat(format!(
             "`{}` is a distribution format, and this parser reads only balanced \

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -77,6 +77,8 @@ pub use geo::{
     geo_layer_from_aux_substations, geo_layer_from_pwd, pwd_mercator_to_lonlat,
 };
 pub use indexed::{ConnectivityReport, IndexCore, IndexedNetwork};
+#[allow(deprecated)]
+pub use network::Network;
 pub use network::{
     Area, BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet,
     BranchSolution, Bus, BusId, BusType, DEFAULT_BASE_FREQUENCY, Diagnostic, Extras, GenCaps,

--- a/powerio/src/network.rs
+++ b/powerio/src/network.rs
@@ -947,6 +947,17 @@ impl Branch {
         fr_vmax.max(to_vmax) * widest / zmag
     }
 
+    /// The 0.8 spelling of [`total_charging_b`](Branch::total_charging_b).
+    /// The alias goes away at 1.0.0.
+    #[deprecated(
+        since = "0.9.0",
+        note = "renamed to total_charging_b in 0.9.0; the alias goes away at 1.0.0"
+    )]
+    #[must_use]
+    pub fn legacy_total_charging_b(&self) -> f64 {
+        self.total_charging_b()
+    }
+
     /// Total susceptance projection for MATPOWER shaped formats that only carry
     /// one line charging value.
     #[must_use]
@@ -2178,6 +2189,13 @@ impl BalancedNetwork {
         Ok(())
     }
 }
+
+/// The 0.8 spelling of [`BalancedNetwork`]. The alias goes away at 1.0.0.
+#[deprecated(
+    since = "0.9.0",
+    note = "renamed to BalancedNetwork in 0.9.0; the alias goes away at 1.0.0"
+)]
+pub type Network = BalancedNetwork;
 
 #[cfg(test)]
 mod tests {

--- a/powerio/tests/deprecation_shims.rs
+++ b/powerio/tests/deprecation_shims.rs
@@ -1,0 +1,44 @@
+//! The 0.8 names still compile against 0.9 behind deprecation warnings, and
+//! the retired `powerio-json` token gets guidance instead of a bare unknown.
+//! Everything here goes away at 1.0.0 along with the aliases it pins.
+#![allow(deprecated)]
+
+use powerio::{DcConvention, Network};
+
+#[test]
+fn the_08_type_name_still_compiles() {
+    let net: Network = powerio::BalancedNetwork::new("shim", 100.0);
+    let same: &powerio::BalancedNetwork = &net;
+    assert_eq!(same.name, "shim");
+}
+
+#[test]
+fn paper_pure_works_in_expression_and_pattern_position() {
+    let convention = DcConvention::PaperPure;
+    assert_eq!(convention, DcConvention::ReactanceOnly);
+    match convention {
+        DcConvention::PaperPure => {}
+        other => panic!("PaperPure must match its successor, got {other:?}"),
+    }
+}
+
+#[test]
+fn the_retired_powerio_json_token_gets_guidance() {
+    let err = powerio::parse_str("x", "powerio-json").unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("retired in 0.9.0"), "{msg}");
+    assert!(msg.contains("model-json"), "{msg}");
+}
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn the_08_branch_method_still_answers() {
+    let net = powerio::parse_str(
+        "function mpc = s\nmpc.version = '2';\nmpc.baseMVA = 100;\nmpc.bus = [\n  1 3 0 0 0 0 1 1 0 230 1 1.1 0.9;\n  2 1 0 0 0 0 1 1 0 230 1 1.1 0.9;\n];\nmpc.branch = [\n  1 2 0.01 0.1 0.04 0 0 0 0 0 1 -360 360;\n];\n",
+        "matpower",
+    )
+    .unwrap()
+    .network;
+    let b = &net.branches[0];
+    assert_eq!(b.legacy_total_charging_b(), b.total_charging_b());
+}

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -1114,3 +1114,22 @@ class Package:
 
     def __repr__(self) -> str:
         return repr(self._inner)
+
+# 0.8 names, aliased for one release. The deprecated inventory script reads
+# `_RENAMED_IN_*`; delete the dict and the hook together at 1.0.0.
+_RENAMED_IN_0_9_0 = {"Network": "BalancedNetwork"}
+
+
+def __getattr__(name):
+    if name in _RENAMED_IN_0_9_0:
+        import warnings
+
+        successor = _RENAMED_IN_0_9_0[name]
+        warnings.warn(
+            f"powerio.{name} was renamed powerio.{successor} in 0.9.0; "
+            "the alias goes away at 1.0.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[successor]
+    raise AttributeError(f"module 'powerio' has no attribute {name!r}")

--- a/python/powerio/dist.py
+++ b/python/powerio/dist.py
@@ -183,3 +183,21 @@ def convert_str(text: str, to: str, format: str) -> Conversion:
     """
     text, warnings = _powerio.dist_convert_str(text, to, format)
     return Conversion(text, warnings)
+
+# 0.8 names, aliased for one release; same convention as the package root.
+_RENAMED_IN_0_9_0 = {"DistNetwork": "MulticonductorNetwork"}
+
+
+def __getattr__(name):
+    if name in _RENAMED_IN_0_9_0:
+        import warnings
+
+        successor = _RENAMED_IN_0_9_0[name]
+        warnings.warn(
+            f"powerio.dist.{name} was renamed powerio.dist.{successor} in 0.9.0; "
+            "the alias goes away at 1.0.0",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[successor]
+    raise AttributeError(f"module 'powerio.dist' has no attribute {name!r}")

--- a/python/tests/test_deprecation_shims.py
+++ b/python/tests/test_deprecation_shims.py
@@ -1,0 +1,28 @@
+"""The 0.8 python names alias their successors for one release with a
+DeprecationWarning; both the dict and the hook go away at 1.0.0."""
+
+import warnings
+
+import powerio.dist
+import pytest
+
+import powerio
+
+
+def test_the_08_network_name_warns_and_aliases():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert powerio.Network is powerio.BalancedNetwork
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_the_08_dist_name_warns_and_aliases():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert powerio.dist.DistNetwork is powerio.dist.MulticonductorNetwork
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_an_unknown_name_still_raises():
+    with pytest.raises(AttributeError, match="no_such_name"):
+        _ = powerio.no_such_name

--- a/python/tests/test_dist.py
+++ b/python/tests/test_dist.py
@@ -25,7 +25,15 @@ def test_multiconductor_is_the_only_model_name():
     assert isinstance(case, dist.MulticonductorNetwork)
     assert "MulticonductorNetwork" in dist.__all__
     assert "DistCase" not in dist.__all__
-    assert not hasattr(dist, "DistNetwork")
+    # DistNetwork is the 0.8 bridge alias: same object, DeprecationWarning,
+    # gone at 1.0.0. DistCase stays removed.
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        assert dist.DistNetwork is dist.MulticonductorNetwork
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert "DistNetwork" not in dist.__all__
     assert not hasattr(dist, "DistCase")
 
 

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -119,7 +119,15 @@ def test_public_type_is_balanced_network(case9):
     assert isinstance(case9, powerio.BalancedNetwork)
     assert "BalancedNetwork" in powerio.__all__
     assert not hasattr(powerio, "Case")
-    assert not hasattr(powerio, "Network")
+    # Network is the 0.8 bridge alias: same object, DeprecationWarning, gone
+    # at 1.0.0; it stays out of __all__ so nothing advertises it.
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        assert powerio.Network is powerio.BalancedNetwork
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+    assert "Network" not in powerio.__all__
     assert repr(case9).startswith("BalancedNetwork(")
 
 


### PR DESCRIPTION
0.9.0 renamed the model types and entry points in a single release, and the 0.8 deprecation aliases had never worked (reachable at powerio::network::Network, never the crate root), so a 0.8 consumer got a compile break with no bridging window. The four renames now carry working deprecated aliases through 0.9: powerio::Network for BalancedNetwork, powerio_dist::DistNetwork for MulticonductorNetwork, build_scopf_instance_from_str for parse_scopf_str, Branch::legacy_total_charging_b for total_charging_b, and DcConvention::PaperPure as an associated constant equal to ReactanceOnly, usable in expression and pattern position because the enum is structurally matchable. Python mirrors the bridge: powerio.Network and powerio.dist.DistNetwork resolve through a module __getattr__ with a DeprecationWarning naming the successor, driven by the _RENAMED_IN_0_9_0 dicts the deprecated inventory script reads. Every warning names the 1.0.0 removal; scripts/deprecated-inventory.sh lists the whole set and its --assert-empty run is the 1.0.0 gate that deletes them.

The retired powerio-json format token cannot alias to anything, since model JSON stopped being a conversion target; passing it now gets guidance naming to_json, the MCP json_format channel, .pio.json packaging, and the model-json classification family, instead of the accepted names list. The migration guide gains a "Coming from 0.8.x in Rust" section stating the aliases, the two behaviors that bridge loudly instead (the nonfinite spelling change and the moved error variants), and why the C ABI cannot bridge at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN