### PR TITLE
docs, schema: fix the spellings that would freeze wrong at 1.0

### DIFF
--- a/docs/schema/pio-package/0.9/schema.json
+++ b/docs/schema/pio-package/0.9/schema.json
@@ -6174,7 +6174,7 @@
             "branch": {
               "$ref": "#/$defs/ElementRef"
             },
-            "delta_mw": {
+            "delta_mva": {
               "type": "number"
             },
             "kind": {
@@ -6184,7 +6184,7 @@
           "required": [
             "kind",
             "branch",
-            "delta_mw"
+            "delta_mva"
           ],
           "type": "object"
         },
@@ -7427,7 +7427,7 @@
       "type": "string"
     }
   },
-  "$id": "https://powerio.dev/schema/pio-package/0.9",
+  "$id": "https://powerio.dev/schema/pio-package/0.9/schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "A versioned package containing one model payload, provenance, diagnostics,\nvalidation results, and lowering history. Serializes to `.pio.json`.\n\n`model_kind` is stored explicitly and is authoritative; the payload is also\nself-describing (tagged by `kind`). [`NetworkPackage::kind_is_consistent`]\nasserts the two agree. The reader ignores unknown top level fields from a\nnewer producer.",
   "properties": {

--- a/docs/src/abi-v5.md
+++ b/docs/src/abi-v5.md
@@ -130,7 +130,7 @@ EMIT.PSSE.FIELD_DROPPED: generator cost curves dropped: PSS/E .raw has no cost d
 
 Split at the first `": "`. The left side is `NAMESPACE.SCOPE.SPECIFIC` and contains no colon; the right side is prose, covered by no stability promise, so branch on the code and never on the message. The first segment names the stage and is the only segment to parse; treat the rest as opaque identity, and read more than three segments without complaint.
 
-`pio_build_info` reports `diagnostic_namespaces`, the ten first segments powerio emits, and `error_categories`, the coarse five bucket projection each fatal code is published under. A code whose first segment is outside the ten came from somewhere else, which is data rather than a failure.
+`pio_build_info` reports `diagnostic_namespaces`, the ten first segments powerio emits, and `error_categories`, the coarse five bucket projection each fatal code is published under. A code whose first segment is outside the ten came from somewhere else, which is data rather than a failure. The three closed sets keep their own casings deliberately: a namespace is UPPERCASE because it is the first segment of a code and codes spell their segments uppercase, a category is snake case because ABI 4 published it that way and 0.8.x consumers read it, and a JSON class is kebab case because it is a format token and format tokens are kebab. Matching each set to the surface it indexes beats one casing that matches none of them.
 
 A published code keeps its identity forever. It may be retired, which stops it being emitted and never reassigns it, and a family may be refined by adding narrower codes beside it. A default severity may move in a minor release, so a consumer that needs a fixed policy pins by code.
 

--- a/docs/src/capi-arrow.md
+++ b/docs/src/capi-arrow.md
@@ -87,7 +87,6 @@ Shape:
     {
       "id": 17,
       "name": "bprime",
-      "powerio_version": "0.9.0",
       "format": "coo",
       "feature_requirements": ["arrow", "matrix"],
       "available": true,

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -59,7 +59,7 @@ needs regenerating.
   error), so a same lineage document from a newer producer still loads.
 
 The generated JSON Schema for the document is served at
-`https://powerio.dev/schema/pio-package/0.2/schema.json`; the `$id` names that
+`https://powerio.dev/schema/pio-package/0.9/schema.json`; the `$id` names that
 location. It embeds the model JSON types, so it validates complete `.pio.json`
 documents. It does not define a standalone case format.
 
@@ -291,7 +291,7 @@ bindings, or MCP operations.
 ```json
 {
   "powerio_version": "0.9.0",
-  "producer": { "tool": "powerio", "version": "0.8.0" },
+  "producer": { "tool": "powerio", "version": "0.9.0" },
   "model_kind": "multiconductor",
   "model": {
     "kind": "multiconductor",

--- a/docs/src/study-block.md
+++ b/docs/src/study-block.md
@@ -34,7 +34,7 @@ axis or accumulation semantics.
           "bus": { "table": "buses", "source_uid": "buses:1" }, "p_mw": 50.0 },
         { "kind": "rating_delta",
           "branch": { "table": "branches", "source_uid": "branches:2" },
-          "delta_mw": -210.0 }
+          "delta_mva": -210.0 }
     ]}
   ],
   "app": { "tellegen": { "formulation": "dcopf", "options": { "shed": false } } }
@@ -56,7 +56,7 @@ existing behavior and metadata schema version.
 
 - `demand_delta { bus, p_mw, q_mvar? }` adds demand at a bus, including a bus
   with no load rows.
-- `rating_delta { branch, delta_mw }` adds to a branch thermal rating.
+- `rating_delta { branch, delta_mva }` adds to a branch thermal rating.
 - `set_fields { update }` wraps an `ElementUpdate` and overwrites fields on one
   payload row.
 - An unknown `kind` is retained during parsing. Materialization returns an

--- a/powerio-pkg/examples/generate_schemas.rs
+++ b/powerio-pkg/examples/generate_schemas.rs
@@ -32,7 +32,7 @@ mod generate {
         write_schema::<powerio_pkg::NetworkPackage>(
             &out,
             &format!("pio-package/{lineage}"),
-            &format!("https://powerio.dev/schema/pio-package/{lineage}"),
+            &format!("https://powerio.dev/schema/pio-package/{lineage}/schema.json"),
             // `powerio_version` carries `serde(default)` so the reader can name
             // a missing field rather than fail on it, and schemars reads any
             // `serde` default as "optional" — `schemars(required)` does not

--- a/powerio-pkg/src/study.rs
+++ b/powerio-pkg/src/study.rs
@@ -72,7 +72,7 @@ pub enum StudyEdit {
     },
     RatingDelta {
         branch: ElementRef,
-        delta_mw: f64,
+        delta_mva: f64,
     },
     SetFields {
         update: ElementUpdate,
@@ -119,11 +119,11 @@ impl schemars::JsonSchema for StudyEdit {
                 },
                 {
                     "type": "object",
-                    "required": ["kind", "branch", "delta_mw"],
+                    "required": ["kind", "branch", "delta_mva"],
                     "properties": {
                         "kind": { "const": "rating_delta" },
                         "branch": element_ref,
-                        "delta_mw": { "type": "number" }
+                        "delta_mva": { "type": "number" }
                     }
                 },
                 {
@@ -173,17 +173,17 @@ impl Serialize for StudyEdit {
                 }
                 .serialize(serializer)
             }
-            Self::RatingDelta { branch, delta_mw } => {
+            Self::RatingDelta { branch, delta_mva } => {
                 #[derive(Serialize)]
                 struct Stated<'a> {
                     kind: &'static str,
                     branch: &'a ElementRef,
-                    delta_mw: f64,
+                    delta_mva: f64,
                 }
                 Stated {
                     kind: "rating_delta",
                     branch,
-                    delta_mw: *delta_mw,
+                    delta_mva: *delta_mva,
                 }
                 .serialize(serializer)
             }
@@ -234,12 +234,12 @@ impl<'de> Deserialize<'de> for StudyEdit {
                 #[derive(Deserialize)]
                 struct Stated {
                     branch: ElementRef,
-                    delta_mw: f64,
+                    delta_mva: f64,
                 }
                 let stated = serde_json::from_value::<Stated>(value).map_err(D::Error::custom)?;
                 Ok(Self::RatingDelta {
                     branch: stated.branch,
-                    delta_mw: stated.delta_mw,
+                    delta_mva: stated.delta_mva,
                 })
             }
             "set_fields" => {
@@ -386,12 +386,12 @@ impl StudyApplyContext<'_> {
                 }
                 self.indexes.remove("loads");
             }
-            StudyEdit::RatingDelta { branch, delta_mw } => {
+            StudyEdit::RatingDelta { branch, delta_mva } => {
                 let branch_row = resolve_update_row(self.payload, self.indexes, branch)
                     .map_err(crate::Error::Payload)?;
                 let branch = row_object_mut(self.payload, "branches", branch_row)?;
                 let old = number_field(branch, "rate_a", "branch", branch_row)?;
-                branch.insert("rate_a".to_owned(), json!(old + delta_mw));
+                branch.insert("rate_a".to_owned(), json!(old + delta_mva));
                 self.updated_paths.insert(format!(
                     "/model/{}/branches/{branch_row}/rate_a",
                     self.payload_key

--- a/powerio-pkg/tests/roundtrip.rs
+++ b/powerio-pkg/tests/roundtrip.rs
@@ -2201,7 +2201,7 @@ fn study_commit_materialization_folds_commits_and_set_fields() {
             },
             StudyEdit::RatingDelta {
                 branch: ElementRef::by_source_uid("branches", "branch_1"),
-                delta_mw: -10.0,
+                delta_mva: -10.0,
             },
         ]),
         study_commit(vec![


### PR DESCRIPTION
Four findings from the pre-tag regret review of the frozen surfaces. The study edit's rating_delta field is delta_mva now: it patches rate_a/b/c, which are apparent power, and delta_mw was the one unit suffix in the document that stated its unit wrong outright. The generated schema's $id gains its real filename (https://powerio.dev/schema/pio-package/0.9/schema.json) so programmatic $id construction resolves, and the docs page stops pointing at the 0.2 lineage. The capi arrow docs example drops a per table powerio_version field the generator never emits, and the .pio.json worked example stops showing two versions of one tool. The migration guide states why pio_build_info's three closed sets keep three casings: each matches the surface it indexes — codes spell segments uppercase, ABI 4 published the categories snake case, and a JSON class is a format token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN