### PR TITLE
py: raise PathNotAllowed for the non-local path refusals

### DIFF
--- a/python/powerio/mcp/sandbox.py
+++ b/python/powerio/mcp/sandbox.py
@@ -45,10 +45,11 @@ __all__ = [
 
 
 class PathNotAllowed(ValueError):
-    """The containment policy refused a path.
+    """The path gate refused a value: outside the allowed roots, a remote
+    URI, or a non-local file URI.
 
-    Subclasses :class:`ValueError`, which is what
-    :func:`check_allowed_path` raised before this type existed.
+    Subclasses :class:`ValueError`, which is what every refusal site
+    raised before this type existed.
     """
 
 
@@ -79,13 +80,13 @@ def decode_local_path(value: str, *, purpose: str = "path") -> Path:
     windows_drive = os.name == "nt" and len(parsed.scheme) == 1
     if parsed.scheme and not windows_drive:
         if parsed.scheme != "file":
-            raise ValueError(f"`{purpose}` must be a local path or file:// URI")
+            raise PathNotAllowed(f"`{purpose}` must be a local path or file:// URI")
         netloc = unquote(parsed.netloc)
         path = unquote(parsed.path)
         if len(netloc) == 2 and netloc[0].isalpha() and netloc[1] == ":":
             return Path(f"{netloc}{path}").expanduser()
         if netloc.lower() not in ("", "localhost"):
-            raise ValueError(f"`{purpose}` file URI must be local")
+            raise PathNotAllowed(f"`{purpose}` file URI must be local")
         if (
             len(path) >= 3
             and path[0] == "/"

--- a/python/tests/test_mcp_sandbox.py
+++ b/python/tests/test_mcp_sandbox.py
@@ -103,9 +103,9 @@ def test_decode_local_path_reads_file_uris_and_refuses_remote_schemes():
     assert sandbox.decode_local_path("file://localhost/data/case.raw") == Path(
         "/data/case.raw"
     )
-    with pytest.raises(ValueError, match="local path or file:// URI"):
+    with pytest.raises(sandbox.PathNotAllowed, match="local path or file:// URI"):
         sandbox.decode_local_path("https://example.com/case9.m", purpose="path")
-    with pytest.raises(ValueError, match="must be local"):
+    with pytest.raises(sandbox.PathNotAllowed, match="must be local"):
         sandbox.decode_local_path("file://server/share/case.raw")
 
 


### PR DESCRIPTION
decode_local_path refused a remote URI and a non-local file URI with a bare ValueError while the containment refusals raised PathNotAllowed. One gate, one refusal type: a consumer catching PathNotAllowed now sees every way the sandbox can turn a path argument down. Nonbreaking, the type subclasses ValueError.

Found by the PowerMCP verification pass: its suite pins `pytest.raises(PathNotAllowed, match="must be a local path")`, which only passed while PowerMCP aliased the type to ValueError. With the alias gone the pin failed against these two sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012iuj7EXLRVU9s2BUNadUeN