### PR TITLE
Reuse sparse Cholesky factors for sensitivities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ powerio-matrix/               # matrices + graph views on powerio
 │   ├── bprime.rs / bdoubleprime.rs / ybus.rs / lacpf.rs / adjacency.rs
 │   ├── incidence.rs         # A, b, B Aᵀ, P_shift
 │   ├── laplacian.rs         # L = A diag(w) Aᵀ, ground_at, GroundedIndexMap, e_r
-│   └── sensitivity.rs       # PTDF, LODF; SensitivityOptions (auto/dense/iterative)
+│   └── sensitivity.rs       # PTDF, LODF; SensitivityOptions (auto/dense/sparse)
 ├── src/io/                  # mtx (lower-triangle symmetric), meta, sensitivity,
 │                            #   gridfm (gridfm-datakit Parquet, feature = "gridfm")
 ├── src/pipeline.rs          # case → square MatrixKind family
@@ -319,7 +319,7 @@ fuzz/                        # libFuzzer targets (detached workspace; see fuzz/R
 - **`rate_a == 0` means unlimited.** `f_max`/`s_max` keep the zero. The opt-in `synthesize_unrated_limits` build option replaces it with `Branch::synthesize_rate_a`: the widest voltage phasor difference the terminal ceilings and the branch angle window allow, over `|Z|`, times the larger ceiling. The caller passes the window in radians and the method holds it at π; `angmin`/`angmax` are degrees in the neutral model and radians after `to_normalized`, so the builders convert them through `IndexedNetwork::angle_radians` and a raw case and its normalized form get the same bound.
 - **`gen`/`gencost` are optional.** A power flow case with no `mpc.gen` parses with `gens` empty; the OPF builders return `Error::NoGenerators`.
 - **Reference (slack) buses are a set, grounded one row/column each.** `IndexedNetwork::reference_bus_indices` returns every `BusType::Ref`; the matrix builders ground the whole set, so a network needs one reference *per connected component* (`IndexedNetwork::check_reference_coverage`). Several within one island is a distributed-slack solve. `reference_bus_index` is the exactly-one convenience query (errors otherwise) for the single-slack C/Python/gridfm paths. `DcOpfInstance`/`AcOpfInstance` carry the set as `ReferenceBuses`, which has no `first()`: a consumer picks `iter()` or the named `single()` (`Error::ReferenceBusCount`) rather than grounding one island of many by accident. Its serde form is the same array of dense indices.
-- **PTDF/LODF need a solve.** They factor the reference grounded Laplacian (SPD when every island has a reference) in `matrix::sensitivity`; no external solver dep. The option based builders select dense Cholesky below the reduced-dimension threshold and a preconditioned conjugate gradient above it (`SensitivityOptions`, default `auto`). PTDF is dense `m×n`; sparse work would compute selected columns or use sparse factors, not make PTDF itself sparse.
+- **PTDF/LODF need a solve.** They factor the reference grounded Laplacian (SPD when every island has a reference) in `matrix::sensitivity`. The option based builders select dense Cholesky below the reduced-dimension threshold and an AMD-ordered `faer` sparse Cholesky above it (`SensitivityOptions`, default `auto`); the sparse factor is reused for batched right hand sides. PTDF is dense `m×n`; the sparse path changes the solve, not the output shape.
 - **MTX output is lower triangle, 1 based, spec compliant.** `sprs::io::write_matrix_market_sym` writes the *upper* triangle, so `io::mtx::write_mtx` ships its own writer.
 - **`CooBuilder`.** HashMap COO with O(nnz) inserts; replaces the old O(nnz²) Vec search.
 - **TUI lives in the CLI crate.** `powerio-cli/src/tui/`, part of the `powerio` binary. Testable via `ratatui::backend::TestBackend`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,12 +199,18 @@ records. Upgrade if you write text formats from names you do not control.
   extract|apply` read and classify a `.json` once instead of twice. The
   distribution reader's own document rule still applies on that path, so
   a JSON that is not a distribution case is refused as before.
-- Python `Network.ptdf()` / `lodf()` route through the auto sensitivity
-  solver (dense below the reduced-dimension threshold, iterative
-  conjugate gradient above it), matching the CLI `sensitivities`
-  command. Both take `solver="auto"|"dense"|"iterative"`. On a case above
-  the threshold results move from exact-dense to iterative-CG at a 1e-10
-  relative residual (#273).
+- DC sensitivities factor the grounded Laplacian once on the sparse path and
+  reuse its AMD-ordered Cholesky factors for batched PTDF and non-bridge LODF
+  right hand sides (#291). `SensitivitySolver::Sparse`, CLI/Python `sparse`,
+  and metadata path `sparse_cholesky` replace the iterative/CG names and the CG
+  tolerance and iteration fields are removed. `SensitivitySolveDidNotConverge`
+  is removed and its diagnostic code retired; allocation or index failures use
+  `SensitivityFactorizationFailed`. `Auto` remains dense through a
+  reduced dimension of 8192 while the predicted dense footprint is at most
+  2 GiB, then selects sparse. The sparse path requires positive finite branch
+  susceptances; dense remains available for nonsingular indefinite cases.
+  Results can differ in the last bits, so an entry at `drop_tolerance` can move
+  across the pruning boundary.
 
 ## 0.8.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,6 +816,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dyn-stack"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
+dependencies = [
+ "bytemuck",
+ "dyn-stack-macros",
+]
+
+[[package]]
+name = "dyn-stack-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +845,41 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro 0.2.1",
+]
+
+[[package]]
+name = "equator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da895aab06bbebefb6b2595f6d637b18c9ff629b4cd840965bb3164e4194b0"
+dependencies = [
+ "equator-macro 0.6.0",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b14b339eb76d07f052cdbad76ca7c1310e56173a138095d3bf42a23c06ef5d8"
 
 [[package]]
 name = "equivalent"
@@ -853,6 +904,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "faer"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab6df3dd147fe8d702a288b95bcd8fcc499ab572fc80da6828f60cd4d524d67"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "equator 0.6.0",
+ "faer-traits",
+ "gemm",
+ "generativity",
+ "libm",
+ "nano-gemm",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "reborrow",
+]
+
+[[package]]
+name = "faer-traits"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87d23ed7ab1f26c0cba0e5b9e061a796fbb7dc170fa8bee6970055a1308bb0f"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "generativity",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "pulp",
+ "qd",
+ "reborrow",
 ]
 
 [[package]]
@@ -995,6 +1083,109 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "gemm"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
+dependencies = [
+ "dyn-stack",
+ "gemm-c32",
+ "gemm-c64",
+ "gemm-common",
+ "gemm-f32",
+ "gemm-f64",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
+dependencies = [
+ "bytemuck",
+ "dyn-stack",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "generativity"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
 name = "generic-array"
@@ -1582,6 +1773,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "nano-gemm"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e04345dc84b498ff89fe0d38543d1f170da9e43a2c2bcee73a0f9069f72d081"
+dependencies = [
+ "equator 0.2.2",
+ "nano-gemm-c32",
+ "nano-gemm-c64",
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "nano-gemm-f32",
+ "nano-gemm-f64",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0775b1e2520e64deee8fc78b7732e3091fb7585017c0b0f9f4b451757bbbc562"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-c64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af49a20d58816e6b5ee65f64142e50edb5eba152678d4bb7377fcbf63f8437a"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+ "num-complex",
+]
+
+[[package]]
+name = "nano-gemm-codegen"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cc8d495c791627779477a2cf5df60049f5b165342610eb0d76bee5ff5c5d74c"
+
+[[package]]
+name = "nano-gemm-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d998dfa644de87a0f8660e5ea511d7cb5c33b5a2d9847b7af57a2565105089f0"
+
+[[package]]
+name = "nano-gemm-f32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879d962e79bc8952e4ad21ca4845a21132540ed3f5e01184b2ff7f720e666523"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
+name = "nano-gemm-f64"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9a513473dce7dc00c7e7c318481ca4494034e76997218d8dad51bd9f007a815"
+dependencies = [
+ "nano-gemm-codegen",
+ "nano-gemm-core",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1664,6 +1925,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
+ "bytemuck",
  "num-traits",
 ]
 
@@ -2078,6 +2340,7 @@ dependencies = [
  "approx",
  "arrow",
  "criterion",
+ "faer",
  "num-complex",
  "parquet",
  "powerio",
@@ -2167,6 +2430,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046aa45b989642ec2e4717c8e72d677b13edd831a4d3b6cf37d9a3e54912496a"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8f70e07b9c3962945a74e59ca1c511bba65b6419468acc217c457d93f3c740"
+
+[[package]]
 name = "pyo3"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,6 +2507,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "qd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1304a5aecdcfe9ee72fbba90aa37b3aa067a69d14cb7f3d9deada0be7c07c"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "num-traits",
+ "pulp",
 ]
 
 [[package]]
@@ -2379,6 +2677,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +2710,12 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "reborrow"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"

--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Known limits for every format are documented in the
 - Nodal admittance matrix
 - LACPF block matrix
 - Signed incidence matrix
-- PTDF and LODF sensitivity matrices, with dense and iterative solver paths
-- Streamed CLI PTDF/LODF writes for iterative sensitivity exports
+- PTDF and LODF sensitivity matrices, with dense and sparse Cholesky solver paths
+- Streamed CLI PTDF/LODF writes for sparse sensitivity exports
 - Adjacency matrix and `petgraph` graph output
 
 `powerio-prob` builds matrix free problem instances: DC OPF and AC OPF input

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -21,7 +21,7 @@ instances into sparse operators. The DC OPF bundle schema is in
 | signed incidence matrix \\(A\\) | \\(n \times m\\) | `build_incidence` | column \\(e\\) has \\(+1\\) at from-bus, \\(-1\\) at to-bus |
 | weighted bus Laplacian \\(L\\) | \\(n \times n\\) | `build_weighted_laplacian` | \\(L = A \operatorname{diag}(w) A^\mathsf{T}\\); for DC OPF and PTDF/LODF, \\(w\\) is the branch susceptance vector \\(b\\) |
 | flow map \\(B A^\mathsf{T}\\) | \\(m \times n\\) | `build_flow_map` | \\(f = B A^\mathsf{T}\theta\\) |
-| PTDF | \\(m \times n\\) | `build_ptdf` | dense oracle builder; `build_ptdf_lodf_with_options` can use iterative solves |
+| PTDF | \\(m \times n\\) | `build_ptdf` | dense oracle builder; `build_ptdf_lodf_with_options` can use sparse Cholesky |
 | LODF | \\(m \times m\\) | `build_lodf` | dense oracle builder; option based builds can prune small output entries |
 | adjacency | \\(n \times n\\) | `build_adjacency` | sparse graph adjacency |
 | petgraph graph | n/a | `IndexedNetwork::to_petgraph` | `UnGraph<bus_idx, branch_idx>` |
@@ -30,14 +30,15 @@ Computing PTDF and LODF matrices requires a linear solve. The stable
 `build_ptdf`, `build_lodf`, and `build_ptdf_lodf` builders keep the dense
 grounded inverse path and remain the small case oracle. The option based
 `build_ptdf_lodf_with_options` path accepts `SensitivityOptions`: `Dense` forces
-the dense oracle path, `Iterative` uses preconditioned conjugate gradient on one
-grounded right hand side at a time, and `Auto` selects dense up to a reduced
-dimension of 512 and iterative above it. The iterative path avoids forming the
-\\((n-r) \times (n-r)\\) dense inverse; the PTDF/LODF outputs themselves can still
-be large. The iterative path requires positive finite branch susceptances, so
-the grounded DC bus susceptance matrix is positive definite after reference
-coverage is checked; the dense path remains the fallback for nonsingular
-indefinite cases.
+the dense oracle path, `Sparse` performs one AMD-ordered sparse Cholesky
+factorization and reuses it for batches of PTDF and LODF right hand sides, and
+`Auto` selects dense through a reduced dimension of 8192 while the predicted
+dense footprint remains at or below 2 GiB, then selects sparse. The sparse path
+avoids forming the \\((n-r) \times (n-r)\\) dense inverse; the PTDF/LODF outputs
+themselves can still be large. It requires positive finite branch
+susceptances, so the grounded DC bus susceptance matrix is positive definite
+after reference coverage is checked; the dense path remains the fallback for
+nonsingular indefinite cases.
 Every connected component must contain at least one reference bus. The DC OPF
 instance bundle (\\(A\\), \\(b\\), \\(L\\), costs, bounds, thermal limits,
 \\(C_g\\)) is produced by `powerio-prob` and documented in
@@ -127,9 +128,9 @@ Matrices write as Matrix Market files or stay in memory. A symmetric matrix is
 stored as its lower triangle with the `symmetric` header and 1-based indices
 (`io::mtx::write_mtx`). The `sensitivities` command writes
 `<case>_ptdf.mtx`, `<case>_lodf.mtx`, and `<case>_sensitivity_meta.json`. Use
-`--solver dense|iterative|auto` to choose the PTDF/LODF solve path and
+`--solver dense|sparse|auto` to choose the PTDF/LODF solve path and
 `--drop-tolerance <value>` to omit entries with absolute value at or below the
-tolerance. When the CLI uses the iterative path, it writes retained Matrix
+tolerance. When the CLI uses the sparse path, it writes retained Matrix
 Market coordinates through temp files and does not hold the full sparse output
 in memory. The Rust `build_ptdf_lodf_with_options` API still returns `CsMat`
 values and is intended for outputs that fit in memory. The metadata records the

--- a/powerio-cli/README.md
+++ b/powerio-cli/README.md
@@ -20,7 +20,7 @@ powerio sensitivities tests/data/case30.m -o out --solver auto --drop-tolerance 
 powerio
 ```
 
-`powerio sensitivities --solver iterative` writes Matrix Market coordinates
+`powerio sensitivities --solver sparse` writes Matrix Market coordinates
 through temp files, so the command does not keep the full sparse PTDF/LODF
 output in memory.
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -611,7 +611,7 @@ impl From<DcConvArg> for DcConvention {
 enum SensitivitySolverArg {
     Auto,
     Dense,
-    Iterative,
+    Sparse,
 }
 
 impl From<SensitivitySolverArg> for SensitivitySolver {
@@ -619,7 +619,7 @@ impl From<SensitivitySolverArg> for SensitivitySolver {
         match value {
             SensitivitySolverArg::Auto => Self::Auto,
             SensitivitySolverArg::Dense => Self::Dense,
-            SensitivitySolverArg::Iterative => Self::Iterative,
+            SensitivitySolverArg::Sparse => Self::Sparse,
         }
     }
 }

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -229,7 +229,7 @@ fn sensitivities_write_solver_metadata() {
         "-o",
         out_dir.to_str().unwrap(),
         "--solver",
-        "iterative",
+        "sparse",
         "--drop-tolerance",
         "1e-10",
     ]);
@@ -248,15 +248,31 @@ fn sensitivities_write_solver_metadata() {
     )
     .unwrap();
     assert_eq!(meta["case"], "case9");
-    assert_eq!(meta["sensitivity"]["requested_solver"], "iterative");
-    assert_eq!(meta["sensitivity"]["solver_path"], "iterative_cg");
+    assert_eq!(meta["sensitivity"]["requested_solver"], "sparse");
+    assert_eq!(meta["sensitivity"]["solver_path"], "sparse_cholesky");
     assert_eq!(meta["sensitivity"]["drop_tolerance"], 1e-10);
+    assert!(meta["sensitivity"].get("cg_tolerance").is_none());
+    assert!(meta["sensitivity"].get("cg_max_iterations").is_none());
     assert_eq!(meta["sensitivity"]["ptdf"]["rows"], 9);
     assert_eq!(meta["sensitivity"]["ptdf"]["cols"], 9);
     assert_eq!(meta["sensitivity"]["lodf"]["rows"], 9);
     assert_eq!(meta["sensitivity"]["lodf"]["cols"], 9);
 
     let _ = std::fs::remove_dir_all(out_dir);
+}
+
+#[test]
+fn sensitivities_reject_removed_iterative_solver_name() {
+    let case = repo_file("tests/data/case9.m");
+    let out = run(&[
+        "sensitivities",
+        case.to_str().unwrap(),
+        "--solver",
+        "iterative",
+    ]);
+    assert_failure(&out);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("sparse"), "stderr:\n{stderr}");
 }
 
 #[test]

--- a/powerio-matrix/Cargo.toml
+++ b/powerio-matrix/Cargo.toml
@@ -30,6 +30,7 @@ powerio-diag = { workspace = true }
 powerio.workspace = true
 thiserror = "2"
 sprs.workspace = true
+faer = { version = "0.24.4", default-features = false, features = ["sparse-linalg"] }
 num-complex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/powerio-matrix/benches/matrix.rs
+++ b/powerio-matrix/benches/matrix.rs
@@ -9,8 +9,9 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use powerio_matrix::matrix::{
-    BuildOptions, DcConvention, build_adjacency, build_bdoubleprime, build_bprime, build_flow_map,
-    build_incidence, build_lacpf, build_ptdf_lodf, build_weighted_laplacian, build_ybus,
+    BuildOptions, DcConvention, SensitivityOptions, SensitivitySolver, build_adjacency,
+    build_bdoubleprime, build_bprime, build_flow_map, build_incidence, build_lacpf,
+    build_ptdf_lodf, build_ptdf_lodf_with_options, build_weighted_laplacian, build_ybus,
     ground_at_each,
 };
 use powerio_matrix::pipeline::{MatrixKind, Pipeline, RhsKind};
@@ -91,12 +92,37 @@ fn bench_dcopf_parts(c: &mut Criterion) {
     });
 }
 
-fn bench_dense_sensitivities(c: &mut Criterion) {
+fn bench_sensitivities(c: &mut Criterion) {
     let net = network("case118");
     let view = IndexedNetwork::new(&net);
     c.bench_function("sensitivity_ptdf_lodf_case118", |b| {
         b.iter(|| {
             build_ptdf_lodf(black_box(&view), black_box(DcConvention::ReactanceOnly)).unwrap()
+        });
+    });
+    let sparse = SensitivityOptions {
+        convention: DcConvention::ReactanceOnly,
+        solver: SensitivitySolver::Sparse,
+        ..Default::default()
+    };
+    c.bench_function("sensitivity_ptdf_lodf_sparse_case118", |b| {
+        b.iter(|| build_ptdf_lodf_with_options(black_box(&view), black_box(&sparse)).unwrap());
+    });
+
+    let net = network("case2869pegase");
+    let view = IndexedNetwork::new(&net);
+    let sparse_solve = SensitivityOptions {
+        convention: DcConvention::ReactanceOnly,
+        solver: SensitivitySolver::Sparse,
+        // A normal PTDF/LODF is dense-like at this size. Dropping all
+        // non-structural entries keeps this benchmark focused on factorization,
+        // batched solves, and flow evaluation instead of output allocation.
+        drop_tolerance: f64::MAX,
+        ..Default::default()
+    };
+    c.bench_function("sensitivity_solve_sparse_case2869pegase", |b| {
+        b.iter(|| {
+            build_ptdf_lodf_with_options(black_box(&view), black_box(&sparse_solve)).unwrap()
         });
     });
 }
@@ -126,7 +152,7 @@ criterion_group!(
     benches,
     bench_matrix_builders,
     bench_dcopf_parts,
-    bench_dense_sensitivities,
+    bench_sensitivities,
     bench_pipeline_paths
 );
 criterion_main!(benches);

--- a/powerio-matrix/src/diagnostics.rs
+++ b/powerio-matrix/src/diagnostics.rs
@@ -19,8 +19,12 @@ pub mod codes {
             "the reference grounded Laplacian is singular", category = Data;
         BUILD_SENSITIVITY_INVALID_OPTION = "BUILD.SENSITIVITY.INVALID_OPTION", Fatal,
             "a DC sensitivity option is outside the range it is defined on", category = Data;
+        BUILD_SENSITIVITY_FACTORIZATION_FAILED = "BUILD.SENSITIVITY.FACTORIZATION_FAILED", Fatal,
+            "the sparse DC sensitivity factorization could not be allocated or indexed", category = Data;
+        /// Retired in 0.9.0: the sparse direct solver has no convergence loop.
         BUILD_SENSITIVITY_NO_CONVERGENCE = "BUILD.SENSITIVITY.NO_CONVERGENCE", Fatal,
-            "the iterative DC sensitivity solve ran out of iterations", category = Data;
+            "the iterative DC sensitivity solve ran out of iterations", category = Data,
+            retired = "0.9.0";
         BUILD_GRIDFM_EMPTY_BATCH = "BUILD.GRIDFM.EMPTY_BATCH", Fatal,
             "a gridfm scenario batch holds no snapshot", category = Data;
         BUILD_GRIDFM_SCENARIO_ID_OVERFLOW = "BUILD.GRIDFM.SCENARIO_ID_OVERFLOW", Fatal,

--- a/powerio-matrix/src/error.rs
+++ b/powerio-matrix/src/error.rs
@@ -44,13 +44,8 @@ pub enum Error {
     #[error("invalid DC sensitivity option: {reason}")]
     InvalidSensitivityOptions { reason: String },
 
-    #[error(
-        "DC sensitivity iterative solve did not converge after {iterations} iterations (relative residual {relative_residual:.3e})"
-    )]
-    SensitivitySolveDidNotConverge {
-        iterations: usize,
-        relative_residual: f64,
-    },
+    #[error("DC sensitivity sparse factorization failed: {reason}")]
+    SensitivityFactorizationFailed { reason: String },
 
     #[error("matrix-market I/O: {0}")]
     Mtx(String),
@@ -112,8 +107,8 @@ impl Error {
             }
             Error::SingularNetwork => &codes::BUILD_SENSITIVITY_SINGULAR,
             Error::InvalidSensitivityOptions { .. } => &codes::BUILD_SENSITIVITY_INVALID_OPTION,
-            Error::SensitivitySolveDidNotConverge { .. } => {
-                &codes::BUILD_SENSITIVITY_NO_CONVERGENCE
+            Error::SensitivityFactorizationFailed { .. } => {
+                &codes::BUILD_SENSITIVITY_FACTORIZATION_FAILED
             }
             Error::EmptyScenarioBatch => &codes::BUILD_GRIDFM_EMPTY_BATCH,
             Error::ScenarioIdOverflow { .. } => &codes::BUILD_GRIDFM_SCENARIO_ID_OVERFLOW,
@@ -140,7 +135,7 @@ impl Error {
             | Error::ShapeMismatch { .. }
             | Error::SingularNetwork
             | Error::InvalidSensitivityOptions { .. }
-            | Error::SensitivitySolveDidNotConverge { .. }
+            | Error::SensitivityFactorizationFailed { .. }
             | Error::EmptyScenarioBatch
             | Error::ScenarioIdOverflow { .. }
             | Error::NormalizedGridfmSnapshot { .. }
@@ -237,9 +232,8 @@ mod tests {
             Error::InvalidSensitivityOptions {
                 reason: "tol".into(),
             },
-            Error::SensitivitySolveDidNotConverge {
-                iterations: 10,
-                relative_residual: 1.0,
+            Error::SensitivityFactorizationFailed {
+                reason: "allocation".into(),
             },
             Error::EmptyScenarioBatch,
             Error::ScenarioIdOverflow { base: 1, index: 0 },

--- a/powerio-matrix/src/io/sensitivity.rs
+++ b/powerio-matrix/src/io/sensitivity.rs
@@ -11,7 +11,7 @@ use crate::matrix::sensitivity::for_each_ptdf_lodf_entry;
 use crate::matrix::{SensitivityMetadata, SensitivityOptions};
 
 /// Write PTDF and LODF Matrix Market files from the option based sensitivity
-/// path and return the metadata for the same entries. The iterative solver path
+/// path and return the metadata for the same entries. The sparse solver path
 /// streams retained coordinates through temp files, so it does not keep the
 /// full sparse output in memory.
 pub fn write_sensitivity_mtx_with_options(

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -6,9 +6,9 @@
 //! `ABA = ground_with(L, refs)`: one row/column removed per reference bus. The
 //! default public builders keep the dense Cholesky path, with dense Gaussian
 //! elimination as the nonsingular indefinite fallback. Option based builders can
-//! choose an iterative path that solves one grounded right hand side at a time
-//! and writes directly into sparse output. Disconnected networks with one
-//! reference per island are supported.
+//! choose an AMD-ordered sparse Cholesky path that factors the grounded matrix
+//! once and solves reusable batches of right hand sides. Disconnected networks
+//! with one reference per island are supported.
 //! Several references in one island are fixed angle buses; this is not a
 //! participation factor based distributed slack model.
 
@@ -16,6 +16,14 @@
 // sparse traversal read clearer than the iterator rewrites clippy suggests.
 #![allow(clippy::needless_range_loop, clippy::explicit_iter_loop)]
 
+use faer::dyn_stack::{MemBuffer, MemStack};
+use faer::linalg::cholesky::llt::factor::LltRegularization;
+use faer::sparse::linalg::cholesky::{
+    CholeskySymbolicParams, LltRef, SymbolicCholesky, SymmetricOrdering,
+    factorize_symbolic_cholesky,
+};
+use faer::sparse::{FaerError, SparseColMatRef, SymbolicSparseColMatRef};
+use faer::{Conj, MatMut, Par, Side, Spec};
 use sprs::CsMat;
 
 use crate::indexed::IndexedNetwork;
@@ -27,15 +35,13 @@ use crate::{Error, Result};
 
 /// Entries below this magnitude are dropped from the emitted sparse matrices.
 const PRUNE: f64 = 1e-12;
-const DEFAULT_CG_TOLERANCE: f64 = 1e-10;
-const DEFAULT_CG_MAX_ITERATIONS: usize = 20_000;
-/// Reduced-dimension ceiling for the `Auto` dense path. The old value of 512
-/// was far below the real crossover: at nr = 600 the dense path is a ~7e7
-/// flop factorization while the iterative path runs ~1200 conjugate-gradient
-/// solves, so `Auto` picked the slower solver by one to three orders of
-/// magnitude across the whole range that holds the common published cases
-/// (1354, 2869, 3120, 6470 buses).
+/// Reduced-dimension ceiling for the `Auto` dense oracle path. Kept at the
+/// policy established in #295; the separate footprint guard prevents a wide
+/// problem from selecting dense output allocations through this dimension
+/// check alone.
 const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 8192;
+const MAX_RHS_BATCH_COLUMNS: usize = 32;
+const RHS_BATCH_MEMORY_BUDGET: usize = 8 << 20;
 
 /// Memory ceiling for the `Auto` dense path. The dimension alone does not
 /// bound the cost: the dense path also materializes an m x n PTDF and an
@@ -61,13 +67,13 @@ const LODF_ISLAND_TOLERANCE: f64 = 1e-9;
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SensitivitySolver {
-    /// Dense below [`SensitivityOptions::auto_dense_threshold`], iterative above it.
+    /// Dense below [`SensitivityOptions::auto_dense_threshold`], sparse above it.
     #[default]
     Auto,
     /// Dense grounded inverse. This is the historical builder path.
     Dense,
-    /// Preconditioned conjugate gradient, one right hand side at a time.
-    Iterative,
+    /// AMD-ordered sparse Cholesky with reusable batched solves.
+    Sparse,
 }
 
 /// Solver path actually used for a sensitivity build.
@@ -77,7 +83,7 @@ pub enum SensitivitySolver {
 pub enum SensitivitySolverPath {
     DenseCholesky,
     DenseInverse,
-    IterativeCg,
+    SparseCholesky,
 }
 
 impl SensitivitySolverPath {
@@ -86,7 +92,7 @@ impl SensitivitySolverPath {
         match self {
             Self::DenseCholesky => "dense_cholesky",
             Self::DenseInverse => "dense_inverse",
-            Self::IterativeCg => "iterative_cg",
+            Self::SparseCholesky => "sparse_cholesky",
         }
     }
 }
@@ -101,12 +107,8 @@ pub struct SensitivityOptions {
     /// Entries with absolute value at or below this value are omitted from the
     /// returned sparse matrices. LODF diagonal entries are structural and kept.
     pub drop_tolerance: f64,
-    /// Relative residual tolerance for the iterative solver.
-    pub cg_tolerance: f64,
-    /// Maximum conjugate gradient iterations per right hand side.
-    pub cg_max_iterations: usize,
     /// Reduced dimension above which [`SensitivitySolver::Auto`] selects the
-    /// iterative path.
+    /// sparse path.
     pub auto_dense_threshold: usize,
 }
 
@@ -116,8 +118,6 @@ impl Default for SensitivityOptions {
             convention: DcConvention::default(),
             solver: SensitivitySolver::Auto,
             drop_tolerance: PRUNE,
-            cg_tolerance: DEFAULT_CG_TOLERANCE,
-            cg_max_iterations: DEFAULT_CG_MAX_ITERATIONS,
             auto_dense_threshold: DEFAULT_AUTO_DENSE_THRESHOLD,
         }
     }
@@ -131,19 +131,6 @@ impl SensitivityOptions {
                     "drop_tolerance must be finite and nonnegative, got {}",
                     self.drop_tolerance
                 ),
-            });
-        }
-        if !self.cg_tolerance.is_finite() || self.cg_tolerance <= 0.0 {
-            return Err(Error::InvalidSensitivityOptions {
-                reason: format!(
-                    "cg_tolerance must be finite and positive, got {}",
-                    self.cg_tolerance
-                ),
-            });
-        }
-        if self.cg_max_iterations == 0 {
-            return Err(Error::InvalidSensitivityOptions {
-                reason: "cg_max_iterations must be positive".into(),
             });
         }
         Ok(())
@@ -178,7 +165,7 @@ impl SensitivityOptions {
                 if fits {
                     SensitivitySolver::Dense
                 } else {
-                    SensitivitySolver::Iterative
+                    SensitivitySolver::Sparse
                 }
             }
             other => other,
@@ -200,8 +187,6 @@ pub struct SensitivityMetadata {
     pub requested_solver: SensitivitySolver,
     pub solver_path: SensitivitySolverPath,
     pub drop_tolerance: f64,
-    pub cg_tolerance: Option<f64>,
-    pub cg_max_iterations: Option<usize>,
     pub auto_dense_threshold: usize,
     pub reduced_dimension: usize,
     pub ptdf: SensitivityMatrixMetadata,
@@ -280,14 +265,12 @@ pub fn build_ptdf_lodf_with_options(
                 lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
             (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped)
         }
-        SensitivitySolver::Iterative => {
-            ensure_iterative_solver_eligible(&inc)?;
-            let (ptdf, ptdf_dropped, lodf, lodf_dropped) =
-                iterative_ptdf_lodf(&inc, &refs, options)?;
+        SensitivitySolver::Sparse => {
+            let (ptdf, ptdf_dropped, lodf, lodf_dropped) = sparse_ptdf_lodf(&inc, &refs, options)?;
             (
                 ptdf,
                 lodf,
-                SensitivitySolverPath::IterativeCg,
+                SensitivitySolverPath::SparseCholesky,
                 ptdf_dropped,
                 lodf_dropped,
             )
@@ -340,11 +323,10 @@ pub(crate) fn for_each_ptdf_lodf_entry(
                 }
                 (solver_path, ptdf_meta, lodf_meta)
             }
-            SensitivitySolver::Iterative => {
-                ensure_iterative_solver_eligible(&inc)?;
+            SensitivitySolver::Sparse => {
                 let (ptdf, lodf) =
-                    iterative_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
-                (SensitivitySolverPath::IterativeCg, ptdf, lodf)
+                    sparse_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
+                (SensitivitySolverPath::SparseCholesky, ptdf, lodf)
             }
             SensitivitySolver::Auto => {
                 unreachable!("selected_solver_for_reduced_dimension resolves Auto")
@@ -371,10 +353,6 @@ fn sensitivity_metadata(
         requested_solver: options.solver,
         solver_path,
         drop_tolerance: options.drop_tolerance,
-        cg_tolerance: matches!(solver_path, SensitivitySolverPath::IterativeCg)
-            .then_some(options.cg_tolerance),
-        cg_max_iterations: matches!(solver_path, SensitivitySolverPath::IterativeCg)
-            .then_some(options.cg_max_iterations),
         auto_dense_threshold: options.auto_dense_threshold,
         reduced_dimension,
         ptdf,
@@ -490,15 +468,14 @@ fn ptdf_dense_with_path(
     Ok((ptdf, m, n, solver_path))
 }
 
-fn iterative_ptdf_lodf(
+fn sparse_ptdf_lodf(
     inc: &IncidenceParts,
     refs: &[usize],
     options: &SensitivityOptions,
 ) -> Result<(CsMat<f64>, usize, CsMat<f64>, usize)> {
-    ensure_iterative_solver_eligible(inc)?;
     let mut ptdf = CooBuilder::new_rect(inc.m(), inc.n());
     let mut lodf = CooBuilder::new(inc.m());
-    let (ptdf_meta, lodf_meta) = iterative_ptdf_lodf_entries(
+    let (ptdf_meta, lodf_meta) = sparse_ptdf_lodf_entries(
         inc,
         refs,
         options,
@@ -519,38 +496,51 @@ fn iterative_ptdf_lodf(
     ))
 }
 
-fn iterative_ptdf_lodf_entries(
+fn sparse_ptdf_lodf_entries(
     inc: &IncidenceParts,
     refs: &[usize],
     options: &SensitivityOptions,
     mut ptdf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
     mut lodf_entry: impl FnMut(usize, usize, f64) -> Result<()>,
 ) -> Result<(SensitivityMatrixMetadata, SensitivityMatrixMetadata)> {
+    ensure_sparse_solver_eligible(inc)?;
     let n = inc.n();
     let m = inc.m();
     let g = Grounding::new(refs);
     let nr = n - g.len();
     let lr = ground_with(&build_weighted_laplacian(&inc.a, &inc.b), &g);
-    let solver = CgSolver::new(&lr, options.cg_tolerance, options.cg_max_iterations)?;
+    let batch_width = rhs_batch_width(nr);
+    let mut solver = SparseCholeskyFactor::factor(&lr, batch_width)?;
     let (from, to) = endpoints(&inc.a, m);
 
-    let mut rhs = vec![0.0; nr];
+    let rhs_len = nr
+        .checked_mul(batch_width)
+        .ok_or_else(|| sensitivity_factorization_failed("RHS batch dimensions overflow usize"))?;
+    let mut rhs = try_zeroed_rhs(rhs_len)?;
     let mut ptdf_nnz = 0usize;
     let mut ptdf_dropped = 0usize;
-    for bus in 0..n {
-        let Some(rb) = g.reduced(bus) else {
-            continue;
-        };
+    let full_of_reduced = g.full_of_reduced(n);
+    for buses in full_of_reduced.chunks(batch_width) {
+        let used = buses.len();
+        let rhs = &mut rhs[..nr * used];
         rhs.fill(0.0);
-        rhs[rb] = 1.0;
-        let theta = solver.solve(&rhs)?;
-        for branch in 0..m {
-            let v = branch_flow(branch, &from, &to, &inc.b, &g, &theta);
-            if v.abs() > options.drop_tolerance {
-                ptdf_entry(branch, bus, v)?;
-                ptdf_nnz += 1;
-            } else if v != 0.0 {
-                ptdf_dropped += 1;
+        for (column, &bus) in buses.iter().enumerate() {
+            let rb = g
+                .reduced(bus)
+                .expect("full_of_reduced contains only ungrounded buses");
+            rhs[column * nr + rb] = 1.0;
+        }
+        solver.solve_batch(rhs, used)?;
+        for (column, &bus) in buses.iter().enumerate() {
+            let theta = &rhs[column * nr..(column + 1) * nr];
+            for branch in 0..m {
+                let v = branch_flow(branch, &from, &to, &inc.b, &g, theta);
+                if v.abs() > options.drop_tolerance {
+                    ptdf_entry(branch, bus, v)?;
+                    ptdf_nnz += 1;
+                } else if v != 0.0 {
+                    ptdf_dropped += 1;
+                }
             }
         }
     }
@@ -561,72 +551,263 @@ fn iterative_ptdf_lodf_entries(
 
     let mut lodf_nnz = 0usize;
     let mut lodf_dropped = 0usize;
-    for outage in 0..m {
-        // Its column is the diagonal alone, so neither the solve that would
-        // have produced the rest nor the scan that would emit it runs: every
-        // other entry is an exact zero, which is neither above the drop
-        // tolerance nor counted as dropped. Every branch of a radial feeder is
-        // a bridge, which is every solve here.
-        if is_bridge[outage] {
-            lodf_entry(outage, outage, -1.0)?;
-            lodf_nnz += 1;
-            continue;
+    for first_outage in (0..m).step_by(batch_width) {
+        let last_outage = first_outage.saturating_add(batch_width).min(m);
+        let mut solved_columns = 0usize;
+        rhs[..nr * (last_outage - first_outage)].fill(0.0);
+        for outage in first_outage..last_outage {
+            if is_bridge[outage] {
+                continue;
+            }
+            let offset = solved_columns * nr;
+            if let Some(rf) = g.reduced(from[outage]) {
+                rhs[offset + rf] += 1.0;
+            }
+            if let Some(rt) = g.reduced(to[outage]) {
+                rhs[offset + rt] -= 1.0;
+            }
+            solved_columns += 1;
         }
-        rhs.fill(0.0);
-        if let Some(rf) = g.reduced(from[outage]) {
-            rhs[rf] += 1.0;
+        if solved_columns != 0 {
+            solver.solve_batch(&mut rhs[..nr * solved_columns], solved_columns)?;
         }
-        if let Some(rt) = g.reduced(to[outage]) {
-            rhs[rt] -= 1.0;
-        }
-        let theta = solver.solve(&rhs)?;
-        let denom = 1.0 - branch_flow(outage, &from, &to, &inc.b, &g, &theta);
-        let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
-        for branch in 0..m {
-            let v = if branch == outage {
-                -1.0
-            } else if islands {
-                0.0
-            } else {
-                branch_flow(branch, &from, &to, &inc.b, &g, &theta) / denom
-            };
-            if branch == outage || v.abs() > options.drop_tolerance {
-                lodf_entry(branch, outage, v)?;
+
+        let mut solved_column = 0usize;
+        for outage in first_outage..last_outage {
+            // A bridge column is the diagonal alone, so it consumes neither a
+            // right hand side nor solve work. Emitting it here preserves the
+            // same outage-major callback order as every other column.
+            if is_bridge[outage] {
+                lodf_entry(outage, outage, -1.0)?;
                 lodf_nnz += 1;
-            } else if v != 0.0 {
-                lodf_dropped += 1;
+                continue;
+            }
+            let theta = &rhs[solved_column * nr..(solved_column + 1) * nr];
+            solved_column += 1;
+            let denom = 1.0 - branch_flow(outage, &from, &to, &inc.b, &g, theta);
+            let islands = denom.abs() < LODF_ISLAND_TOLERANCE;
+            for branch in 0..m {
+                let v = if branch == outage {
+                    -1.0
+                } else if islands {
+                    0.0
+                } else {
+                    branch_flow(branch, &from, &to, &inc.b, &g, theta) / denom
+                };
+                if branch == outage || v.abs() > options.drop_tolerance {
+                    lodf_entry(branch, outage, v)?;
+                    lodf_nnz += 1;
+                } else if v != 0.0 {
+                    lodf_dropped += 1;
+                }
             }
         }
     }
 
-    Ok((
+    Ok(metadata_from_counts(
+        m,
+        n,
+        ptdf_nnz,
+        ptdf_dropped,
+        lodf_nnz,
+        lodf_dropped,
+    ))
+}
+
+fn metadata_from_counts(
+    branches: usize,
+    buses: usize,
+    ptdf_nnz: usize,
+    ptdf_dropped: usize,
+    lodf_nnz: usize,
+    lodf_dropped: usize,
+) -> (SensitivityMatrixMetadata, SensitivityMatrixMetadata) {
+    (
         SensitivityMatrixMetadata {
-            rows: m,
-            cols: n,
+            rows: branches,
+            cols: buses,
             nnz: ptdf_nnz,
             dropped_entries: ptdf_dropped,
         },
         SensitivityMatrixMetadata {
-            rows: m,
-            cols: m,
+            rows: branches,
+            cols: branches,
             nnz: lodf_nnz,
             dropped_entries: lodf_dropped,
         },
-    ))
+    )
 }
 
-fn ensure_iterative_solver_eligible(inc: &IncidenceParts) -> Result<()> {
+fn ensure_sparse_solver_eligible(inc: &IncidenceParts) -> Result<()> {
     for (branch, &b) in inc.b.iter().enumerate() {
         if !b.is_finite() || b <= 0.0 {
             return Err(Error::InvalidSensitivityOptions {
                 reason: format!(
-                    "iterative sensitivity solver requires positive finite branch susceptances; \
+                    "sparse sensitivity solver requires positive finite branch susceptances; \
                      branch {branch} has {b}; use solver=dense for nonsingular indefinite cases"
                 ),
             });
         }
     }
     Ok(())
+}
+
+fn rhs_batch_width(reduced_dimension: usize) -> usize {
+    if reduced_dimension == 0 {
+        return MAX_RHS_BATCH_COLUMNS;
+    }
+    let bytes_per_column = reduced_dimension.saturating_mul(size_of::<f64>());
+    (RHS_BATCH_MEMORY_BUDGET / bytes_per_column).clamp(1, MAX_RHS_BATCH_COLUMNS)
+}
+
+fn try_zeroed_rhs(len: usize) -> Result<Vec<f64>> {
+    let mut rhs = Vec::new();
+    rhs.try_reserve_exact(len).map_err(|_| {
+        sensitivity_factorization_failed("allocating the reusable RHS batch failed")
+    })?;
+    rhs.resize(len, 0.0);
+    Ok(rhs)
+}
+
+fn sensitivity_factorization_failed(reason: impl Into<String>) -> Error {
+    Error::SensitivityFactorizationFailed {
+        reason: reason.into(),
+    }
+}
+
+fn map_faer_error(stage: &str, error: FaerError) -> Error {
+    sensitivity_factorization_failed(format!("{stage}: {error}"))
+}
+
+/// One AMD symbolic analysis and numeric sparse `LL^T`, plus the workspace
+/// reused for every solve batch. A zero-dimensional factor is represented
+/// without calling into the sparse factorization library.
+struct SparseCholeskyFactor {
+    dimension: usize,
+    max_rhs_columns: usize,
+    symbolic: Option<SymbolicCholesky<usize>>,
+    values: Vec<f64>,
+    solve_scratch: Option<MemBuffer>,
+}
+
+impl SparseCholeskyFactor {
+    fn factor(a: &CsMat<f64>, max_rhs_columns: usize) -> Result<Self> {
+        let dimension = a.rows();
+        if a.cols() != dimension {
+            return Err(Error::ShapeMismatch {
+                what: "grounded DC bus susceptance matrix columns",
+                expected: dimension,
+                got: a.cols(),
+            });
+        }
+        if dimension == 0 {
+            return Ok(Self {
+                dimension,
+                max_rhs_columns,
+                symbolic: None,
+                values: Vec::new(),
+                solve_scratch: None,
+            });
+        }
+
+        // `a` is CSR. Its transpose view is CSC over the same three slices,
+        // with no triplet rebuild or numeric copy. The grounded Laplacian is
+        // exactly symmetric, so the view describes the same operator.
+        let a_csc = a.transpose_view();
+        let indptr = a_csc.indptr();
+        let symbolic_a = SymbolicSparseColMatRef::new_checked(
+            dimension,
+            dimension,
+            indptr.raw_storage(),
+            None,
+            a_csc.indices(),
+        );
+        let numeric_a = SparseColMatRef::new(symbolic_a, a_csc.data());
+        let symbolic = factorize_symbolic_cholesky(
+            symbolic_a,
+            Side::Upper,
+            SymmetricOrdering::Amd,
+            CholeskySymbolicParams::default(),
+        )
+        .map_err(|error| map_faer_error("sparse symbolic analysis failed", error))?;
+
+        let mut values = Vec::new();
+        values.try_reserve_exact(symbolic.len_val()).map_err(|_| {
+            map_faer_error(
+                "allocating sparse numeric factors failed",
+                FaerError::OutOfMemory,
+            )
+        })?;
+        values.resize(symbolic.len_val(), 0.0);
+
+        let factor_req = symbolic.factorize_numeric_llt_scratch::<f64>(Par::Seq, Spec::default());
+        let mut factor_scratch = MemBuffer::try_new(factor_req).map_err(|_| {
+            map_faer_error(
+                "allocating sparse factorization workspace failed",
+                FaerError::OutOfMemory,
+            )
+        })?;
+        symbolic
+            .factorize_numeric_llt(
+                &mut values,
+                numeric_a,
+                Side::Upper,
+                LltRegularization::default(),
+                Par::Seq,
+                MemStack::new(&mut factor_scratch),
+                Spec::default(),
+            )
+            .map_err(|_| Error::SingularNetwork)?;
+
+        let solve_req = symbolic.solve_in_place_scratch::<f64>(max_rhs_columns, Par::Seq);
+        let solve_scratch = MemBuffer::try_new(solve_req).map_err(|_| {
+            map_faer_error(
+                "allocating sparse solve workspace failed",
+                FaerError::OutOfMemory,
+            )
+        })?;
+        Ok(Self {
+            dimension,
+            max_rhs_columns,
+            symbolic: Some(symbolic),
+            values,
+            solve_scratch: Some(solve_scratch),
+        })
+    }
+
+    fn solve_batch(&mut self, rhs: &mut [f64], columns: usize) -> Result<()> {
+        if columns > self.max_rhs_columns {
+            return Err(Error::ShapeMismatch {
+                what: "sparse sensitivity RHS batch columns",
+                expected: self.max_rhs_columns,
+                got: columns,
+            });
+        }
+        let expected = self.dimension.checked_mul(columns).ok_or_else(|| {
+            sensitivity_factorization_failed("RHS batch dimensions overflow usize")
+        })?;
+        if rhs.len() != expected {
+            return Err(Error::DimensionMismatch {
+                n: expected,
+                b_len: rhs.len(),
+            });
+        }
+        let Some(symbolic) = &self.symbolic else {
+            return Ok(());
+        };
+        let matrix = MatMut::from_column_major_slice_mut(rhs, self.dimension, columns);
+        LltRef::new(symbolic, &self.values).solve_in_place_with_conj(
+            Conj::No,
+            matrix,
+            Par::Seq,
+            MemStack::new(
+                self.solve_scratch
+                    .as_mut()
+                    .expect("nonempty sparse factor has solve workspace"),
+            ),
+        );
+        Ok(())
+    }
 }
 
 fn branch_flow(
@@ -851,125 +1032,6 @@ fn swap_dense_rows(a: &mut [f64], n: usize, r1: usize, r2: usize) {
     }
 }
 
-struct CgSolver<'a> {
-    a: &'a CsMat<f64>,
-    diag: Vec<f64>,
-    tolerance: f64,
-    max_iterations: usize,
-}
-
-impl<'a> CgSolver<'a> {
-    fn new(a: &'a CsMat<f64>, tolerance: f64, max_iterations: usize) -> Result<Self> {
-        let n = a.rows();
-        if a.cols() != n {
-            return Err(Error::ShapeMismatch {
-                what: "grounded DC bus susceptance matrix columns",
-                expected: n,
-                got: a.cols(),
-            });
-        }
-        let mut diag = vec![0.0; n];
-        for (i, slot) in diag.iter_mut().enumerate() {
-            *slot = a.get(i, i).copied().unwrap_or(0.0);
-            if !slot.is_finite() || *slot <= 0.0 {
-                return Err(Error::SingularNetwork);
-            }
-        }
-        Ok(Self {
-            a,
-            diag,
-            tolerance,
-            max_iterations,
-        })
-    }
-
-    fn solve(&self, rhs: &[f64]) -> Result<Vec<f64>> {
-        let n = self.a.rows();
-        if rhs.len() != n {
-            return Err(Error::DimensionMismatch {
-                n,
-                b_len: rhs.len(),
-            });
-        }
-        if n == 0 {
-            return Ok(Vec::new());
-        }
-
-        let rhs_norm = norm2(rhs);
-        if rhs_norm == 0.0 {
-            return Ok(vec![0.0; n]);
-        }
-        let target = self.tolerance * rhs_norm;
-        let mut solution = vec![0.0; n];
-        let mut residual_vec = rhs.to_vec();
-        let mut preconditioned = self.precondition(&residual_vec);
-        let mut direction = preconditioned.clone();
-        let mut residual_dot = dot(&residual_vec, &preconditioned);
-        if !residual_dot.is_finite() || residual_dot <= 0.0 {
-            return Err(Error::SingularNetwork);
-        }
-        let mut matvec_out = vec![0.0; n];
-
-        for iter in 1..=self.max_iterations {
-            matvec(self.a, &direction, &mut matvec_out);
-            let denom = dot(&direction, &matvec_out);
-            if !denom.is_finite() || denom <= 0.0 {
-                return Err(Error::SingularNetwork);
-            }
-            let alpha = residual_dot / denom;
-            for i in 0..n {
-                solution[i] += alpha * direction[i];
-                residual_vec[i] -= alpha * matvec_out[i];
-            }
-            let residual = norm2(&residual_vec);
-            if residual <= target {
-                return Ok(solution);
-            }
-            preconditioned = self.precondition(&residual_vec);
-            let next_residual_dot = dot(&residual_vec, &preconditioned);
-            if !next_residual_dot.is_finite() || next_residual_dot <= 0.0 {
-                return Err(Error::SingularNetwork);
-            }
-            let beta = next_residual_dot / residual_dot;
-            for i in 0..n {
-                direction[i] = preconditioned[i] + beta * direction[i];
-            }
-            residual_dot = next_residual_dot;
-
-            if iter == self.max_iterations {
-                return Err(Error::SensitivitySolveDidNotConverge {
-                    iterations: iter,
-                    relative_residual: residual / rhs_norm,
-                });
-            }
-        }
-        unreachable!("positive max_iterations loop returns")
-    }
-
-    fn precondition(&self, r: &[f64]) -> Vec<f64> {
-        r.iter().zip(&self.diag).map(|(&ri, &di)| ri / di).collect()
-    }
-}
-
-fn matvec(a: &CsMat<f64>, x: &[f64], out: &mut [f64]) {
-    out.fill(0.0);
-    for (i, row) in a.outer_iterator().enumerate() {
-        let mut sum = 0.0;
-        for (j, &v) in row.iter() {
-            sum += v * x[j];
-        }
-        out[i] = sum;
-    }
-}
-
-fn dot(a: &[f64], b: &[f64]) -> f64 {
-    a.iter().zip(b).map(|(&x, &y)| x * y).sum()
-}
-
-fn norm2(a: &[f64]) -> f64 {
-    dot(a, a).sqrt()
-}
-
 /// Dense lower-triangular Cholesky `A = L Lᵀ` for a small SPD matrix.
 struct DenseCholesky {
     n: usize,
@@ -1141,6 +1203,45 @@ mod pivot_tests {
 }
 
 #[cfg(test)]
+mod sparse_factor_tests {
+    use faer::sparse::FaerError;
+    use sprs::CsMat;
+
+    use super::{SparseCholeskyFactor, map_faer_error, rhs_batch_width};
+    use crate::Error;
+
+    #[test]
+    fn allocation_and_index_failures_keep_the_factorization_identity() {
+        for failure in [FaerError::OutOfMemory, FaerError::IndexOverflow] {
+            let error = map_faer_error("symbolic analysis", failure);
+            match error {
+                Error::SensitivityFactorizationFailed { reason } => {
+                    assert!(reason.contains("symbolic analysis"));
+                    assert!(reason.contains(&failure.to_string()));
+                }
+                other => panic!("unexpected error: {other}"),
+            }
+        }
+    }
+
+    #[test]
+    fn a_non_positive_sparse_pivot_is_singular() {
+        let matrix = CsMat::new((1, 1), vec![0, 1], vec![0], vec![-1.0]);
+        assert!(matches!(
+            SparseCholeskyFactor::factor(&matrix, 1),
+            Err(Error::SingularNetwork)
+        ));
+    }
+
+    #[test]
+    fn rhs_batches_respect_the_column_and_memory_caps() {
+        assert_eq!(rhs_batch_width(1), 32);
+        assert_eq!(rhs_batch_width(usize::MAX), 1);
+        assert_eq!(rhs_batch_width((8 << 20) / size_of::<f64>()), 1);
+    }
+}
+
+#[cfg(test)]
 mod auto_policy_tests {
     use super::{
         AUTO_DENSE_MEMORY_BUDGET, SensitivityOptions, SensitivitySolver, dense_footprint_bytes,
@@ -1148,9 +1249,8 @@ mod auto_policy_tests {
 
     #[test]
     fn auto_takes_the_dense_path_for_a_mid_size_case() {
-        // 2869 buses is a common published case, far inside the dense path's
-        // real crossover; the old 512 ceiling sent it to the iterative
-        // solver, one to three orders of magnitude slower in this range.
+        // 2869 buses is a common published case inside the compatibility
+        // policy's dense range.
         let o = SensitivityOptions::default();
         assert_eq!(
             o.selected_solver_for_shape(2868, 4582, 2869),
@@ -1169,13 +1269,13 @@ mod auto_policy_tests {
         assert!(dense_footprint_bytes(nr, m, n) > AUTO_DENSE_MEMORY_BUDGET);
         assert_eq!(
             o.selected_solver_for_shape(nr, m, n),
-            SensitivitySolver::Iterative
+            SensitivitySolver::Sparse
         );
     }
 
     #[test]
     fn an_explicit_solver_choice_ignores_both_ceilings() {
-        for solver in [SensitivitySolver::Dense, SensitivitySolver::Iterative] {
+        for solver in [SensitivitySolver::Dense, SensitivitySolver::Sparse] {
             let o = SensitivityOptions {
                 solver,
                 ..SensitivityOptions::default()
@@ -1193,7 +1293,7 @@ mod auto_policy_tests {
                 usize::MAX,
                 usize::MAX
             ),
-            SensitivitySolver::Iterative
+            SensitivitySolver::Sparse
         );
     }
 }

--- a/powerio-matrix/src/matrix/tests.rs
+++ b/powerio-matrix/src/matrix/tests.rs
@@ -676,7 +676,7 @@ fn a_radial_tie_gets_a_structurally_zero_lodf_column() {
 
     for solver in [
         crate::matrix::SensitivitySolver::Dense,
-        crate::matrix::SensitivitySolver::Iterative,
+        crate::matrix::SensitivitySolver::Sparse,
     ] {
         let out = crate::matrix::build_ptdf_lodf_with_options(
             &view,

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -341,7 +341,7 @@ fn lodf_diagonal_is_minus_one() {
 }
 
 #[test]
-fn iterative_sensitivities_match_dense_oracle() {
+fn sparse_sensitivities_match_dense_oracle() {
     for path in [
         "../tests/data/case9.m",
         "../tests/data/case14.m",
@@ -352,23 +352,120 @@ fn iterative_sensitivities_match_dense_oracle() {
         // Both paths take the same convention: this compares the two solvers,
         // not two weightings.
         let (dense_ptdf, dense_lodf) = build_ptdf_lodf(&view, DcConvention::default()).unwrap();
-        let iterative = build_ptdf_lodf_with_options(
+        let sparse = build_ptdf_lodf_with_options(
             &view,
             &SensitivityOptions {
-                solver: SensitivitySolver::Iterative,
+                solver: SensitivitySolver::Sparse,
                 drop_tolerance: 1e-12,
                 ..Default::default()
             },
         )
         .unwrap();
         assert_eq!(
-            iterative.metadata.solver_path,
-            SensitivitySolverPath::IterativeCg,
+            sparse.metadata.solver_path,
+            SensitivitySolverPath::SparseCholesky,
             "{path}: solver path"
         );
-        assert_matrix_close(&iterative.ptdf, &dense_ptdf, 1e-7, path);
-        assert_matrix_close(&iterative.lodf, &dense_lodf, 1e-7, path);
+        assert_matrix_close(&sparse.ptdf, &dense_ptdf, 1e-10, path);
+        assert_matrix_close(&sparse.lodf, &dense_lodf, 1e-10, path);
     }
+}
+
+#[test]
+fn sparse_handles_disconnected_and_multi_reference_networks() {
+    let cases = [
+        net(
+            "grounded-islands",
+            vec![
+                bus(1, BusType::Ref),
+                bus(2, BusType::Pq),
+                bus(3, BusType::Ref),
+                bus(4, BusType::Pq),
+            ],
+            vec![branch(1, 2, 0.1), branch(3, 4, 0.2)],
+        ),
+        net(
+            "multi-reference",
+            vec![
+                bus(1, BusType::Ref),
+                bus(2, BusType::Pq),
+                bus(3, BusType::Ref),
+            ],
+            vec![branch(1, 2, 0.1), branch(2, 3, 0.2)],
+        ),
+    ];
+    for case in &cases {
+        let view = IndexedNetwork::new(case);
+        let dense = build_ptdf_lodf_with_options(
+            &view,
+            &SensitivityOptions {
+                solver: SensitivitySolver::Dense,
+                drop_tolerance: 0.0,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let sparse = build_ptdf_lodf_with_options(
+            &view,
+            &SensitivityOptions {
+                solver: SensitivitySolver::Sparse,
+                drop_tolerance: 0.0,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_matrix_close(&sparse.ptdf, &dense.ptdf, 1e-12, &case.name);
+        assert_matrix_close(&sparse.lodf, &dense.lodf, 1e-12, &case.name);
+    }
+}
+
+#[test]
+fn sparse_handles_zero_reduced_dimension_and_parallel_branches() {
+    let case = net(
+        "all-reference-parallel",
+        vec![bus(1, BusType::Ref), bus(2, BusType::Ref)],
+        vec![branch(1, 2, 0.1), branch(1, 2, 0.2)],
+    );
+    let view = IndexedNetwork::new(&case);
+    let out = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Sparse,
+            drop_tolerance: 0.0,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(out.metadata.reduced_dimension, 0);
+    assert_eq!((out.ptdf.rows(), out.ptdf.cols()), (2, 2));
+    assert_eq!(out.ptdf.nnz(), 0);
+    assert_eq!(dense(&out.lodf), vec![vec![-1.0, 0.0], vec![0.0, -1.0]]);
+
+    let one_ref = net(
+        "parallel",
+        vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+        vec![branch(1, 2, 0.1), branch(1, 2, 0.1)],
+    );
+    let parallel = build_ptdf_lodf_with_options(
+        &IndexedNetwork::new(&one_ref),
+        &SensitivityOptions {
+            solver: SensitivitySolver::Sparse,
+            drop_tolerance: 0.0,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_matrix_close(
+        &parallel.lodf,
+        &sprs::CsMat::new(
+            (2, 2),
+            vec![0, 2, 4],
+            vec![0, 1, 0, 1],
+            vec![-1.0, 1.0, 1.0, -1.0],
+        ),
+        1e-12,
+        "parallel LODF",
+    );
 }
 
 #[test]
@@ -405,11 +502,11 @@ fn sensitivity_drop_tolerance_records_dropped_entries() {
 }
 
 #[test]
-fn streamed_iterative_sensitivities_match_in_memory() {
+fn streamed_sparse_sensitivities_match_in_memory() {
     let case = load("../tests/data/case30.m");
     let view = IndexedNetwork::new(&case);
     let options = SensitivityOptions {
-        solver: SensitivitySolver::Iterative,
+        solver: SensitivitySolver::Sparse,
         drop_tolerance: 1e-9,
         ..Default::default()
     };
@@ -422,15 +519,19 @@ fn streamed_iterative_sensitivities_match_in_memory() {
     let ptdf = read_mtx(&ptdf_path).unwrap();
     let lodf = read_mtx(&lodf_path).unwrap();
 
-    assert_eq!(meta.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(meta.solver_path, SensitivitySolverPath::SparseCholesky);
     assert_eq!(meta.ptdf.nnz, ptdf.nnz());
     assert_eq!(meta.lodf.nnz, lodf.nnz());
+    assert_eq!(
+        serde_json::to_value(&meta).unwrap(),
+        serde_json::to_value(&expected.metadata).unwrap()
+    );
     assert_matrix_close(&ptdf, &expected.ptdf, 0.0, "streamed PTDF");
     assert_matrix_close(&lodf, &expected.lodf, 0.0, "streamed LODF");
 }
 
 #[test]
-fn auto_sensitivity_solver_switches_to_iterative_above_threshold() {
+fn auto_sensitivity_solver_switches_to_sparse_above_threshold() {
     let case = load("../tests/data/case118.m");
     let view = IndexedNetwork::new(&case);
     let out = build_ptdf_lodf_with_options(
@@ -445,7 +546,10 @@ fn auto_sensitivity_solver_switches_to_iterative_above_threshold() {
     .unwrap();
 
     assert_eq!(out.metadata.requested_solver, SensitivitySolver::Auto);
-    assert_eq!(out.metadata.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(
+        out.metadata.solver_path,
+        SensitivitySolverPath::SparseCholesky
+    );
     assert_eq!(out.metadata.ptdf.rows, out.ptdf.rows());
     assert_eq!(out.metadata.ptdf.cols, out.ptdf.cols());
     assert_eq!(out.metadata.lodf.rows, out.lodf.rows());
@@ -454,7 +558,7 @@ fn auto_sensitivity_solver_switches_to_iterative_above_threshold() {
 }
 
 #[test]
-fn auto_writes_iterative_outputs_above_the_dense_threshold() {
+fn auto_writes_sparse_outputs_above_the_dense_threshold() {
     let n = 600;
     let mut buses = Vec::with_capacity(n);
     buses.push(bus(1, BusType::Ref));
@@ -469,7 +573,7 @@ fn auto_writes_iterative_outputs_above_the_dense_threshold() {
     assert!(reduced_dimension > 512);
 
     // Drive the routing through the knob rather than the default ceiling:
-    // 599 unknowns is far below the real dense/iterative crossover, so the
+    // 599 unknowns is far below the real dense/sparse crossover, so the
     // default now (correctly) takes the dense path here.
     let options = SensitivityOptions {
         auto_dense_threshold: 512,
@@ -482,7 +586,7 @@ fn auto_writes_iterative_outputs_above_the_dense_threshold() {
     let ptdf = read_mtx(&ptdf_path).unwrap();
     let lodf = read_mtx(&lodf_path).unwrap();
 
-    assert_eq!(meta.solver_path, SensitivitySolverPath::IterativeCg);
+    assert_eq!(meta.solver_path, SensitivitySolverPath::SparseCholesky);
     assert_eq!(meta.reduced_dimension, reduced_dimension);
     assert_eq!(ptdf.rows(), branch_count);
     assert_eq!(ptdf.cols(), n);
@@ -495,7 +599,7 @@ fn auto_writes_iterative_outputs_above_the_dense_threshold() {
 }
 
 #[test]
-fn auto_iterative_rejects_non_positive_susceptance() {
+fn auto_sparse_rejects_non_positive_susceptance() {
     let case = net(
         "negative_x",
         vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -194,8 +194,8 @@ fn parse_convention(s: &str) -> PyResult<DcConvention> {
 }
 
 /// PTDF/LODF options from the Python keywords. The solver defaults to `auto`,
-/// which is dense below the reduced-dimension threshold and the iterative
-/// conjugate gradient path above it — the same policy the CLI `sensitivities`
+/// which is dense below the reduced-dimension threshold and sparse Cholesky
+/// above it — the same policy the CLI `sensitivities`
 /// command applies, so a very large case cannot force the dense n×n
 /// factorization from Python.
 fn sensitivity_options(
@@ -206,10 +206,15 @@ fn sensitivity_options(
     let solver = match normalize(solver.unwrap_or("auto")).as_str() {
         "auto" => SensitivitySolver::Auto,
         "dense" => SensitivitySolver::Dense,
-        "iterative" | "cg" => SensitivitySolver::Iterative,
+        "sparse" => SensitivitySolver::Sparse,
+        "iterative" | "cg" => {
+            return Err(PyValueError::new_err(
+                "solver 'iterative'/'cg' was removed in 0.9; use 'sparse' for the reusable sparse Cholesky path",
+            ));
+        }
         other => {
             return Err(PyValueError::new_err(format!(
-                "unknown solver {other:?}; expected 'auto', 'dense', or 'iterative'"
+                "unknown solver {other:?}; expected 'auto', 'dense', or 'sparse'"
             )));
         }
     };

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -453,9 +453,9 @@ class BalancedNetwork:
     def ptdf(self, convention: str = "series", solver: str = "auto"):
         """DC PTDF (m×n). ``convention`` is ``"series"`` or ``"matpower"``.
 
-        ``solver`` is ``"auto"``, ``"dense"``, or ``"iterative"``. ``"auto"``
-        uses the dense factorization on small cases and the iterative
-        conjugate gradient path on large ones, the same policy as the CLI.
+        ``solver`` is ``"auto"``, ``"dense"``, or ``"sparse"``. ``"auto"``
+        uses the dense factorization on small cases and reusable sparse
+        Cholesky on large ones, the same policy as the CLI.
         """
         return _to_csr(self._inner.ptdf(convention, solver))
 

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -4,7 +4,7 @@ __version__: str
 
 Scheme = Literal["bx", "xb"]
 Convention = Literal["series", "matpower", "reactance-only"]
-SensitivitySolver = Literal["auto", "dense", "iterative"]
+SensitivitySolver = Literal["auto", "dense", "sparse"]
 Units = Literal["perunit", "native"]
 GridfmOutputs = Dict[str, Any]
 

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -1000,14 +1000,16 @@ def test_convention_aliases(case9):
 
 def test_sensitivity_solver_kwarg(case9):
     # On a small case the auto policy picks the dense path, so the explicit
-    # spellings must agree with the default. The iterative path agrees only
-    # to its 1e-10 relative residual.
+    # spellings must agree with the default.
     base = case9.ptdf().toarray()
     assert np.allclose(case9.ptdf(solver="dense").toarray(), base, atol=1e-9)
-    assert np.allclose(case9.ptdf(solver="iterative").toarray(), base, atol=1e-6)
+    assert np.allclose(case9.ptdf(solver="sparse").toarray(), base, atol=1e-10)
     lodf = case9.lodf().toarray()
     assert np.allclose(case9.lodf(solver="dense").toarray(), lodf, atol=1e-9)
-    assert np.allclose(case9.lodf(solver="CG").toarray(), lodf, atol=1e-6)
+    assert np.allclose(case9.lodf(solver="SPARSE").toarray(), lodf, atol=1e-10)
+    for old in ["iterative", "cg", "CG"]:
+        with pytest.raises(ValueError, match="use 'sparse'"):
+            case9.ptdf(solver=old)
 
 
 def test_bad_enum_strings_raise(case9, tmp_path):


### PR DESCRIPTION
Closes #291.

## Summary

- replace per-right-hand-side Jacobi-CG solves with one AMD-ordered sparse `LLT` factorization reused across PTDF and non-bridge LODF batches
- cap reusable RHS batches at 32 columns and approximately 8 MiB while preserving streamed output, pruning counts, reference columns, callback order, and bridge semantics
- rename the public solver surface from `iterative` to `sparse`, retire the convergence diagnostic, and add factorization failure reporting
- keep the dense oracle and the 8192-dimension/2 GiB auto-selection policy
- add `faer 0.24.4` with default features disabled and only `sparse-linalg`; public matrices remain `sprs::CsMat`

@samtalki please confirm the intentional API rename and the MIT-licensed `faer` dependency.

## Numerical comparison

Release-mode dense versus sparse comparison on case118 with pruning disabled:

- PTDF maximum absolute error: `8.327e-15`
- LODF maximum absolute error: `5.584e-14`

Last-bit differences can move values that lie at `drop_tolerance` across the pruning boundary.

## Benchmarks

Release Criterion runs use `DcConvention::ReactanceOnly` and force the compared solver.

| workload | before | after | change |
| --- | ---: | ---: | ---: |
| case118 full PTDF + LODF | 17.414 ms | 2.4022 ms | 7.25x faster |
| case2869pegase factorization, all RHS solves, and flow evaluation | 89.547 s | 192.48 ms | about 465x faster |

case118 uses 10 samples, a 1 s warm-up, and a 5 s measurement target. For case2869pegase, `drop_tolerance = f64::MAX` avoids materializing tens of millions of output coordinates while retaining all factorization, solve, and flow-evaluation work. The old solver's warm-up estimated 910 seconds for 10 samples, so its reported baseline is a Criterion quick-mode run; the sparse result is a 10-sample run with a 190.71–194.26 ms interval.

## Verification

- `cargo fmt --all --check`
- `cargo test -p powerio-matrix --lib`
- `cargo test -p powerio-matrix --test dcopf`
- focused CLI sensitivity tests
- Python binding sensitivity tests and the Python package suite
- C ABI tests
- rustdoc with warnings denied, mdBook build, and mdBook tests
- relevant clippy feature-matrix commands, including matrix + gridfm, C ABI feature sets, and the Python extension
- dependency tree confirms `faer` enables only `sparse-linalg`, `linalg`, and `sparse`, with no `faer` default, Rayon, or native-library features


## 1.0 architecture audit

Retain this factorization and reuse work for 1.0, tracked by #291. Do not merge it into a 0.9.1 patch because the public `Iterative` to `Sparse` rename is breaking. Rebuild it on the 1.0 matrix layer after the crate move in #408.