### PR TITLE
Satisfy the Rust 1.98 clippy lint

### DIFF
--- a/powerio-cli/src/corpus/anonymize.rs
+++ b/powerio-cli/src/corpus/anonymize.rs
@@ -252,9 +252,7 @@ fn build_vocabulary() -> BTreeSet<String> {
     // Filled so `caps_serde` writes its column names, which the schema
     // states as a plain string map.
     let mut generator = Generator::new(BusId(1));
-    for slot in &mut generator.caps {
-        *slot = Some(0.0);
-    }
+    generator.caps.fill(Some(0.0));
     net.generators.push(generator);
     net.loads.push(Load::new(BusId(1), 0.0, 0.0));
     net.shunts.push(Shunt::new(BusId(1), 0.0, 0.0));


### PR DESCRIPTION
Rust 1.98 adds manual_slice_fill to the warning set. Use the slice fill method so current main and every open release PR pass the CI clippy job.

Validation:
- cargo fmt --all --check
- cargo clippy --locked -p powerio-cli --all-targets -- -D warnings