### PR TITLE
Contain MCP directory reads and writes

### DIFF
--- a/python/powerio/mcp/sandbox.py
+++ b/python/powerio/mcp/sandbox.py
@@ -5,7 +5,9 @@ The powerio MCP server accepts local paths and ``file://`` URIs for its
 directories named by ``POWERIO_MCP_ALLOWED_ROOTS`` (an ``os.pathsep``
 separated list). This module is the policy on its own: it imports nothing but
 the standard library, so a server built on a different MCP SDK, or on no SDK
-at all, can apply the same rules by calling :func:`checked_path`.
+at all, can apply the same rules. Use :func:`checked_path` for one file,
+:func:`checked_read_tree` before a directory reader, and
+:func:`staged_directory_write` for a directory writer.
 
 Two legacy single root spellings are still read, in this order after the
 primary variable: ``POWERIO_MCP_ROOT``, then ``POWERIO_MCP_ALLOWED_ROOT``, an
@@ -23,7 +25,11 @@ policy is off and every path is allowed.
 from __future__ import annotations
 
 import os
+import shutil
+import stat
+import tempfile
 from pathlib import Path
+from typing import Any, Callable, TypeVar, cast
 from urllib.parse import unquote, urlparse
 
 ALLOWED_ROOTS_ENV = "POWERIO_MCP_ALLOWED_ROOTS"
@@ -39,9 +45,14 @@ __all__ = [
     "admitting_root",
     "allowed_roots",
     "check_allowed_path",
+    "check_allowed_read_tree",
     "checked_path",
+    "checked_read_tree",
     "decode_local_path",
+    "staged_directory_write",
 ]
+
+_T = TypeVar("_T")
 
 
 class PathNotAllowed(ValueError):
@@ -167,3 +178,225 @@ def checked_path(
     path = decode_local_path(value, purpose=purpose)
     check_allowed_path(path, for_write=for_write, purpose=purpose)
     return str(path)
+
+
+def _inside(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def _check_tree_target(path: Path, root: Path | None, *, purpose: str) -> os.stat_result:
+    """Resolve one read-tree entry and return its followed stat record."""
+    try:
+        resolved = path.resolve(strict=True)
+        info = path.stat()
+    except FileNotFoundError as exc:
+        raise PathNotAllowed(f"`{purpose}` contains a broken link: {path}") from exc
+    except OSError as exc:
+        raise PathNotAllowed(f"cannot inspect `{purpose}` entry {path}: {exc}") from exc
+    if root is not None and not _inside(resolved, root):
+        raise PathNotAllowed(
+            f"`{purpose}` contains a link outside its allowed MCP root: {path}"
+        )
+    if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+        raise PathNotAllowed(
+            f"`{purpose}` contains a non-file, non-directory entry: {path}"
+        )
+    return info
+
+
+def check_allowed_read_tree(path: Path, *, purpose: str = "path") -> None:
+    """Preflight every file reachable from a directory input.
+
+    The input and each followed symlink must remain under the same configured
+    allowed root. Contained directory links are followed, with inode based
+    cycle detection; broken links and special files are refused. A regular
+    file is accepted as a one-entry tree.
+
+    This closes the gap between checking a directory name and handing that
+    directory to a reader which opens its children. It is still a path
+    preflight, not a kernel sandbox: another process can replace an entry
+    between this check and the reader's later ``open`` call.
+    """
+    root = admitting_root(path, purpose=purpose)
+    stack = [path]
+    visited: set[tuple[int, int]] = set()
+    while stack:
+        current = stack.pop()
+        info = _check_tree_target(current, root, purpose=purpose)
+        if stat.S_ISREG(info.st_mode):
+            continue
+        identity = (info.st_dev, info.st_ino)
+        if identity in visited:
+            continue
+        visited.add(identity)
+        try:
+            with os.scandir(current) as entries:
+                children = [Path(entry.path) for entry in entries]
+        except OSError as exc:
+            raise PathNotAllowed(
+                f"cannot inspect `{purpose}` directory {current}: {exc}"
+            ) from exc
+        stack.extend(children)
+
+
+def checked_read_tree(value: str, *, purpose: str = "path") -> str:
+    """Decode a local path and preflight its complete readable tree."""
+    path = decode_local_path(value, purpose=purpose)
+    check_allowed_read_tree(path, purpose=purpose)
+    return str(path)
+
+
+def _plain_tree(root: Path, *, purpose: str) -> tuple[list[Path], list[Path]]:
+    """List a directory tree that contains no links or special files."""
+    try:
+        root_info = root.lstat()
+    except OSError as exc:
+        raise PathNotAllowed(f"cannot inspect `{purpose}` directory {root}: {exc}") from exc
+    if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+        raise PathNotAllowed(f"`{purpose}` must be a real directory, not a link or file")
+
+    directories: list[Path] = []
+    files: list[Path] = []
+    for directory, names, filenames in os.walk(root, topdown=True, followlinks=False):
+        base = Path(directory)
+        for name in names:
+            child = base / name
+            try:
+                info = child.lstat()
+            except OSError as exc:
+                raise PathNotAllowed(
+                    f"cannot inspect `{purpose}` entry {child}: {exc}"
+                ) from exc
+            if stat.S_ISLNK(info.st_mode):
+                raise PathNotAllowed(f"`{purpose}` contains a link: {child}")
+            if not stat.S_ISDIR(info.st_mode):
+                raise PathNotAllowed(f"`{purpose}` contains a special entry: {child}")
+            directories.append(child.relative_to(root))
+        for name in filenames:
+            child = base / name
+            try:
+                info = child.lstat()
+            except OSError as exc:
+                raise PathNotAllowed(
+                    f"cannot inspect `{purpose}` entry {child}: {exc}"
+                ) from exc
+            if stat.S_ISLNK(info.st_mode):
+                raise PathNotAllowed(f"`{purpose}` contains a link: {child}")
+            if not stat.S_ISREG(info.st_mode):
+                raise PathNotAllowed(f"`{purpose}` contains a special entry: {child}")
+            files.append(child.relative_to(root))
+    directories.sort()
+    files.sort()
+    return directories, files
+
+
+def _rebase_writer_result(result: _T, staging: Path, output: Path) -> _T:
+    """Rewrite the directory and file paths returned by powerio writers."""
+    if not isinstance(result, dict):
+        return result
+
+    staging_text = str(staging)
+    output_text = str(output)
+
+    def rebase(value: Any) -> Any:
+        if isinstance(value, str) and (
+            value == staging_text or value.startswith(staging_text + os.sep)
+        ):
+            return output_text + value[len(staging_text) :]
+        return value
+
+    rebased = dict(result)
+    if "dir" in rebased:
+        rebased["dir"] = rebase(rebased["dir"])
+    if "files" in rebased and isinstance(rebased["files"], list):
+        rebased["files"] = [rebase(item) for item in rebased["files"]]
+    return cast(_T, rebased)
+
+
+def staged_directory_write(
+    out_path: str, overwrite: bool, write: Callable[[str], _T]
+) -> _T:
+    """Run a directory writer privately, preflight it, then install it.
+
+    A new output is installed by one same-filesystem rename. Updating an
+    existing directory builds a complete sibling replacement, preserving
+    unrelated files, then swaps it in. If the second rename fails, the original
+    directory is restored. ``overwrite=False`` refuses every file collision
+    before changing the output. Existing and generated trees must contain only
+    real directories and regular files: links and special files are refused.
+
+    The sibling rename prevents readers from seeing a partially copied output.
+    As with the read-tree preflight, callers needing protection from a hostile
+    concurrent process must also use an operating-system sandbox.
+    """
+    output = Path(os.path.abspath(out_path))
+    parent = output.parent
+    if not parent.is_dir():
+        raise PathNotAllowed(f"cannot resolve `out_path`: parent does not exist: {parent}")
+    check_allowed_path(output, for_write=True, purpose="out_path")
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{output.name}.stage-", dir=parent))
+    staging_installed = False
+    os.chmod(staging, 0o755)
+    replacement: Path | None = None
+    backup: Path | None = None
+    try:
+        result = write(str(staging))
+        staged_dirs, staged_files = _plain_tree(staging, purpose="staged output")
+        for relative in [*staged_dirs, *staged_files]:
+            check_allowed_path(output / relative, purpose="out_path")
+
+        if not os.path.lexists(output):
+            os.replace(staging, output)
+            staging_installed = True
+            return _rebase_writer_result(result, staging, output)
+
+        existing_dirs, existing_files = _plain_tree(output, purpose="out_path")
+        existing_dir_set = set(existing_dirs)
+        existing_file_set = set(existing_files)
+        for relative in staged_dirs:
+            if relative in existing_file_set:
+                raise ValueError(f"cannot replace file with directory: {output / relative}")
+        for relative in staged_files:
+            target = output / relative
+            if relative in existing_dir_set:
+                raise ValueError(f"cannot replace directory with file: {target}")
+            if not overwrite and relative in existing_file_set:
+                raise ValueError(
+                    f"refusing to overwrite existing file: {target}; pass overwrite=true"
+                )
+
+        replacement = Path(
+            tempfile.mkdtemp(prefix=f".{output.name}.install-", dir=parent)
+        )
+        replacement.rmdir()
+        shutil.copytree(output, replacement, copy_function=shutil.copy2)
+        for relative in staged_dirs:
+            (replacement / relative).mkdir(parents=True, exist_ok=True)
+        for relative in staged_files:
+            target = replacement / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(staging / relative, target)
+
+        backup = Path(tempfile.mkdtemp(prefix=f".{output.name}.backup-", dir=parent))
+        backup.rmdir()
+        os.replace(output, backup)
+        try:
+            os.replace(replacement, output)
+            replacement = None
+        except BaseException:
+            os.replace(backup, output)
+            backup = None
+            raise
+        shutil.rmtree(backup)
+        backup = None
+        return _rebase_writer_result(result, staging, output)
+    finally:
+        if not staging_installed:
+            shutil.rmtree(staging, ignore_errors=True)
+        if replacement is not None:
+            shutil.rmtree(replacement, ignore_errors=True)
+        if backup is not None:
+            # A backup remains only when an exceptional concurrent filesystem
+            # change prevented rollback. Never delete the user's old output.
+            pass

--- a/python/powerio/mcp/server.py
+++ b/python/powerio/mcp/server.py
@@ -23,11 +23,9 @@ from __future__ import annotations
 
 import json as jsonlib
 import os
-import shutil
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Callable, Dict, Optional, TypeAlias
+from typing import Annotated, Any, Dict, Optional, TypeAlias
 
 from mcp.server.mcpserver import MCPServer
 from pydantic import Field
@@ -556,6 +554,8 @@ def _parse_any(
     include_root: Optional[str] = None
     if path is not None:
         path = _local_path(path, purpose="path")
+        if Path(path).is_dir():
+            sandbox.check_allowed_read_tree(Path(path), purpose="path")
         # A dss parse widens include confinement to the root that admitted the
         # path, so the operator's configured containment is the one policy in
         # force. Unconfined, the case directory default stands.
@@ -732,72 +732,6 @@ def _write_text(
     }
 
 
-def _install_dir_tree(tmp_dir: str, out_path: str, overwrite: bool) -> None:
-    """Move a directory writer's staged output into place.
-
-    Every target runs through the same containment resolution as a single
-    file write, and `overwrite=False` refuses before anything has moved.
-    """
-    if not os.path.lexists(out_path):
-        os.rename(tmp_dir, out_path)
-        return
-    tmp = Path(tmp_dir)
-    files = [p for p in sorted(tmp.rglob("*")) if p.is_file()]
-    targets = [Path(out_path) / p.relative_to(tmp) for p in files]
-    if not overwrite:
-        for target in targets:
-            if os.path.lexists(target):
-                raise ValueError(
-                    f"refusing to overwrite existing file: {target}; pass overwrite=true"
-                )
-    for target in targets:
-        sandbox.check_allowed_path(target.parent, purpose="out_path")
-        os.makedirs(target.parent, exist_ok=True)
-        sandbox.check_allowed_path(target, for_write=True, purpose="out_path")
-    for source, target in zip(files, targets):
-        os.replace(source, target)
-
-
-def _rebase_result_paths(
-    result: Dict[str, Any], tmp_dir: str, out_path: str
-) -> Dict[str, Any]:
-    """Rewrite writer-reported paths from the staging directory to the
-    installed location."""
-
-    def rebase(value: Any) -> Any:
-        if isinstance(value, str) and value.startswith(tmp_dir):
-            return out_path + value[len(tmp_dir) :]
-        return value
-
-    rebased = dict(result)
-    if "dir" in rebased:
-        rebased["dir"] = rebase(rebased["dir"])
-    if "files" in rebased:
-        rebased["files"] = [rebase(item) for item in rebased["files"]]
-    return rebased
-
-
-def _staged_dir_write(
-    out_path: str, overwrite: bool, write: Callable[[str], Dict[str, Any]]
-) -> Dict[str, Any]:
-    """Run a directory writer against a fresh staging directory, then install.
-
-    The writers create children unchecked, so they never see `out_path`;
-    installation applies the containment policy and `overwrite` per file.
-    """
-    parent = os.path.dirname(os.path.abspath(out_path)) or os.curdir
-    os.makedirs(parent, exist_ok=True)
-    tmp_dir = tempfile.mkdtemp(prefix=Path(out_path).name + ".", dir=parent)
-    # mkdtemp creates 0o700; the installed directory is ordinary output.
-    os.chmod(tmp_dir, 0o755)
-    try:
-        result = write(tmp_dir)
-        _install_dir_tree(tmp_dir, out_path, overwrite)
-    finally:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-    return _rebase_result_paths(result, tmp_dir, out_path)
-
-
 def _choose_from_format(
     from_format: Optional[str] = None,
     *,
@@ -933,7 +867,7 @@ def _save_impl(
             )
 
         try:
-            return _staged_dir_write(out_path, overwrite, write_gridfm)
+            return sandbox.staged_directory_write(out_path, overwrite, write_gridfm)
         except ImportError as exc:
             raise ValueError(str(exc)) from exc
         except powerio.PowerIOError as exc:
@@ -945,7 +879,7 @@ def _save_impl(
         if loaded.domain != "transmission":
             raise ValueError("pypsa-csv export needs a transmission network")
         try:
-            result = _staged_dir_write(
+            result = sandbox.staged_directory_write(
                 out_path,
                 overwrite,
                 lambda staging: dict(loaded.network.write_pypsa_csv_folder(staging)),

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -431,6 +431,40 @@ def test_mcp_allowed_roots_restrict_filesystem_paths(monkeypatch, tmp_path):
         server.summary(path=str(DATA / "case9.m"))
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_mcp_refuses_pypsa_child_symlink_escape(monkeypatch, tmp_path):
+    root = tmp_path / "allowed"
+    folder = root / "pypsa"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    powerio.parse_file(str(DATA / "case9.m")).write_pypsa_csv_folder(str(folder))
+    escaped = outside / "buses.csv"
+    escaped.write_text((folder / "buses.csv").read_text())
+    (folder / "buses.csv").unlink()
+    os.symlink(escaped, folder / "buses.csv")
+    monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(root))
+
+    with pytest.raises(ValueError, match="outside its allowed MCP root"):
+        server.summary(path=str(folder), from_format="pypsa-csv")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_mcp_preflights_a_directory_before_format_detection(monkeypatch, tmp_path):
+    root = tmp_path / "allowed"
+    folder = root / "dataset" / "raw"
+    outside = tmp_path / "outside"
+    folder.mkdir(parents=True)
+    outside.mkdir()
+    parquet = outside / "bus_data.parquet"
+    parquet.write_bytes(b"not parquet")
+    os.symlink(parquet, folder / "bus_data.parquet")
+    monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(root))
+
+    with pytest.raises(ValueError, match="outside its allowed MCP root"):
+        server.summary(path=str(root / "dataset"))
+
+
 @pytest.mark.parametrize("name", ["POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT"])
 def test_mcp_tools_honour_the_legacy_single_root_variables(
     monkeypatch, tmp_path, name

--- a/python/tests/test_mcp_sandbox.py
+++ b/python/tests/test_mcp_sandbox.py
@@ -175,3 +175,149 @@ def test_admitting_root_names_the_containing_root(monkeypatch, tmp_path):
 
 def test_admitting_root_is_none_when_the_policy_is_off(tmp_path):
     assert sandbox.admitting_root(tmp_path / "case.dss") is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_read_tree_refuses_escaping_and_broken_child_links(monkeypatch, tmp_path):
+    root = tmp_path / "allowed"
+    case = root / "case"
+    outside = tmp_path / "outside"
+    case.mkdir(parents=True)
+    outside.mkdir()
+    (outside / "buses.csv").write_text("outside")
+    monkeypatch.setenv(sandbox.ALLOWED_ROOTS_ENV, str(root))
+
+    os.symlink(outside / "buses.csv", case / "buses.csv")
+    with pytest.raises(sandbox.PathNotAllowed, match="outside its allowed MCP root"):
+        sandbox.checked_read_tree(str(case))
+
+    (case / "buses.csv").unlink()
+    os.symlink(case / "missing.csv", case / "buses.csv")
+    with pytest.raises(sandbox.PathNotAllowed, match="broken link"):
+        sandbox.check_allowed_read_tree(case)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_read_tree_follows_contained_directory_links_without_looping(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "allowed"
+    case = root / "case"
+    shared = root / "shared"
+    case.mkdir(parents=True)
+    shared.mkdir()
+    (shared / "buses.csv").write_text("inside")
+    os.symlink(shared, case / "tables")
+    os.symlink(root, shared / "back-to-root")
+    monkeypatch.setenv(sandbox.ALLOWED_ROOTS_ENV, str(root))
+
+    assert sandbox.checked_read_tree(str(case)) == str(case)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX special-file semantics")
+def test_read_tree_refuses_special_files(monkeypatch, tmp_path):
+    root = tmp_path / "allowed"
+    root.mkdir()
+    os.mkfifo(root / "stream")
+    monkeypatch.setenv(sandbox.ALLOWED_ROOTS_ENV, str(root))
+
+    with pytest.raises(sandbox.PathNotAllowed, match="non-file, non-directory"):
+        sandbox.check_allowed_read_tree(root)
+
+
+def _write_tree(staging: str, files: dict[str, str]) -> dict:
+    root = Path(staging)
+    paths = []
+    for relative, text in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+        paths.append(str(path))
+    return {"dir": staging, "files": paths}
+
+
+def test_staged_directory_write_preserves_unrelated_files_and_rebases_paths(tmp_path):
+    out = tmp_path / "dataset"
+    out.mkdir()
+    (out / "keep.txt").write_text("keep")
+    (out / "replace.csv").write_text("old")
+
+    result = sandbox.staged_directory_write(
+        str(out),
+        True,
+        lambda staging: _write_tree(
+            staging, {"replace.csv": "new", "nested/new.csv": "new"}
+        ),
+    )
+
+    assert (out / "keep.txt").read_text() == "keep"
+    assert (out / "replace.csv").read_text() == "new"
+    assert (out / "nested/new.csv").read_text() == "new"
+    assert result["dir"] == str(out)
+    assert result["files"] == [str(out / "replace.csv"), str(out / "nested/new.csv")]
+
+
+def test_staged_directory_write_refuses_collisions_before_install(tmp_path):
+    out = tmp_path / "dataset"
+    out.mkdir()
+    (out / "same.csv").write_text("old")
+
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        sandbox.staged_directory_write(
+            str(out),
+            False,
+            lambda staging: _write_tree(
+                staging, {"same.csv": "new", "new.csv": "new"}
+            ),
+        )
+
+    assert (out / "same.csv").read_text() == "old"
+    assert not (out / "new.csv").exists()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_staged_directory_write_refuses_generated_and_existing_links(tmp_path):
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside")
+    out = tmp_path / "dataset"
+
+    def linked_output(staging: str) -> dict:
+        os.symlink(outside, Path(staging) / "linked.csv")
+        return {"dir": staging, "files": [str(Path(staging) / "linked.csv")]}
+
+    with pytest.raises(sandbox.PathNotAllowed, match="contains a link"):
+        sandbox.staged_directory_write(str(out), False, linked_output)
+    assert not out.exists()
+
+    out.mkdir()
+    os.symlink(outside, out / "existing.csv")
+    with pytest.raises(sandbox.PathNotAllowed, match="contains a link"):
+        sandbox.staged_directory_write(
+            str(out), True, lambda staging: _write_tree(staging, {"new.csv": "new"})
+        )
+    assert outside.read_text() == "outside"
+    assert not (out / "new.csv").exists()
+
+
+def test_staged_directory_write_rolls_back_a_failed_swap(monkeypatch, tmp_path):
+    out = tmp_path / "dataset"
+    out.mkdir()
+    (out / "same.csv").write_text("old")
+    real_replace = sandbox.os.replace
+    failed = False
+
+    def fail_install(source, target):
+        nonlocal failed
+        if not failed and ".install-" in Path(source).name and Path(target) == out:
+            failed = True
+            raise OSError("simulated install failure")
+        return real_replace(source, target)
+
+    monkeypatch.setattr(sandbox.os, "replace", fail_install)
+    with pytest.raises(OSError, match="simulated install failure"):
+        sandbox.staged_directory_write(
+            str(out), True, lambda staging: _write_tree(staging, {"same.csv": "new"})
+        )
+
+    assert (out / "same.csv").read_text() == "old"
+    assert not [path for path in tmp_path.iterdir() if path.name.startswith(".dataset.")]


### PR DESCRIPTION
Contain directory readers and writers under the same MCP filesystem policy as single-file operations.

`check_allowed_read_tree` and `checked_read_tree` preflight every reachable descendant, reject broken or escaping links and special files, and follow contained directory links without looping. Directory format detection now runs this check before PyPSA CSV or GridFM opens child files.

`staged_directory_write` builds output in a private sibling, rejects generated or existing links and collisions before installation, preserves unrelated files, swaps complete trees, and restores the original directory if installation fails. The MCP server now uses this exported helper instead of its private installer.

This remains a path preflight, not a kernel sandbox: a hostile local process can race a checked entry before the reader opens it. The API and documentation state that boundary.

Validated with 63 MCP and sandbox tests plus mypy. Regression tests cover child-link read escape, pre-detection GridFM escape, contained directory cycles, special files, collision preflight, unrelated-file preservation, generated/existing links, path rebasing, and failed-swap rollback.
