### PR TITLE
Bind release publishing to immutable tags

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -8,6 +8,11 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing published release tag to retry
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -23,9 +28,12 @@ jobs:
       id-token: write  # crates.io trusted publishing; no stored token
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: refs/tags/${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Read the workspace version
         run: |
           set -o pipefail
@@ -44,25 +52,41 @@ jobs:
             echo "publishable workspace members ($actual) do not match the publish list in crates.yml" >&2
             exit 1
           fi
-      - name: Check the ref against the workspace version
+      - name: Verify the immutable published release
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        # On a release event the tag must match the workspace version. On
-        # dispatch the version must at least be tagged, so a stray version bump
-        # on a branch cannot publish an untagged version; content drift between
-        # the dispatched ref and the tag is what the environment reviewer is
-        # approving.
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ -n "$RELEASE_TAG" ]; then
-            if [ "v$VERSION" != "$RELEASE_TAG" ]; then
-              echo "release tag $RELEASE_TAG does not match workspace version $VERSION" >&2
-              exit 1
-            fi
-          else
-            git ls-remote --exit-code --tags origin "refs/tags/v$VERSION" >/dev/null \
-              || { echo "v$VERSION is not a tag; tag the release before dispatching" >&2; exit 1; }
+          test -n "$RELEASE_TAG" || { echo "an explicit release tag is required" >&2; exit 1; }
+          git check-ref-format "refs/tags/$RELEASE_TAG" >/dev/null \
+            || { echo "invalid release tag: $RELEASE_TAG" >&2; exit 1; }
+          git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null \
+            || { echo "$RELEASE_TAG is not an origin tag" >&2; exit 1; }
+          tag_commit="$(git rev-list -n1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "checked out $head_commit, but $RELEASE_TAG names $tag_commit" >&2
+            exit 1
           fi
-      - uses: rust-lang/crates-io-auth-action@v1.0.4
+          if [ "v$VERSION" != "$RELEASE_TAG" ]; then
+            echo "release tag $RELEASE_TAG does not match workspace version $VERSION" >&2
+            exit 1
+          fi
+          release="$RUNNER_TEMP/release.json"
+          curl --fail --silent --show-error --retry 3 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            -o "$release"
+          jq -e '.draft == false and .prerelease == false' "$release" >/dev/null \
+            || { echo "$RELEASE_TAG is not a published stable GitHub release" >&2; exit 1; }
+      - name: Build and audit crate archives
+        run: |
+          cargo package --workspace --exclude powerio-capi --exclude powerio-py \
+            --locked --no-verify
+          python3 scripts/audit-release-archives.py target/package/*.crate
+      - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
       - name: Publish in dependency order
         env:
@@ -93,5 +117,5 @@ jobs:
                 echo "crates.io returned $code for $crate $VERSION; re-run once it is reachable" >&2
                 exit 1 ;;
             esac
-            cargo publish -p "$crate"
+            cargo publish --locked -p "$crate"
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,12 +35,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: "3.12"
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
     - name: Install mdBook
       run: cargo install mdbook --version 0.5.2 --locked
     # -D warnings turns a broken intra-doc link into a failed build, so the docs
@@ -198,7 +198,7 @@ jobs:
           lineage="${schema#docs/schema/}"
           redirect_schema_page "${lineage%/schema.json}"
         done
-    - uses: actions/upload-pages-artifact@v5
+    - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
       with:
         path: target/doc
 
@@ -212,4 +212,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - id: deployment
-      uses: actions/deploy-pages@v5
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,6 +8,11 @@ on:
   release:
     types: [ published ]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing published stable release tag to retry
+        required: true
+        type: string
 
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it
@@ -28,18 +33,72 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+  SOURCE_REF: ${{ github.event_name == 'release' && format('refs/tags/{0}', github.event.release.tag_name) || github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.sha }}
+
 jobs:
+  release-preflight:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      sha: ${{ steps.release.outputs.sha }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 0
+      - name: Verify the immutable published release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git check-ref-format "refs/tags/$RELEASE_TAG" >/dev/null \
+            || { echo "invalid release tag: $RELEASE_TAG" >&2; exit 1; }
+          git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null \
+            || { echo "$RELEASE_TAG is not an origin tag" >&2; exit 1; }
+          tag_commit="$(git rev-list -n1 "refs/tags/$RELEASE_TAG")"
+          head_commit="$(git rev-parse HEAD)"
+          if [ "$head_commit" != "$tag_commit" ]; then
+            echo "checked out $head_commit, but $RELEASE_TAG names $tag_commit" >&2
+            exit 1
+          fi
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -er '.packages[] | select(.name == "powerio-py") | .version')"
+          if [ "v$version" != "$RELEASE_TAG" ]; then
+            echo "release tag $RELEASE_TAG does not match package version $version" >&2
+            exit 1
+          fi
+          release="$RUNNER_TEMP/release.json"
+          curl --fail --silent --show-error --retry 3 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            -o "$release"
+          jq -e '.draft == false' "$release" >/dev/null \
+            || { echo "$RELEASE_TAG is not a published GitHub release" >&2; exit 1; }
+          if [ "$GITHUB_EVENT_NAME" = workflow_dispatch ]; then
+            jq -e '.prerelease == false' "$release" >/dev/null \
+              || { echo "manual recovery refuses prerelease $RELEASE_TAG" >&2; exit 1; }
+          fi
+          echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "sha=$head_commit" >> "$GITHUB_OUTPUT"
+
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # `cargo clippy` at the root skips powerio-py (it's not in default-members),
       # so lint the extension explicitly with the same native features as wheels.
       - name: Clippy (powerio-py)
@@ -53,12 +112,14 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Install gates
         run: pip install ruff mypy
       - name: ruff
@@ -88,12 +149,14 @@ jobs:
       matrix:
         python: [ "3.9", "3.12" ]
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       # This job is the gridfm-absent build: compile the extension without the
       # gridfm cargo feature so `test_gridfm_absent_raises_clean_importerror` and
       # the `_require_gridfm()` ImportError fallback actually run (every other
@@ -137,12 +200,14 @@ jobs:
     name: test (gridfm extra)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - name: Install maturin
         run: pip install maturin
       # Install a wheel (not `develop`): a regular site-packages install wins the
@@ -161,6 +226,7 @@ jobs:
   wheels:
     name: wheels (${{ matrix.platform.target }} on ${{ matrix.platform.runner }})
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: release-preflight
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -174,33 +240,40 @@ jobs:
           - { runner: macos-14,       target: aarch64 }
           - { runner: windows-latest, target: x64 }
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.release-preflight.outputs.sha }}
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
       # abi3-py39 → one wheel per platform covers Python 3.9+.
       - name: Build powerio wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           manylinux: auto
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
           path: dist
 
   sdist:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    needs: release-preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.release-preflight.outputs.sha }}
       - name: Build powerio sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:
           command: sdist
           args: --out dist
-      - uses: actions/upload-artifact@v7
+      - name: Audit licenses and excluded fixtures
+        run: python3 scripts/audit-release-archives.py dist/*.tar.gz
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sdist
           path: dist
@@ -213,7 +286,7 @@ jobs:
     # recovery path for a missed event. A prerelease still builds wheels and an
     # sdist as run artifacts, but never uploads them to PyPI.
     if: (github.event_name == 'release' && github.event.release.prerelease == false) || github.event_name == 'workflow_dispatch'
-    needs: [ lint, test, test-gridfm, wheels, sdist ]
+    needs: [ release-preflight, lint, test, test-gridfm, wheels, sdist ]
     runs-on: ubuntu-latest
     # Deployment protection (required reviewers, tag rules) lives on the pypi
     # environment in the repo settings, not in this file.
@@ -221,18 +294,18 @@ jobs:
     permissions:
       id-token: write  # PyPI trusted publishing; no stored token
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
           merge-multiple: true
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
       - name: Check distributions
         run: |
           python -m pip install twine
           python -m twine check dist/*
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           packages-dir: dist
           # A partially failed upload (e.g. wheels in, sdist rejected) is

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -242,7 +242,17 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.release-preflight.outputs.sha }}
+          ref: ${{ env.SOURCE_REF }}
+      - name: Match the preflight release commit
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.release-preflight.outputs.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "checked out $actual_sha, but release preflight verified $EXPECTED_SHA" >&2
+            exit 1
+          fi
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.x"
@@ -265,7 +275,17 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ needs.release-preflight.outputs.sha }}
+          ref: ${{ env.SOURCE_REF }}
+      - name: Match the preflight release commit
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.release-preflight.outputs.sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+          if [ "$actual_sha" != "$EXPECTED_SHA" ]; then
+            echo "checked out $actual_sha, but release preflight verified $EXPECTED_SHA" >&2
+            exit 1
+          fi
       - name: Build powerio sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -63,23 +63,23 @@ jobs:
         Set a valid POWERIO_JL_REPO_TOKEN to release. A workflow_dispatch run builds \
         artifact-only tarballs without the gate."
         exit 1
-    - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@stable
-    - uses: Swatinem/rust-cache@v2
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
     - name: Build powerio-capi
       run: |
         cargo build -p powerio-capi --release \
           --features arrow,matrix,gridfm,dist,pkg,prob
     - name: Check out PowerIO.jl default branch
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       with:
         repository: eigenergy/PowerIO.jl
         path: PowerIO.jl
         token: ${{ secrets.POWERIO_JL_REPO_TOKEN || github.token }}
-    - uses: julia-actions/setup-julia@v3
+    - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32 # v3
       with:
         version: '1'
-    - uses: julia-actions/cache@v3
+    - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
     - name: Test PowerIO.jl against this tag
       env:
         POWERIO_CAPI: ${{ github.workspace }}/target/release/libpowerio_capi.so
@@ -126,11 +126,11 @@ jobs:
             triplet: x86_64-w64-mingw32
             lib: powerio_capi.dll
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.rust_target }}
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           key: ${{ matrix.rust_target }}
       # The tarballs and the draft release are named for the tag, and PowerIO.jl
@@ -140,7 +140,7 @@ jobs:
       # lineage. crates.yml catches the mismatch, but only after a human has
       # published the release.
       - name: Check the tag against the workspace version
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'push'
         shell: bash
         env:
           TAG: ${{ github.ref_name }}
@@ -156,7 +156,7 @@ jobs:
         if: matrix.cross_gcc != ''
         run: |
           sudo apt-get update
-          sudo apt-get install -y ${{ matrix.cross_gcc }}
+          sudo apt-get install -y ${{ matrix.cross_gcc }} qemu-user
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
       - name: Build powerio-capi
         run: cargo build -p powerio-capi --release --features arrow,matrix,gridfm,dist,pkg,prob --target ${{ matrix.rust_target }}
@@ -182,19 +182,92 @@ jobs:
           cp powerio-capi/include/powerio.h "$stage/include/"
           cp LICENSE-MIT LICENSE-APACHE "$stage/"
           tar -czf "libpowerio_capi.${{ matrix.triplet }}.tar.gz" -C "$stage" .
+          python3 scripts/audit-release-archives.py \
+            "libpowerio_capi.${{ matrix.triplet }}.tar.gz"
           # informational; gen/update_artifacts.jl recomputes from the release assets
           shasum -a 256 "libpowerio_capi.${{ matrix.triplet }}.tar.gz" \
             || sha256sum "libpowerio_capi.${{ matrix.triplet }}.tar.gz"
-      - uses: actions/upload-artifact@v7
+      - name: Runtime smoke test packaged Unix library
+        if: matrix.triplet != 'x86_64-w64-mingw32'
+        shell: bash
+        run: |
+          version="$(cargo metadata --no-deps --format-version 1 \
+            | jq -er '.packages[] | select(.name == "powerio-capi") | .version')"
+          stage="stage/libpowerio_capi"
+          defs=(-DPIO_ARROW -DPIO_MATRIX -DPIO_GRIDFM -DPIO_DIST -DPIO_PKG -DPIO_PROB)
+          case "${{ matrix.triplet }}" in
+            x86_64-linux-gnu)
+              # shellcheck disable=SC2016
+              cc "${defs[@]}" -I "$stage/include" powerio-capi/examples/release_smoke.c \
+                -L "$stage/lib" -lpowerio_capi \
+                -Wl,-rpath,'$ORIGIN/stage/libpowerio_capi/lib' -o release-smoke
+              ./release-smoke "$version"
+              ;;
+            aarch64-linux-gnu)
+              # shellcheck disable=SC2016
+              aarch64-linux-gnu-gcc "${defs[@]}" -I "$stage/include" \
+                powerio-capi/examples/release_smoke.c \
+                -L "$stage/lib" -lpowerio_capi \
+                -Wl,-rpath,'$ORIGIN/stage/libpowerio_capi/lib' -o release-smoke
+              qemu-aarch64 -L /usr/aarch64-linux-gnu ./release-smoke "$version"
+              ;;
+            x86_64-apple-darwin)
+              /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+              cc -arch x86_64 "${defs[@]}" -I "$stage/include" \
+                powerio-capi/examples/release_smoke.c \
+                -L "$stage/lib" -lpowerio_capi \
+                -Wl,-rpath,@executable_path/stage/libpowerio_capi/lib \
+                -o release-smoke
+              arch -x86_64 ./release-smoke "$version"
+              ;;
+            aarch64-apple-darwin)
+              cc -arch arm64 "${defs[@]}" -I "$stage/include" \
+                powerio-capi/examples/release_smoke.c \
+                -L "$stage/lib" -lpowerio_capi \
+                -Wl,-rpath,@executable_path/stage/libpowerio_capi/lib \
+                -o release-smoke
+              arch -arm64 ./release-smoke "$version"
+              ;;
+          esac
+      - name: Runtime smoke test packaged Windows library
+        if: matrix.triplet == 'x86_64-w64-mingw32'
+        shell: pwsh
+        run: |
+          $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
+          $version = ($metadata.packages | Where-Object { $_.name -eq 'powerio-capi' }).version
+          $defines = @('/DPIO_ARROW', '/DPIO_MATRIX', '/DPIO_GRIDFM', '/DPIO_DIST', '/DPIO_PKG', '/DPIO_PROB')
+          $importLib = Get-ChildItem target/${{ matrix.rust_target }}/release -Filter '*powerio_capi*.dll.lib' |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $importLib) { throw 'powerio-capi import library is missing' }
+          cl.exe /nologo /std:c11 $defines /Istage/libpowerio_capi/include `
+            powerio-capi/examples/release_smoke.c `
+            $importLib `
+            /Fe:release-smoke.exe
+          Copy-Item stage/libpowerio_capi/bin/libpowerio_capi.dll powerio_capi.dll
+          ./release-smoke.exe $version
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: libpowerio_capi.${{ matrix.triplet }}
           path: libpowerio_capi.${{ matrix.triplet }}.tar.gz
+
+  attach:
+    name: attach draft release assets
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: libpowerio_capi.*
+          path: release-assets
+          merge-multiple: true
       # The draft release body is the CHANGELOG section for this version (the
       # v0.0.1 release shipped with a bare one-liner); auto-generated notes are
-      # appended below it. All five matrix jobs write the same body, which
-      # softprops applies idempotently.
+      # appended below it.
       - name: Release body from CHANGELOG
-        if: github.ref_type == 'tag'
         shell: bash
         env:
           TAG: ${{ github.ref_name }}
@@ -208,11 +281,15 @@ jobs:
             echo "CHANGELOG.md has no \"## ${TAG#v}\" section" >&2
             exit 1
           fi
+          asset_count="$(find release-assets -maxdepth 1 -type f -name '*.tar.gz' | wc -l | tr -d ' ')"
+          if [ "$asset_count" != 5 ]; then
+            echo "expected five release assets, found $asset_count" >&2
+            exit 1
+          fi
       - name: Attach to release
-        if: github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
-          files: libpowerio_capi.${{ matrix.triplet }}.tar.gz
+          files: release-assets/*.tar.gz
           body_path: release-body.md
           generate_release_notes: true
           # Stage the release as a draft a human publishes: the release event

--- a/powerio-capi/examples/release_smoke.c
+++ b/powerio-capi/examples/release_smoke.c
@@ -1,0 +1,56 @@
+/* Runtime probe for the five packaged release libraries. */
+#include "powerio.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define CHECK(condition, message)                                              \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "release smoke: %s\n", (message));               \
+            return 1;                                                          \
+        }                                                                      \
+    } while (0)
+
+int main(int argc, char **argv) {
+    CHECK(argc == 2, "expected release version argument");
+    CHECK(strcmp(pio_version(), argv[1]) == 0, "library version mismatch");
+    CHECK(pio_abi_version() == PIO_ABI_VERSION, "core ABI mismatch");
+    CHECK(pio_dist_abi_version() == PIO_DIST_ABI_VERSION, "distribution ABI mismatch");
+
+    const char *features[] = {"arrow", "matrix", "gridfm", "dist", "pkg", "prob"};
+    for (size_t i = 0; i < sizeof features / sizeof features[0]; i++) {
+        CHECK(pio_has_feature(features[i]) == 1, "required release feature missing");
+    }
+
+    char *schemas = pio_schema_versions_json();
+    CHECK(schemas != NULL, "schema version report missing");
+    CHECK(strstr(schemas, "powerio_version") != NULL, "schema report has no release version");
+    pio_string_free(schemas);
+
+    char *build = pio_build_info();
+    CHECK(build != NULL, "build report missing");
+    CHECK(strstr(build, argv[1]) != NULL, "build report has the wrong release version");
+    for (size_t i = 0; i < sizeof features / sizeof features[0]; i++) {
+        CHECK(strstr(build, features[i]) != NULL, "build report omits a release feature");
+    }
+    pio_string_free(build);
+
+    /* Exercise one representative entry point for each additive feature. */
+    char err[PIO_ERRBUF_MIN] = {0};
+    char *arrow = pio_arrow_catalog_json(err, sizeof err);
+    CHECK(arrow != NULL, err);
+    pio_string_free(arrow);
+    CHECK(pio_matrix_available() == 1, "matrix entry point is unavailable");
+    CHECK(pio_scenario_ids("", "gridfm", NULL, 0, err, sizeof err) < 0,
+          "invalid gridfm path should fail through the gridfm entry point");
+    char *dist = pio_dist_capabilities_json();
+    CHECK(dist != NULL, "distribution capability report missing");
+    pio_string_free(dist);
+    pio_package_free(NULL);
+    pio_scopf_instance_free(NULL);
+
+    printf("powerio %s; ABI %u; distribution ABI %u; release features OK\n",
+           pio_version(), pio_abi_version(), pio_dist_abi_version());
+    return 0;
+}


### PR DESCRIPTION
Manual crates.io and PyPI retries now require an explicit existing release tag. Each workflow checks out that tag, verifies its commit, workspace version, and published stable GitHub release, audits the source archives, and publishes with the lockfile enforced.

Manual binary workflow runs produce workflow artifacts only. Draft release attachment is limited to tag pushes after all five platform builds pass archive layout and runtime API probes. The probes check the reported version, both ABIs, all six release features, schema and build reports, and representative feature entry points.

The actions used by the publish, binary release, and documentation deployment paths are pinned to full commit SHAs.

Validated with `actionlint`, YAML parsing, exact changed path review, C11 syntax checking for the runtime probe, and `git diff --check`.
