### PR TITLE
Enter the MSVC developer shell before the Windows release smoke test

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -233,6 +233,16 @@ jobs:
         if: matrix.triplet == 'x86_64-w64-mingw32'
         shell: pwsh
         run: |
+          # cargo reaches the MSVC toolset through the cc crate, but a bare
+          # cl.exe is not on PATH until the developer shell is entered.
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+            -property installationPath
+          if (-not $vsPath) { throw 'no Visual Studio C++ toolset on this runner' }
+          Import-Module "$vsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $vsPath -SkipAutomaticLocation `
+            -DevCmdArguments '-arch=x64 -host_arch=x64'
           $metadata = cargo metadata --no-deps --format-version 1 | ConvertFrom-Json
           $version = ($metadata.packages | Where-Object { $_.name -eq 'powerio-capi' }).version
           $defines = @('/DPIO_ARROW', '/DPIO_MATRIX', '/DPIO_GRIDFM', '/DPIO_DIST', '/DPIO_PKG', '/DPIO_PROB')


### PR DESCRIPTION
The `v0.9.0` tag build failed on Windows alone, at the step that smoke tests the packaged library by compiling `release_smoke.c` against it:

```
cl.exe : The term 'cl.exe' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

`cl.exe` is not on `PATH` in a plain `pwsh` step. Nothing before it noticed because cargo reaches the same MSVC toolset through the `cc` crate's own lookup, so the cross build succeeded and only the smoke test failed.

The step is new. It arrived with the tag binding work in #394 and the last tagged build predates it, so it had never run on a tag.

`vswhere` locates the installed toolset and `Enter-VsDevShell` puts `cl.exe`, the linker and the SDK headers on `PATH`. `-SkipAutomaticLocation` keeps the working directory at the checkout.

Verified by dispatching this workflow on this branch: all five platform jobs pass, and `x86_64-w64-mingw32` reports `Runtime smoke test packaged Windows library -> success` ([run](https://github.com/eigenergy/powerio/actions/runs/32458412332)). `actionlint` is clean.
