### PR TITLE
Route Auto to the sparse sensitivity path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,18 +199,8 @@ records. Upgrade if you write text formats from names you do not control.
   extract|apply` read and classify a `.json` once instead of twice. The
   distribution reader's own document rule still applies on that path, so
   a JSON that is not a distribution case is refused as before.
-- DC sensitivities factor the grounded Laplacian once on the sparse path and
-  reuse its AMD-ordered Cholesky factors for batched PTDF and non-bridge LODF
-  right hand sides (#291). `SensitivitySolver::Sparse`, CLI/Python `sparse`,
-  and metadata path `sparse_cholesky` replace the iterative/CG names and the CG
-  tolerance and iteration fields are removed. `SensitivitySolveDidNotConverge`
-  is removed and its diagnostic code retired; allocation or index failures use
-  `SensitivityFactorizationFailed`. `Auto` remains dense through a
-  reduced dimension of 8192 while the predicted dense footprint is at most
-  2 GiB, then selects sparse. The sparse path requires positive finite branch
-  susceptances; dense remains available for nonsingular indefinite cases.
-  Results can differ in the last bits, so an entry at `drop_tolerance` can move
-  across the pruning boundary.
+- DC sensitivities factor the grounded Laplacian once on the sparse path and reuse its AMD-ordered Cholesky factors for batched PTDF and non-bridge LODF right hand sides (#291). `SensitivitySolver::Sparse`, CLI/Python `sparse`, and metadata path `sparse_cholesky` replace the iterative/CG names, and the CG tolerance and iteration fields are removed. `SensitivitySolveDidNotConverge` is removed and its diagnostic code retired; allocation or index failures use `SensitivityFactorizationFailed`. Python `Network.ptdf()` / `lodf()` route through the auto solver and take `solver="auto"|"dense"|"sparse"`, matching the CLI `sensitivities` command (#273).
+- `SensitivityOptions::auto_dense_threshold` defaults to 64, down from the 8192 that #295 set against the conjugate gradient path. Dense stops beating the sparse Cholesky path near a reduced dimension of 50: case2869pegase is 22.1 s dense against 2.2 s sparse, and a 1200 bus case is 9x. `Auto` therefore takes sparse on every published case above a few dozen buses, and takes dense below that, when the predicted dense footprint would exceed 2 GiB, or when the case falls outside the sparse path's positive finite susceptance requirement. An explicit `Sparse` still reports that refusal as an error. Set `auto_dense_threshold` to restore the old routing. Because more cases now resolve to sparse by default, results can differ in the last bits and an entry at `drop_tolerance` can move across the pruning boundary.
 
 ## 0.8.0
 

--- a/docs/src/matrices.md
+++ b/docs/src/matrices.md
@@ -32,9 +32,12 @@ grounded inverse path and remain the small case oracle. The option based
 `build_ptdf_lodf_with_options` path accepts `SensitivityOptions`: `Dense` forces
 the dense oracle path, `Sparse` performs one AMD-ordered sparse Cholesky
 factorization and reuses it for batches of PTDF and LODF right hand sides, and
-`Auto` selects dense through a reduced dimension of 8192 while the predicted
-dense footprint remains at or below 2 GiB, then selects sparse. The sparse path
-avoids forming the \\((n-r) \times (n-r)\\) dense inverse; the PTDF/LODF outputs
+`Auto` selects dense through a reduced dimension of 64 while the predicted
+dense footprint remains at or below 2 GiB, then selects sparse, and falls back
+to dense again for a case the sparse path refuses. The ceiling is the measured
+crossover: dense stops winning near a reduced dimension of 50, and
+case2869pegase takes 22.1 s dense against 2.2 s sparse. The sparse path avoids
+forming the \\((n-r) \times (n-r)\\) dense inverse; the PTDF/LODF outputs
 themselves can still be large. It requires positive finite branch
 susceptances, so the grounded DC bus susceptance matrix is positive definite
 after reference coverage is checked; the dense path remains the fallback for

--- a/powerio-matrix/src/matrix/sensitivity.rs
+++ b/powerio-matrix/src/matrix/sensitivity.rs
@@ -35,11 +35,10 @@ use crate::{Error, Result};
 
 /// Entries below this magnitude are dropped from the emitted sparse matrices.
 const PRUNE: f64 = 1e-12;
-/// Reduced-dimension ceiling for the `Auto` dense oracle path. Kept at the
-/// policy established in #295; the separate footprint guard prevents a wide
-/// problem from selecting dense output allocations through this dimension
-/// check alone.
-const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 8192;
+/// Reduced-dimension ceiling for the `Auto` dense oracle path. Measured against
+/// the sparse Cholesky path, dense stops winning near 50 and is 9x slower by
+/// 1200. The separate footprint guard still vetoes a wide problem below it.
+const DEFAULT_AUTO_DENSE_THRESHOLD: usize = 64;
 const MAX_RHS_BATCH_COLUMNS: usize = 32;
 const RHS_BATCH_MEMORY_BUDGET: usize = 8 << 20;
 
@@ -67,7 +66,9 @@ const LODF_ISLAND_TOLERANCE: f64 = 1e-9;
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum SensitivitySolver {
-    /// Dense below [`SensitivityOptions::auto_dense_threshold`], sparse above it.
+    /// Dense at or below [`SensitivityOptions::auto_dense_threshold`], sparse
+    /// above it, and dense again when the case falls outside the sparse path's
+    /// positive finite susceptance requirement.
     #[default]
     Auto,
     /// Dense grounded inverse. This is the historical builder path.
@@ -151,6 +152,8 @@ impl SensitivityOptions {
     /// the dense path while both the reduced dimension and the predicted
     /// dense footprint stay within their ceilings, so a wide case (few buses,
     /// many branches) no longer picks a path that would ask for tens of GB.
+    /// This sees the shape only. The builders additionally send an `Auto` case
+    /// whose susceptances the sparse path refuses back to dense.
     pub fn selected_solver_for_shape(
         &self,
         reduced_dimension: usize,
@@ -255,28 +258,29 @@ pub fn build_ptdf_lodf_with_options(
     let inc = build_incidence(case, options.convention, &BuildOptions::default())?;
     let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
 
-    let (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped) = match options
-        .selected_solver_for_shape(reduced_dimension, inc.m(), inc.n())
-    {
-        SensitivitySolver::Dense => {
-            let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
-            let (ptdf, ptdf_dropped) = dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
-            let (lodf, lodf_dropped) =
-                lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
-            (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped)
-        }
-        SensitivitySolver::Sparse => {
-            let (ptdf, ptdf_dropped, lodf, lodf_dropped) = sparse_ptdf_lodf(&inc, &refs, options)?;
-            (
-                ptdf,
-                lodf,
-                SensitivitySolverPath::SparseCholesky,
-                ptdf_dropped,
-                lodf_dropped,
-            )
-        }
-        SensitivitySolver::Auto => unreachable!("selected_solver resolves Auto"),
-    };
+    let (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped) =
+        match resolve_solver(options, &inc, reduced_dimension) {
+            SensitivitySolver::Dense => {
+                let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
+                let (ptdf, ptdf_dropped) =
+                    dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
+                let (lodf, lodf_dropped) =
+                    lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
+                (ptdf, lodf, solver_path, ptdf_dropped, lodf_dropped)
+            }
+            SensitivitySolver::Sparse => {
+                let (ptdf, ptdf_dropped, lodf, lodf_dropped) =
+                    sparse_ptdf_lodf(&inc, &refs, options)?;
+                (
+                    ptdf,
+                    lodf,
+                    SensitivitySolverPath::SparseCholesky,
+                    ptdf_dropped,
+                    lodf_dropped,
+                )
+            }
+            SensitivitySolver::Auto => unreachable!("selected_solver resolves Auto"),
+        };
 
     let metadata = sensitivity_metadata(
         options,
@@ -305,33 +309,31 @@ pub(crate) fn for_each_ptdf_lodf_entry(
     let inc = build_incidence(case, options.convention, &BuildOptions::default())?;
     let reduced_dimension = inc.n().saturating_sub(Grounding::new(&refs).len());
 
-    let (solver_path, ptdf, lodf) =
-        match options.selected_solver_for_shape(reduced_dimension, inc.m(), inc.n()) {
-            SensitivitySolver::Dense => {
-                let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
-                let (ptdf, ptdf_dropped) =
-                    dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
-                let (lodf, lodf_dropped) =
-                    lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
-                let ptdf_meta = matrix_metadata(&ptdf, ptdf_dropped);
-                let lodf_meta = matrix_metadata(&lodf, lodf_dropped);
-                for (&v, (row, col)) in &ptdf {
-                    ptdf_entry(row, col, v)?;
-                }
-                for (&v, (row, col)) in &lodf {
-                    lodf_entry(row, col, v)?;
-                }
-                (solver_path, ptdf_meta, lodf_meta)
+    let (solver_path, ptdf, lodf) = match resolve_solver(options, &inc, reduced_dimension) {
+        SensitivitySolver::Dense => {
+            let (dense, m, n, solver_path) = ptdf_dense_with_path(&inc, &refs)?;
+            let (ptdf, ptdf_dropped) = dense_to_csr_with_drop(&dense, m, n, options.drop_tolerance);
+            let (lodf, lodf_dropped) =
+                lodf_from_dense_with_drop(&dense, &inc.a, m, n, options.drop_tolerance);
+            let ptdf_meta = matrix_metadata(&ptdf, ptdf_dropped);
+            let lodf_meta = matrix_metadata(&lodf, lodf_dropped);
+            for (&v, (row, col)) in &ptdf {
+                ptdf_entry(row, col, v)?;
             }
-            SensitivitySolver::Sparse => {
-                let (ptdf, lodf) =
-                    sparse_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
-                (SensitivitySolverPath::SparseCholesky, ptdf, lodf)
+            for (&v, (row, col)) in &lodf {
+                lodf_entry(row, col, v)?;
             }
-            SensitivitySolver::Auto => {
-                unreachable!("selected_solver_for_reduced_dimension resolves Auto")
-            }
-        };
+            (solver_path, ptdf_meta, lodf_meta)
+        }
+        SensitivitySolver::Sparse => {
+            let (ptdf, lodf) =
+                sparse_ptdf_lodf_entries(&inc, &refs, options, ptdf_entry, lodf_entry)?;
+            (SensitivitySolverPath::SparseCholesky, ptdf, lodf)
+        }
+        SensitivitySolver::Auto => {
+            unreachable!("selected_solver_for_reduced_dimension resolves Auto")
+        }
+    };
 
     Ok(sensitivity_metadata(
         options,
@@ -638,6 +640,25 @@ fn metadata_from_counts(
     )
 }
 
+/// Resolve the solver for a build, seeing the case and not only its shape.
+/// The sparse path refuses nonpositive or nonfinite susceptances, so `Auto`
+/// keeps the dense indefinite fallback for those. An explicit `Sparse` request
+/// still reports the refusal.
+fn resolve_solver(
+    options: &SensitivityOptions,
+    inc: &IncidenceParts,
+    reduced_dimension: usize,
+) -> SensitivitySolver {
+    let selected = options.selected_solver_for_shape(reduced_dimension, inc.m(), inc.n());
+    if options.solver == SensitivitySolver::Auto
+        && selected == SensitivitySolver::Sparse
+        && ensure_sparse_solver_eligible(inc).is_err()
+    {
+        return SensitivitySolver::Dense;
+    }
+    selected
+}
+
 fn ensure_sparse_solver_eligible(inc: &IncidenceParts) -> Result<()> {
     for (branch, &b) in inc.b.iter().enumerate() {
         if !b.is_finite() || b <= 0.0 {
@@ -714,11 +735,20 @@ impl SparseCholeskyFactor {
         // with no triplet rebuild or numeric copy. The grounded Laplacian is
         // exactly symmetric, so the view describes the same operator.
         let a_csc = a.transpose_view();
+        // `raw_storage` is sprs's unchecked accessor and faer never tests that
+        // the pointers start at 0, so a view sliced out of a larger matrix
+        // would factor the wrong operator. `as_slice` yields them only when
+        // they are proper, and the row indices then line up with them.
         let indptr = a_csc.indptr();
+        let col_ptr = indptr.as_slice().ok_or_else(|| {
+            sensitivity_factorization_failed(
+                "grounded DC bus susceptance matrix does not own its index pointers",
+            )
+        })?;
         let symbolic_a = SymbolicSparseColMatRef::new_checked(
             dimension,
             dimension,
-            indptr.raw_storage(),
+            col_ptr,
             None,
             a_csc.indices(),
         );
@@ -1248,13 +1278,18 @@ mod auto_policy_tests {
     };
 
     #[test]
-    fn auto_takes_the_dense_path_for_a_mid_size_case() {
-        // 2869 buses is a common published case inside the compatibility
-        // policy's dense range.
+    fn auto_takes_the_dense_path_only_below_the_measured_crossover() {
+        // Dense wins on a case too small for the factorization to pay for
+        // itself and loses everywhere above it: case2869pegase is 10x slower
+        // dense than sparse.
         let o = SensitivityOptions::default();
         assert_eq!(
-            o.selected_solver_for_shape(2868, 4582, 2869),
+            o.selected_solver_for_shape(30, 39, 31),
             SensitivitySolver::Dense
+        );
+        assert_eq!(
+            o.selected_solver_for_shape(2868, 4582, 2869),
+            SensitivitySolver::Sparse
         );
     }
 
@@ -1264,7 +1299,7 @@ mod auto_policy_tests {
         // small but the dense LODF alone is m x m, so the footprint veto has
         // to fire even though the dimension test passes.
         let o = SensitivityOptions::default();
-        let (nr, m, n) = (400usize, 40_000usize, 401usize);
+        let (nr, m, n) = (64usize, 40_000usize, 65usize);
         assert!(nr <= o.auto_dense_threshold);
         assert!(dense_footprint_bytes(nr, m, n) > AUTO_DENSE_MEMORY_BUDGET);
         assert_eq!(

--- a/powerio-matrix/tests/dcopf.rs
+++ b/powerio-matrix/tests/dcopf.rs
@@ -572,13 +572,7 @@ fn auto_writes_sparse_outputs_above_the_dense_threshold() {
     let reduced_dimension = view.n() - view.reference_bus_indices().len();
     assert!(reduced_dimension > 512);
 
-    // Drive the routing through the knob rather than the default ceiling:
-    // 599 unknowns is far below the real dense/sparse crossover, so the
-    // default now (correctly) takes the dense path here.
-    let options = SensitivityOptions {
-        auto_dense_threshold: 512,
-        ..SensitivityOptions::default()
-    };
+    let options = SensitivityOptions::default();
     let temp = tempfile::tempdir().unwrap();
     let ptdf_path = temp.path().join("ptdf.mtx");
     let lodf_path = temp.path().join("lodf.mtx");
@@ -599,7 +593,35 @@ fn auto_writes_sparse_outputs_above_the_dense_threshold() {
 }
 
 #[test]
-fn auto_sparse_rejects_non_positive_susceptance() {
+fn auto_falls_back_to_dense_for_non_positive_susceptance() {
+    // The dimension ceiling would send this to sparse, which refuses the sign.
+    // `Auto` promises an answer wherever one path can produce it, so it keeps
+    // the dense indefinite fallback.
+    let case = net(
+        "negative_x",
+        vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
+        vec![branch(1, 2, -0.1)],
+    );
+    let view = IndexedNetwork::new(&case);
+    let out = build_ptdf_lodf_with_options(
+        &view,
+        &SensitivityOptions {
+            solver: SensitivitySolver::Auto,
+            auto_dense_threshold: 0,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(out.metadata.requested_solver, SensitivitySolver::Auto);
+    assert!(matches!(
+        out.metadata.solver_path,
+        SensitivitySolverPath::DenseCholesky | SensitivitySolverPath::DenseInverse
+    ));
+}
+
+#[test]
+fn explicit_sparse_rejects_non_positive_susceptance() {
     let case = net(
         "negative_x",
         vec![bus(1, BusType::Ref), bus(2, BusType::Pq)],
@@ -609,8 +631,7 @@ fn auto_sparse_rejects_non_positive_susceptance() {
     let err = build_ptdf_lodf_with_options(
         &view,
         &SensitivityOptions {
-            solver: SensitivitySolver::Auto,
-            auto_dense_threshold: 0,
+            solver: SensitivitySolver::Sparse,
             ..Default::default()
         },
     )


### PR DESCRIPTION
Two fixes from the review of #387, on top of `ck/laplacian-factorization`.

## Auto never selects the sparse path

The `Auto` dense ceiling of 8192 was set in #295 against the conjugate gradient path this branch replaces. Against sparse Cholesky the comparison inverts. Release build, synthetic PEGASE-like cases, mean ms per build:

```
   n     m   dense_ms  sparse_ms  ratio
  30    39      0.057      0.068   0.84
  40    52      0.090      0.095   0.94
  50    65      0.152      0.148   1.03
  70    92      0.358      0.305   1.18
 300   399     19.430      7.129   2.73
1200  1599   1227.311    133.618   9.19
3000  3999  29409.191   1250.378  23.52
```

Dense wins below a reduced dimension of about 50, by tens of microseconds, and loses without bound above it. `powerio sensitivities tests/data/case2869pegase.m` is 22.1 s dense against 2.2 s sparse, so on the corpus `Auto` never reached the path #291 added.

The default moves to 64. Lowering it alone would have been a regression: `ensure_sparse_solver_eligible` refuses nonpositive and nonfinite susceptances, so indefinite cases that `Auto` answers today through the dense inverse fallback would start erroring instead, which `auto_sparse_rejects_non_positive_susceptance` pins with `auto_dense_threshold: 0`. The 8192 ceiling is what kept that hidden. `Auto` now resolves against the case and not its shape alone, and falls back to dense for those; an explicit `Sparse` still reports the refusal. That test splits into the two behaviors.

## Unchecked CSC index pointers

`IndPtrBase::raw_storage` is sprs's unchecked accessor and faer's `check_col_ptr` does not test that the pointers start at zero, so a view sliced out of a larger matrix would be accepted and factor the wrong operator. Only the owned `ground_with` result reaches it today. `as_slice` is the checked form and errors instead.

## Verification

Against the dense oracle at `drop_tolerance = 0`: case118 max |ΔPTDF| 8.3e-15 and max |ΔLODF| 5.6e-14; case2869pegase 4.2e-13 and 3.6e-11. Full workspace suite green, `cargo fmt --check` and `clippy --all-targets -D warnings` clean.

The changelog also regains the #273 entry, which the #291 bullet replaced rather than amended.

One review comment on #387 is retracted: the `LltError` on the factorization path is `faer::linalg::solvers::LltError`, whose only variant is `NonPositivePivot`, so `SingularNetwork` is the correct mapping and nothing changes there.

## 1.0 architecture audit

Retain automatic sparse routing, dense fallback, checked CSC handling, and the measured tests. Rebuild it above the retained #387 work in the 1.0 matrix stack and fold in applicable sensitivity allocation fixes from #405. Do not ship its public rename in 0.9.1.