### PR TITLE
Add the IR reference, test serialize determinism, and attach reader spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,18 @@ retained source. Two PowSybl Core revision 32 cases join the fixtures under
 their MPL-2.0 license, and the PowSybl interoperability gate loads the fresh
 revision 33 output written from each.
 
+The guide gains a PowerIO IR reference (`docs/src/ir-reference.md`) that
+defines every structural value type field by field: type, unit, sign
+convention, invariant, and the value a reader takes when a field is absent;
+`powerio/tests/ir_reference.rs` holds the page to the generated schema in both
+directions. `serialize` is deterministic: one module serializes to identical
+text every time, and serializing what that text deserializes to reproduces
+it. The MATPOWER and PSS/E readers attach the byte range of the record a
+finding is about, into the retained source, to the diagnostics they raise:
+the failure that ends a read and the warnings alike. `powerio_core::Error`
+gains `with_span`, which attaches a range to the diagnostic that ended an
+operation.
+
 ## 0.10.0
 
 PowerIO 0.10 is the public beta of the 1.0 API. API corrections may land before 1.0.0 as downstream integrations exercise the new design.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -21,6 +21,7 @@
   - [From the 1.0 beta to 1.0](migration-v1.md)
   - [1.0 API surface](final-v1-api-cleanup.md)
   - [.pio.json schema](pio-json-schema.md)
+  - [PowerIO IR reference](ir-reference.md)
   - [Crate graph and dependency rules](crate-graph.md)
   - [Architecture map](architecture-map.md)
   - [LLVM and MLIR lessons](compiler-ir.md)

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -6,7 +6,9 @@ PowerIO's design borrows from LLVM and MLIR where their problems genuinely overl
 
 **A small shared foundation under acyclic higher layers.** LLVM's library layering puts Support under IR under the producers. PowerIO's `powerio-core` owns sources, diagnostics, errors, the module, and the generic containers; the network crates, the calculation crate, and the matrix crate stack over it in one direction, and CI asserts the edges from `cargo metadata` ([Crate graph](crate-graph.md)).
 
-**Source ownership that survives parsing.** MLIR's source manager keeps buffers alive so locations mean something after parsing. A `PioModule` retains its source, and the byte exact same format echo reads it back; the diagnostic wire form carries a source identifier plus a byte range into those exact bytes end to end, though 1.0 parsers do not yet emit a span on any diagnostic.
+**Source ownership that survives parsing.** MLIR's source manager keeps buffers alive so locations mean something after parsing. A `PioModule` retains its source, and same format emission returns those bytes unchanged. A diagnostic carries a source identifier plus a byte range into those exact bytes end to end, and the MATPOWER and PSS/E readers attach the range of the record a finding is about, for the failure that ends a read and for warnings alike; the other readers attach no span yet.
+
+**Deterministic serialization.** `serialize` is a function of the module alone: one module serializes to identical text every time, and serializing the module that text deserializes to reproduces the text. Members are written in a fixed order (record fields in declaration order, map keys sorted), diagnostic identities are minted `d0`, `d1`, ... in record order for records that carry none, and every float is written in the shortest decimal form that reads back to the same value. Two equal modules therefore compare equal as documents, which is what a cache key, a golden file, or a content digest needs.
 
 **Structured diagnostics with stable severities and attached context.** The four severities (`error`, `warning`, `remark`, `note`) are MLIR's, with the same meanings: a remark reports on success, a note attaches context to another finding. PowerIO adds the stable dotted code as the identity a consumer branches on, plus targets, related records, and suggested actions.
 
@@ -22,7 +24,7 @@ PowerIO's design borrows from LLVM and MLIR where their problems genuinely overl
 
 **Registries checked mechanically where tables drift.** Structural type names, format tokens, diagnostic codes, and drawn architecture edges are each held to one source by a CI gate, which is the maintainable slice of MLIR's declarative dialect definitions.
 
-**Serialization specified apart from memory.** `.pio.json` version 1 has an explicit schema and validation rules; the Rust structs never derive the public document layout. PowerIO 1.0 reads and writes only that final shape.
+**Serialization specified apart from memory.** `.pio.json` version 1 has an explicit schema and validation rules; the Rust structs never derive the public document layout. PowerIO 1.0 reads and writes only that final shape, and [PowerIO IR reference](ir-reference.md) defines every structural type of that shape field by field, the way the MLIR language reference defines its types; a test holds the page to the generated schema.
 
 **Scrutiny proportional to permanence.** A new core concept (a value family or common module record) needs a registered structural type name, an exact IR representation, and binding coverage. A new format adapter needs none of that.
 

--- a/docs/src/ir-reference.md
+++ b/docs/src/ir-reference.md
@@ -1,0 +1,1703 @@
+# PowerIO IR reference
+
+This page defines every structural value type the PowerIO IR carries, field
+by field: the type of each field, its unit, its sign convention, the
+invariant the deserializer or the constructors hold it to, and what a reader
+supplies when the field is absent. The generated schema at
+`docs/schema/pio-module/1/schema.json` is the machine form of the same
+definitions. `powerio/tests/ir_reference.rs` reads this page and checks, in
+both directions, that each table names exactly the fields the schema defines
+for its definition, so the two cannot drift apart.
+
+## Reading the tables
+
+Every field table follows a line that begins with the words "Schema
+definition" and names, in backticks, the `$defs` entries of the schema the
+table documents. The columns are:
+
+- **field**: the JSON member name in `value.data` (or in the nested record).
+- **type**: `float` is a JSON number or one of the strings `"Infinity"`,
+  `"-Infinity"`, and `"NaN"`; `null` is refused at a float position.
+  `float or null` is a float the source may leave unstated. `id` is a bus
+  identifier: a nonnegative integer, the source's own bus number. `matrix`
+  is an array of equal length float arrays. `token` is one of the listed
+  strings.
+- **unit**: the physical unit. `p.u.` is per unit on the network's
+  `base_mva` and the bus `base_kv` unless the row says otherwise.
+- **sign**: the direction a positive value means; blank when the quantity is
+  unsigned or the sign carries no convention.
+- **invariant**: what the deserializer refuses or the constructors hold.
+- **if absent**: `required` when the serializer always writes the field and
+  the deserializer refuses a document without it; otherwise the value a
+  reader takes when the member is missing.
+
+Every element row of a network carries `uid`, the stable component identity
+that operating points, solutions, and updates address. `parse` and
+`serialize` assign `{table}:{row}` to a row whose source states none, so a
+document written by PowerIO always carries one. `extras` on an element is
+the map of source fields the typed model has no slot for, keyed by the
+source's own field names; it is required in the document and may be empty.
+
+## Structural type names
+
+`value.type` is one of these names, and `value.data` has the shape of the
+schema definition beside it.
+
+| structural type | schema definition |
+|---|---|
+| `powerio.BalancedNetwork` | `BalancedNetwork` |
+| `powerio.MulticonductorNetwork` | `MulticonductorNetwork` |
+| `powerio.OperatingPoint<powerio.BalancedNetwork>` | `StoredOperatingPoint` |
+| `powerio.OperatingPoint<powerio.MulticonductorNetwork>` | `StoredOperatingPoint2` |
+| `powerio.TimeSeries<powerio.BalancedNetwork>` | `StoredTimeSeries` |
+| `powerio.TimeSeries<powerio.MulticonductorNetwork>` | `StoredTimeSeries2` |
+| `powerio.TimeSeries<powerio.OperatingPoint<powerio.BalancedNetwork>>` | `StoredOperatingPointTimeSeries` |
+| `powerio.TimeSeries<powerio.OperatingPoint<powerio.MulticonductorNetwork>>` | `StoredOperatingPointTimeSeries2` |
+| `powerio.ScenarioSet<powerio.BalancedNetwork>` | `StoredScenarioSet` |
+| `powerio.ScenarioSet<powerio.MulticonductorNetwork>` | `StoredScenarioSet2` |
+| `powerio.ScenarioSet<powerio.OperatingPoint<powerio.BalancedNetwork>>` | `StoredOperatingPointScenarioSet` |
+| `powerio.ScenarioSet<powerio.OperatingPoint<powerio.MulticonductorNetwork>>` | `StoredOperatingPointScenarioSet2` |
+| `powerio.ScenarioSet<powerio.TimeSeries<powerio.BalancedNetwork>>` | `StoredScenarioSet3` |
+| `powerio.ScenarioSet<powerio.TimeSeries<powerio.MulticonductorNetwork>>` | `StoredScenarioSet4` |
+| `powerio.ScenarioSet<powerio.TimeSeries<powerio.OperatingPoint<powerio.BalancedNetwork>>>` | `StoredScenarioSet5` |
+| `powerio.ScenarioSet<powerio.TimeSeries<powerio.OperatingPoint<powerio.MulticonductorNetwork>>>` | `StoredScenarioSet6` |
+| `powerio.DcPfInstance` | `DcPfInstance` |
+| `powerio.AcPfInstance` | `AcPfInstance` |
+| `powerio.DcOpfInstance` | `DcOpfInstance` |
+| `powerio.AcOpfInstance` | `AcOpfInstance` |
+| `powerio.McAcPfInstance` | `McAcPfInstance` |
+| `powerio.McAcOpfInstance` | `McAcOpfInstance` |
+| `powerio.AcScucInstance` | `AcScucInstance` |
+| `powerio.DcPfSolution` | `DcPfSolution` |
+| `powerio.AcPfSolution` | `AcPfSolution` |
+| `powerio.DcOpfSolution` | `DcOpfSolution` |
+| `powerio.AcOpfSolution` | `AcOpfSolution` |
+| `powerio.SocwrOpfSolution` | `SocwrOpfSolution` |
+| `powerio.McAcPfSolution` | `McAcPfSolution` |
+| `powerio.McAcOpfSolution` | `McAcOpfSolution` |
+| `powerio.AcScucSolution` | `AcScucSolution` |
+
+## powerio.BalancedNetwork
+
+The positive sequence transmission model. Powers are MW and MVAr, voltage
+magnitudes per unit, angles degrees, impedances per unit on `base_mva`, as
+MATPOWER states them. Bus identifiers are the source's own.
+
+Schema definition: `BalancedNetwork`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | | required |
+| `base_mva` | float | MVA | | finite and positive | required |
+| `base_frequency` | float | Hz | | positive | 60 |
+| `source_format` | token | | | one of the format tokens (`matpower`, `psse`, `psse-rawx`, `powermodels-json`, `egret-json`, `powerworld`, `powerworld-pwb`, `pslf`, `pandapower-json`, `pypsa-csv`, `gridfm`, `goc3-json`, `surge-json`, `opfdata-json`, `xiidm`, `cgmes`, `in-memory`, `normalized`) | required |
+| `buses` | array of `Bus` | | | `id` unique | required |
+| `loads` | array of `Load` | | | `bus` names a bus | required |
+| `shunts` | array of `Shunt` | | | `bus` names a bus | required |
+| `branches` | array of `Branch` | | | `from` and `to` name buses | required |
+| `generators` | array of `Generator` | | | `bus` names a bus | required |
+| `storage` | array of `Storage` | | | `bus` names a bus | required |
+| `hvdc` | array of `Hvdc` | | | `from` and `to` name buses | required |
+| `switches` | array of `Switch` | | | `from` and `to` name buses | `[]` |
+| `transformers_3w` | array of `Transformer3W` | | | every winding `bus` names a bus | `[]` |
+| `static_var_compensators` | array of `StaticVarCompensator` | | | `bus` names a bus | `[]` |
+| `areas` | array of `Area` | | | `number` unique | `[]` |
+| `solver` | `SolverParams` or null | | | | null |
+| `case_metadata` | `CaseMetadata` | | | | every member null |
+| `geo` | `GeoMeta` or null | | | | null |
+| `detailed_connectivity` | `DetailedConnectivity` or null | | | | null |
+
+### Bus
+
+Schema definition: `Bus`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | id | | | unique within `buses` | required |
+| `kind` | token `PQ`, `PV`, `REF`, `ISOLATED` | | | MATPOWER type codes 1, 2, 3, 4 | required |
+| `vm` | float | p.u. | | | required |
+| `va` | float | degrees | | | required |
+| `base_kv` | float | kV | | nonnegative; 0 when the source states none | required |
+| `vmax` | float | p.u. | | `vmin <= vmax`; `Infinity` for no bound | required |
+| `vmin` | float | p.u. | | | required |
+| `evhi` | float or null | p.u. | | emergency band, stated only when it differs from `vmax` | null (equals `vmax`) |
+| `evlo` | float or null | p.u. | | stated only when it differs from `vmin` | null (equals `vmin`) |
+| `area` | integer | | | | required |
+| `zone` | integer | | | | required |
+| `name` | string or null | | | | null |
+| `uid` | string or null | | | unique within `buses` | assigned at serialization |
+| `location` | `Location` or null | network coordinate space | | | null |
+| `extras` | object | | | | required |
+
+### Load
+
+Schema definition: `Load`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `p` | float | MW | positive is consumption | | required |
+| `q` | float | MVAr | positive is inductive consumption | | required |
+| `in_service` | boolean | | | | required |
+| `voltage_model` | `LoadVoltageModel` or null | | | | null (constant power) |
+| `uid` | string or null | | | unique within `loads` | assigned at serialization |
+| `extras` | object | | | | required |
+
+`LoadVoltageModel` is tagged by `kind`: `constant_power` states no further
+member; `zip` states `p_constant_power`, `p_constant_current`,
+`p_constant_impedance` (MW, summing to `p`) and `q_constant_power`,
+`q_constant_current`, `q_constant_impedance` (MVAr, summing to `q`), an
+optional `v_nom` (kV), an optional source `load_type` code, and an optional
+`scaling` factor; `exponential` states `gamma_p`, `gamma_q`, and `v_nom`
+with `P = p (V / v_nom)^gamma_p` and `Q = q (V / v_nom)^gamma_q`.
+
+### Shunt
+
+Schema definition: `Shunt`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `g` | float | MW at V = 1 p.u. | positive is consumption | | required |
+| `b` | float | MVAr at V = 1 p.u. | positive is capacitive injection | the initial value of a switched shunt | required |
+| `in_service` | boolean | | | | required |
+| `section_count` | integer or null | | | | null (unset) |
+| `control` | `SwitchedShuntControl` or null | | | | null (fixed shunt) |
+| `uid` | string or null | | | unique within `shunts` | assigned at serialization |
+| `extras` | object | | | | required |
+
+Schema definition: `SwitchedShuntControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `mode` | token `locked`, `continuous`, `discrete` | | | PSS/E `MODSW` 0, 1, 2 and up | required |
+| `vhigh` | float | p.u. | | `vlow <= vhigh` | required |
+| `vlow` | float | p.u. | | | required |
+| `control_bus` | id or null | | | names a bus | null (the shunt's own bus) |
+| `regulating_terminal` | `TerminalReference` or null | | | | null |
+| `rmpct` | float | percent | | | required |
+| `blocks` | array of `ShuntBlock` | | | | required |
+
+Schema definition: `ShuntBlock`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `steps` | integer | | | | required |
+| `g` | float | MW at V = 1 p.u. per step | positive is consumption | | required |
+| `b` | float | MVAr at V = 1 p.u. per step | positive is capacitive injection | | required |
+
+### Branch
+
+Schema definition: `Branch`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `from` | id | | | names a bus | required |
+| `to` | id | | | names a bus | required |
+| `r` | float | p.u. | | | required |
+| `x` | float | p.u. | | `r` and `x` not both zero when a matrix is built | required |
+| `b` | float | p.u. | positive is capacitive | total line charging; half at each end unless `charging` is present | required |
+| `charging` | `BranchCharging` or null | | | canonical per terminal admittance when present | null (derive from `b`) |
+| `rate_a` | float | MVA | | 0 is unrated | required |
+| `rate_b` | float | MVA | | 0 is unrated | required |
+| `rate_c` | float | MVA | | 0 is unrated | required |
+| `rating_sets` | array of `BranchRatingSet` | | | | `[]` |
+| `current_ratings` | `BranchCurrentRatings` or null | | | | null |
+| `tap` | float | ratio at the from side | | 0 means 1 (a line); otherwise positive | required |
+| `shift` | float | degrees | positive means the from side voltage leads the to side | | required |
+| `in_service` | boolean | | | | required |
+| `angmin` | float | degrees | | `angmin <= angmax`; -360 and 360 mean unconstrained | required |
+| `angmax` | float | degrees | | | required |
+| `control` | `TransformerControl` or null | | | | null (a line or a fixed ratio transformer) |
+| `solution` | `BranchSolution` or null | | | | null |
+| `name` | string or null | | | | null |
+| `uid` | string or null | | | unique within `branches` | assigned at serialization |
+| `route` | array of `Location` or null | network coordinate space | | | null |
+| `extras` | object | | | | required |
+
+Schema definition: `BranchCharging`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `g_fr` | float | p.u. | | | required |
+| `b_fr` | float | p.u. | positive is capacitive | | required |
+| `g_to` | float | p.u. | | | required |
+| `b_to` | float | p.u. | positive is capacitive | | required |
+
+Schema definition: `BranchRatingSet`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | | required |
+| `rate_mva` | float | MVA | | | required |
+
+Schema definition: `BranchCurrentRatings`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `c_rating_a` | float | source units (amperes for PSS/E) | | | required |
+| `c_rating_b` | float | source units | | | required |
+| `c_rating_c` | float | source units | | | required |
+
+Schema definition: `BranchSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `pf` | float | MW | positive flows into the branch at the from terminal | | required |
+| `qf` | float | MVAr | positive flows into the branch at the from terminal | | required |
+| `pt` | float | MW | positive flows into the branch at the to terminal | | required |
+| `qt` | float | MVAr | positive flows into the branch at the to terminal | | required |
+
+Schema definition: `TransformerControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `mode` | token `fixed`, `voltage`, `reactive_flow`, `active_flow`, `dc_line_quantity`, `asymmetric_active_flow` | | | PSS/E `COD` magnitude 0 through 5 | required |
+| `enabled` | boolean | | | automatic adjustment on; the sign of PSS/E `COD` | required |
+| `controlled_bus` | id or null | | | names a bus | null |
+| `controlled_bus_on_winding_side` | boolean | | | | false |
+| `regulating_terminal` | `TerminalReference` or null | | | | null |
+| `band_min` | float | p.u. voltage, MVAr, or MW as `mode` selects | | `band_min <= band_max` | required |
+| `band_max` | float | as `band_min` | | | required |
+| `tap_min` | float | ratio, or degrees for phase control | | `tap_min <= tap_max` | required |
+| `tap_max` | float | as `tap_min` | | | required |
+| `ntp` | integer | | | number of tap positions | required |
+| `mva_base` | float | MVA | | | required |
+| `winding_connection_angle` | float or null | degrees | | asymmetric active power flow control only | null |
+
+### Generator
+
+Schema definition: `Generator`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `pg` | float | MW | positive is generation | | required |
+| `qg` | float | MVAr | positive is generation | | required |
+| `qmax` | float | MVAr | | `qmin <= qmax`; `Infinity` and `-Infinity` mean unbounded | required |
+| `qmin` | float | MVAr | | | required |
+| `vg` | float | p.u. | | | required |
+| `mbase` | float | MVA | | positive when stated | required |
+| `pmax` | float | MW | | `pmin <= pmax` | required |
+| `pmin` | float | MW | | | required |
+| `in_service` | boolean | | | | required |
+| `cost` | `GenCost` or null | | | | null (no cost curve) |
+| `caps` | map of string to float | MW, MVAr, MW per minute, or a fraction per key | | keys among `pc1`, `pc2`, `qc1min`, `qc1max`, `qc2min`, `qc2max`, `ramp_agc`, `ramp_10`, `ramp_30`, `ramp_q`, `apf`, the MATPOWER columns past `PMIN` | `{}` |
+| `energy_source` | token `hydro`, `nuclear`, `wind`, `thermal`, `solar`, `other` | | | | `other` |
+| `voltage_regulation_on` | boolean | | | | true |
+| `regulated_bus` | id or null | | | names a bus | null (the generator's own bus) |
+| `regulating_terminal` | `TerminalReference` or null | | | | null |
+| `active_power_control` | `ActivePowerControl` or null | | | | null |
+| `uid` | string or null | | | unique within `generators` | assigned at serialization |
+
+Schema definition: `GenCost`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `model` | integer | | | 1 is piecewise linear, 2 is polynomial | required |
+| `startup` | float | currency | | | required |
+| `shutdown` | float | currency | | | required |
+| `ncost` | integer | | | polynomial: `coeffs.len() == ncost`; piecewise: `coeffs.len() == 2 * ncost` | required |
+| `coeffs` | array of float | polynomial: currency per MW^k per hour, highest order first; piecewise: alternating MW and currency per hour breakpoints | | | required |
+
+Schema definition: `ActivePowerControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `participate` | boolean | | | | required |
+| `droop_percent` | float or null | percent | | | null |
+| `participation_factor` | float or null | | | | null |
+| `minimum_target_active_power_mw` | float or null | MW | | | null |
+| `maximum_target_active_power_mw` | float or null | MW | | | null |
+
+### Storage
+
+The PowerModels `storage` model.
+
+Schema definition: `Storage`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `ps` | float | MW | positive is withdrawn from the network (charging) | | required |
+| `qs` | float | MVAr | positive is withdrawn from the network | | required |
+| `energy` | float | MWh | | `0 <= energy <= energy_rating` | required |
+| `energy_rating` | float | MWh | | | required |
+| `charge_rating` | float | MW | | | required |
+| `discharge_rating` | float | MW | | | required |
+| `charge_efficiency` | float | fraction | | in `[0, 1]` | required |
+| `discharge_efficiency` | float | fraction | | in `[0, 1]` | required |
+| `thermal_rating` | float | MVA | | | required |
+| `current_rating` | float or null | amperes | | | null |
+| `qmin` | float | MVAr | | `qmin <= qmax` | required |
+| `qmax` | float | MVAr | | | required |
+| `r` | float | p.u. | | | required |
+| `x` | float | p.u. | | | required |
+| `p_loss` | float | MW | | standby loss | required |
+| `q_loss` | float | MVAr | | standby loss | required |
+| `in_service` | boolean | | | | required |
+| `active_power_control` | `ActivePowerControl` or null | | | | null |
+| `uid` | string or null | | | unique within `storage` | assigned at serialization |
+| `extras` | object | | | | required |
+
+### Hvdc
+
+A two terminal HVDC line in the MATPOWER `dcline` convention, whatever the
+source format.
+
+Schema definition: `Hvdc`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `from` | id | | | names a bus | required |
+| `to` | id | | | names a bus | required |
+| `in_service` | boolean | | | | required |
+| `pf` | float | MW | positive flows from the from bus to the to bus, measured at the from end | | required |
+| `pt` | float | MW | positive flows from the from bus to the to bus, measured at the to end | | required |
+| `qf` | float | MVAr | positive is injected into the from bus | | required |
+| `qt` | float | MVAr | positive is injected into the to bus | | required |
+| `vf` | float | p.u. | | voltage setpoint at the from bus | required |
+| `vt` | float | p.u. | | voltage setpoint at the to bus | required |
+| `pmin` | float | MW | | bounds on `pf`; `pmin <= pmax` | required |
+| `pmax` | float | MW | | | required |
+| `qminf` | float | MVAr | | bounds on `qf` | required |
+| `qmaxf` | float | MVAr | | | required |
+| `qmint` | float | MVAr | | bounds on `qt` | required |
+| `qmaxt` | float | MVAr | | | required |
+| `loss0` | float | MW | | constant loss term | required |
+| `loss1` | float | MW per MW | | linear loss term in `pf` | required |
+| `resistance_ohm` | float or null | ohm | | | null |
+| `nominal_voltage_kv` | float or null | kV | | | null |
+| `converters_mode` | token `side1_rectifier_side2_inverter`, `side1_inverter_side2_rectifier`, or null | | | | null |
+| `converter1` | `HvdcConverter` or null | | | | null |
+| `converter2` | `HvdcConverter` or null | | | | null |
+| `cost` | `GenCost` or null | | | usage cost in `pf` | null |
+| `uid` | string or null | | | unique within `hvdc` | assigned at serialization |
+| `extras` | object | | | | required |
+
+Schema definition: `HvdcConverter`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `component` | `ComponentId` | | | | required |
+| `kind` | token `vsc`, `lcc` | | | | required |
+| `loss_factor_percent` | float | percent of active power | | | required |
+| `power_factor` | float or null | | | | null |
+| `reactive_power_setpoint_mvar` | float or null | MVAr | | | null |
+| `regulating_terminal` | `TerminalReference` or null | | | | null |
+| `voltage_regulator_on` | boolean or null | | | | null |
+| `voltage_setpoint_kv` | float or null | kV | | | null |
+
+### Switch
+
+A transmission switch. A closed switch is data; matrix calculations do not
+lower it to a zero impedance branch.
+
+Schema definition: `Switch`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `from` | id | | | names a bus | required |
+| `to` | id | | | names a bus | required |
+| `closed` | boolean | | | | required |
+| `thermal_rating` | float or null | MVA | | | null |
+| `current_rating` | float or null | amperes | | | null |
+| `pf` | float or null | MW | positive flows into the switch at the from terminal | | null |
+| `qf` | float or null | MVAr | positive flows into the switch at the from terminal | | null |
+| `pt` | float or null | MW | positive flows into the switch at the to terminal | | null |
+| `qt` | float or null | MVAr | positive flows into the switch at the to terminal | | null |
+| `uid` | string or null | | | unique within `switches` | assigned at serialization |
+| `extras` | object | | | | required |
+
+### Transformer3W
+
+Three windings joined at a star point; the indexed view star-lowers the
+record for matrix calculations.
+
+Schema definition: `Transformer3W`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string or null | | | | null |
+| `windings` | array of `Winding` | | | exactly three, in the order primary, secondary, tertiary | required |
+| `z` | array of `Impedance` | | | exactly three: `z12`, `z23`, `z31` | required |
+| `mag_g` | float | p.u. on the system base, at the star point | | | required |
+| `mag_b` | float | p.u. on the system base, at the star point | positive is capacitive | | required |
+| `star_vm` | float | p.u. | | solved star point voltage | required |
+| `star_va` | float | degrees | | | required |
+| `in_service` | boolean | | | | required |
+| `uid` | string or null | | | unique within `transformers_3w` | assigned at serialization |
+| `extras` | object | | | | required |
+
+Schema definition: `Winding`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `nominal_kv` | float | kV | | 0 defers to the terminal bus `base_kv` | required |
+| `tap` | float | ratio | | 1 is nominal (PSS/E `WINDV` with `CW = 1`) | required |
+| `shift` | float | degrees | as `Branch.shift` | | required |
+| `rate_a` | float | MVA | | 0 is unrated | required |
+| `rate_b` | float | MVA | | | required |
+| `rate_c` | float | MVA | | | required |
+| `control` | `TransformerControl` or null | | | | null |
+
+Schema definition: `Impedance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `r` | float | p.u. on the system base | | | required |
+| `x` | float | p.u. on the system base | | | required |
+| `base_mva` | float | MVA | | the source's declared base for the pair; positive | required |
+
+### Area
+
+Schema definition: `Area`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `number` | integer | | | unique within `areas`; matches `Bus.area` | required |
+| `name` | string or null | | | | null |
+| `net_interchange` | float | MW | positive is export out of the area | | required |
+| `tolerance` | float | MW | | | required |
+| `slack_bus` | id or null | | | names a bus | null |
+| `area_type` | string or null | | | | null |
+| `uid` | string or null | | | | null |
+
+### StaticVarCompensator
+
+Schema definition: `StaticVarCompensator`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | id | | | names a bus | required |
+| `b_min_siemens` | float | siemens | | `b_min_siemens <= b_max_siemens` | required |
+| `b_max_siemens` | float | siemens | | | required |
+| `voltage_setpoint_kv` | float | kV | | | required |
+| `reactive_power_setpoint_mvar` | float | MVAr | positive is injection | | required |
+| `regulation_mode` | token `voltage`, `reactive_power` | | | | required |
+| `regulating` | boolean | | | | required |
+| `regulating_terminal` | `TerminalReference` or null | | | | null |
+| `p` | float | MW | positive is consumption | | required |
+| `q` | float | MVAr | positive is consumption | | required |
+| `in_service` | boolean | | | | required |
+| `uid` | string or null | | | | null |
+| `extras` | object | | | | required |
+
+### SolverParams
+
+Each member is stated only when the source carries it.
+
+Schema definition: `SolverParams`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `newton_tolerance` | float or null | MW and MVAr mismatch | | | null |
+| `max_iterations` | integer or null | | | | null |
+| `zero_impedance_threshold` | float or null | p.u. reactance | | | null |
+| `adjust_taps` | boolean or null | | | | null |
+| `adjust_phase_shift` | boolean or null | | | | null |
+| `adjust_dc_taps` | boolean or null | | | | null |
+| `adjust_switched_shunt` | boolean or null | | | | null |
+| `adjust_area_interchange` | boolean or null | | | | null |
+
+### CaseMetadata
+
+Schema definition: `CaseMetadata`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `case_date` | string or null | | | | null |
+| `forecast_distance` | integer or null | minutes, as the source states | | | null |
+| `source_model_format` | string or null | | | | null |
+| `minimum_validation_level` | string or null | | | | null |
+
+### Coordinates
+
+Schema definition: `GeoMeta`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `kind` | token `source`, `synthetic`, `manual`, `derived`, or null | | | default origin of points without their own `kind` | null |
+
+Schema definition: `Location`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `x` | float | network coordinate space; longitude in geographic space | | | required |
+| `y` | float | network coordinate space; latitude in geographic space | | | required |
+| `kind` | token as `GeoMeta.kind`, or null | | | | null (the network default) |
+
+### Component references
+
+Schema definition: `ComponentId`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `component_type` | string | | | the element table or record kind | required |
+| `local_id` | string | | | the source supplied or assigned identity | required |
+
+Schema definition: `TerminalReference`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `equipment` | `ComponentId` | | | | required |
+| `terminal` | integer | | | 1 for single terminal equipment, else the side number | required |
+
+### DetailedConnectivity
+
+The hierarchy and bus breaker or node breaker connectivity a source states
+beyond the balanced calculation view (XIIDM, CGMES, PSS/E RAW 35 and RAWX).
+Every collection is empty when absent. The record types are defined in the
+schema under the names below; their field names carry their units (`_kv`,
+`_mw`, `_mvar`, `_a`, `_ohm`, `_h`, `_f`, `_km`, `_degrees`, `_percent`,
+`_seconds`), and terminal powers use the load sign convention (positive is
+consumption) where the record says so.
+
+Schema definition: `DetailedConnectivity`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `subnetworks` | array of `Subnetwork` | | | | `[]` |
+| `substations` | array of `Substation` | | | | `[]` |
+| `voltage_levels` | array of `VoltageLevel` | kV | | `nominal_kv` positive | `[]` |
+| `bus_breaker_buses` | array of `BusBreakerBus` | | | | `[]` |
+| `calculated_buses` | array of `CalculatedBus` | | | | `[]` |
+| `connectivity_nodes` | array of `ConnectivityNode` | | | | `[]` |
+| `busbar_sections` | array of `BusbarSection` | | | | `[]` |
+| `junctions` | array of `Junction` | | | | `[]` |
+| `terminals` | array of `Terminal` | | | | `[]` |
+| `switches` | array of `TopologySwitch` | | | | `[]` |
+| `internal_connections` | array of `InternalConnection` | | | | `[]` |
+| `operational_limit_groups` | array of `OperationalLimitGroup` | amperes, MW, or MVA per limit kind | | | `[]` |
+| `tap_changers` | array of `TapChanger` | | | `low_tap_position <= tap_position` when stated | `[]` |
+| `equipment_reactive_limits` | array of `EquipmentReactiveLimits` | MVAr | | | `[]` |
+| `boundary_lines` | array of `BoundaryLine` | | | | `[]` |
+| `tie_lines` | array of `TieLine` | | | | `[]` |
+| `component_metadata` | array of `ComponentMetadata` | | | | `[]` |
+| `omitted_fields` | array of `OmittedField` | | | a field absent from the source, distinct from a stated zero | `[]` |
+| `dc_converter_units` | array of `DcConverterUnit` | | | | `[]` |
+| `dc_topological_nodes` | array of `DcTopologicalNode` | | | | `[]` |
+| `dc_nodes` | array of `DcNode` | | | | `[]` |
+| `dc_grounds` | array of `DcGround` | | | | `[]` |
+| `dc_busbars` | array of `DcBusbar` | | | | `[]` |
+| `dc_lines` | array of `DcLine` | | | | `[]` |
+| `dc_series_devices` | array of `DcSeriesDevice` | | | | `[]` |
+| `dc_switches` | array of `DcSwitch` | | | | `[]` |
+| `voltage_source_converters` | array of `VoltageSourceConverter` | | | | `[]` |
+| `line_commutated_converters` | array of `LineCommutatedConverter` | | | | `[]` |
+
+## powerio.MulticonductorNetwork
+
+The conductor level distribution model, in SI units with radian angles: watts,
+vars, volts, amperes, ohms, siemens, meters. Bus identifiers are the source's
+own strings. Terminal names are the source's own (OpenDSS node numbers as
+strings), and a `terminal_map` lists, in conductor order, the terminals of
+the named bus an element connects to.
+
+Schema definition: `MulticonductorNetwork`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string or null | | | | null |
+| `base_frequency` | float | Hz | | positive | required |
+| `source_format` | token `dss`, `bmopf-json`, `pmd-json`, or null | | | | null |
+| `buses` | array of `DistBus` | | | `id` unique | required |
+| `linecodes` | array of `DistLineCode` | | | `name` unique | required |
+| `lines` | array of `DistLine` | | | `bus_from`, `bus_to` name buses; `linecode` names a line code | required |
+| `switches` | array of `DistSwitch` | | | `bus_from`, `bus_to` name buses | required |
+| `transformers` | array of `DistTransformer` | | | every winding `bus` names a bus | required |
+| `loads` | array of `DistLoad` | | | `bus` names a bus | required |
+| `shunts` | array of `DistShunt` | | | `bus` names a bus | required |
+| `capacitors` | array of `DistCapacitor` | | | `bus` names a bus | `[]` |
+| `generators` | array of `DistGenerator` | | | `bus` names a bus | required |
+| `ibrs` | array of `DistIbr` | | | `bus` names a bus; `control_profile` names a profile | `[]` |
+| `control_profiles` | array of `DistControlProfile` | | | `name` unique | `[]` |
+| `sources` | array of `VoltageSource` | | | BMOPF carries exactly one | required |
+| `untyped` | array of `UntypedObject` | | | | required |
+| `commands` | array of `[verb, args]` string pairs | | | source order | required |
+| `options` | array of `[name, value]` string pairs | | | source order | required |
+| `extras` | object | | | | required |
+| `geo` | `DistGeoMeta` or null | | | | null |
+
+### DistBus
+
+Schema definition: `DistBus`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | unique within `buses` | required |
+| `terminals` | array of string | | | ordered, unique | required |
+| `grounded` | array of string | | | each names a terminal of this bus; zero impedance to ground | required |
+| `v_min` | float or null | volts | | `v_min <= v_max` | null (unbounded) |
+| `v_max` | float or null | volts | | | null (unbounded) |
+| `vpn_min` | array of float or null | volts | | per phase to neutral bound | null |
+| `vpn_max` | array of float or null | volts | | | null |
+| `vpp_min` | array of float or null | volts | | per phase to phase bound | null |
+| `vpp_max` | array of float or null | volts | | | null |
+| `vpos_min` | float or null | volts | | positive sequence bound | null |
+| `vpos_max` | float or null | volts | | | null |
+| `vneg_max` | float or null | volts | | negative sequence magnitude cap | null |
+| `vzero_max` | float or null | volts | | zero sequence magnitude cap | null |
+| `vn_max` | float or null | volts | | neutral to ground magnitude cap | null |
+| `location` | `DistLocation` or null | network coordinate space | | | null |
+| `extras` | object | | | | required |
+
+### DistLineCode
+
+Schema definition: `DistLineCode`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `linecodes` | required |
+| `n_conductors` | integer | | | positive; the order of every matrix | required |
+| `r_series` | matrix | ohm per meter | | `n_conductors` square, symmetric | required |
+| `x_series` | matrix | ohm per meter | | `n_conductors` square, symmetric | required |
+| `g_from` | matrix | siemens per meter | | half of the shunt admittance, at the from end | required |
+| `b_from` | matrix | siemens per meter | positive is capacitive | | required |
+| `g_to` | matrix | siemens per meter | | half of the shunt admittance, at the to end | required |
+| `b_to` | matrix | siemens per meter | positive is capacitive | | required |
+| `i_max` | array of float or null | amperes per conductor | | | null |
+| `s_max` | array of float or null | VA per conductor | | | null |
+| `source` | string or null | | | origin of the matrices (BMOPF `source`) | null |
+| `extras` | object | | | | required |
+
+### DistLine
+
+Schema definition: `DistLine`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `lines` | required |
+| `bus_from` | string | | | names a bus | required |
+| `bus_to` | string | | | names a bus | required |
+| `terminal_map_from` | array of string | | | `n_conductors` terminals of `bus_from` | required |
+| `terminal_map_to` | array of string | | | `n_conductors` terminals of `bus_to` | required |
+| `linecode` | string | | | names a line code | required |
+| `length` | float | meters | | nonnegative | required |
+| `i_max` | array of float or null | amperes per conductor | | | null (the line code's) |
+| `s_max` | array of float or null | VA per conductor | | | null (the line code's) |
+| `route` | array of `DistLocation` or null | network coordinate space | | | null |
+| `extras` | object | | | | required |
+
+### DistSwitch
+
+Schema definition: `DistSwitch`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `switches` | required |
+| `bus_from` | string | | | names a bus | required |
+| `bus_to` | string | | | names a bus | required |
+| `terminal_map_from` | array of string | | | terminals of `bus_from`, same length as `terminal_map_to` | required |
+| `terminal_map_to` | array of string | | | terminals of `bus_to` | required |
+| `open` | boolean | | | | required |
+| `i_max` | array of float or null | amperes per conductor | | | null |
+| `extras` | object | | | | required |
+
+### DistTransformer
+
+Schema definition: `DistTransformer`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `transformers` | required |
+| `phases` | integer | | | 1 through 3 | required |
+| `windings` | array of `DistWinding` | | | two or three | required |
+| `xsc_pct` | array of float | percent | | `[xhl]` for two windings, `[xhl, xht, xlt]` for three | required |
+| `extras` | object | | | | required |
+
+Schema definition: `DistWinding`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `conn` | token `wye`, `delta` | | | | required |
+| `v_ref` | float | volts, line to line for two and three phases | | positive | required |
+| `s_rating` | float | VA | | positive | required |
+| `r_pct` | float | percent of the winding base | | | required |
+| `tap` | float | ratio | | 1 is nominal | required |
+| `r_neutral` | float or null | ohm | | | null |
+| `x_neutral` | float or null | ohm | | | null |
+
+### DistLoad
+
+Schema definition: `DistLoad`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `loads` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `configuration` | token `wye`, `delta`, `single_phase` | | | | required |
+| `p_nom` | array of float | watts per phase | positive is consumption | one entry per active phase | required |
+| `q_nom` | array of float | vars per phase | positive is inductive consumption | same length as `p_nom` | required |
+| `voltage_model` | `DistLoadVoltageModel` | | | | required |
+| `extras` | object | | | | required |
+
+`DistLoadVoltageModel` is tagged by `model`: `constant_power`,
+`constant_current`, and `constant_impedance` each state `v_nom` (volts per
+active phase); `zip` states `v_nom` and the per phase coefficient arrays
+`alpha_z`, `alpha_i`, `alpha_p` (active power) and `beta_z`, `beta_i`,
+`beta_p` (reactive power), each triple summing to one; `exponential` states
+`v_nom`, `gamma_p`, and `gamma_q`.
+
+### DistCapacitor
+
+Schema definition: `DistCapacitor`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `capacitors` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `configuration` | token `wye`, `delta`, `single_phase` | | | | required |
+| `q_rated` | float | vars, whole bank at `v_nom` | positive is capacitive injection | | required |
+| `v_nom` | float | volts, line to line for the three phase configurations | | positive | required |
+| `extras` | object | | | | required |
+
+### DistShunt
+
+Schema definition: `DistShunt`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `shunts` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus`, the order of the matrices | required |
+| `g` | matrix | siemens | | square in `terminal_map` | required |
+| `b` | matrix | siemens | positive is capacitive | square in `terminal_map` | required |
+| `extras` | object | | | | required |
+
+### DistGenerator
+
+Schema definition: `DistGenerator`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `generators` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `configuration` | token `wye`, `delta`, `single_phase` | | | | required |
+| `p_nom` | array of float | watts per phase | positive is generation | | required |
+| `q_nom` | array of float | vars per phase | positive is generation | same length as `p_nom` | required |
+| `p_min` | array of float or null | watts per phase | | `p_min <= p_max` | null |
+| `p_max` | array of float or null | watts per phase | | | null |
+| `q_min` | array of float or null | vars per phase | | `q_min <= q_max` | null |
+| `q_max` | array of float or null | vars per phase | | | null |
+| `s_max` | array of float or null | VA per conductor | | | null |
+| `i_max` | array of float or null | amperes per conductor | | | null |
+| `cost` | array of float or null | currency per kWh per phase, or one scalar | | | null |
+| `extras` | object | | | | required |
+
+### DistIbr
+
+Schema definition: `DistIbr`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `ibrs` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `prime_mover` | token `PV`, `BATTERY`, `GENERIC`, `STATCOM`, `DSTATCOM` | | | | required |
+| `topology` | token `SINGLE_PHASE`, `THREE_LEG`, `FOUR_LEG` | | | | required |
+| `s_max` | array of float | VA per phase | | nameplate | required |
+| `p_avail` | float or null | watts | | | null |
+| `p_min` | array of float or null | watts per phase | | | null |
+| `p_max` | array of float or null | watts per phase | | | null |
+| `q_min` | array of float or null | vars per phase | | | null |
+| `q_max` | array of float or null | vars per phase | | | null |
+| `i_max` | array of float or null | amperes per conductor | | | null |
+| `voltage_aggregation` | token `PER_PHASE`, `AVERAGE`, or null | | | | null |
+| `control_profile` | string or null | | | names a control profile | null |
+| `extras` | object | | | | required |
+
+### DistControlProfile
+
+Schema definition: `DistControlProfile`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `control_profiles` | required |
+| `volt_var` | `VoltVarControl` or null | | | | null |
+| `volt_watt` | `VoltWattControl` or null | | | | null |
+| `power_factor` | `PowerFactorControl` or null | | | | null |
+| `extras` | object | | | | required |
+
+Schema definition: `VoltVarControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `breakpoints` | array of float | p.u. voltage | | ascending | required |
+| `q_limits` | array of float | `q_unit` | positive is injection | same length as `breakpoints` | required |
+| `voltage_reference` | token `PN_PER_PHASE`, `PP_PER_PHASE`, `PP_AVERAGED`, `PG_AVERAGED`, `PN_AVERAGED`, `PG_PER_PHASE`, or null | | | | null |
+| `q_ref` | token `VAR_MAX`, `VAR_AVAILABLE`, or null | | | | null |
+| `q_unit` | token `VA_FRACTION`, `VAR`, or null | | | | null |
+| `p_min_for_q` | float or null | watts | | | null |
+| `p_min_for_q_max` | float or null | watts | | | null |
+
+Schema definition: `VoltWattControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `breakpoints` | array of float | p.u. voltage | | ascending | required |
+| `p_limits` | array of float | `p_unit` | | same length as `breakpoints` | required |
+| `voltage_reference` | token as `VoltVarControl.voltage_reference`, or null | | | | null |
+| `p_ref` | token `P_AVAILABLE`, `P_MAX`, `S_MAX`, or null | | | | null |
+| `p_unit` | token `VA_FRACTION`, `W`, or null | | | | null |
+
+Schema definition: `PowerFactorControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `pf` | float | | | in `[-1, 1]` | required |
+
+### VoltageSource
+
+Schema definition: `VoltageSource`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | unique within `sources` | required |
+| `bus` | string | | | names a bus | required |
+| `terminal_map` | array of string | | | terminals of `bus` | required |
+| `v_magnitude` | array of float | volts per terminal | | 0 on a grounded terminal; same length as `terminal_map` | required |
+| `v_angle` | array of float | radians per terminal | | same length as `terminal_map` | required |
+| `extras` | object | | | | required |
+
+### UntypedObject
+
+An object the reader recognized but does not type, kept so a conversion can
+report it precisely.
+
+Schema definition: `UntypedObject`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `class` | string | | | | required |
+| `name` | string | | | | required |
+| `props` | array of `[key, value]` string pairs | | | source order | required |
+
+### Distribution coordinates
+
+Schema definition: `DistGeoMeta`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `kind` | token `source`, `synthetic`, `manual`, `derived`, or null | | | | null |
+
+Schema definition: `DistLocation`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `x` | float | network coordinate space; longitude in geographic space | | | required |
+| `y` | float | network coordinate space; latitude in geographic space | | | required |
+| `kind` | token as `DistGeoMeta.kind`, or null | | | | null (the network default) |
+
+## powerio.OperatingPoint\<N\>
+
+A possibly partial alternate electrical assignment over the fixed component
+identities of one base network `N`: demand, setpoints, dispatch, voltages,
+injections, service status, switch positions, transformer taps, and phase
+shifts. A quantity the point does not state resolves to the network's own
+value.
+
+Schema definitions: `StoredOperatingPoint`, `StoredOperatingPoint2`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` or `MulticonductorNetwork`, as the type name says | | | the complete base network | required |
+| `quantities` | map of quantity name to `StoredQuantity` | per quantity, below | | keys among the quantity names of the network family | required |
+
+Schema definition: `StoredQuantity`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `identities` | array of string | | | each names a component of the network; unique; same length as `values` | required |
+| `values` | array of float | the quantity's unit; a flag is 0 or 1 | | | required |
+
+An operating point stored inside a collection or an instance omits the
+network, which the enclosing record states once.
+
+Schema definition: `StoredOperatingPointAssignment`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `quantities` | map of quantity name to `StoredQuantity` | | | as `StoredOperatingPoint.quantities` | required |
+
+Balanced quantities. A bus quantity is keyed by the bus id's decimal
+spelling; an element quantity by the element's `uid`.
+
+| quantity | keyed by | unit | sign |
+|---|---|---|---|
+| `bus_voltage_magnitude` | bus id | p.u. | |
+| `bus_voltage_angle` | bus id | degrees | |
+| `bus_active_injection` | bus id | MW | positive into the network |
+| `bus_reactive_injection` | bus id | MVAr | positive into the network |
+| `generator_active_power` | generator `uid` | MW | positive is generation |
+| `generator_reactive_power` | generator `uid` | MVAr | positive is generation |
+| `generator_voltage_setpoint` | generator `uid` | p.u. | |
+| `generator_in_service` | generator `uid` | flag | |
+| `load_active_power` | load `uid` | MW | positive is consumption |
+| `load_reactive_power` | load `uid` | MVAr | positive is consumption |
+| `branch_in_service` | branch `uid` | flag | |
+| `branch_tap_ratio` | branch `uid` | ratio | |
+| `branch_phase_shift` | branch `uid` | degrees | as `Branch.shift` |
+| `switch_closed` | switch `uid` | flag | |
+
+Multiconductor quantities. A terminal quantity is keyed `bus_id/terminal`, a
+per phase element quantity `element_name/terminal`, and a whole element
+quantity by the element name.
+
+| quantity | keyed by | unit | sign |
+|---|---|---|---|
+| `terminal_voltage_magnitude` | `bus/terminal` | volts | |
+| `terminal_voltage_angle` | `bus/terminal` | radians | |
+| `load_active_power` | `load/terminal` | watts | positive is consumption |
+| `load_reactive_power` | `load/terminal` | vars | positive is consumption |
+| `generator_active_power` | `generator/terminal` | watts | positive is generation |
+| `generator_reactive_power` | `generator/terminal` | vars | positive is generation |
+| `transformer_tap` | transformer name | ratio | |
+| `capacitor_steps` | capacitor name | count | |
+| `switch_closed` | switch name | flag | |
+
+## powerio.TimeSeries\<T\>
+
+Ordered time points and one value of `T` per point. Labels are the source's
+own; PowerIO imposes no calendar meaning.
+
+Schema definitions: `StoredTimeSeries`, `StoredTimeSeries2`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `time_points` | array of `TimePoint` | | | | required |
+| `values` | array of the element type, each a complete network | | | same length as `time_points` | required |
+
+A series of operating points states the shared base network once.
+
+Schema definitions: `StoredOperatingPointTimeSeries`, `StoredOperatingPointTimeSeries2`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | the base network, or null | | | null only for an empty series | required when `values` is nonempty |
+| `time_points` | array of `TimePoint` | | | | required |
+| `values` | array of `StoredOperatingPointAssignment` | | | same length as `time_points`; identities name components of `network` | required |
+
+Schema definition: `TimePoint`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `label` | string | | | nonempty, bounded | required |
+| `duration` | `Duration` or null | | | the interval the point covers | null |
+
+Schema definition: `Duration`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `secs` | integer | seconds | | | required |
+| `nanos` | integer | nanoseconds | | below one billion | required |
+
+## powerio.ScenarioSet\<T\>
+
+Named alternatives of `T` with no implied order. Either every scenario states
+a probability or none does; stated probabilities are nonnegative and sum to
+one within `SCENARIO_PROBABILITY_TOLERANCE`.
+
+Schema definitions: `StoredScenarioSet`, `StoredScenarioSet2`, `StoredScenarioSet3`, `StoredScenarioSet4`, `StoredScenarioSet5`, `StoredScenarioSet6`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `scenarios` | array of the scenario record | | | `id` unique | required |
+
+Schema definitions: `StoredScenario`, `StoredScenario2`, `StoredScenario3`, `StoredScenario4`, `StoredScenario5`, `StoredScenario6`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | nonempty, bounded, unique in the set | required |
+| `probability` | float or null | | | in `[0, 1]` | null |
+| `value` | the element type: a network, a network time series, or an operating point time series | | | | required |
+
+A scenario set of operating points states the shared base network once.
+
+Schema definitions: `StoredOperatingPointScenarioSet`, `StoredOperatingPointScenarioSet2`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | the base network, or null | | | null only for an empty set | required when `scenarios` is nonempty |
+| `scenarios` | array of `StoredOperatingPointScenario` | | | `id` unique | required |
+
+Schema definition: `StoredOperatingPointScenario`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | nonempty, bounded, unique in the set | required |
+| `probability` | float or null | | | in `[0, 1]` | null |
+| `quantities` | map of quantity name to `StoredQuantity` | | | identities name components of `network` | required |
+
+## Instances
+
+An instance is the complete input of one named calculation over a network it
+contains. Every instance may carry an `initial_point`, the starting operating
+assignment a solver may use, whose identities name components of the
+instance's network.
+
+### powerio.DcPfInstance
+
+Schema definition: `DcPfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` | | | at least one `REF` bus | required |
+| `approximation` | token `series_susceptance`, `tap_adjusted_reactance`, `reactance_only` | | | the DC branch susceptance formula | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+The bus specifications are derived from the network: a `REF` bus contributes
+its stated angle, an `ISOLATED` bus no equation, and every other bus its net
+active injection over in service generators and loads.
+
+### powerio.AcPfInstance
+
+Schema definition: `AcPfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` | | | at least one `REF` bus | required |
+| `specifications` | array of `AcBusSpecification` | | | one per bus, in bus table order | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+`AcBusSpecification` is tagged by `kind`: `pq` states `p` (MW) and `q`
+(MVAr), the prescribed net injection; `pv` states `p` and `vm` (p.u.);
+`reference` states `vm` and `va` (degrees); `isolated` states nothing.
+Powers are net injections into the network, positive for generation.
+
+### powerio.DcOpfInstance
+
+Schema definition: `DcOpfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` | | | at least one `REF` bus and one in service generator on a non isolated bus | required |
+| `objective` | `Objective` | | | | required |
+| `constraints` | `ActiveConstraints` | | | | required |
+| `approximation` | token as `DcPfInstance.approximation` | | | | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+### powerio.AcOpfInstance
+
+Schema definition: `AcOpfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` | | | at least one `REF` bus and one in service generator on a non isolated bus | required |
+| `objective` | `Objective` | | | | required |
+| `constraints` | `ActiveConstraints` | | | | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+Schema definition: `Objective`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `terms` | array of `ObjectiveTerm` | | | empty is a feasibility problem | `[]` |
+
+`ObjectiveTerm` is tagged by `term`: `network_generator_cost` sums the
+network's generator cost curves; `active_power_dispatch_cost` prices active
+dispatch.
+
+Schema definition: `ActiveConstraints`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `generator_capability` | `ConstraintSelection` | | | active and reactive generator limits | required |
+| `voltage_bounds` | `ConstraintSelection` | | | bus voltage magnitude bounds | required |
+| `thermal_limits` | `ConstraintSelection` | | | branch thermal limits | required |
+| `angle_bounds` | `ConstraintSelection` | | | branch angle difference bounds | required |
+
+`ConstraintSelection` is tagged by `select`: `all` (every element with a
+stated limit), `none` (the family is relaxed), or `only` with `identities`,
+the exact element identities (`uid` values, or bus ids) the family applies
+to.
+
+### powerio.McAcPfInstance
+
+Schema definition: `McAcPfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `MulticonductorNetwork` | | | at least one voltage source | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+The prescribed terminal powers, source voltages, and active regulator and
+capacitor controls are derived from the network.
+
+### powerio.McAcOpfInstance
+
+Schema definition: `McAcOpfInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `MulticonductorNetwork` | | | at least one voltage source | required |
+| `objective` | `Objective` | | | | required |
+| `constraints` | `MulticonductorActiveConstraints` | | | | required |
+| `initial_point` | `StoredOperatingPointAssignment` or null | | | | null |
+
+Schema definition: `MulticonductorActiveConstraints`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `terminal_voltage_bounds` | `ConstraintSelection` | | | | required |
+| `conductor_limits` | `ConstraintSelection` | | | current or apparent power limits | required |
+| `generator_capability` | `ConstraintSelection` | | | per phase bounds | required |
+
+### powerio.AcScucInstance
+
+The DOE GO Challenge 3 formulation: one balanced network plus scheduling,
+reserve, and contingency inputs. Powers in the inputs are per unit on the
+network's `base_mva`, times are hours from the start of the horizon, and
+costs are dollars or dollars per per unit hour, as the data format states
+them.
+
+Schema definition: `AcScucInstance`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `network` | `BalancedNetwork` | | | | required |
+| `inputs` | `ScucInputs` | | | identities name components of `network`; time varying records match the horizon | required |
+
+Schema definition: `ScucInputs`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `interval_durations` | array of float | hours | | positive; chronological | required |
+| `devices` | array of `ScucDevice` | | | `id` unique | required |
+| `active_reserve_zones` | array of `ScucActiveReserveZone` | | | | required |
+| `reactive_reserve_zones` | array of `ScucReactiveReserveZone` | | | | required |
+| `contingencies` | array of `ScucContingency` | | | | required |
+| `shunts` | array of `ScucShunt` | | | | required |
+| `transformer_controls` | array of `ScucTransformerControl` | | | | required |
+| `branch_switching_costs` | array of `ScucBranchSwitchingCost` | | | | required |
+| `violation_costs` | `ScucViolationCosts` | | | | required |
+
+Schema definition: `ScucDevice`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | the generator or load in the network | required |
+| `kind` | token `producer`, `consumer` | | | | required |
+| `on_cost` | float | dollars | | | required |
+| `startup_cost` | float | dollars | | | required |
+| `shutdown_cost` | float | dollars | | | required |
+| `initial_on_status` | boolean | | | | required |
+| `initial_commitment` | `ScucInitialCommitment` | | | | required |
+| `minimum_up_time` | float | hours | | | required |
+| `minimum_down_time` | float | hours | | | required |
+| `ramp_limits` | `ScucRampLimits` | | | | required |
+| `reserve_limits` | `ScucReserveLimits` | | | | required |
+| `reactive_capability` | `ScucReactiveCapability` | | | | required |
+| `energy_lower_bounds` | array of `ScucEnergyRequirement` | | | | required |
+| `energy_upper_bounds` | array of `ScucEnergyRequirement` | | | | required |
+| `startup_cost_adjustments` | array of `ScucStartupCostAdjustment` | | | | required |
+| `startup_limits` | array of `ScucStartupLimit` | | | | required |
+| `periods` | array of `ScucDevicePeriod` | | | one per interval, chronological | required |
+
+`ScucReactiveCapability` is tagged by `kind`: `none`; `linear` with
+`reactive_power_at_zero_active_power` and a slope; `bounded` with the
+`_max` and `_min` forms of both.
+
+Schema definition: `ScucDevicePeriod`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `on_status_min` | boolean | | | | required |
+| `on_status_max` | boolean | | | | required |
+| `active_power_min` | float | p.u. | | `active_power_min <= active_power_max` | required |
+| `active_power_max` | float | p.u. | | | required |
+| `reactive_power_min` | float | p.u. | | `reactive_power_min <= reactive_power_max` | required |
+| `reactive_power_max` | float | p.u. | | | required |
+| `energy_cost_blocks` | array of `ScucEnergyCostBlock` | | | | required |
+| `reserve_costs` | `ScucReserveCosts` | | | | required |
+
+Schema definition: `ScucEnergyCostBlock`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `block_size` | float | p.u. | | nonnegative | required |
+| `marginal_cost` | float | dollars per p.u. hour | | | required |
+
+Schema definition: `ScucReserveCosts`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `regulation_up` | float | dollars per p.u. hour | | | required |
+| `regulation_down` | float | dollars per p.u. hour | | | required |
+| `synchronized` | float | dollars per p.u. hour | | | required |
+| `nonsynchronized` | float | dollars per p.u. hour | | | required |
+| `ramping_up_online` | float | dollars per p.u. hour | | | required |
+| `ramping_up_offline` | float | dollars per p.u. hour | | | required |
+| `ramping_down_online` | float | dollars per p.u. hour | | | required |
+| `ramping_down_offline` | float | dollars per p.u. hour | | | required |
+| `reactive_up` | float | dollars per p.u. hour | | | required |
+| `reactive_down` | float | dollars per p.u. hour | | | required |
+
+Schema definition: `ScucReserveLimits`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `regulation_up` | float | p.u. | | nonnegative | required |
+| `regulation_down` | float | p.u. | | nonnegative | required |
+| `synchronized` | float | p.u. | | nonnegative | required |
+| `nonsynchronized` | float | p.u. | | nonnegative | required |
+| `ramping_up_online` | float | p.u. | | nonnegative | required |
+| `ramping_up_offline` | float | p.u. | | nonnegative | required |
+| `ramping_down_online` | float | p.u. | | nonnegative | required |
+| `ramping_down_offline` | float | p.u. | | nonnegative | required |
+
+Schema definition: `ScucRampLimits`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `up` | float | p.u. per hour | | nonnegative | required |
+| `down` | float | p.u. per hour | | nonnegative | required |
+| `startup` | float | p.u. per hour | | nonnegative | required |
+| `shutdown` | float | p.u. per hour | | nonnegative | required |
+
+Schema definition: `ScucInitialCommitment`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `accumulated_up_time` | float | hours | | nonnegative | required |
+| `accumulated_down_time` | float | hours | | nonnegative | required |
+
+Schema definition: `ScucEnergyRequirement`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `start_time` | float | hours | | `start_time <= end_time` | required |
+| `end_time` | float | hours | | | required |
+| `energy` | float | p.u. hour | | | required |
+
+Schema definition: `ScucStartupCostAdjustment`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `maximum_down_time` | float | hours | | | required |
+| `cost` | float | dollars | | | required |
+
+Schema definition: `ScucStartupLimit`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `start_time` | float | hours | | `start_time <= end_time` | required |
+| `end_time` | float | hours | | | required |
+| `maximum_startups` | integer | | | | required |
+
+Schema definition: `ScucActiveReserveZone`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | unique | required |
+| `buses` | array of `ComponentId` | | | each names a bus of the network | required |
+| `regulation_up_requirement_fraction` | float | fraction of zone load | | | required |
+| `regulation_down_requirement_fraction` | float | fraction of zone load | | | required |
+| `synchronized_requirement_fraction` | float | fraction of zone load | | | required |
+| `nonsynchronized_requirement_fraction` | float | fraction of zone load | | | required |
+| `ramping_up_requirement` | array of float | p.u. | | one per interval | required |
+| `ramping_down_requirement` | array of float | p.u. | | one per interval | required |
+| `regulation_up_violation_cost` | float | dollars per p.u. hour | | | required |
+| `regulation_down_violation_cost` | float | dollars per p.u. hour | | | required |
+| `synchronized_violation_cost` | float | dollars per p.u. hour | | | required |
+| `nonsynchronized_violation_cost` | float | dollars per p.u. hour | | | required |
+| `ramping_up_violation_cost` | float | dollars per p.u. hour | | | required |
+| `ramping_down_violation_cost` | float | dollars per p.u. hour | | | required |
+
+Schema definition: `ScucReactiveReserveZone`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | unique | required |
+| `buses` | array of `ComponentId` | | | each names a bus of the network | required |
+| `reactive_up_requirement` | array of float | p.u. | | one per interval | required |
+| `reactive_down_requirement` | array of float | p.u. | | one per interval | required |
+| `reactive_up_violation_cost` | float | dollars per p.u. hour | | | required |
+| `reactive_down_violation_cost` | float | dollars per p.u. hour | | | required |
+
+Schema definition: `ScucContingency`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | unique | required |
+| `components` | array of `ComponentId` | | | Challenge 3 requires exactly one AC line, transformer, or DC line | required |
+
+Schema definition: `ScucShunt`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | the shunt in the network | required |
+| `initial_step` | integer | | | `step_min <= initial_step <= step_max` | required |
+| `step_min` | integer | | | | required |
+| `step_max` | integer | | | | required |
+| `conductance_per_step` | float | p.u. | | | required |
+| `susceptance_per_step` | float | p.u. | positive is capacitive | | required |
+
+Schema definition: `ScucTransformerControl`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | the two winding transformer in the network | required |
+| `tap_ratio_min` | float | p.u. | | `tap_ratio_min <= tap_ratio_max` | required |
+| `tap_ratio_max` | float | p.u. | | | required |
+| `phase_shift_min` | float | radians | | `phase_shift_min <= phase_shift_max` | required |
+| `phase_shift_max` | float | radians | | | required |
+
+Schema definition: `ScucBranchSwitchingCost`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | `ComponentId` | | | the branch or transformer in the network | required |
+| `connection_cost` | float | dollars | | | required |
+| `disconnection_cost` | float | dollars | | | required |
+
+Schema definition: `ScucViolationCosts`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `active_power_balance` | float | dollars per p.u. hour | | | required |
+| `reactive_power_balance` | float | dollars per p.u. hour | | | required |
+| `branch_thermal_limit` | float | dollars per p.u. hour | | | required |
+| `energy_requirement` | float | dollars per p.u. hour | | | required |
+
+## Solutions
+
+A solution contains the instance it solves and records its values in the
+instance network's table order: one entry per bus, per branch, or per
+generator. Injections are net injections into the network at a bus,
+positive for generation; branch flows are measured into the branch at the
+named terminal. Every solution states how the calculation ended and the
+residuals a producer reported. `producer` is the free text solver identity
+the producer states, or null.
+
+`Termination` is tagged by `kind`: `converged`, `iteration_limit`,
+`infeasible`, `unbounded`, `failed`, or `not_reported` (a source that records
+a solved calculation without termination information, as DeepMind OPFData
+does).
+
+Schema definition: `Residuals`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `max_active_power_mismatch` | float or null | MW | | largest absolute active balance mismatch | null (not reported) |
+| `max_reactive_power_mismatch` | float or null | MVAr | | largest absolute reactive balance mismatch | null (not reported) |
+
+Schema definition: `GeneratorDispatch`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `p_mw` | array of float | MW | positive is generation | one per generator | required |
+| `q_mvar` | array of float | MVAr | positive is generation | one per generator, or empty | required |
+
+Schema definition: `ThreeWindingTransformerTerminalActivePower`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `p_mw` | array of float | MW | positive flows into the transformer at the winding | three entries, winding order | required |
+
+Schema definition: `ThreeWindingTransformerTerminalPower`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `p_mw` | array of float | MW | positive flows into the transformer at the winding | three entries, winding order | required |
+| `q_mvar` | array of float | MVAr | positive flows into the transformer at the winding | three entries, winding order | required |
+
+### powerio.DcPfSolution
+
+Schema definition: `DcPfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `DcPfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `bus_voltage_angle` | array of float | degrees | | one per bus | required |
+| `bus_active_injection` | array of float | MW | positive into the network | one per bus | required |
+| `branch_from_active_flow` | array of float | MW | positive into the branch at the from terminal | one per branch | required |
+| `branch_to_active_flow` | array of float | MW | positive into the branch at the to terminal | one per branch | required |
+| `three_winding_transformer_terminal_active_powers` | array of `ThreeWindingTransformerTerminalActivePower` | | | one per three winding transformer | required |
+| `generator_dispatch` | `GeneratorDispatch` or null | | | | null |
+
+### powerio.AcPfSolution
+
+Schema definition: `AcPfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `AcPfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `bus_voltage_magnitude` | array of float | p.u. | | one per bus | required |
+| `bus_voltage_angle` | array of float | degrees | | one per bus | required |
+| `bus_active_injection` | array of float | MW | positive into the network | one per bus | required |
+| `bus_reactive_injection` | array of float | MVAr | positive into the network | one per bus | required |
+| `branch_from_active_flow` | array of float | MW | positive into the branch at the from terminal | one per branch | required |
+| `branch_from_reactive_flow` | array of float | MVAr | positive into the branch at the from terminal | one per branch | required |
+| `branch_to_active_flow` | array of float | MW | positive into the branch at the to terminal | one per branch | required |
+| `branch_to_reactive_flow` | array of float | MVAr | positive into the branch at the to terminal | one per branch | required |
+| `three_winding_transformer_terminal_powers` | array of `ThreeWindingTransformerTerminalPower` | | | one per three winding transformer | required |
+| `generator_dispatch` | `GeneratorDispatch` or null | | | | null |
+
+### powerio.DcOpfSolution
+
+Multipliers and marginals are the optimizing producer's optional economic
+outputs, in the objective's units per MW; no currency is assumed.
+
+Schema definition: `DcOpfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `DcOpfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `bus_voltage_angle` | array of float | degrees | | one per bus | required |
+| `bus_active_injection` | array of float | MW | positive into the network | one per bus | required |
+| `branch_from_active_flow` | array of float | MW | positive into the branch at the from terminal | one per branch | required |
+| `branch_to_active_flow` | array of float | MW | positive into the branch at the to terminal | one per branch | required |
+| `generator_active_power` | array of float | MW | positive is generation | one per generator | required |
+| `three_winding_transformer_terminal_active_powers` | array of `ThreeWindingTransformerTerminalActivePower` | | | one per three winding transformer | required |
+| `objective` | float | objective units | | | required |
+| `bus_active_power_marginal` | array of float or null | objective units per MW | | one per bus | null |
+| `branch_from_limit_multiplier` | array of float or null | objective units per MW | | one per branch; finite and nonnegative | null |
+| `branch_to_limit_multiplier` | array of float or null | objective units per MW | | one per branch; finite and nonnegative | null |
+
+### powerio.AcOpfSolution
+
+Schema definition: `AcOpfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `AcOpfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `bus_voltage_magnitude` | array of float | p.u. | | one per bus | required |
+| `bus_voltage_angle` | array of float | degrees | | one per bus | required |
+| `bus_active_injection` | array of float | MW | positive into the network | one per bus | required |
+| `bus_reactive_injection` | array of float | MVAr | positive into the network | one per bus | required |
+| `branch_from_active_flow` | array of float | MW | positive into the branch at the from terminal | one per branch | required |
+| `branch_from_reactive_flow` | array of float | MVAr | positive into the branch at the from terminal | one per branch | required |
+| `branch_to_active_flow` | array of float | MW | positive into the branch at the to terminal | one per branch | required |
+| `branch_to_reactive_flow` | array of float | MVAr | positive into the branch at the to terminal | one per branch | required |
+| `generator_active_power` | array of float | MW | positive is generation | one per generator | required |
+| `generator_reactive_power` | array of float | MVAr | positive is generation | one per generator | required |
+| `three_winding_transformer_terminal_powers` | array of `ThreeWindingTransformerTerminalPower` | | | one per three winding transformer | required |
+| `objective` | float | objective units | | | required |
+| `bus_active_power_marginal` | array of float or null | objective units per MW | | one per bus | null |
+| `bus_reactive_power_marginal` | array of float or null | objective units per MVAr | | one per bus | null |
+| `branch_from_limit_multiplier` | array of float or null | objective units per MVA | | one per branch; finite and nonnegative | null |
+| `branch_to_limit_multiplier` | array of float or null | objective units per MVA | | one per branch; finite and nonnegative | null |
+
+### powerio.SocwrOpfSolution
+
+The PowerModels SOCWR relaxation of an `AcOpfInstance`. Its objective is a
+lower bound, and its voltage products make no claim of an AC feasible
+phasor.
+
+Schema definition: `SocwrOpfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `AcOpfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `values` | `SocwrOpfValues` | | | | required |
+| `duals` | `SocwrOpfDuals` | | | | every member null |
+| `objective_lower_bound` | float | objective units | | | required |
+
+Schema definition: `SocwrOpfValues`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus_voltage_magnitude_squared` | array of float | p.u. squared | | `w[i] = \|V_i\|^2`; one per bus | required |
+| `branch_voltage_product_real` | array of float | p.u. squared | | `Re(V_from conj(V_to))`; one per branch | required |
+| `branch_voltage_product_imaginary` | array of float | p.u. squared | | `Im(V_from conj(V_to))`; one per branch | required |
+| `generator_active_power` | array of float | MW | positive is generation | one per generator | required |
+| `generator_reactive_power` | array of float | MVAr | positive is generation | one per generator | required |
+| `branch_from_active_power` | array of float | MW | positive into the branch at the from terminal | one per branch | required |
+| `branch_from_reactive_power` | array of float | MVAr | positive into the branch at the from terminal | one per branch | required |
+| `branch_to_active_power` | array of float | MW | positive into the branch at the to terminal | one per branch | required |
+| `branch_to_reactive_power` | array of float | MVAr | positive into the branch at the to terminal | one per branch | required |
+| `three_winding_transformer_terminal_powers` | array of `ThreeWindingTransformerTerminalPower` | | | one per three winding transformer | required |
+
+Schema definition: `SocwrOpfDuals`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus_active_power_marginal` | array of float or null | objective units per MW | | one per bus | null |
+| `bus_reactive_power_marginal` | array of float or null | objective units per MVAr | | one per bus | null |
+| `branch_from_thermal_limit_multiplier` | array of float or null | objective units per MVA | | one per branch; finite and nonnegative | null |
+| `branch_to_thermal_limit_multiplier` | array of float or null | objective units per MVA | | one per branch; finite and nonnegative | null |
+
+### powerio.McAcPfSolution
+
+Terminal columns run in bus table order and, within a bus, in the bus's
+stated terminal order. Source columns run in source table order and, within
+a source, in its `terminal_map` order.
+
+Schema definition: `McAcPfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `McAcPfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `terminal_voltage_magnitude` | array of float | volts | | one per terminal | required |
+| `terminal_voltage_angle` | array of float | radians | | one per terminal | required |
+| `terminal_current_magnitude` | array of float or null | amperes | | one per terminal | null |
+| `terminal_active_power` | array of float or null | watts | positive into the network | one per terminal | null |
+| `source_active_injection` | array of float | watts | positive into the network | one per source terminal | required |
+
+### powerio.McAcOpfSolution
+
+Schema definition: `McAcOpfSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `McAcOpfInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `terminal_voltage_magnitude` | array of float | volts | | one per terminal | required |
+| `terminal_voltage_angle` | array of float | radians | | one per terminal | required |
+| `terminal_current_magnitude` | array of float or null | amperes | | one per terminal | null |
+| `terminal_active_power` | array of float or null | watts | positive into the network | one per terminal | null |
+| `source_active_injection` | array of float | watts | positive into the network | one per source terminal | required |
+| `generator_active_power` | array of float | watts | positive is generation | generator table order, each generator's `terminal_map` order | required |
+| `objective` | float | objective units | | | required |
+
+### powerio.AcScucSolution
+
+The GO Challenge 3 output fields. Every series is `values[t][row]` over the
+instance's time points and the corresponding table order; a series a
+producer did not supply is empty.
+
+Schema definition: `AcScucSolution`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `instance` | `AcScucInstance` | | | | required |
+| `termination` | `Termination` | | | | required |
+| `residuals` | `Residuals` | | | | required |
+| `producer` | string or null | | | | null |
+| `network_outputs` | `ScucNetworkOutputs` | | | | required |
+| `device_outputs` | `ScucDeviceOutputs` | | | | required |
+| `objective` | float or null | dollars | | | null |
+
+Schema definition: `ScucNetworkOutputs`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `bus_vm` | array of array of float | p.u. | | one row per time point, one per bus | required |
+| `bus_va` | array of array of float | radians | | one per bus | required |
+| `shunt_step` | array of array of integer | | | one per shunt | required |
+| `ac_line_on_status` | array of array of boolean | | | one per AC line | required |
+| `transformer_tm` | array of array of float | ratio | | one per two winding transformer | required |
+| `transformer_ta` | array of array of float | radians | | one per two winding transformer | required |
+| `transformer_on_status` | array of array of boolean | | | one per two winding transformer | required |
+| `dc_line_pdc_fr` | array of array of float | p.u. | positive from the from bus to the to bus | one per DC line | `[]` |
+| `dc_line_qdc_fr` | array of array of float | p.u. | positive is injected into the from bus | one per DC line | `[]` |
+| `dc_line_qdc_to` | array of array of float | p.u. | positive is injected into the to bus | one per DC line | `[]` |
+
+Schema definition: `ScucDeviceOutputs`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `on_status` | array of array of boolean | | | one row per time point, one per device | required |
+| `startup_status` | array of array of boolean | | | | required |
+| `shutdown_status` | array of array of boolean | | | | required |
+| `p_on` | array of array of float | p.u. | positive is production for a producer, consumption for a consumer | | required |
+| `q` | array of array of float | p.u. | as `p_on` | | required |
+| `p_reg_res_up` | array of array of float | p.u. | | nonnegative | required |
+| `p_reg_res_down` | array of array of float | p.u. | | nonnegative | required |
+| `p_syn_res` | array of array of float | p.u. | | nonnegative | required |
+| `p_nsyn_res` | array of array of float | p.u. | | nonnegative | required |
+| `p_ramp_res_up_online` | array of array of float | p.u. | | nonnegative | required |
+| `p_ramp_res_up_offline` | array of array of float | p.u. | | nonnegative | required |
+| `p_ramp_res_down_online` | array of array of float | p.u. | | nonnegative | required |
+| `p_ramp_res_down_offline` | array of array of float | p.u. | | nonnegative | required |
+| `q_res_up` | array of array of float | p.u. | | nonnegative | required |
+| `q_res_down` | array of array of float | p.u. | | nonnegative | required |
+
+## Module records
+
+The records beside `value` in a `.pio.json` document. Their meaning is
+described in [.pio.json schema](pio-json-schema.md); their fields are:
+
+Schema definition: `Producer`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `name` | string | | | nonempty, bounded | required |
+| `version` | string | | | nonempty, bounded | required |
+
+Schema definition: `SourceDescriptor`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | unique among `sources`; spans and source map entries name it | required |
+| `name` | string | | | a file name, never a local file path | required |
+| `byte_length` | integer | bytes | | every span into this source ends at or before it | required |
+| `format` | string or null | | | a format token | null |
+| `digest` | `Digest` or null | | | | null |
+
+Schema definition: `Digest`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `algorithm` | token `sha256` | | | | required |
+| `value` | string | | | 64 lowercase hexadecimal characters | required |
+
+Schema definition: `SourceSpan`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `source` | string | | | names a source `id` | required |
+| `byte_start` | integer | bytes into the retained source | | `byte_start <= byte_end <= byte_length` | required |
+| `byte_end` | integer | bytes into the retained source | | half open | required |
+
+Schema definition: `SourceMapEntry`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `target` | string | | | an RFC 6901 pointer into `value.data` | required |
+| `relation` | token `exact`, `defaulted`, `inferred`, `converted_units`, `aggregated`, `split`, `synthetic`, `transformed`, `retained_extra` | | | | required |
+| `spans` | array of `SourceSpan` | | | empty only for `defaulted`, `synthetic`, and `transformed` | `[]` |
+
+Schema definition: `Diagnostic`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | unique among `diagnostics`; assigned `d0`, `d1`, ... at serialization when a record has none | required |
+| `code` | string | | | `NAMESPACE.SCOPE.SPECIFIC` | required |
+| `severity` | token `error`, `warning`, `remark`, `note` | | | | required |
+| `message` | string | | | one line | required |
+| `target` | string or null | | | an RFC 6901 pointer into `value.data` | null |
+| `spans` | array of `SourceSpan` | | | the records the finding is about | `[]` |
+| `related` | array of string | | | each names a diagnostic `id` in the document | `[]` |
+| `details` | object | | | | `{}` |
+| `suggested_action` | string or null | | | | null |
+
+Schema definition: `HistoryEntry`.
+
+| field | type | unit | sign | invariant | if absent |
+|---|---|---|---|---|---|
+| `id` | string | | | unique among `history` | required |
+| `kind` | token `parse`, `transform`, `edit`, `repair`, `solve` | | | | required |
+| `name` | string | | | the operation | required |
+| `input_type` | string or null | | | a structural type name | null |
+| `output_type` | string or null | | | a structural type name | null |
+| `parameters` | object | | | | `{}` |
+| `assumptions` | array of string | | | | `[]` |
+| `losses` | array of string | | | | `[]` |

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -56,7 +56,10 @@ buffer is separate from the stored module.
 Diagnostic source references and source mappings must name declared source
 IDs. Byte ranges must fit the declared source length. History references must
 name records present in the same document. The deserializer validates those
-relationships before returning a module.
+relationships before returning a module. The MATPOWER and PSS/E readers
+attach the byte range of the record a finding is about to every diagnostic
+they raise at a known record, so a document serialized from their modules
+carries those spans; the other readers attach none yet.
 
 ## Typed values
 
@@ -77,7 +80,9 @@ powerio.SocwrOpfSolution
 data must agree. An incorrect schema name or version, an unknown PowerIO type,
 duplicate identities, invalid references, nonfinite values in untyped
 positions, or a collection whose entries disagree with its element type is
-rejected.
+rejected. [PowerIO IR reference](ir-reference.md) defines every structural
+type field by field: type, unit, sign convention, invariant, and the value a
+reader takes when a field is absent.
 
 Typed floating point fields spell nonfinite values as `"Infinity"`,
 `"-Infinity"`, and `"NaN"`. JSON `null` is not a floating point value.
@@ -92,6 +97,20 @@ document does not invent flattened names for each composition.
 An `OperatingPoint<N>` stores a shared base network and typed overrides keyed
 by stable component identity. The serializer preserves that relationship
 without expanding each entry into another complete static network.
+
+## Determinism
+
+`serialize` is a function of the module alone. Serializing one module twice
+produces identical text, and serializing the module that text deserializes to
+produces the same text again. Members are written in a fixed order: record
+fields in declaration order and map keys (`extras`, `quantities`,
+`extensions`, `details`) sorted. Diagnostic identities are minted `d0`, `d1`,
+... in record order for records that carry none, so the minted identities
+depend only on record order. Every float is written in the shortest decimal
+form that reads back to the same value, and nonfinite values use the three
+string spellings above. Equal modules therefore produce equal documents,
+which lets a document serve as a cache key, a golden file, or the input of a
+content digest.
 
 ## Resource limits
 

--- a/docs/src/scope-v1.md
+++ b/docs/src/scope-v1.md
@@ -9,7 +9,7 @@ documentation state the shipped API.
 
 - One `parse` operation for every supported source, returning a typed module across networks, series, scenario sets, instances, and solutions.
 - Byte exact same format writing, diagnosed cross format conversion, and the explicit multiconductor to balanced transformation.
-- Structured diagnostics with stable codes and native record access in every language; the wire form carries span fields end to end, though 1.0 parsers do not yet emit them.
+- Structured diagnostics with stable codes and native record access in every language. A diagnostic carries source spans end to end, and the MATPOWER and PSS/E readers attach the byte range of the record a finding is about; the other readers attach none yet (see Known limits).
 - Balanced matrices (Y bus, FDPF B' and B'', LACPF, incidence, DC operators, AC power flow Jacobians, PTDF and LODF), all carrying element mappings; direct multiconductor admittance assembles in Rust only this release (see Known limits).
 - One stored `.pio.json` document with `"schema": "powerio.module"` and
   `"version": 1`. Prerelease PowerIO document shapes are not accepted.
@@ -29,6 +29,7 @@ documentation state the shipped API.
 - Classifying an undeclared JSON source is one cheap typed pass, except that a document nesting its payload under a `network`, `grid`, `solution`, or `metadata` marker key (GO Challenge 3, Surge) still allocates that subtree once during classification; cost is linear in the nested payload and transient.
 - The parser allocation rules in the architecture record (`docs/design/v1-architecture.md`) are implemented for MATPOWER, PSS/E, and PowerWorld AUX; PyPSA CSV, PSLF, and OpenDSS still tokenize through owned strings, and several JSON readers (Egret, GO Challenge 3, DeepMind OPFData, pandapower) decode through a `serde_json::Value` tree. Scheduled work, stated here so the architecture record is not read as already shipped.
 - Multiconductor admittance assembly (`powerio_matrix::calc_multiconductor_admittance_matrix`) is Rust only in 1.0: no C entry point, and so no Python or Julia binding yet.
+- Diagnostic source spans come from the MATPOWER and PSS/E readers, which mark the record each finding is about. Findings from the other readers, from transformations, and from emitters carry no byte range, and the text rendering of a diagnostic (`render_diagnostic`) stays `CODE: message`: the rendering function sees only the record, not the retained source, so it cannot state a file, line, and column without an API change.
 - The sparse direct DC sensitivity factorization trades memory for speed against the previous conjugate gradient path: dense band peak memory is up about 3x at 2000 to 3000 buses for an 8 to 10x wall time win, measured against the committed allocation baseline in `evals/allocation`.
 
 ## Version boundaries

--- a/powerio-core/src/diagnostic.rs
+++ b/powerio-core/src/diagnostic.rs
@@ -409,6 +409,13 @@ impl Diagnostic {
     }
 
     pub fn with_span(mut self, span: SourceSpan) -> Result<Self, Error> {
+        self.add_span(span)?;
+        Ok(self)
+    }
+
+    /// Attach one source span to a finding already built, under the same
+    /// count limit the decoder enforces.
+    pub(crate) fn add_span(&mut self, span: SourceSpan) -> Result<(), Error> {
         if self.spans.len() >= crate::validation::MAX_DIAGNOSTIC_SPANS {
             return Err(record_too_large(
                 "source spans",
@@ -416,7 +423,7 @@ impl Diagnostic {
             ));
         }
         self.spans.push(span);
-        Ok(self)
+        Ok(())
     }
 
     pub(crate) fn prefix_target(&mut self, prefix: &str) -> Result<(), Error> {

--- a/powerio-core/src/error.rs
+++ b/powerio-core/src/error.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 use crate::{
-    Diagnostic, DiagnosticInfo, DiagnosticSeverity, ErrorCategory, Source, render_diagnostic,
+    Diagnostic, DiagnosticInfo, DiagnosticSeverity, ErrorCategory, Source, SourceSpan,
+    render_diagnostic,
 };
 
 type BoxedCause = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -75,6 +76,32 @@ impl Error {
     #[must_use]
     pub fn with_source(mut self, source: Source) -> Self {
         self.retained_source = Some(source);
+        self
+    }
+
+    /// Attach the byte range of the record that ended the operation to the
+    /// failure's error diagnostic.
+    ///
+    /// The diagnostic keeps at most `limits::MAX_DIAGNOSTIC_SPANS` spans. A
+    /// span past that limit is not attached; the refusal is recorded as a
+    /// note so the omission stays visible.
+    #[must_use]
+    pub fn with_span(mut self, span: SourceSpan) -> Self {
+        let Some(position) = self
+            .diagnostics
+            .iter()
+            .position(|diagnostic| diagnostic.severity() == DiagnosticSeverity::Error)
+        else {
+            return self;
+        };
+        if let Err(refused) = self.diagnostics[position].add_span(span) {
+            self.diagnostics.extend(
+                refused
+                    .into_diagnostics()
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.with_severity(DiagnosticSeverity::Note)),
+            );
+        }
         self
     }
 
@@ -166,6 +193,38 @@ mod tests {
             error
                 .to_string()
                 .starts_with("VALIDATE.TIME_SERIES.SHAPE: ")
+        );
+    }
+
+    #[test]
+    fn a_span_attaches_to_the_diagnostic_that_ended_the_operation() {
+        let source = crate::SourceId::new("/input").unwrap();
+        let error = Error::new(&crate::codes::READ_IO_READ, "read failed")
+            .with_diagnostic(
+                Diagnostic::of(&crate::codes::READ_IO_READ, "context")
+                    .with_severity(DiagnosticSeverity::Note),
+            )
+            .with_span(SourceSpan::new(source.clone(), 4, 9).unwrap());
+        let spans = error.diagnostics()[0].spans();
+        assert_eq!(spans.len(), 1);
+        assert_eq!(spans[0].source(), &source);
+        assert_eq!((spans[0].byte_start(), spans[0].byte_end()), (4, 9));
+        assert!(error.diagnostics()[1].spans().is_empty());
+
+        // Past the span limit the range is not attached and a note records
+        // the refusal, so nothing is dropped silently.
+        let mut crowded = Error::new(&crate::codes::READ_IO_READ, "read failed");
+        for _ in 0..crate::validation::MAX_DIAGNOSTIC_SPANS {
+            crowded = crowded.with_span(SourceSpan::new(source.clone(), 0, 1).unwrap());
+        }
+        let overflow = crowded.with_span(SourceSpan::new(source, 0, 1).unwrap());
+        assert_eq!(
+            overflow.diagnostics()[0].spans().len(),
+            crate::validation::MAX_DIAGNOSTIC_SPANS
+        );
+        assert_eq!(
+            overflow.diagnostics().last().unwrap().severity(),
+            DiagnosticSeverity::Note
         );
     }
 

--- a/powerio-dist/src/collect.rs
+++ b/powerio-dist/src/collect.rs
@@ -5,7 +5,27 @@
 //! emitting crate carries its own copy of this file. Keep the copies byte
 //! identical; the shared record types come from `powerio-core`.
 
-use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagnostics};
+use powerio_core::{
+    Diagnostic, DiagnosticInfo, DiagnosticSeverity, SourceId, SourceSpan, render_diagnostics,
+};
+
+/// The buffer a reader decodes and the record it is on. While a record is
+/// set, every finding the collector records carries that record's byte range
+/// as a span into the buffer.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "the collector copies stay identical across crates"
+)]
+pub(crate) struct RecordLocation {
+    source: SourceId,
+    /// Byte offset of the decoded text within the retained buffer: the
+    /// length of the byte order mark the reader never sees.
+    base: u64,
+    /// Half open byte range of the current record, relative to the decoded
+    /// text.
+    record: Option<(usize, usize)>,
+}
 
 /// An ordered set of findings, built up as a reader, a lowering pass, or a
 /// writer runs.
@@ -15,7 +35,10 @@ use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagno
 /// carries are rendered from the records by [`Diagnostics::lines`], never
 /// collected alongside them.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub(crate) struct Diagnostics(Vec<Diagnostic>);
+pub(crate) struct Diagnostics {
+    records: Vec<Diagnostic>,
+    location: Option<RecordLocation>,
+}
 
 #[allow(
     dead_code,
@@ -24,12 +47,16 @@ pub(crate) struct Diagnostics(Vec<Diagnostic>);
 impl Diagnostics {
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self(Vec::new())
+        Self {
+            records: Vec::new(),
+            location: None,
+        }
     }
 
     /// Record a finding at its registered default severity.
     pub(crate) fn push(&mut self, info: &'static DiagnosticInfo, message: impl Into<String>) {
-        self.0.push(Diagnostic::of(info, message));
+        let diagnostic = self.located(Diagnostic::of(info, message));
+        self.records.push(diagnostic);
     }
 
     /// Record a finding at a severity this site raises or lowers.
@@ -39,70 +66,145 @@ impl Diagnostics {
         severity: DiagnosticSeverity,
         message: impl Into<String>,
     ) {
-        self.0
-            .push(Diagnostic::of(info, message).with_severity(severity));
+        let diagnostic = self.located(Diagnostic::of(info, message).with_severity(severity));
+        self.records.push(diagnostic);
     }
 
-    /// Record a finding built with the record's own builders.
+    /// Record a finding built with the record's own builders. A finding that
+    /// already names a span keeps it; one without receives the current
+    /// record's span.
     pub(crate) fn record(&mut self, diagnostic: Diagnostic) {
-        self.0.push(diagnostic);
+        let diagnostic = self.located(diagnostic);
+        self.records.push(diagnostic);
     }
 
     /// Record every finding of another set, in order.
     pub(crate) fn absorb(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
-        self.0.extend(other);
+        self.records.extend(other);
     }
 
     /// Put `other`'s findings ahead of this set's, which is what a conversion
     /// does with the read side.
     pub(crate) fn prepend(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
         let mut front: Vec<_> = other.into_iter().collect();
-        front.append(&mut self.0);
-        self.0 = front;
+        front.append(&mut self.records);
+        self.records = front;
+    }
+
+    /// Name the buffer the running reader decodes so record spans can be
+    /// attached. `base` is the byte offset of the decoded text within the
+    /// retained buffer.
+    pub(crate) fn locate_in(&mut self, source: SourceId, base: u64) {
+        self.location = Some(RecordLocation {
+            source,
+            base,
+            record: None,
+        });
+    }
+
+    /// Take the location off the collector for a reader that decodes text
+    /// other than the retained buffer; [`Diagnostics::resume_location`] puts
+    /// it back.
+    pub(crate) fn suspend_location(&mut self) -> Option<RecordLocation> {
+        self.location.take()
+    }
+
+    pub(crate) fn resume_location(&mut self, location: Option<RecordLocation>) {
+        self.location = location;
+    }
+
+    /// Mark the record being decoded, as a half open byte range of the
+    /// decoded text. A no-op when no buffer is located.
+    pub(crate) fn enter_record(&mut self, start: usize, end: usize) {
+        if let Some(location) = &mut self.location {
+            location.record = Some((start, end.max(start)));
+        }
+    }
+
+    /// Extend the current record to `end`, for a record that continues over
+    /// more than one line.
+    pub(crate) fn extend_record(&mut self, end: usize) {
+        if let Some(location) = &mut self.location
+            && let Some((_, record_end)) = &mut location.record
+        {
+            *record_end = end.max(*record_end);
+        }
+    }
+
+    /// Leave the current record: findings recorded next carry no span.
+    pub(crate) fn leave_record(&mut self) {
+        if let Some(location) = &mut self.location {
+            location.record = None;
+        }
+    }
+
+    /// The span of the record being decoded, in the retained buffer's bytes.
+    #[must_use]
+    pub(crate) fn record_span(&self) -> Option<SourceSpan> {
+        let location = self.location.as_ref()?;
+        let (start, end) = location.record?;
+        SourceSpan::new(
+            location.source.clone(),
+            location.base + start as u64,
+            location.base + end as u64,
+        )
+        .ok()
+    }
+
+    fn located(&self, diagnostic: Diagnostic) -> Diagnostic {
+        match self.record_span() {
+            Some(span) if diagnostic.spans().is_empty() => diagnostic
+                .with_span(span)
+                .expect("a finding with no spans is below the span limit"),
+            _ => diagnostic,
+        }
     }
 
     #[must_use]
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.records.is_empty()
     }
 
     #[must_use]
     pub(crate) fn len(&self) -> usize {
-        self.0.len()
+        self.records.len()
     }
 
     #[must_use]
     pub(crate) fn records(&self) -> &[Diagnostic] {
-        &self.0
+        &self.records
     }
 
     #[must_use]
     pub(crate) fn into_records(self) -> Vec<Diagnostic> {
-        self.0
+        self.records
     }
 
     /// The `CODE: message` lines for the text channels.
     #[must_use]
     pub(crate) fn lines(&self) -> Vec<String> {
-        render_diagnostics(&self.0)
+        render_diagnostics(&self.records)
     }
 
     /// The worst severity recorded, or `None` when nothing was.
     #[must_use]
     pub(crate) fn worst_severity(&self) -> Option<DiagnosticSeverity> {
-        self.0.iter().map(Diagnostic::severity).max()
+        self.records.iter().map(Diagnostic::severity).max()
     }
 }
 
 impl From<Vec<Diagnostic>> for Diagnostics {
     fn from(records: Vec<Diagnostic>) -> Self {
-        Self(records)
+        Self {
+            records,
+            location: None,
+        }
     }
 }
 
 impl From<Diagnostics> for Vec<Diagnostic> {
     fn from(diagnostics: Diagnostics) -> Self {
-        diagnostics.0
+        diagnostics.records
     }
 }
 
@@ -111,7 +213,7 @@ impl IntoIterator for Diagnostics {
     type IntoIter = std::vec::IntoIter<Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.records.into_iter()
     }
 }
 
@@ -170,5 +272,36 @@ mod tests {
         );
         assert_eq!(write.len(), 2);
         assert!(!write.is_empty());
+    }
+
+    #[test]
+    fn findings_carry_the_current_record_span_while_located() {
+        let source = SourceId::new("/input").unwrap();
+        let mut d = Diagnostics::new();
+        d.enter_record(0, 4);
+        d.push(&DROPPED, "before any buffer is located");
+        assert!(d.records()[0].spans().is_empty());
+
+        d.locate_in(source.clone(), 3);
+        d.enter_record(10, 20);
+        d.extend_record(25);
+        d.push(&DROPPED, "inside a record");
+        let span = &d.records()[1].spans()[0];
+        assert_eq!(span.source(), &source);
+        assert_eq!((span.byte_start(), span.byte_end()), (13, 28));
+        assert_eq!(d.record_span().as_ref(), Some(span));
+
+        d.leave_record();
+        d.push(&DROPPED, "between records");
+        assert!(d.records()[2].spans().is_empty());
+        assert_eq!(d.record_span(), None);
+
+        d.enter_record(30, 31);
+        let location = d.suspend_location();
+        d.push(&DROPPED, "while suspended");
+        assert!(d.records()[3].spans().is_empty());
+        d.resume_location(location);
+        d.push(&DROPPED, "after resuming");
+        assert_eq!(d.records()[4].spans()[0].byte_start(), 33);
     }
 }

--- a/powerio-tx/src/collect.rs
+++ b/powerio-tx/src/collect.rs
@@ -5,7 +5,27 @@
 //! emitting crate carries its own copy of this file. Keep the copies byte
 //! identical; the shared record types come from `powerio-core`.
 
-use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagnostics};
+use powerio_core::{
+    Diagnostic, DiagnosticInfo, DiagnosticSeverity, SourceId, SourceSpan, render_diagnostics,
+};
+
+/// The buffer a reader decodes and the record it is on. While a record is
+/// set, every finding the collector records carries that record's byte range
+/// as a span into the buffer.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "the collector copies stay identical across crates"
+)]
+pub(crate) struct RecordLocation {
+    source: SourceId,
+    /// Byte offset of the decoded text within the retained buffer: the
+    /// length of the byte order mark the reader never sees.
+    base: u64,
+    /// Half open byte range of the current record, relative to the decoded
+    /// text.
+    record: Option<(usize, usize)>,
+}
 
 /// An ordered set of findings, built up as a reader, a lowering pass, or a
 /// writer runs.
@@ -15,7 +35,10 @@ use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagno
 /// carries are rendered from the records by [`Diagnostics::lines`], never
 /// collected alongside them.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub(crate) struct Diagnostics(Vec<Diagnostic>);
+pub(crate) struct Diagnostics {
+    records: Vec<Diagnostic>,
+    location: Option<RecordLocation>,
+}
 
 #[allow(
     dead_code,
@@ -24,12 +47,16 @@ pub(crate) struct Diagnostics(Vec<Diagnostic>);
 impl Diagnostics {
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self(Vec::new())
+        Self {
+            records: Vec::new(),
+            location: None,
+        }
     }
 
     /// Record a finding at its registered default severity.
     pub(crate) fn push(&mut self, info: &'static DiagnosticInfo, message: impl Into<String>) {
-        self.0.push(Diagnostic::of(info, message));
+        let diagnostic = self.located(Diagnostic::of(info, message));
+        self.records.push(diagnostic);
     }
 
     /// Record a finding at a severity this site raises or lowers.
@@ -39,70 +66,145 @@ impl Diagnostics {
         severity: DiagnosticSeverity,
         message: impl Into<String>,
     ) {
-        self.0
-            .push(Diagnostic::of(info, message).with_severity(severity));
+        let diagnostic = self.located(Diagnostic::of(info, message).with_severity(severity));
+        self.records.push(diagnostic);
     }
 
-    /// Record a finding built with the record's own builders.
+    /// Record a finding built with the record's own builders. A finding that
+    /// already names a span keeps it; one without receives the current
+    /// record's span.
     pub(crate) fn record(&mut self, diagnostic: Diagnostic) {
-        self.0.push(diagnostic);
+        let diagnostic = self.located(diagnostic);
+        self.records.push(diagnostic);
     }
 
     /// Record every finding of another set, in order.
     pub(crate) fn absorb(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
-        self.0.extend(other);
+        self.records.extend(other);
     }
 
     /// Put `other`'s findings ahead of this set's, which is what a conversion
     /// does with the read side.
     pub(crate) fn prepend(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
         let mut front: Vec<_> = other.into_iter().collect();
-        front.append(&mut self.0);
-        self.0 = front;
+        front.append(&mut self.records);
+        self.records = front;
+    }
+
+    /// Name the buffer the running reader decodes so record spans can be
+    /// attached. `base` is the byte offset of the decoded text within the
+    /// retained buffer.
+    pub(crate) fn locate_in(&mut self, source: SourceId, base: u64) {
+        self.location = Some(RecordLocation {
+            source,
+            base,
+            record: None,
+        });
+    }
+
+    /// Take the location off the collector for a reader that decodes text
+    /// other than the retained buffer; [`Diagnostics::resume_location`] puts
+    /// it back.
+    pub(crate) fn suspend_location(&mut self) -> Option<RecordLocation> {
+        self.location.take()
+    }
+
+    pub(crate) fn resume_location(&mut self, location: Option<RecordLocation>) {
+        self.location = location;
+    }
+
+    /// Mark the record being decoded, as a half open byte range of the
+    /// decoded text. A no-op when no buffer is located.
+    pub(crate) fn enter_record(&mut self, start: usize, end: usize) {
+        if let Some(location) = &mut self.location {
+            location.record = Some((start, end.max(start)));
+        }
+    }
+
+    /// Extend the current record to `end`, for a record that continues over
+    /// more than one line.
+    pub(crate) fn extend_record(&mut self, end: usize) {
+        if let Some(location) = &mut self.location
+            && let Some((_, record_end)) = &mut location.record
+        {
+            *record_end = end.max(*record_end);
+        }
+    }
+
+    /// Leave the current record: findings recorded next carry no span.
+    pub(crate) fn leave_record(&mut self) {
+        if let Some(location) = &mut self.location {
+            location.record = None;
+        }
+    }
+
+    /// The span of the record being decoded, in the retained buffer's bytes.
+    #[must_use]
+    pub(crate) fn record_span(&self) -> Option<SourceSpan> {
+        let location = self.location.as_ref()?;
+        let (start, end) = location.record?;
+        SourceSpan::new(
+            location.source.clone(),
+            location.base + start as u64,
+            location.base + end as u64,
+        )
+        .ok()
+    }
+
+    fn located(&self, diagnostic: Diagnostic) -> Diagnostic {
+        match self.record_span() {
+            Some(span) if diagnostic.spans().is_empty() => diagnostic
+                .with_span(span)
+                .expect("a finding with no spans is below the span limit"),
+            _ => diagnostic,
+        }
     }
 
     #[must_use]
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.records.is_empty()
     }
 
     #[must_use]
     pub(crate) fn len(&self) -> usize {
-        self.0.len()
+        self.records.len()
     }
 
     #[must_use]
     pub(crate) fn records(&self) -> &[Diagnostic] {
-        &self.0
+        &self.records
     }
 
     #[must_use]
     pub(crate) fn into_records(self) -> Vec<Diagnostic> {
-        self.0
+        self.records
     }
 
     /// The `CODE: message` lines for the text channels.
     #[must_use]
     pub(crate) fn lines(&self) -> Vec<String> {
-        render_diagnostics(&self.0)
+        render_diagnostics(&self.records)
     }
 
     /// The worst severity recorded, or `None` when nothing was.
     #[must_use]
     pub(crate) fn worst_severity(&self) -> Option<DiagnosticSeverity> {
-        self.0.iter().map(Diagnostic::severity).max()
+        self.records.iter().map(Diagnostic::severity).max()
     }
 }
 
 impl From<Vec<Diagnostic>> for Diagnostics {
     fn from(records: Vec<Diagnostic>) -> Self {
-        Self(records)
+        Self {
+            records,
+            location: None,
+        }
     }
 }
 
 impl From<Diagnostics> for Vec<Diagnostic> {
     fn from(diagnostics: Diagnostics) -> Self {
-        diagnostics.0
+        diagnostics.records
     }
 }
 
@@ -111,7 +213,7 @@ impl IntoIterator for Diagnostics {
     type IntoIter = std::vec::IntoIter<Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.records.into_iter()
     }
 }
 
@@ -170,5 +272,36 @@ mod tests {
         );
         assert_eq!(write.len(), 2);
         assert!(!write.is_empty());
+    }
+
+    #[test]
+    fn findings_carry_the_current_record_span_while_located() {
+        let source = SourceId::new("/input").unwrap();
+        let mut d = Diagnostics::new();
+        d.enter_record(0, 4);
+        d.push(&DROPPED, "before any buffer is located");
+        assert!(d.records()[0].spans().is_empty());
+
+        d.locate_in(source.clone(), 3);
+        d.enter_record(10, 20);
+        d.extend_record(25);
+        d.push(&DROPPED, "inside a record");
+        let span = &d.records()[1].spans()[0];
+        assert_eq!(span.source(), &source);
+        assert_eq!((span.byte_start(), span.byte_end()), (13, 28));
+        assert_eq!(d.record_span().as_ref(), Some(span));
+
+        d.leave_record();
+        d.push(&DROPPED, "between records");
+        assert!(d.records()[2].spans().is_empty());
+        assert_eq!(d.record_span(), None);
+
+        d.enter_record(30, 31);
+        let location = d.suspend_location();
+        d.push(&DROPPED, "while suspended");
+        assert!(d.records()[3].spans().is_empty());
+        d.resume_location(location);
+        d.push(&DROPPED, "after resuming");
+        assert_eq!(d.records()[4].spans()[0].byte_start(), 33);
     }
 }

--- a/powerio-tx/src/format/matpower/locate.rs
+++ b/powerio-tx/src/format/matpower/locate.rs
@@ -11,25 +11,42 @@ use super::tokens;
 /// A line's text with its `\n`/`\r\n` terminator trimmed off (`str::lines`
 /// semantics) given a `split_inclusive('\n')` piece.
 #[inline]
-fn trim_eol(piece: &str) -> &str {
+pub(super) fn trim_eol(piece: &str) -> &str {
     piece
         .strip_suffix('\n')
         .map_or(piece, |s| s.strip_suffix('\r').unwrap_or(s))
 }
 
-/// Locate each `mpc.<field> = <rhs>;` assignment's text, borrowing `(field, full)`
-/// slices from `content` in source order. For a numeric `[ … ]` matrix it scans
-/// for the closing `]` directly — numeric bodies never nest brackets — and uses
-/// the quote-aware depth FSM only for `{ … }` cell arrays (whose strings may hold
-/// `]`/`}`). Infallible: an unclosed block runs to EOF and
-/// [`super::matlab::for_each_matrix_row`] reports the truncation.
+/// One `mpc.<field> = ...;` assignment: its field name, its complete text,
+/// and the byte offset of that text within the source.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Assignment<'a> {
+    pub(crate) field: &'a str,
+    pub(crate) text: &'a str,
+    pub(crate) start: usize,
+}
+
+impl Assignment<'_> {
+    /// The half open byte range of the assignment text within the source.
+    pub(crate) fn range(&self) -> (usize, usize) {
+        (self.start, self.start + self.text.len())
+    }
+}
+
+/// Locate each `mpc.<field> = <rhs>;` assignment's text, borrowing the field
+/// name and the complete assignment from `content` in source order. For a
+/// numeric `[ ... ]` matrix it scans for the closing `]` directly (numeric
+/// bodies never nest brackets) and uses the quote-aware depth FSM only for
+/// `{ ... }` cell arrays (whose strings may hold `]`/`}`). Infallible: an
+/// unclosed block runs to EOF and [`super::matlab::for_each_matrix_row`]
+/// reports the truncation.
 ///
 /// One forward pass over `content.split_inclusive('\n')` with a running byte
-/// offset — no materialized `Vec` of every line (which on a 56 MB / 192k-bus case
-/// is tens of MB written before a single field is found). A multi-line block
-/// consumes following lines from the same iterator, so the next assignment starts
-/// after the block's closing line.
-pub(crate) fn locate_assignments(content: &str) -> Vec<(&str, &str)> {
+/// offset, so no `Vec` of every line is materialized (which on a 56 MB /
+/// 192k-bus case is tens of MB written before a single field is found). A
+/// multi-line block consumes following lines from the same iterator, so the
+/// next assignment starts after the block's closing line.
+pub(crate) fn locate_assignments(content: &str) -> Vec<Assignment<'_>> {
     let mut out = Vec::new();
     let mut off = 0usize;
     let mut lines = content.split_inclusive('\n');
@@ -65,7 +82,11 @@ pub(crate) fn locate_assignments(content: &str) -> Vec<(&str, &str)> {
                     depth += net_bracket_depth(tokens::comment_split(l).0);
                 }
             }
-            out.push((field, &content[start..end]));
+            out.push(Assignment {
+                field,
+                text: &content[start..end],
+                start,
+            });
         }
     }
     out
@@ -155,8 +176,8 @@ mod tests {
     fn located<'a>(src: &'a str, field: &str) -> Option<&'a str> {
         locate_assignments(src)
             .into_iter()
-            .find(|(f, _)| *f == field)
-            .map(|(_, full)| full)
+            .find(|assignment| assignment.field == field)
+            .map(|assignment| assignment.text)
     }
 
     #[test]
@@ -169,7 +190,7 @@ mod tests {
                    mpc.branch = [\n\t1\t2\t0.1;\n];\n";
         let fields: Vec<&str> = locate_assignments(src)
             .into_iter()
-            .map(|(f, _)| f)
+            .map(|assignment| assignment.field)
             .collect();
         assert_eq!(fields, vec!["baseMVA", "bus", "branch"]);
         assert_eq!(located(src, "baseMVA"), Some("mpc.baseMVA = 100;"));
@@ -177,6 +198,21 @@ mod tests {
         assert!(bus.starts_with("mpc.bus = ["));
         assert!(bus.ends_with("];"));
         assert!(bus.contains("2\t1"));
+    }
+
+    #[test]
+    fn each_assignment_records_its_byte_offset_in_the_source() {
+        let src =
+            "% header\nmpc.baseMVA = 100;\r\nmpc.bus = [\n\t1\t3;\n];\nmpc.branch = [1 2 0.1];\n";
+        for assignment in locate_assignments(src) {
+            let (start, end) = assignment.range();
+            assert_eq!(&src[start..end], assignment.text, "{}", assignment.field);
+        }
+        let branch = locate_assignments(src)
+            .into_iter()
+            .find(|assignment| assignment.field == "branch")
+            .unwrap();
+        assert_eq!(branch.start, src.find("mpc.branch").unwrap());
     }
 
     #[test]
@@ -201,7 +237,7 @@ mod tests {
         let src = "mpc.bus_name = {\n\t'Bus ]1';\n\t'Bus 2';\n};\nmpc.baseMVA = 100;\n";
         let fields: Vec<&str> = locate_assignments(src)
             .into_iter()
-            .map(|(f, _)| f)
+            .map(|assignment| assignment.field)
             .collect();
         assert_eq!(fields, vec!["bus_name", "baseMVA"]);
         assert!(located(src, "bus_name").unwrap().contains("Bus 2"));
@@ -213,7 +249,7 @@ mod tests {
         let src = "% mpc.bus = [fake];\nmpc.baseMVA = 100;\n";
         let fields: Vec<&str> = locate_assignments(src)
             .into_iter()
-            .map(|(f, _)| f)
+            .map(|assignment| assignment.field)
             .collect();
         assert_eq!(fields, vec!["baseMVA"]);
     }

--- a/powerio-tx/src/format/matpower/matlab.rs
+++ b/powerio-tx/src/format/matpower/matlab.rs
@@ -5,6 +5,7 @@
 //! comments inline per line, splits rows on `;`, and yields each row into a
 //! reused buffer — no whole-section copy and no `Vec<Vec<f64>>` intermediate.
 
+use crate::collect::Diagnostics;
 use crate::{Error, Result};
 
 /// The first `mpc.<field> = <scalar>` RHS (a matrix RHS is skipped), trimmed.
@@ -64,29 +65,51 @@ pub(crate) fn scalar_from_assignment(raw: &str, field: &str) -> Result<Option<f6
 
 /// Stream the rows of an `mpc.<field> = [ … ];` assignment. `assignment` is the
 /// raw (comment-bearing, possibly multi-line) source of one assignment from the
-/// document. Comments are stripped per line, rows split on `;`, tokens parsed
-/// into a reused buffer, and `f` is invoked per non-empty row — so the caller
-/// builds its typed `Vec` directly, with no `Vec<Vec<f64>>` and no whole-section
-/// comment-strip copy. `f` receives the same 0-based non-empty-row index the
-/// old `Vec<Vec<f64>>` path passed to `from_row`.
-pub(crate) fn for_each_matrix_row<F>(assignment: &str, field: &str, mut f: F) -> Result<()>
+/// document and `base` its byte offset within the source. Comments are
+/// stripped per line, rows split on `;`, tokens parsed into a reused buffer,
+/// and `f` is invoked per non-empty row, so the caller builds its typed `Vec`
+/// directly with no `Vec<Vec<f64>>` and no whole-section comment-strip copy.
+/// `f` receives the 0-based non-empty-row index.
+///
+/// Before each row reaches `f`, the row's byte range in the source (first
+/// token through last token) is the collector's current record, so a finding
+/// raised while the row is decoded carries that range and a row constructor
+/// failure leaves it on the collector. A malformed token marks the row up to
+/// the end of its line; a truncated matrix marks the whole assignment. The
+/// record is cleared once the assignment is read.
+pub(crate) fn for_each_matrix_row<F>(
+    assignment: &str,
+    base: usize,
+    field: &str,
+    warnings: &mut Diagnostics,
+    mut f: F,
+) -> Result<()>
 where
     F: FnMut(&[f64], usize) -> Result<()>,
 {
     let mut buf: Vec<f64> = Vec::with_capacity(24);
     let mut row = 0usize;
-    let mut inside = false; // have we passed the opening `[`?
-    let mut done = false; // have we hit the closing `]`?
-    for line in assignment.lines() {
+    // Byte range of the row being tokenized, relative to `assignment`.
+    let mut row_start = 0usize;
+    let mut row_end = 0usize;
+    let mut inside = false; // past the opening `[`
+    let mut done = false; // reached the closing `]`
+    let mut line_start = 0usize;
+    for piece in assignment.split_inclusive('\n') {
+        let this_line_start = line_start;
+        line_start += piece.len();
         if done {
             break;
         }
+        let line = super::locate::trim_eol(piece);
         let mut code = super::tokens::comment_split(line).0;
+        let mut code_start = this_line_start;
         if !inside {
             let Some(open) = code.find('[') else {
                 continue;
             };
             code = &code[open + 1..];
+            code_start += open + 1;
             inside = true;
         }
         // Numeric matrix bodies have no nested `[`, so the first `]` closes it.
@@ -95,10 +118,9 @@ where
             done = true;
         }
         // One byte-level pass over the line's code: `;` ends a row, ASCII
-        // whitespace separates tokens, and a trailing comma is stripped (MATPOWER
-        // rows are space/semicolon-delimited). This replaces split(';') +
-        // split_ascii_whitespace — the generic Unicode searcher was the dominant
-        // tokenizing cost — and feeds raw bytes straight to the float parser.
+        // whitespace separates tokens, and a trailing comma is stripped
+        // (MATPOWER rows are space/semicolon-delimited). Raw bytes go straight
+        // to the float parser.
         //
         // MATLAB also ends a matrix row at the line break itself unless the
         // line ends with a `...` continuation; PowerWorld's `.m` exports write
@@ -116,6 +138,7 @@ where
             let b = bytes[i];
             if b == b';' {
                 if !buf.is_empty() {
+                    warnings.enter_record(base + row_start, base + row_end);
                     f(&buf, row)?;
                     row += 1;
                     buf.clear();
@@ -138,31 +161,42 @@ where
             if tok.is_empty() {
                 continue;
             }
-            buf.push(parse_float(tok).ok_or_else(|| Error::BadFloat {
-                field: leak_field(field),
-                row,
-                value: String::from_utf8_lossy(tok).into_owned(),
-            })?);
+            if buf.is_empty() {
+                row_start = code_start + start;
+            }
+            row_end = code_start + start + tok.len();
+            let Some(value) = parse_float(tok) else {
+                warnings.enter_record(base + row_start, base + code_start + code.trim_end().len());
+                return Err(Error::BadFloat {
+                    field: leak_field(field),
+                    row,
+                    value: String::from_utf8_lossy(tok).into_owned(),
+                });
+            };
+            buf.push(value);
         }
         // End of line ends the row, unless continued with `...`.
         if !continuation && !buf.is_empty() {
+            warnings.enter_record(base + row_start, base + row_end);
             f(&buf, row)?;
             row += 1;
             buf.clear();
         }
     }
-    // Entered the matrix (`[`) but never saw the closing `]`: the assignment is
-    // truncated. The old `find_matrix` rejected this; keep that behavior rather
-    // than silently accepting a partial matrix. A closed matrix sets `done`, so
-    // a legitimate last row with no trailing `;` (handled by the flush below)
-    // does not trip this.
+    // Entered the matrix (`[`) but never saw the closing `]`: the assignment
+    // is truncated and refused rather than read as a partial matrix. A closed
+    // matrix sets `done`, so a legitimate last row with no trailing `;`
+    // (handled by the flush below) does not trip this.
     if inside && !done {
+        warnings.enter_record(base, base + assignment.len());
         return Err(Error::UnbalancedBrackets(leak_field(field)));
     }
     // A final row not terminated by `;` (e.g. the last row before `];`).
     if !buf.is_empty() {
+        warnings.enter_record(base + row_start, base + row_end);
         f(&buf, row)?;
     }
+    warnings.leave_record();
     Ok(())
 }
 

--- a/powerio-tx/src/format/matpower/mod.rs
+++ b/powerio-tx/src/format/matpower/mod.rs
@@ -13,21 +13,30 @@ mod tests;
 pub(crate) use writer::write_matpower;
 pub(crate) use writer::write_matpower_conversion;
 
+use self::locate::Assignment;
+use crate::collect::Diagnostics;
 use crate::network::{BalancedNetwork, BalancedNetworkTables, Generator, Hvdc, SourceFormat};
 use crate::{Error, Result};
 
 /// Owned-source entry used by the format hub: move the buffer straight into the
 /// retained source (no copy) and take `name_hint` (e.g. the file stem) as the
 /// network name.
+///
+/// A failure at a known record leaves that record's byte range on
+/// `warnings` (see [`Diagnostics::record_span`]): a malformed or short matrix
+/// row, a truncated matrix, a malformed scalar, or a cost table whose row
+/// count disagrees with its element table. A missing field and a dangling
+/// reference name no record.
 pub(crate) fn parse_matpower_source(
     source: &str,
     name_hint: Option<&str>,
+    warnings: &mut Diagnostics,
 ) -> Result<BalancedNetwork> {
     let name = name_hint
         .map(str::to_owned)
         .or_else(|| matpower_function_name(source).map(str::to_owned))
         .unwrap_or_else(|| "case".to_string());
-    parse_matpower_named(source, &name)
+    parse_matpower_named(source, &name, warnings)
 }
 
 fn matpower_function_name(source: &str) -> Option<&str> {
@@ -54,18 +63,26 @@ fn matpower_function_name(source: &str) -> Option<&str> {
     None
 }
 
-fn parse_matpower_named(source: &str, name: &str) -> Result<BalancedNetwork> {
+fn parse_matpower_named(
+    source: &str,
+    name: &str,
+    warnings: &mut Diagnostics,
+) -> Result<BalancedNetwork> {
     // Locate each assignment's text directly in `source` and build the network
     // from those borrowed slices in one pass; the typed model owns its data, so
     // the borrows end with `located` and the source Arc moves into the network.
     let net = {
         let located = locate::locate_assignments(source);
-        build_case(name, |field| {
-            located
-                .iter()
-                .find(|(f, _)| *f == field)
-                .map(|(_, full)| *full)
-        })?
+        build_case(
+            name,
+            |field| {
+                located
+                    .iter()
+                    .find(|assignment| assignment.field == field)
+                    .copied()
+            },
+            warnings,
+        )?
     };
     // The other format readers validate references; the MATPOWER path must too,
     // or a duplicate or dangling bus id reaches `IndexedNetwork` as silently
@@ -74,23 +91,35 @@ fn parse_matpower_named(source: &str, name: &str) -> Result<BalancedNetwork> {
     Ok(net)
 }
 
-/// Build a [`BalancedNetwork`] from a per-field assignment-text accessor `get`, which
-/// returns the raw `mpc.<field> = …;` text for a field name. MATPOWER folds
-/// demand and shunts onto the bus row; [`rows::bus_row`] splits them back out
-/// into the hub's first-class [`Load`](crate::network::Load) /
+/// Build a [`BalancedNetwork`] from a per-field assignment accessor `get`,
+/// which returns the located `mpc.<field> = ...;` assignment for a field name.
+/// MATPOWER folds demand and shunts onto the bus row; [`rows::bus_row`] splits
+/// them back out into the hub's first-class [`Load`](crate::network::Load) /
 /// [`Shunt`](crate::network::Shunt). The caller attaches the source afterward.
-fn build_case<'a>(name: &str, get: impl Fn(&str) -> Option<&'a str>) -> Result<BalancedNetwork> {
-    let base_mva = get("baseMVA")
-        .and_then(|raw| matlab::scalar_from_assignment(raw, "baseMVA").transpose())
-        .transpose()?
-        .ok_or(Error::MissingField("baseMVA"))?;
+fn build_case<'a>(
+    name: &str,
+    get: impl Fn(&str) -> Option<Assignment<'a>>,
+    warnings: &mut Diagnostics,
+) -> Result<BalancedNetwork> {
+    let base_mva = match get("baseMVA") {
+        Some(assignment) => {
+            // A malformed scalar is reported against its whole assignment.
+            let (start, end) = assignment.range();
+            warnings.enter_record(start, end);
+            let value = matlab::scalar_from_assignment(assignment.text, "baseMVA")?;
+            warnings.leave_record();
+            value
+        }
+        None => None,
+    }
+    .ok_or(Error::MissingField("baseMVA"))?;
 
-    let bus_raw = get("bus").ok_or(Error::MissingField("bus"))?;
-    let n_bus = estimate_rows(bus_raw);
+    let bus = get("bus").ok_or(Error::MissingField("bus"))?;
+    let n_bus = estimate_rows(bus.text);
     let mut buses = Vec::with_capacity(n_bus);
     let mut loads = Vec::with_capacity(n_bus);
     let mut shunts = Vec::with_capacity(n_bus);
-    matlab::for_each_matrix_row(bus_raw, "bus", |row, i| {
+    matlab::for_each_matrix_row(bus.text, bus.start, "bus", warnings, |row, i| {
         let (bus, load, shunt) = rows::bus_row(row, i)?;
         buses.push(bus);
         if let Some(l) = load {
@@ -106,18 +135,19 @@ fn build_case<'a>(name: &str, get: impl Fn(&str) -> Option<&'a str>) -> Result<B
         get("branch").ok_or(Error::MissingField("branch"))?,
         "branch",
         rows::branch_row,
+        warnings,
     )?;
 
-    let generators = parse_gens(&get)?;
-    let storage = parse_optional(&get, "storage", rows::storage_row)?;
-    let areas = parse_optional(&get, "areas", rows::area_row)?;
-    let mut hvdc = parse_optional(&get, "dcline", rows::hvdc_row)?;
-    attach_dcline_costs(&get, &mut hvdc)?;
+    let generators = parse_gens(&get, warnings)?;
+    let storage = parse_optional(&get, "storage", rows::storage_row, warnings)?;
+    let areas = parse_optional(&get, "areas", rows::area_row, warnings)?;
+    let mut hvdc = parse_optional(&get, "dcline", rows::hvdc_row, warnings)?;
+    attach_dcline_costs(&get, &mut hvdc, warnings)?;
 
     // Bus names live in a `{...}` cell array; pull them (quotes kept) and attach
     // by position when the count matches.
-    if let Some(raw) = get("bus_name") {
-        let names = locate::parse_string_cell(raw);
+    if let Some(assignment) = get("bus_name") {
+        let names = locate::parse_string_cell(assignment.text);
         if names.len() == buses.len() {
             for (bus, label) in buses.iter_mut().zip(names) {
                 // An empty cell is an unnamed bus, not a bus named "".
@@ -166,26 +196,34 @@ fn estimate_rows(assignment: &str) -> usize {
 
 /// Stream the rows of one assignment, building a typed `T` per row via `ctor`.
 fn parse_rows<T>(
-    assignment: &str,
+    assignment: Assignment<'_>,
     field: &str,
     ctor: impl Fn(&[f64], usize) -> Result<T>,
+    warnings: &mut Diagnostics,
 ) -> Result<Vec<T>> {
-    let mut out = Vec::with_capacity(estimate_rows(assignment));
-    matlab::for_each_matrix_row(assignment, field, |row, i| {
-        out.push(ctor(row, i)?);
-        Ok(())
-    })?;
+    let mut out = Vec::with_capacity(estimate_rows(assignment.text));
+    matlab::for_each_matrix_row(
+        assignment.text,
+        assignment.start,
+        field,
+        warnings,
+        |row, i| {
+            out.push(ctor(row, i)?);
+            Ok(())
+        },
+    )?;
     Ok(out)
 }
 
 /// Like [`parse_rows`] but for an optional `mpc.<field>` block (empty if absent).
 fn parse_optional<'a, T>(
-    get: &impl Fn(&str) -> Option<&'a str>,
+    get: &impl Fn(&str) -> Option<Assignment<'a>>,
     field: &str,
     ctor: impl Fn(&[f64], usize) -> Result<T>,
+    warnings: &mut Diagnostics,
 ) -> Result<Vec<T>> {
     match get(field) {
-        Some(raw) => parse_rows(raw, field, ctor),
+        Some(assignment) => parse_rows(assignment, field, ctor, warnings),
         None => Ok(Vec::new()),
     }
 }
@@ -194,18 +232,21 @@ fn parse_optional<'a, T>(
 /// one row per dcline in order (MATPOWER's `toggle_dcline` requires full
 /// coverage, so unlike `gencost` there is no reactive second block). A line
 /// with no usage cost is padded with an all-zero polynomial row, and a zero
-/// cost prices the line exactly as no cost term at all — so a zero row reads
-/// back as no cost, and write-then-read stays stable for networks whose lines
+/// cost prices the line exactly as no cost term at all, so a zero row reads
+/// back as no cost and write-then-read stays stable for networks whose lines
 /// carry none.
 fn attach_dcline_costs<'a>(
-    get: &impl Fn(&str) -> Option<&'a str>,
+    get: &impl Fn(&str) -> Option<Assignment<'a>>,
     hvdc: &mut [Hvdc],
+    warnings: &mut Diagnostics,
 ) -> Result<()> {
-    let Some(raw) = get("dclinecost") else {
+    let Some(assignment) = get("dclinecost") else {
         return Ok(());
     };
-    let costs = parse_rows(raw, "dclinecost", rows::gencost_row)?;
+    let costs = parse_rows(assignment, "dclinecost", rows::gencost_row, warnings)?;
     if costs.len() != hvdc.len() {
+        let (start, end) = assignment.range();
+        warnings.enter_record(start, end);
         return Err(Error::DcLineCostCountMismatch {
             dclines: hvdc.len(),
             dclinecost: costs.len(),
@@ -223,20 +264,25 @@ fn attach_dcline_costs<'a>(
 
 /// Parse `mpc.gen` and fold in the active-power block of `mpc.gencost`.
 /// Both are optional: a case with only power flow data has neither and gets no gens.
-fn parse_gens<'a>(get: &impl Fn(&str) -> Option<&'a str>) -> Result<Vec<Generator>> {
-    let Some(raw) = get("gen") else {
+fn parse_gens<'a>(
+    get: &impl Fn(&str) -> Option<Assignment<'a>>,
+    warnings: &mut Diagnostics,
+) -> Result<Vec<Generator>> {
+    let Some(assignment) = get("gen") else {
         return Ok(Vec::new());
     };
-    let mut gens = parse_rows(raw, "gen", rows::gen_row)?;
+    let mut gens = parse_rows(assignment, "gen", rows::gen_row, warnings)?;
 
     // MATPOWER lays the active-power costs first, one row per generator and in
     // the same order; reactive-power costs (if any) follow in a second block.
-    if let Some(craw) = get("gencost") {
-        let costs = parse_rows(craw, "gencost", rows::gencost_row)?;
+    if let Some(costs_assignment) = get("gencost") {
+        let costs = parse_rows(costs_assignment, "gencost", rows::gencost_row, warnings)?;
         // Reject a count that is neither `n_gen` (active only) nor `2·n_gen`
-        // (active + reactive). A per-row defect surfaces as `ShortRow` first.
+        // (active + reactive). A per-row defect is reported as `ShortRow` first.
         let n = gens.len();
         if costs.len() != n && costs.len() != 2 * n {
+            let (start, end) = costs_assignment.range();
+            warnings.enter_record(start, end);
             return Err(Error::GenCostCountMismatch {
                 gens: n,
                 gencost: costs.len(),

--- a/powerio-tx/src/format/matpower/tests.rs
+++ b/powerio-tx/src/format/matpower/tests.rs
@@ -1,5 +1,101 @@
 fn parse_mpc(content: &str) -> crate::Result<crate::network::BalancedNetwork> {
-    super::parse_matpower_source(content, None)
+    let mut warnings = crate::collect::Diagnostics::new();
+    super::parse_matpower_source(content, None, &mut warnings)
+}
+
+/// Parse a case with the collector located in a source named `/input`, and
+/// return the failure with the byte range left on the collector.
+fn parse_mpc_located(content: &str) -> (crate::Error, Option<powerio_core::SourceSpan>) {
+    let mut warnings = crate::collect::Diagnostics::new();
+    warnings.locate_in(powerio_core::SourceId::new("/input").unwrap(), 0);
+    let error = super::parse_matpower_source(content, None, &mut warnings)
+        .expect_err("the case is malformed");
+    (error, warnings.record_span())
+}
+
+fn byte_range(source: &str, text: &str) -> (u64, u64) {
+    let start = source.find(text).expect("the text is in the source");
+    (start as u64, (start + text.len()) as u64)
+}
+
+#[test]
+fn a_short_row_leaves_the_row_byte_range_on_the_collector() {
+    let src = "mpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n\t2  1  0 0;\n];\n";
+    let (error, span) = parse_mpc_located(src);
+    assert!(matches!(
+        error,
+        crate::Error::ShortRow {
+            field: "bus",
+            row: 1,
+            ..
+        }
+    ));
+    let span = span.unwrap();
+    assert_eq!(span.source().as_str(), "/input");
+    assert_eq!(
+        (span.byte_start(), span.byte_end()),
+        byte_range(src, "2  1  0 0")
+    );
+}
+
+#[test]
+fn a_malformed_token_marks_its_row_up_to_the_end_of_the_line() {
+    let src = "mpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n\t2  1  0 abc 0 0 1 1.0 0 345 1 1.1 0.9;  % comment\n];\n";
+    let (error, span) = parse_mpc_located(src);
+    assert!(matches!(
+        error,
+        crate::Error::BadFloat {
+            field: "bus",
+            row: 1,
+            ..
+        }
+    ));
+    let span = span.unwrap();
+    assert_eq!(
+        (span.byte_start(), span.byte_end()),
+        byte_range(src, "2  1  0 abc 0 0 1 1.0 0 345 1 1.1 0.9;")
+    );
+}
+
+#[test]
+fn a_truncated_matrix_marks_the_whole_assignment() {
+    let src = "mpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n";
+    let (error, span) = parse_mpc_located(src);
+    assert!(matches!(error, crate::Error::UnbalancedBrackets("bus")));
+    let span = span.unwrap();
+    assert_eq!(
+        (span.byte_start(), span.byte_end()),
+        byte_range(src, "mpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;")
+    );
+}
+
+#[test]
+fn a_cost_count_mismatch_marks_the_cost_table() {
+    let src = "mpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n];\nmpc.branch = [];\nmpc.gen = [\n\t1 0 0 10 -10 1 100 1 20 0;\n];\nmpc.gencost = [\n\t2 0 0 3 0.1 1 0;\n\t2 0 0 3 0.1 1 0;\n\t2 0 0 3 0.1 1 0;\n];\n";
+    let (error, span) = parse_mpc_located(src);
+    assert!(matches!(
+        error,
+        crate::Error::GenCostCountMismatch {
+            gens: 1,
+            gencost: 3
+        }
+    ));
+    let span = span.unwrap();
+    let (start, end) = byte_range(src, "mpc.gencost = [");
+    assert_eq!(span.byte_start(), start);
+    assert!(span.byte_end() > end);
+    assert_eq!(
+        &src[span.byte_start() as usize..span.byte_end() as usize].trim_end(),
+        &src[start as usize..].trim_end()
+    );
+}
+
+#[test]
+fn a_well_formed_case_leaves_no_record_on_the_collector() {
+    let mut warnings = crate::collect::Diagnostics::new();
+    warnings.locate_in(powerio_core::SourceId::new("/input").unwrap(), 0);
+    super::parse_matpower_source(CASE_TINY, None, &mut warnings).unwrap();
+    assert_eq!(warnings.record_span(), None);
 }
 use super::write_matpower;
 use crate::indexed::IndexedNetwork;

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -582,7 +582,12 @@ pub fn parse_with_json_class(
             PioModule::parsed(network, source, warnings.into_records())
         }
         Err(error) => {
-            let core = powerio_core::Error::new(error.code(), error.to_string());
+            // A reader that failed on a located record leaves that record's
+            // byte range on the collector; the failure carries it as a span.
+            let mut core = powerio_core::Error::new(error.code(), error.to_string());
+            if let Some(span) = warnings.record_span() {
+                core = core.with_span(span);
+            }
             Err(core
                 .with_diagnostics(warnings.into_records())
                 .with_cause(error)
@@ -748,6 +753,12 @@ fn parse_to_network(
         return Ok(network);
     }
     let text = source_text(&buffer)?;
+    // Readers that locate records mark them as byte ranges of `text`; the
+    // retained buffer starts with the byte order mark `text` omits.
+    warnings.locate_in(
+        buffer.id().clone(),
+        (buffer.bytes().len() - buffer.content_bytes().len()) as u64,
+    );
     let fmt = match fmt_hint {
         Some(fmt) => fmt,
         // A caller ahead of this (the `powerio` facade's own routing) may
@@ -763,13 +774,7 @@ fn parse_to_network(
             class => json_target_from_class(class)?,
         },
     };
-    read_source(
-        text,
-        fmt,
-        stem,
-        Some(TextPosition::of_buffer(&buffer)),
-        warnings,
-    )
+    read_source(text, fmt, stem, warnings)
 }
 
 /// The primary buffer of a file or memory source.
@@ -789,62 +794,24 @@ fn source_text(buffer: &powerio_core::SourceBuffer) -> Result<&str> {
     })
 }
 
-/// Where a reader's decoded text sits in its retained source buffer: the
-/// buffer id and the byte offset of the text within the buffer, which is the
-/// length of the byte order mark the decoded slice omits. A reader that knows
-/// where a record starts builds that record's span from it; the module
-/// constructor then maps the buffer id onto the module's source id.
-#[derive(Clone, Copy)]
-pub(crate) struct TextPosition<'a> {
-    source: &'a powerio_core::SourceId,
-    offset: u64,
-}
-
-impl<'a> TextPosition<'a> {
-    fn of_buffer(buffer: &'a powerio_core::SourceBuffer) -> Self {
-        let offset = buffer.bytes().len() - buffer.content_bytes().len();
-        Self {
-            source: buffer.id(),
-            offset: offset as u64,
-        }
-    }
-
-    /// The span of `record`, a subslice of the decoded `text`, in the source
-    /// buffer. `None` when `record` is not a subslice of `text`.
-    pub(crate) fn span(&self, text: &str, record: &str) -> Option<powerio_core::SourceSpan> {
-        let base = text.as_ptr() as usize;
-        let start = record.as_ptr() as usize;
-        let end = start.checked_add(record.len())?;
-        if start < base || end > base.checked_add(text.len())? {
-            return None;
-        }
-        let byte_start = self.offset.checked_add((start - base) as u64)?;
-        let byte_end = self.offset.checked_add((end - base) as u64)?;
-        powerio_core::SourceSpan::new(self.source.clone(), byte_start, byte_end).ok()
-    }
-}
-
 /// Read decoded `text` as `fmt`, using `name_hint` (e.g. the file stem) when
 /// the format carries no name of its own. The single format to reader map:
 /// every parse route funnels through it, so every format is dispatched the
-/// same way. Readers borrow the text; the module retains the source bytes.
-/// `position` locates the text in that retained buffer for readers that
-/// attach record spans to their findings.
+/// same way. Readers borrow the text; the module retains the source bytes,
+/// and `warnings` is located in that buffer for readers that attach record
+/// spans to their findings.
 fn read_source(
     text: &str,
     fmt: TargetFormat,
     name_hint: Option<&str>,
-    position: Option<TextPosition<'_>>,
     warnings: &mut Diagnostics,
 ) -> Result<BalancedNetwork> {
     let net = match fmt {
-        TargetFormat::Matpower => matpower::parse_matpower_source(text, name_hint),
+        TargetFormat::Matpower => matpower::parse_matpower_source(text, name_hint, warnings),
         TargetFormat::PowerModelsJson => {
             powermodels::parse_powermodels_json_source(text, name_hint, warnings)
         }
-        TargetFormat::Psse { .. } => {
-            psse::parse_psse_source_at(text, name_hint, position, warnings)
-        }
+        TargetFormat::Psse { .. } => psse::parse_psse_source(text, name_hint, warnings),
         TargetFormat::PsseRawx => rawx::parse_rawx_source(text, name_hint, warnings),
         TargetFormat::PowerWorld => {
             powerworld::map::parse_powerworld_source(text, name_hint, warnings)

--- a/powerio-tx/src/format/psse.rs
+++ b/powerio-tx/src/format/psse.rs
@@ -27,13 +27,13 @@ use std::fmt::Write as _;
 use serde_json::Value;
 
 use super::{
-    TextEmission, TextPosition, branch_rating_set_drop_warning, jnum, sanitize_quoted,
+    TextEmission, branch_rating_set_drop_warning, jnum, sanitize_quoted,
     warn_extra_branch_rating_sets,
 };
 use std::borrow::Cow;
 
 use crate::diagnostics::codes::EMIT_PSSE as F;
-use crate::diagnostics::{Diagnostic, Diagnostics, codes};
+use crate::diagnostics::{Diagnostics, codes};
 use crate::network::{
     Area, BalancedNetwork, BalancedNetworkTables, Branch, BranchCharging, BranchRatingSet, Bus,
     BusId, BusType, ComponentMetadata, DetailedConnectivity, Extras, Generator,
@@ -1783,32 +1783,25 @@ fn revision32_shape(section: Section) -> Option<Revision32Shape> {
 }
 
 /// Report a revision 32 record that ends before the last field its typed
-/// layout reads. `span` locates the record in the retained source when the
-/// reader was given its position; the missing fields have already taken their
+/// layout reads. The finding carries the collector's current record span,
+/// the byte range of the record being decoded, when the collector is located
+/// in the source buffer. The missing fields have already taken their
 /// defaults, so the finding is a warning rather than a failure.
-fn check_revision32_width(
-    f: &[Cow<'_, str>],
-    shape: Revision32Shape,
-    span: impl FnOnce() -> Option<powerio_core::SourceSpan>,
-    warnings: &mut Diagnostics,
-) {
+fn check_revision32_width(f: &[Cow<'_, str>], shape: Revision32Shape, warnings: &mut Diagnostics) {
     if f.len() >= shape.width {
         return;
     }
     let first = f.first().map_or("", Cow::as_ref);
-    let message = format!(
-        "PSS/E revision 32 {} record beginning {first:?} has {} field(s); the revision 32 layout reads {} fields through {}, so the missing fields took their defaults",
-        shape.record,
-        f.len(),
-        shape.width,
-        shape.last
+    warnings.push(
+        &codes::READ_PSSE_VALUE_DEFAULTED,
+        format!(
+            "PSS/E revision 32 {} record beginning {first:?} has {} field(s); the revision 32 layout reads {} fields through {}, so the missing fields took their defaults",
+            shape.record,
+            f.len(),
+            shape.width,
+            shape.last
+        ),
     );
-    let diagnostic = Diagnostic::of(&codes::READ_PSSE_VALUE_DEFAULTED, message);
-    let diagnostic = match span() {
-        Some(span) => diagnostic.clone().with_span(span).unwrap_or(diagnostic),
-        None => diagnostic,
-    };
-    warnings.record(diagnostic);
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1908,29 +1901,20 @@ fn apply_pending_regulating_nodes(
 }
 
 /// Parse `source` by borrowing it; the caller retains the buffer. `name_hint`
-/// (e.g. a file stem) names the network when the title line is blank. Findings
-/// carry no source spans; [`parse_psse_source_at`] is the entry the format hub
-/// uses when it knows where the text sits in its retained buffer.
+/// (e.g. a file stem) names the network when the title line is blank.
+///
+/// Every finding raised at a record, and a failure that ends the read at
+/// one, carries that record's byte range when `warnings` is located in the
+/// source buffer (the format hub locates it); an unlocated collector attaches
+/// no span.
 // A flat reader: header parse plus one match arm per section. Splitting it would
 // add indirection without clarity.
-#[cfg(test)]
-fn parse_psse_source(
+pub(crate) fn parse_psse_source(
     source: &str,
     name_hint: Option<&str>,
     warnings: &mut Diagnostics,
 ) -> Result<BalancedNetwork> {
-    parse_psse_source_inner(source, name_hint, None, warnings, false)
-}
-
-/// [`parse_psse_source`] with the position of `source` in its retained buffer,
-/// so a record finding can name the bytes it concerns.
-pub(super) fn parse_psse_source_at(
-    source: &str,
-    name_hint: Option<&str>,
-    position: Option<TextPosition<'_>>,
-    warnings: &mut Diagnostics,
-) -> Result<BalancedNetwork> {
-    parse_psse_source_inner(source, name_hint, position, warnings, false)
+    parse_psse_source_inner(source, name_hint, warnings, false)
 }
 
 pub(super) fn parse_psse_source_deferred_regulating_nodes(
@@ -1938,31 +1922,33 @@ pub(super) fn parse_psse_source_deferred_regulating_nodes(
     name_hint: Option<&str>,
     warnings: &mut Diagnostics,
 ) -> Result<BalancedNetwork> {
-    parse_psse_source_inner(source, name_hint, None, warnings, true)
+    parse_psse_source_inner(source, name_hint, warnings, true)
 }
 
 #[expect(clippy::too_many_lines)]
 fn parse_psse_source_inner(
     source: &str,
     name_hint: Option<&str>,
-    position: Option<TextPosition<'_>>,
     warnings: &mut Diagnostics,
     defer_regulating_nodes: bool,
 ) -> Result<BalancedNetwork> {
     let content: &str = source;
-    let mut lines = content.lines();
+    let mut lines = RawLines::new(content);
 
     // Header line 1: IC, SBASE, REV, ...
-    let header = lines
-        .by_ref()
-        .find(|line| {
-            let line = line.trim();
-            !line.is_empty() && !is_comment(line)
-        })
-        .ok_or_else(|| Error::FormatRead {
-            format: FMT,
-            message: "empty file".into(),
-        })?;
+    let header = loop {
+        let Some((start, raw)) = lines.next_line() else {
+            return Err(Error::FormatRead {
+                format: FMT,
+                message: "empty file".into(),
+            });
+        };
+        let line = raw.trim();
+        if !line.is_empty() && !is_comment(line) {
+            mark_record(warnings, start, raw);
+            break raw;
+        }
+    };
     let header_fields = fields(header);
     let base_mva = header_fields
         .get(1)
@@ -2003,14 +1989,16 @@ fn parse_psse_source_inner(
             value
         }
     };
-    // Line 2 is the case title; we write the network name there, so read it back.
-    let title = lines.next().unwrap_or("").trim();
+    warnings.leave_record();
+    // Line 2 is the case title; the emitter writes the network name there, so
+    // read it back.
+    let title = lines.next_line().map_or("", |(_, line)| line).trim();
     let name = if title.is_empty() {
         name_hint.unwrap_or("case").to_string()
     } else {
         title.to_string()
     };
-    lines.next(); // line 3: second comment
+    lines.next_line(); // line 3: second comment
 
     let mut buses = Vec::new();
     let mut loads = Vec::new();
@@ -2034,8 +2022,7 @@ fn parse_psse_source_inner(
     let mut section = Section::Bus;
     let mut saw_bus_marker = false;
     let mut skipped_section_name: Option<String> = None;
-    let mut lines = lines.peekable();
-    while let Some(raw) = lines.next() {
+    while let Some((start, raw)) = lines.next_line() {
         let line = raw.trim();
         if line.is_empty() {
             continue;
@@ -2047,6 +2034,7 @@ fn parse_psse_source_inner(
             break;
         }
         if is_terminator(line) {
+            warnings.leave_record();
             // The terminator names the section that begins next ("…, BEGIN
             // SWITCHED SHUNT DATA"); read that rather than counting, so the many
             // unmodeled sections between transformers and switched shunts don't
@@ -2058,19 +2046,18 @@ fn parse_psse_source_inner(
             saw_bus_marker |= matches!(section, Section::Bus);
             continue;
         }
+        // Every finding raised while this record is decoded, and a failure
+        // that ends the read here, carries the record's byte range; a
+        // continuation line extends it.
+        mark_record(warnings, start, raw);
         let f = fields(line);
         // Revision 32 has the shortest layouts, so a record that ends before
         // its last typed field is missing electrical data; the reader reports
-        // the record, with its bytes when the text's position is known.
+        // the record, with its byte range when the collector is located.
         if raw_rev == 32
             && let Some(shape) = revision32_shape(section)
         {
-            check_revision32_width(
-                &f,
-                shape,
-                || position.and_then(|position| position.span(content, raw)),
-                warnings,
-            );
+            check_revision32_width(&f, shape, warnings);
         }
         match section {
             Section::Bus if !saw_bus_marker && buses.is_empty() && is_system_wide_record(&f) => {
@@ -2124,25 +2111,31 @@ fn parse_psse_source_inner(
                 let two_winding = int_at(&f, 2, 0)? == 0;
                 let l2 = next_continuation_line(
                     &mut lines,
+                    warnings,
                     "transformer",
                     "transformer impedance line",
                 )?;
-                let l3 = next_continuation_line(&mut lines, "transformer", "winding data line 1")?;
-                let l4 = next_continuation_line(&mut lines, "transformer", "winding data line 2")?;
+                let l3 = next_continuation_line(
+                    &mut lines,
+                    warnings,
+                    "transformer",
+                    "winding data line 1",
+                )?;
+                let l4 = next_continuation_line(
+                    &mut lines,
+                    warnings,
+                    "transformer",
+                    "winding data line 2",
+                )?;
                 let (f2, f3, f4) = (fields(l2), fields(l3), fields(l4));
                 if two_winding {
                     if raw_rev == 32 {
-                        for (record, f, shape) in [
-                            (l2, &f2, REVISION32_TRANSFORMER_IMPEDANCE_2W),
-                            (l3, &f3, REVISION32_TRANSFORMER_WINDING),
-                            (l4, &f4, REVISION32_TRANSFORMER_WINDING_2),
+                        for (f, shape) in [
+                            (&f2, REVISION32_TRANSFORMER_IMPEDANCE_2W),
+                            (&f3, REVISION32_TRANSFORMER_WINDING),
+                            (&f4, REVISION32_TRANSFORMER_WINDING_2),
                         ] {
-                            check_revision32_width(
-                                f,
-                                shape,
-                                || position.and_then(|position| position.span(content, record)),
-                                warnings,
-                            );
+                            check_revision32_width(f, shape, warnings);
                         }
                     }
                     let index = branches.len();
@@ -2164,22 +2157,21 @@ fn parse_psse_source_inner(
                         });
                     }
                 } else {
-                    let l5 =
-                        next_continuation_line(&mut lines, "transformer", "winding data line 3")?;
+                    let l5 = next_continuation_line(
+                        &mut lines,
+                        warnings,
+                        "transformer",
+                        "winding data line 3",
+                    )?;
                     let f5 = fields(l5);
                     if raw_rev == 32 {
-                        for (record, f, shape) in [
-                            (l2, &f2, REVISION32_TRANSFORMER_IMPEDANCE_3W),
-                            (l3, &f3, REVISION32_TRANSFORMER_WINDING),
-                            (l4, &f4, REVISION32_TRANSFORMER_WINDING),
-                            (l5, &f5, REVISION32_TRANSFORMER_WINDING),
+                        for (f, shape) in [
+                            (&f2, REVISION32_TRANSFORMER_IMPEDANCE_3W),
+                            (&f3, REVISION32_TRANSFORMER_WINDING),
+                            (&f4, REVISION32_TRANSFORMER_WINDING),
+                            (&f5, REVISION32_TRANSFORMER_WINDING),
                         ] {
-                            check_revision32_width(
-                                f,
-                                shape,
-                                || position.and_then(|position| position.span(content, record)),
-                                warnings,
-                            );
+                            check_revision32_width(f, shape, warnings);
                         }
                     }
                     let index = transformers_3w.len();
@@ -2211,10 +2203,18 @@ fn parse_psse_source_inner(
             Section::TwoTerminalDc => {
                 // 3-line record: control line, then the rectifier and inverter
                 // converter lines whose first field is the AC terminal bus.
-                let rectifier =
-                    next_continuation_line(&mut lines, "two-terminal DC", "rectifier line")?;
-                let inverter =
-                    next_continuation_line(&mut lines, "two-terminal DC", "inverter line")?;
+                let rectifier = next_continuation_line(
+                    &mut lines,
+                    warnings,
+                    "two-terminal DC",
+                    "rectifier line",
+                )?;
+                let inverter = next_continuation_line(
+                    &mut lines,
+                    warnings,
+                    "two-terminal DC",
+                    "inverter line",
+                )?;
                 hvdc.push(read_dc_line(
                     &f,
                     &fields(rectifier),
@@ -2232,6 +2232,8 @@ fn parse_psse_source_inner(
             }
         }
     }
+
+    warnings.leave_record();
 
     if raw_rev >= 34 {
         unmodeled_sections.retain(|name, _| !name.starts_with("SUBSTATION"));
@@ -2341,12 +2343,52 @@ fn is_terminator(line: &str) -> bool {
     fields(line).first().map(Cow::as_ref) == Some("0")
 }
 
+/// The lines of the RAW text, each with the byte offset of its first
+/// character, so a record's byte range can be attached to the findings it
+/// produces. A line terminator (`\n` or `\r\n`) is excluded from the yielded
+/// text, as by `str::lines`.
+struct RawLines<'a> {
+    text: &'a str,
+    offset: usize,
+}
+
+impl<'a> RawLines<'a> {
+    fn new(text: &'a str) -> Self {
+        Self { text, offset: 0 }
+    }
+
+    fn next_line(&mut self) -> Option<(usize, &'a str)> {
+        if self.offset >= self.text.len() {
+            return None;
+        }
+        let start = self.offset;
+        let rest = &self.text[start..];
+        let (line, consumed) = match rest.find('\n') {
+            Some(end) => (&rest[..end], end + 1),
+            None => (rest, rest.len()),
+        };
+        self.offset += consumed;
+        Some((start, line.strip_suffix('\r').unwrap_or(line)))
+    }
+}
+
+/// Mark the record on `raw`, a line starting at byte `start`, as the
+/// collector's current record: its text without surrounding whitespace.
+fn mark_record(warnings: &mut Diagnostics, start: usize, raw: &str) {
+    let record_start = start + (raw.len() - raw.trim_start().len());
+    warnings.enter_record(record_start, record_start + raw.trim().len());
+}
+
+/// The next data line of a multi-line record, extending the collector's
+/// current record over it.
 fn next_continuation_line<'a>(
-    lines: &mut std::iter::Peekable<std::str::Lines<'a>>,
+    lines: &mut RawLines<'a>,
+    warnings: &mut Diagnostics,
     record: &str,
     expected: &str,
 ) -> Result<&'a str> {
-    for line in lines.by_ref().map(str::trim) {
+    while let Some((start, raw)) = lines.next_line() {
+        let line = raw.trim();
         if line.is_empty() || is_comment(line) {
             continue;
         }
@@ -2358,6 +2400,8 @@ fn next_continuation_line<'a>(
                 ),
             });
         }
+        let line_start = start + (raw.len() - raw.trim_start().len());
+        warnings.extend_record(line_start + line.len());
         return Ok(line);
     }
     Err(Error::FormatRead {
@@ -4613,6 +4657,7 @@ mod tests {
         parse_psse_source(content, None, &mut warnings)
     }
     use super::*;
+    use crate::diagnostics::Diagnostic;
 
     fn close(actual: f64, expected: f64) {
         assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
@@ -4732,7 +4777,7 @@ mod tests {
         assert!(short[1].message().contains("reads 13 fields through SCALE"));
         assert!(
             short.iter().all(|diagnostic| diagnostic.spans().is_empty()),
-            "a reader without a text position attaches no span"
+            "an unlocated collector attaches no span"
         );
         let unmodeled = warnings
             .lines()

--- a/powerio-tx/src/format/rawx.rs
+++ b/powerio-tx/src/format/rawx.rs
@@ -458,8 +458,14 @@ pub(super) fn parse_rawx_source(
     warn_unsupported_tables(network, warnings)?;
     warn_unknown_tables(network, warnings);
 
-    let mut parsed =
-        super::psse::parse_psse_source_deferred_regulating_nodes(&raw, name_hint, warnings)?;
+    // The shared reader decodes text synthesized here, not the RAWX document,
+    // so its record offsets name nothing in the retained buffer and no span is
+    // attached while it runs.
+    let location = warnings.suspend_location();
+    let parsed =
+        super::psse::parse_psse_source_deferred_regulating_nodes(&raw, name_hint, warnings);
+    warnings.resume_location(location);
+    let mut parsed = parsed?;
     *parsed.source_format_mut() = SourceFormat::PsseRawx;
     read_system_switches(network, &mut parsed, warnings)?;
     parsed.assign_missing_component_ids();

--- a/powerio/src/collect.rs
+++ b/powerio/src/collect.rs
@@ -5,7 +5,27 @@
 //! emitting crate carries its own copy of this file. Keep the copies byte
 //! identical; the shared record types come from `powerio-core`.
 
-use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagnostics};
+use powerio_core::{
+    Diagnostic, DiagnosticInfo, DiagnosticSeverity, SourceId, SourceSpan, render_diagnostics,
+};
+
+/// The buffer a reader decodes and the record it is on. While a record is
+/// set, every finding the collector records carries that record's byte range
+/// as a span into the buffer.
+#[derive(Clone, Debug, PartialEq)]
+#[allow(
+    dead_code,
+    reason = "the collector copies stay identical across crates"
+)]
+pub(crate) struct RecordLocation {
+    source: SourceId,
+    /// Byte offset of the decoded text within the retained buffer: the
+    /// length of the byte order mark the reader never sees.
+    base: u64,
+    /// Half open byte range of the current record, relative to the decoded
+    /// text.
+    record: Option<(usize, usize)>,
+}
 
 /// An ordered set of findings, built up as a reader, a lowering pass, or a
 /// writer runs.
@@ -15,7 +35,10 @@ use powerio_core::{Diagnostic, DiagnosticInfo, DiagnosticSeverity, render_diagno
 /// carries are rendered from the records by [`Diagnostics::lines`], never
 /// collected alongside them.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub(crate) struct Diagnostics(Vec<Diagnostic>);
+pub(crate) struct Diagnostics {
+    records: Vec<Diagnostic>,
+    location: Option<RecordLocation>,
+}
 
 #[allow(
     dead_code,
@@ -24,12 +47,16 @@ pub(crate) struct Diagnostics(Vec<Diagnostic>);
 impl Diagnostics {
     #[must_use]
     pub(crate) fn new() -> Self {
-        Self(Vec::new())
+        Self {
+            records: Vec::new(),
+            location: None,
+        }
     }
 
     /// Record a finding at its registered default severity.
     pub(crate) fn push(&mut self, info: &'static DiagnosticInfo, message: impl Into<String>) {
-        self.0.push(Diagnostic::of(info, message));
+        let diagnostic = self.located(Diagnostic::of(info, message));
+        self.records.push(diagnostic);
     }
 
     /// Record a finding at a severity this site raises or lowers.
@@ -39,70 +66,145 @@ impl Diagnostics {
         severity: DiagnosticSeverity,
         message: impl Into<String>,
     ) {
-        self.0
-            .push(Diagnostic::of(info, message).with_severity(severity));
+        let diagnostic = self.located(Diagnostic::of(info, message).with_severity(severity));
+        self.records.push(diagnostic);
     }
 
-    /// Record a finding built with the record's own builders.
+    /// Record a finding built with the record's own builders. A finding that
+    /// already names a span keeps it; one without receives the current
+    /// record's span.
     pub(crate) fn record(&mut self, diagnostic: Diagnostic) {
-        self.0.push(diagnostic);
+        let diagnostic = self.located(diagnostic);
+        self.records.push(diagnostic);
     }
 
     /// Record every finding of another set, in order.
     pub(crate) fn absorb(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
-        self.0.extend(other);
+        self.records.extend(other);
     }
 
     /// Put `other`'s findings ahead of this set's, which is what a conversion
     /// does with the read side.
     pub(crate) fn prepend(&mut self, other: impl IntoIterator<Item = Diagnostic>) {
         let mut front: Vec<_> = other.into_iter().collect();
-        front.append(&mut self.0);
-        self.0 = front;
+        front.append(&mut self.records);
+        self.records = front;
+    }
+
+    /// Name the buffer the running reader decodes so record spans can be
+    /// attached. `base` is the byte offset of the decoded text within the
+    /// retained buffer.
+    pub(crate) fn locate_in(&mut self, source: SourceId, base: u64) {
+        self.location = Some(RecordLocation {
+            source,
+            base,
+            record: None,
+        });
+    }
+
+    /// Take the location off the collector for a reader that decodes text
+    /// other than the retained buffer; [`Diagnostics::resume_location`] puts
+    /// it back.
+    pub(crate) fn suspend_location(&mut self) -> Option<RecordLocation> {
+        self.location.take()
+    }
+
+    pub(crate) fn resume_location(&mut self, location: Option<RecordLocation>) {
+        self.location = location;
+    }
+
+    /// Mark the record being decoded, as a half open byte range of the
+    /// decoded text. A no-op when no buffer is located.
+    pub(crate) fn enter_record(&mut self, start: usize, end: usize) {
+        if let Some(location) = &mut self.location {
+            location.record = Some((start, end.max(start)));
+        }
+    }
+
+    /// Extend the current record to `end`, for a record that continues over
+    /// more than one line.
+    pub(crate) fn extend_record(&mut self, end: usize) {
+        if let Some(location) = &mut self.location
+            && let Some((_, record_end)) = &mut location.record
+        {
+            *record_end = end.max(*record_end);
+        }
+    }
+
+    /// Leave the current record: findings recorded next carry no span.
+    pub(crate) fn leave_record(&mut self) {
+        if let Some(location) = &mut self.location {
+            location.record = None;
+        }
+    }
+
+    /// The span of the record being decoded, in the retained buffer's bytes.
+    #[must_use]
+    pub(crate) fn record_span(&self) -> Option<SourceSpan> {
+        let location = self.location.as_ref()?;
+        let (start, end) = location.record?;
+        SourceSpan::new(
+            location.source.clone(),
+            location.base + start as u64,
+            location.base + end as u64,
+        )
+        .ok()
+    }
+
+    fn located(&self, diagnostic: Diagnostic) -> Diagnostic {
+        match self.record_span() {
+            Some(span) if diagnostic.spans().is_empty() => diagnostic
+                .with_span(span)
+                .expect("a finding with no spans is below the span limit"),
+            _ => diagnostic,
+        }
     }
 
     #[must_use]
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.records.is_empty()
     }
 
     #[must_use]
     pub(crate) fn len(&self) -> usize {
-        self.0.len()
+        self.records.len()
     }
 
     #[must_use]
     pub(crate) fn records(&self) -> &[Diagnostic] {
-        &self.0
+        &self.records
     }
 
     #[must_use]
     pub(crate) fn into_records(self) -> Vec<Diagnostic> {
-        self.0
+        self.records
     }
 
     /// The `CODE: message` lines for the text channels.
     #[must_use]
     pub(crate) fn lines(&self) -> Vec<String> {
-        render_diagnostics(&self.0)
+        render_diagnostics(&self.records)
     }
 
     /// The worst severity recorded, or `None` when nothing was.
     #[must_use]
     pub(crate) fn worst_severity(&self) -> Option<DiagnosticSeverity> {
-        self.0.iter().map(Diagnostic::severity).max()
+        self.records.iter().map(Diagnostic::severity).max()
     }
 }
 
 impl From<Vec<Diagnostic>> for Diagnostics {
     fn from(records: Vec<Diagnostic>) -> Self {
-        Self(records)
+        Self {
+            records,
+            location: None,
+        }
     }
 }
 
 impl From<Diagnostics> for Vec<Diagnostic> {
     fn from(diagnostics: Diagnostics) -> Self {
-        diagnostics.0
+        diagnostics.records
     }
 }
 
@@ -111,7 +213,7 @@ impl IntoIterator for Diagnostics {
     type IntoIter = std::vec::IntoIter<Diagnostic>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.records.into_iter()
     }
 }
 
@@ -170,5 +272,36 @@ mod tests {
         );
         assert_eq!(write.len(), 2);
         assert!(!write.is_empty());
+    }
+
+    #[test]
+    fn findings_carry_the_current_record_span_while_located() {
+        let source = SourceId::new("/input").unwrap();
+        let mut d = Diagnostics::new();
+        d.enter_record(0, 4);
+        d.push(&DROPPED, "before any buffer is located");
+        assert!(d.records()[0].spans().is_empty());
+
+        d.locate_in(source.clone(), 3);
+        d.enter_record(10, 20);
+        d.extend_record(25);
+        d.push(&DROPPED, "inside a record");
+        let span = &d.records()[1].spans()[0];
+        assert_eq!(span.source(), &source);
+        assert_eq!((span.byte_start(), span.byte_end()), (13, 28));
+        assert_eq!(d.record_span().as_ref(), Some(span));
+
+        d.leave_record();
+        d.push(&DROPPED, "between records");
+        assert!(d.records()[2].spans().is_empty());
+        assert_eq!(d.record_span(), None);
+
+        d.enter_record(30, 31);
+        let location = d.suspend_location();
+        d.push(&DROPPED, "while suspended");
+        assert!(d.records()[3].spans().is_empty());
+        d.resume_location(location);
+        d.push(&DROPPED, "after resuming");
+        assert_eq!(d.records()[4].spans()[0].byte_start(), 33);
     }
 }

--- a/powerio/tests/ir_reference.rs
+++ b/powerio/tests/ir_reference.rs
@@ -1,0 +1,170 @@
+//! The PowerIO IR reference page and the generated schema name the same
+//! fields.
+//!
+//! Each field table on the page follows a line that names the schema
+//! definitions it documents. Both directions are checked: every field the
+//! page names exists in each named definition, and every property of each
+//! named definition appears in the table. Every structural type name in the
+//! schema's value discriminator must appear on the page, and the definition
+//! each value arm refers to must have a table.
+
+use std::collections::BTreeSet;
+
+const PAGE: &str = include_str!("../../docs/src/ir-reference.md");
+const SCHEMA: &str = include_str!("../../docs/schema/pio-module/1/schema.json");
+
+/// A line beginning with this text names the definitions of the next table.
+const MARKER: &str = "Schema definition";
+
+struct Table {
+    definitions: Vec<String>,
+    fields: Vec<String>,
+    /// The page line of the marker, for reporting.
+    line: usize,
+}
+
+fn backticked(text: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    let mut rest = text;
+    while let Some(open) = rest.find('`') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('`') else {
+            break;
+        };
+        names.push(after[..close].to_owned());
+        rest = &after[close + 1..];
+    }
+    names
+}
+
+fn first_cell(row: &str) -> &str {
+    row.trim_start_matches('|')
+        .split('|')
+        .next()
+        .unwrap_or("")
+        .trim()
+}
+
+fn tables() -> Vec<Table> {
+    let mut tables = Vec::new();
+    let mut pending: Option<(Vec<String>, usize)> = None;
+    let mut current: Option<Table> = None;
+    for (index, line) in PAGE.lines().enumerate() {
+        let number = index + 1;
+        if let Some(rest) = line.strip_prefix(MARKER) {
+            assert!(
+                pending.is_none(),
+                "line {number}: the previous marker has no table"
+            );
+            let definitions = backticked(rest);
+            assert!(
+                !definitions.is_empty(),
+                "line {number}: the marker names no definition"
+            );
+            pending = Some((definitions, number));
+            continue;
+        }
+        if line.starts_with('|') {
+            let cell = first_cell(line);
+            if let Some(table) = &mut current {
+                if cell.starts_with("---") {
+                    continue;
+                }
+                let names = backticked(cell);
+                assert!(!names.is_empty(), "line {number}: the row names no field");
+                table.fields.extend(names);
+            } else if let Some((definitions, marker_line)) = pending.take() {
+                assert_eq!(
+                    cell, "field",
+                    "line {number}: a field table starts with a `field` column"
+                );
+                current = Some(Table {
+                    definitions,
+                    fields: Vec::new(),
+                    line: marker_line,
+                });
+            }
+            continue;
+        }
+        if let Some(table) = current.take() {
+            tables.push(table);
+        }
+    }
+    assert!(pending.is_none(), "the last marker has no table");
+    if let Some(table) = current.take() {
+        tables.push(table);
+    }
+    tables
+}
+
+#[test]
+fn every_documented_field_exists_and_every_schema_field_is_documented() {
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA).unwrap();
+    let definitions = schema["$defs"].as_object().unwrap();
+    let mut documented = BTreeSet::new();
+    let mut problems = Vec::new();
+
+    let tables = tables();
+    assert!(
+        tables.len() > 50,
+        "only {} field tables found",
+        tables.len()
+    );
+    for table in &tables {
+        let page_fields: BTreeSet<&str> = table.fields.iter().map(String::as_str).collect();
+        if page_fields.len() != table.fields.len() {
+            problems.push(format!("line {}: a field is listed twice", table.line));
+        }
+        for definition in &table.definitions {
+            let Some(properties) = definitions
+                .get(definition)
+                .and_then(|entry| entry["properties"].as_object())
+            else {
+                problems.push(format!(
+                    "line {}: `{definition}` is not an object definition of the schema",
+                    table.line
+                ));
+                continue;
+            };
+            if !documented.insert(definition.clone()) {
+                problems.push(format!(
+                    "line {}: `{definition}` has more than one table",
+                    table.line
+                ));
+            }
+            let schema_fields: BTreeSet<&str> = properties.keys().map(String::as_str).collect();
+            for field in page_fields.difference(&schema_fields) {
+                problems.push(format!(
+                    "line {}: `{definition}` has no field `{field}`",
+                    table.line
+                ));
+            }
+            for field in schema_fields.difference(&page_fields) {
+                problems.push(format!(
+                    "line {}: `{definition}.{field}` is not documented",
+                    table.line
+                ));
+            }
+        }
+    }
+
+    for arm in definitions["StoredValue"]["oneOf"].as_array().unwrap() {
+        let type_name = arm["properties"]["type"]["const"].as_str().unwrap();
+        let reference = arm["properties"]["data"]["$ref"].as_str().unwrap();
+        let definition = reference.rsplit('/').next().unwrap();
+        if !documented.contains(definition) {
+            problems.push(format!(
+                "`{definition}`, the data of `{type_name}`, has no field table"
+            ));
+        }
+        if !PAGE.contains(&format!("`{type_name}`")) {
+            problems.push(format!("`{type_name}` is not named on the page"));
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "docs/src/ir-reference.md disagrees with docs/schema/pio-module/1/schema.json:\n{}",
+        problems.join("\n")
+    );
+}

--- a/powerio/tests/reader_spans.rs
+++ b/powerio/tests/reader_spans.rs
@@ -1,0 +1,178 @@
+//! The MATPOWER and PSS/E readers attach the byte range of the record a
+//! finding is about, into the retained source, for failures and warnings
+//! alike.
+
+use powerio::{PioModule, PioValue, Source};
+use powerio_core::{Error, SourceSpan};
+
+fn memory_source(name: &str, text: &str) -> Source {
+    Source::from_memory(name, text.as_bytes().to_vec()).unwrap()
+}
+
+fn parse_failure(name: &str, text: &str, format: &str) -> Error {
+    powerio::parse(memory_source(name, text), Some(format)).expect_err("the case is malformed")
+}
+
+/// The one span of the diagnostic that ended the operation.
+fn failure_span(error: &Error) -> &SourceSpan {
+    let diagnostic = &error.diagnostics()[0];
+    assert_eq!(diagnostic.spans().len(), 1, "{diagnostic:?}");
+    &diagnostic.spans()[0]
+}
+
+/// The retained bytes a span of a failed parse names.
+fn failure_bytes(error: &Error, span: &SourceSpan) -> Vec<u8> {
+    let buffer = error.retained_source().unwrap().primary_buffer().unwrap();
+    assert_eq!(span.source(), buffer.id());
+    buffer.bytes()[span.byte_start() as usize..span.byte_end() as usize].to_vec()
+}
+
+/// One based line and column of a byte offset in `text`.
+fn line_and_column(text: &[u8], offset: usize) -> (usize, usize) {
+    let before = &text[..offset];
+    // Splitting on newlines yields one piece per line, so the piece count is
+    // the one based line number.
+    let line = before.split(|byte| *byte == b'\n').count();
+    let column = before
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(offset, |newline| offset - newline - 1)
+        + 1;
+    (line, column)
+}
+
+const SHORT_ROW: &str = "\t2  1  0 0;";
+
+fn matpower_with_a_short_bus_row() -> String {
+    format!(
+        "function mpc = short\nmpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n{SHORT_ROW}\n];\nmpc.branch = [];\n"
+    )
+}
+
+#[test]
+fn a_short_matpower_row_names_its_bytes_line_and_column() {
+    let text = matpower_with_a_short_bus_row();
+    let error = parse_failure("short.m", &text, "matpower");
+    assert_eq!(error.diagnostics()[0].code(), "PARSE.MATPOWER.MALFORMED");
+    let span = failure_span(&error);
+    assert_eq!(failure_bytes(&error, span), b"2  1  0 0");
+    assert_eq!(
+        line_and_column(text.as_bytes(), span.byte_start() as usize),
+        (5, 2)
+    );
+    assert_eq!(
+        line_and_column(text.as_bytes(), span.byte_end() as usize),
+        (5, 11)
+    );
+}
+
+#[test]
+fn a_byte_order_mark_keeps_the_span_on_the_retained_bytes() {
+    let text = format!("\u{feff}{}", matpower_with_a_short_bus_row());
+    let error = parse_failure("short.m", &text, "matpower");
+    let span = failure_span(&error);
+    assert_eq!(failure_bytes(&error, span), b"2  1  0 0");
+    // `text` starts with the three mark bytes the reader never sees, and so
+    // does the retained buffer, so the span names the same offset.
+    assert_eq!(span.byte_start() as usize, text.find("2  1  0 0").unwrap());
+}
+
+#[test]
+fn a_malformed_matpower_token_names_its_row() {
+    let text = "mpc.baseMVA = 100;\nmpc.bus = [\n\t1  3  0 0 0 0 1 1.0 0 345 1 1.1 0.9;\n\t2  1  0 x 0 0 1 1.0 0 345 1 1.1 0.9;\n];\nmpc.branch = [];\n";
+    let error = parse_failure("token.m", text, "matpower");
+    let span = failure_span(&error);
+    assert_eq!(
+        failure_bytes(&error, span),
+        b"2  1  0 x 0 0 1 1.0 0 345 1 1.1 0.9;"
+    );
+}
+
+#[test]
+fn a_matpower_failure_without_a_record_carries_no_span() {
+    let error = parse_failure("nobus.m", "mpc.baseMVA = 100;\n", "matpower");
+    assert!(error.diagnostics()[0].spans().is_empty());
+}
+
+const RAW_HEADER: &str = "0, 100.00, 33, 0, 0, 60.00\nSPANS\nCOMMENT\n";
+
+fn raw_after_buses(sections: &str) -> String {
+    format!(
+        "{RAW_HEADER}1, 'B1', 138.0, 3, 1, 1, 1, 1.0, 0.0\n2, 'B2', 0.0, 1, 1, 1, 1, 1.0, 0.0\n0 / END OF BUS DATA, BEGIN LOAD DATA\n0 / END OF LOAD DATA, BEGIN FIXED SHUNT DATA\n0 / END OF FIXED SHUNT DATA, BEGIN GENERATOR DATA\n0 / END OF GENERATOR DATA, BEGIN BRANCH DATA\n0 / END OF BRANCH DATA, BEGIN TRANSFORMER DATA\n{sections}0 / END OF TRANSFORMER DATA, BEGIN AREA DATA\n0 / END OF AREA DATA, BEGIN TWO-TERMINAL DC DATA\n0 / END OF TWO-TERMINAL DC DATA, BEGIN VSC DC LINE DATA\n0 / END OF VSC DC LINE DATA, BEGIN IMPEDANCE CORRECTION DATA\n0 / END OF IMPEDANCE CORRECTION DATA, BEGIN MULTI-TERMINAL DC DATA\n0 / END OF MULTI-TERMINAL DC DATA, BEGIN MULTI-SECTION LINE DATA\n0 / END OF MULTI-SECTION LINE DATA, BEGIN ZONE DATA\n0 / END OF ZONE DATA, BEGIN INTER-AREA TRANSFER DATA\n0 / END OF INTER-AREA TRANSFER DATA, BEGIN OWNER DATA\n0 / END OF OWNER DATA, BEGIN FACTS DEVICE DATA\n0 / END OF FACTS DEVICE DATA, BEGIN SWITCHED SHUNT DATA\n0 / END OF SWITCHED SHUNT DATA, BEGIN GNE DEVICE DATA\n0 / END OF GNE DEVICE DATA, BEGIN INDUCTION MACHINE DATA\n0 / END OF INDUCTION MACHINE DATA\nQ\n"
+    )
+}
+
+const TRANSFORMER_LINE_1: &str = "1, 2, 0, '1', 2, 1, 1, 0.0, 0.0, 2, 'T1', 1, 1, 1.0";
+const TRANSFORMER_LINE_2: &str = "0.01, 0.1, 100.0";
+const TRANSFORMER_LINE_3: &str =
+    "1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 1.1, 0.9, 1.1, 0.9, 33, 0, 0.0, 0.0";
+const TRANSFORMER_LINE_4: &str = "1.0, 0.0";
+
+#[test]
+fn a_malformed_psse_record_names_its_line() {
+    let bad_bus = "abc, 'B1', 138.0, 3, 1, 1, 1, 1.0, 0.0";
+    let text = format!("{RAW_HEADER}  {bad_bus}\n0 / END OF BUS DATA\nQ\n");
+    let error = parse_failure("bad.raw", &text, "psse");
+    let span = failure_span(&error);
+    assert_eq!(failure_bytes(&error, span), bad_bus.as_bytes());
+    assert_eq!(
+        line_and_column(text.as_bytes(), span.byte_start() as usize),
+        (4, 3)
+    );
+}
+
+#[test]
+fn a_psse_record_cut_short_by_a_terminator_names_the_lines_read() {
+    let text = raw_after_buses(&format!("{TRANSFORMER_LINE_1}\n{TRANSFORMER_LINE_2}\n"));
+    let error = parse_failure("cut.raw", &text, "psse");
+    let span = failure_span(&error);
+    assert_eq!(
+        failure_bytes(&error, span),
+        format!("{TRANSFORMER_LINE_1}\n{TRANSFORMER_LINE_2}").as_bytes()
+    );
+}
+
+#[test]
+fn a_psse_warning_covers_the_multi_line_record_it_came_from() {
+    let record = format!(
+        "{TRANSFORMER_LINE_1}\n{TRANSFORMER_LINE_2}\n{TRANSFORMER_LINE_3}\n{TRANSFORMER_LINE_4}"
+    );
+    let text = raw_after_buses(&format!("{record}\n"));
+    let module: PioModule<PioValue> =
+        powerio::parse(memory_source("warn.raw", &text), Some("psse")).unwrap();
+    let substituted: Vec<_> = module
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code() == "READ.PSSE.VALUE_SUBSTITUTED")
+        .collect();
+    assert!(!substituted.is_empty(), "{:?}", module.diagnostics);
+    let buffer = module.source().unwrap().primary_buffer().unwrap();
+    for diagnostic in substituted {
+        assert_eq!(diagnostic.spans().len(), 1, "{diagnostic:?}");
+        let span = &diagnostic.spans()[0];
+        assert_eq!(span.source(), module.sources()[0].id());
+        assert_eq!(
+            &buffer.bytes()[span.byte_start() as usize..span.byte_end() as usize],
+            record.as_bytes()
+        );
+    }
+    // Findings about the whole document carry no record span.
+    assert!(
+        module
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code() != "READ.PSSE.VALUE_SUBSTITUTED")
+            .all(|diagnostic| diagnostic.spans().is_empty()),
+        "{:?}",
+        module.diagnostics
+    );
+}
+
+#[test]
+fn a_psse_header_failure_names_the_header_line() {
+    let header = "0, abc, 33, 0, 0, 60.00";
+    let text = format!("{header}\nSPANS\nCOMMENT\nQ\n");
+    let error = parse_failure("header.raw", &text, "psse");
+    let span = failure_span(&error);
+    assert_eq!(failure_bytes(&error, span), header.as_bytes());
+}

--- a/powerio/tests/stored_module.rs
+++ b/powerio/tests/stored_module.rs
@@ -495,6 +495,91 @@ fn balanced_network_scenario_set_round_trips() {
     assert_eq!(serialize_module_text(&back).unwrap(), text);
 }
 
+// ---- determinism of `serialize` ---------------------------------------------
+
+fn fixture_path(relative: &str) -> String {
+    format!("{}/../tests/data/{relative}", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn parse_fixture(relative: &str, format: &str) -> PioModule<PioValue> {
+    powerio::parse(
+        powerio::Source::open(fixture_path(relative)).unwrap(),
+        Some(format),
+    )
+    .unwrap_or_else(|error| panic!("{relative}: {error}"))
+}
+
+/// Serializing a module twice gives identical text, and serializing what
+/// that text deserializes to gives the same text again.
+fn assert_serialization_is_stable(module: &PioModule<PioValue>, label: &str) {
+    let first = serialize_module_text(module).unwrap();
+    let second = serialize_module_text(module).unwrap();
+    assert_eq!(
+        first, second,
+        "{label}: two serializations of one module differ"
+    );
+    let reread = deserialize_module_text(&first).unwrap();
+    let third = serialize_module_text(&reread).unwrap();
+    assert_eq!(
+        first, third,
+        "{label}: serialize, deserialize, serialize is not identity"
+    );
+}
+
+#[test]
+fn serialization_of_the_fixture_cases_is_deterministic() {
+    for (relative, format) in [
+        ("case9.m", "matpower"),
+        ("case14.m", "matpower"),
+        ("dist/bmopf/example_ieee13.json", "bmopf-json"),
+        ("dist/opendss/ieee13/IEEE13Nodeckt.dss", "dss"),
+    ] {
+        assert_serialization_is_stable(&parse_fixture(relative, format), relative);
+    }
+}
+
+#[test]
+fn serialization_of_records_and_collections_is_deterministic() {
+    use powerio_core::{Scenario, ScenarioId, ScenarioSet};
+
+    assert_serialization_is_stable(&module_with_records(), "records");
+
+    let mut second = small_network();
+    second.loads_mut()[0].p = 55.0;
+    let series = powerio_core::TimeSeries::new(
+        vec![
+            TimePoint::new("h0", Some(std::time::Duration::from_secs(3600))).unwrap(),
+            TimePoint::new("h1", None).unwrap(),
+        ],
+        vec![small_network(), second],
+    )
+    .unwrap();
+    assert_serialization_is_stable(&PioModule::new(PioValue::from(series)), "time series");
+
+    let set = ScenarioSet::new(vec![
+        Scenario::new(ScenarioId::new("peak").unwrap(), Some(0.4), small_network()),
+        Scenario::new(ScenarioId::new("base").unwrap(), Some(0.6), small_network()),
+    ])
+    .unwrap();
+    assert_serialization_is_stable(&PioModule::new(PioValue::from(set)), "scenario set");
+
+    let points = powerio_prob::BalancedOperatingPointBuilder::new(
+        small_network(),
+        vec![
+            TimePoint::new("h0", None).unwrap(),
+            TimePoint::new("h1", None).unwrap(),
+        ],
+    )
+    .load_active_powers(vec![40.0, 55.0])
+    .generator_active_powers(vec![42.0, 61.5])
+    .build()
+    .unwrap();
+    assert_serialization_is_stable(
+        &PioModule::new(PioValue::from(points)),
+        "operating point series",
+    );
+}
+
 // ---- reference validation ----------------------------------------------------
 
 #[test]


### PR DESCRIPTION
Stacked on #466. Closes #464.

## Summary

- Add `docs/src/ir-reference.md`: one table per structural type, 92 in all, with field, type, unit, sign, invariant and what a reader may default. `powerio/tests/ir_reference.rs` checks it against the generated schema in both directions.
- State and test that `serialize` is deterministic. No serializer change was needed.
- Add a record location to the diagnostics collector (`enter_record`, `extend_record`, `leave_record`, `record_span`) and `powerio_core::Error::with_span`.
- The MATPOWER reader marks rows, malformed tokens, truncated matrices and cost tables; the PSS/E reader marks every record and extends it over continuation lines.
- `render_diagnostic` receives only the diagnostic, so `file:line:col` text output needs an API change; recorded as a known limit.

## Testing

- `cargo test -p powerio-tx -p powerio -p powerio-core -p powerio-cli`, including `powerio/tests/reader_spans.rs`
- clippy 1.98.0 `-D warnings`, `cargo fmt --all -- --check`, `mdbook build docs`
- `evals/powsybl/run.sh`: 18,681 assertions
