### PR TITLE
Support IIDM 1.0 through 1.17 and JIIDM

### DIFF
--- a/.github/workflows/powsybl.yml
+++ b/.github/workflows/powsybl.yml
@@ -41,12 +41,7 @@ jobs:
         sparse-checkout: |
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-2/MicroGrid/Type2_T2/CGMES_v2.4.15_MicroGridTestConfiguration_T2_Assembled_Complete_v2
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged
-          iidm/iidm-serde/src/test/resources/V1_12/threeWindingsTransformerToBeEstimated.xiidm
-          iidm/iidm-serde/src/test/resources/V1_13/threeWindingsTransformerToBeEstimated.xiidm
-          iidm/iidm-serde/src/test/resources/V1_14/threeWindingsTransformerToBeEstimated.xiidm
-          iidm/iidm-serde/src/test/resources/V1_15/threeWindingsTransformerToBeEstimated.xiidm
-          iidm/iidm-serde/src/test/resources/V1_16/threeWindingsTransformerToBeEstimated.xiidm
-          iidm/iidm-serde/src/test/resources/V1_17/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources
           psse/psse-converter/src/test/resources/remoteControl.xiidm
           psse/psse-converter/src/test/resources/twoTerminalDc.xiidm
           psse/psse-converter/src/test/resources/five_bus_nodeBreaker_rev35.xiidm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,19 @@ the failure that ends a read and the warnings alike. `powerio_core::Error`
 gains `with_span`, which attaches a range to the diagnostic that ended an
 operation.
 
+**IIDM 1.0 through 1.17 and JIIDM.** The PowSybl reader accepts every IIDM
+serialization version, from the iTesla namespaced 1.0 to 1.17, with each
+version's rules: busbar section voltages, inline tie lines, `targetV` ratio
+tap changers, legacy shunt and static VAR compensator attributes, and loading
+limits stated on the equipment. Each maps to the same tables as its 1.17 form.
+The new `jiidm` token reads PowSybl's JSON encoding of any of those versions
+and writes JIIDM 1.17 in PowSybl's field layout and order; a bare `.json`
+whose first key is `version` classifies as `jiidm`. `SourceFormat::Jiidm`
+names a module read from JIIDM, and `EMIT.JIIDM.*` codes report its writer.
+XIIDM output stays 1.17. The XIIDM element mapping now reads one tree
+representation produced by either the XML or JSON reader. In the PowSybl
+gate, PyPowSybl reads PowerIO's JIIDM output and PowerIO reads PyPowSybl's.
+
 ## 0.10.0
 
 PowerIO 0.10 is the public beta of the 1.0 API. API corrections may land before 1.0.0 as downstream integrations exercise the new design.

--- a/docs/schema/pio-module/1/schema.json
+++ b/docs/schema/pio-module/1/schema.json
@@ -11310,7 +11310,12 @@
         },
         {
           "const": "xiidm",
-          "description": "Read from PowSybl's XIIDM XML grid exchange format, versions 1.12 through 1.17.",
+          "description": "Read from PowSybl's XIIDM XML grid exchange format, versions 1.0 through 1.17.",
+          "type": "string"
+        },
+        {
+          "const": "jiidm",
+          "description": "Read from PowSybl's JIIDM JSON grid exchange format, versions 1.0 through 1.17.",
           "type": "string"
         },
         {

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -35,7 +35,7 @@ Three rules hold everywhere:
 - emitting another format keeps everything the target can represent and reports each loss as a coded diagnostic;
 - moving between value families is an explicit, recorded operation, never a side effect.
 
-Supported sources: MATPOWER, PSS/E RAW revisions 32 through 35, PSS/E RAWX 35, PowSybl XIIDM 1.12 through 1.17, CIM CGMES 2.4.15 and 3.0, PowerWorld AUX and PWB, PSLF EPC, PowerModels JSON, Egret JSON, pandapower JSON, PyPSA CSV folders, Surge JSON, DOE GO Challenge 3 JSON, DeepMind OPFData JSON, GridFM Parquet datasets, OpenDSS, PowerModelsDistribution engineering JSON, and BMOPF JSON. PowerIO IR enters through `deserialize`, not `parse`. [Formats and Fidelity](format-fidelity.md) states each format's supported profile and write support.
+Supported sources: MATPOWER, PSS/E RAW revisions 32 through 35, PSS/E RAWX 35, PowSybl XIIDM and JIIDM 1.0 through 1.17, CIM CGMES 2.4.15 and 3.0, PowerWorld AUX and PWB, PSLF EPC, PowerModels JSON, Egret JSON, pandapower JSON, PyPSA CSV folders, Surge JSON, DOE GO Challenge 3 JSON, DeepMind OPFData JSON, GridFM Parquet datasets, OpenDSS, PowerModelsDistribution engineering JSON, and BMOPF JSON. PowerIO IR enters through `deserialize`, not `parse`. [Formats and Fidelity](format-fidelity.md) states each format's supported profile and write support.
 
 Operations exposed on more than one surface use the same value types, format
 names, diagnostic codes, signs, and units. [Rust, Python, Julia, and C](languages.md)

--- a/docs/src/format-fidelity.md
+++ b/docs/src/format-fidelity.md
@@ -113,7 +113,14 @@ on the parsed module. Codes name the format and reason, such as
 there is no generic
 parse warning that hides the cause.
 
-- **XIIDM** reads PowSybl XIIDM 1.12 through 1.17 and writes 1.17. It maps
+- **XIIDM and JIIDM** read PowSybl IIDM 1.0 through 1.17 in the XML (`xiidm`)
+  and JSON (`jiidm`) encodings and write 1.17 in either; the
+  [IIDM versions](#iidm-versions) table names what each version changed. One
+  element mapping consumes both encodings, so a JIIDM document reads to the
+  same network as the XIIDM document of the same network, and fresh JIIDM
+  follows PowSybl's JSON layout: plural array fields for repeated elements,
+  typed scalars, and each element's attributes in the order PowSybl's
+  sequential JSON reader consumes them. The mapping covers
   substations, voltage levels, bus breaker and node breaker topology, busbar
   sections, switches, lines, tie and boundary lines, loads, generators,
   batteries, shunts, static VAR compensators, two- and three-winding
@@ -339,6 +346,42 @@ parse warning that hides the cause.
   identical). The losses are the module's diagnostics. The same direction
   writer is documented in the
   [top level README](https://github.com/eigenergy/powerio#gridfm).
+
+### IIDM versions
+
+PowerIO reads every IIDM serialization version PowSybl has published and
+writes 1.17. A document of an older version is read with that version's rules
+and reported with `READ.XIIDM.VERSION.COMPATIBILITY`; a namespace naming a
+version outside this table is refused with `PARSE.XIIDM.VERSION_UNSUPPORTED`.
+The table lists, per version, what the reader does differently from 1.17.
+Every row is checked against the PowSybl fixture of the same network in
+`tests/data/xiidm/powsybl`.
+
+| Version | Read | What the version states differently |
+| --- | --- | --- |
+| 1.0 | XIIDM | iTesla namespace. Busbar sections carry the calculated bus `v` and `angle`. Three winding transformers have no `ratedU0` (leg 1 rated voltage is the impedance base), no leg 1 tap changer, and no phase tap changers. Tie lines state both half lines inline with `_1`/`_2` suffixes and `ucteXnodeCode`. Shunts state `bPerSection`, `maximumSectionCount`, and `currentSectionCount` and never regulate. Static VAR compensators spell `voltageSetPoint` and `reactivePowerSetPoint`. Batteries spell `p0` and `q0`. Ratio tap changers state `targetV`. Loading limits sit directly on the equipment as the selected `DEFAULT` group. A switch closing a bus or node onto itself is discarded, as PowSybl does. No `minimumValidationLevel`. |
+| 1.1 | XIIDM | PowSybl namespace. Calculated buses under node breaker topology. Three winding transformer `ratedU0`, leg 1 tap changers, and phase tap changers. |
+| 1.2 | XIIDM | `fictitious` on every identifiable, `targetDeadband` on tap changers, `ratedS`, and shunt voltage regulation. |
+| 1.3 | XIIDM | Shunt linear and nonlinear models with `sectionCount`, aliases, and boundary line generation. |
+| 1.4 | XIIDM | Alias types. |
+| 1.5 | XIIDM | Active and apparent power limits. |
+| 1.6 | XIIDM | Voltage levels outside substations and VSC regulating terminals. |
+| 1.7 | XIIDM | `minimumValidationLevel` and the equipment validation namespace. |
+| 1.8 | XIIDM | Batteries spell `targetP` and `targetQ`. Fictitious bus injections (reported, not retained). Self connected switches are refused. |
+| 1.9 | XIIDM | Shunt `p`. |
+| 1.10 | XIIDM | Tie lines reference two dangling lines. Load models. |
+| 1.11 | XIIDM, JIIDM | `pairingKey` replaces `ucteXnodeCode`. Subnetworks. Voltage angle limits (reported, not retained). |
+| 1.12 | XIIDM, JIIDM | Operational limits groups and ratio tap changer `regulationMode`/`regulationValue`. |
+| 1.13 | XIIDM, JIIDM | Areas, `isCondenser`, and active power control 1.2. |
+| 1.14 | XIIDM, JIIDM | Solved tap positions and section counts, `regulating` on static VAR compensators and phase tap changers. |
+| 1.15 | XIIDM, JIIDM | DC nodes, grounds, lines, switches, and AC/DC converters. |
+| 1.16 | XIIDM, JIIDM | `shuntCompensator` and `boundaryLine` element names and multiple selected limit groups. |
+| 1.17 | XIIDM, JIIDM | Optional zero conductance and susceptance, `retained` and `lowTapPosition` defaults, DC switch resistance. Writers use this version. |
+
+JIIDM has no namespace: the document's `version` field selects the same
+rules, and `minimumValidationLevel` selects the validation level. PowSybl
+ships JIIDM fixtures from 1.11 on; an older `version` value reads with that
+version's XML rules.
 
 ## Missing generator costs
 

--- a/evals/powsybl/README.md
+++ b/evals/powsybl/README.md
@@ -3,9 +3,13 @@
 The [CGMES contribution audit](cgmes-contribution-audit.md) compares the final
 implementation with Mohamed Numair's original CGMES reader and writer commits.
 
-The gate keeps the case9 XIIDM, CGMES, PSS/E RAW revisions 33 through 35, and
-PSS/E RAWX smoke outputs. It also reads official PowSybl Core reference cases
-for CGMES 2.4.15, CGMES 3.0, XIIDM 1.12 through 1.17, RAW, and RAWX. CI obtains
+The gate keeps the case9 XIIDM, JIIDM, CGMES, PSS/E RAW revisions 33 through
+35, and PSS/E RAWX smoke outputs. It also reads official PowSybl Core reference
+cases for CGMES 2.4.15, CGMES 3.0, XIIDM 1.12 through 1.17, RAW, and RAWX, and
+it asks PowSybl to write the eurostag tutorial network as XIIDM and JIIDM in
+every IIDM version from 1.0 to 1.17; PowerIO reads each of those, emits the
+same encoding at 1.17, and PyPowSybl compares both against the official
+network. CI obtains
 those files with a sparse checkout of `powsybl/powsybl-core` at
 `0939bfcc2c0c094de907dc818dd688b4cbfb7281`; no PowSybl case is copied into
 this repository.
@@ -19,10 +23,13 @@ and loads the fresh RAW 33 written from each.
 
 The gate also asks PowSybl to export the same remote regulation case as XIIDM
 1.12 through 1.17, CGMES 2.4.15 on CIM16, and CGMES 3.0 on CIM100. PowerIO
-reads each PowSybl output, removes retained source bytes through PowerIO IR,
-emits fresh XIIDM 1.17 or CGMES 3.0, and compares both PowSybl views. This
+reads each PowSybl output, serializes and deserializes it through PowerIO IR,
+emits XIIDM 1.17 or CGMES 3.0 from the typed value, and compares both PowSybl
+views. This
 checks the supported input revisions and profiles against files written by
-PowSybl rather than only against files stored in its source tree.
+PowSybl rather than only against files stored in its source tree. The remote
+regulation case is also emitted as JIIDM, which PyPowSybl loads through
+its JIIDM importer and compares against the official network.
 
 PowSybl writes human readable, non-UUID mRIDs in these two CGMES cases.
 PowerIO writes UUID mRIDs as required by its fresh CGMES output rules. The gate

--- a/evals/powsybl/check_outputs.py
+++ b/evals/powsybl/check_outputs.py
@@ -81,6 +81,10 @@ REMOTE_CONTROL_RELATIVE = Path(
 TWO_TERMINAL_DC_RELATIVE = Path(
     "psse/psse-converter/src/test/resources/twoTerminalDc.xiidm"
 )
+EUROSTAG_RELATIVE = Path(
+    "iidm/iidm-serde/src/test/resources/V1_17/eurostag-tutorial1-lf.xml"
+)
+IIDM_VERSIONS = tuple(range(0, 18))
 XIIDM_VERSION_FIXTURES = {
     "1.12": (
         Path("iidm/iidm-serde/src/test/resources/V1_12/threeWindingsTransformerToBeEstimated.xiidm"),
@@ -1006,6 +1010,22 @@ XIIDM_EXPECTATIONS = {
             "switches": 0,
         }
         for version in XIIDM_VERSION_FIXTURES
+    },
+    "IIDM eurostag": {
+        "voltage levels": 4,
+        "buses": 4,
+        "lines": 2,
+        "2W transformers": 2,
+        "3W transformers": 0,
+        "generators": 1,
+        "loads": 1,
+        "shunts": 0,
+        "LCC converters": 0,
+        "HVDC lines": 0,
+        "operational limits": 0,
+        "ratio changers": 1,
+        "ratio steps": 3,
+        "switches": 0,
     },
 }
 ASSERTION_COUNT = [0]
@@ -3785,8 +3805,10 @@ def check_xiidm_equivalence(
     fresh: pp.network.Network,
     label: str,
     expectation_key: str | None = None,
+    excluded_cells: dict[str, set[tuple[str, str]]] | None = None,
 ) -> None:
     expected = XIIDM_EXPECTATIONS[expectation_key or label]
+    excluded_cells = excluded_cells or {}
     frames = (
         (
             "voltage level",
@@ -3835,6 +3857,7 @@ def check_xiidm_equivalence(
             label,
             XIIDM_ELECTRICAL_FIELDS,
             exact_ids=True,
+            excluded_cells=excluded_cells.get(equipment),
         )
         comparisons += compared
 
@@ -4398,6 +4421,7 @@ def main() -> None:
 
     for path, label in (
         (output_dir / "case9.xiidm", "case9 XIIDM"),
+        (output_dir / "case9.jiidm", "case9 JIIDM"),
         (case9_cgmes_zip, "case9 CGMES"),
         (output_dir / "case9-psse33.raw", "case9 PSS/E RAW revision 33"),
         (output_dir / "case9-psse35.raw", "case9 PSS/E RAW revision 35"),
@@ -4529,6 +4553,17 @@ def main() -> None:
         "XIIDM remote control",
     )
     check_xiidm_remote_control(remote_control)
+    remote_control_jiidm = load_checked(
+        output_dir / "remote-control.jiidm",
+        "fresh JIIDM remote control",
+    )
+    check_xiidm_equivalence(
+        remote_control_source,
+        remote_control_jiidm,
+        "JIIDM remote control",
+        expectation_key="XIIDM remote control",
+    )
+    check_xiidm_remote_control(remote_control_jiidm)
 
     two_terminal_dc_source = load_checked(
         powsybl_core / TWO_TERMINAL_DC_RELATIVE,
@@ -4585,6 +4620,43 @@ def main() -> None:
             f"PowSybl XIIDM 1.{version}",
             expectation_key="XIIDM remote control",
         )
+
+    eurostag_source = load_checked(powsybl_core / EUROSTAG_RELATIVE, "official IIDM eurostag")
+    # The eurostag transformers state rated voltages (24/400 kV and 400/158 kV)
+    # that differ from their terminal nominal voltages. Fresh PowerIO output
+    # keeps the voltage ratio and normalizes the winding voltage base to the
+    # terminal nominal voltage, which the reader reports as
+    # `READ.XIIDM.FIELD_UNMAPPED`; `rho` is still compared.
+    eurostag_fresh_exclusions = {
+        "2W transformer": {
+            (transformer, column)
+            for transformer in ("NGEN_NHV1", "NHV2_NLOAD")
+            for column in ("rated_u1", "rated_u2")
+        }
+    }
+    for version in IIDM_VERSIONS:
+        for encoding, extension in (("xiidm", "xiidm"), ("jiidm", "jiidm")):
+            written = load_checked(
+                powsybl_inputs / f"powsybl-eurostag-{encoding}-1-{version}.{extension}",
+                f"PowSybl generated {encoding.upper()} 1.{version}",
+            )
+            check_xiidm_equivalence(
+                eurostag_source,
+                written,
+                f"PowSybl generated {encoding.upper()} 1.{version}",
+                expectation_key="IIDM eurostag",
+            )
+            fresh = load_checked(
+                output_dir / f"powsybl-eurostag-{encoding}-1-{version}.{extension}",
+                f"fresh {encoding.upper()} from PowSybl {encoding.upper()} 1.{version}",
+            )
+            check_xiidm_equivalence(
+                eurostag_source,
+                fresh,
+                f"fresh {encoding.upper()} from PowSybl {encoding.upper()} 1.{version}",
+                expectation_key="IIDM eurostag",
+                excluded_cells=eurostag_fresh_exclusions,
+            )
 
     for version in ("2415", "30"):
         source_path = powsybl_inputs / f"powsybl-cgmes-{version}.zip"

--- a/evals/powsybl/export_inputs.py
+++ b/evals/powsybl/export_inputs.py
@@ -7,6 +7,8 @@ import argparse
 from pathlib import Path
 
 from check_outputs import (
+    EUROSTAG_RELATIVE,
+    IIDM_VERSIONS,
     REMOTE_CONTROL_RELATIVE,
     check_powsybl_version,
     load_checked,
@@ -31,6 +33,24 @@ def main() -> None:
         network.save(
             output_dir / f"powsybl-xiidm-1-{version}.xiidm",
             "XIIDM",
+            {"iidm.export.xml.version": f"1.{version}"},
+        )
+
+    # The eurostag tutorial network is representable in every IIDM version,
+    # so PowSybl writes it in each version and in both encodings.
+    eurostag = load_checked(
+        args.powsybl_core.resolve() / EUROSTAG_RELATIVE,
+        "PowSybl eurostag export source",
+    )
+    for version in IIDM_VERSIONS:
+        eurostag.save(
+            output_dir / f"powsybl-eurostag-xiidm-1-{version}.xiidm",
+            "XIIDM",
+            {"iidm.export.xml.version": f"1.{version}"},
+        )
+        eurostag.save(
+            output_dir / f"powsybl-eurostag-jiidm-1-{version}.jiidm",
+            "JIIDM",
             {"iidm.export.xml.version": f"1.{version}"},
         )
 

--- a/evals/powsybl/run.sh
+++ b/evals/powsybl/run.sh
@@ -71,6 +71,8 @@ fresh_emit() {
 "$powerio_binary" convert "$repository_root/tests/data/case9.m" \
     --to xiidm -o "$output_dir/case9.xiidm"
 "$powerio_binary" convert "$repository_root/tests/data/case9.m" \
+    --to jiidm -o "$output_dir/case9.jiidm"
+"$powerio_binary" convert "$repository_root/tests/data/case9.m" \
     --to cgmes -o "$output_dir/case9-cgmes"
 "$powerio_binary" convert "$repository_root/tests/data/case9.m" \
     --to psse -o "$output_dir/case9-psse33.raw"
@@ -87,6 +89,8 @@ fresh_emit "$cgmes_30_source" cgmes cgmes cgmes-30 \
     "$output_dir/cgmes-30"
 fresh_emit "$remote_control_source" xiidm xiidm remote-control \
     "$output_dir/remote-control.xiidm"
+fresh_emit "$remote_control_source" xiidm jiidm remote-control-jiidm \
+    "$output_dir/remote-control.jiidm"
 fresh_emit "$two_terminal_dc_source" xiidm xiidm two-terminal-dc \
     "$output_dir/two-terminal-dc.xiidm"
 for version in 12 13 14 15 16 17; do
@@ -113,6 +117,14 @@ for version in 12 13 14 15 16 17; do
     fresh_emit "$powsybl_inputs/powsybl-xiidm-1-$version.xiidm" \
         xiidm xiidm "powsybl-xiidm-1-$version" \
         "$output_dir/powsybl-xiidm-1-$version.xiidm"
+done
+for version in 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17; do
+    fresh_emit "$powsybl_inputs/powsybl-eurostag-xiidm-1-$version.xiidm" \
+        xiidm xiidm "powsybl-eurostag-xiidm-1-$version" \
+        "$output_dir/powsybl-eurostag-xiidm-1-$version.xiidm"
+    fresh_emit "$powsybl_inputs/powsybl-eurostag-jiidm-1-$version.jiidm" \
+        jiidm jiidm "powsybl-eurostag-jiidm-1-$version" \
+        "$output_dir/powsybl-eurostag-jiidm-1-$version.jiidm"
 done
 fresh_emit "$powsybl_inputs/powsybl-cgmes-2415.zip" \
     cgmes cgmes powsybl-cgmes-2415 "$output_dir/powsybl-cgmes-2415"

--- a/powerio-cli/src/corpus/mod.rs
+++ b/powerio-cli/src/corpus/mod.rs
@@ -1449,21 +1449,24 @@ mod tests {
 
     use super::{Case, read_case};
 
-    /// Every serde key of `value` outside its `extras` subtrees, where keys
-    /// are powerio's own field names rather than case data.
-    fn model_keys(value: &serde_json::Value, in_extras: bool, out: &mut BTreeSet<String>) {
+    /// Every serde key of `value` outside maps whose keys come from case data.
+    fn model_keys(value: &serde_json::Value, in_case_map: bool, out: &mut BTreeSet<String>) {
         match value {
             serde_json::Value::Array(xs) => {
                 for x in xs {
-                    model_keys(x, in_extras, out);
+                    model_keys(x, in_case_map, out);
                 }
             }
             serde_json::Value::Object(xs) => {
                 for (key, x) in xs {
-                    if !in_extras {
+                    if !in_case_map {
                         out.insert(key.clone());
                     }
-                    model_keys(x, in_extras || key == "extras", out);
+                    model_keys(
+                        x,
+                        in_case_map || matches!(key.as_str(), "extras" | "properties"),
+                        out,
+                    );
                 }
             }
             _ => {}
@@ -1472,8 +1475,8 @@ mod tests {
 
     /// The vocabulary's completeness gate: parse every fixture the readers
     /// accept, union their serde keys, and require every one to be
-    /// vocabulary. A field name outside it masks as a corpus secret the day
-    /// a real corpus teaches the same spelling.
+    /// vocabulary. Keys in `extras` and `properties` maps come from case data
+    /// and remain subject to anonymization.
     #[test]
     fn every_fixture_field_name_is_vocabulary() {
         let data = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -454,6 +454,9 @@ enum FormatArg {
     /// Accepted as an input spelling for `xiidm`.
     #[value(name = "iidm")]
     IidmInput,
+    /// PowSybl JIIDM 1.17 JSON.
+    #[value(name = "jiidm")]
+    Jiidm,
     /// IEC CIM CGMES profile set.
     #[value(name = "cgmes")]
     Cgmes,
@@ -514,6 +517,7 @@ impl FormatArg {
             FormatArg::Psse35 => TargetFormat::Psse { rev: 35 },
             FormatArg::PsseRawx | FormatArg::RawxInput => TargetFormat::PsseRawx,
             FormatArg::Xiidm | FormatArg::IidmInput => TargetFormat::Xiidm,
+            FormatArg::Jiidm => TargetFormat::Jiidm,
             FormatArg::Cgmes => TargetFormat::Cgmes,
             FormatArg::PowerWorld => TargetFormat::PowerWorld,
             FormatArg::PandapowerJson => TargetFormat::PandapowerJson,
@@ -554,6 +558,7 @@ impl FormatArg {
             | FormatArg::RawxInput
             | FormatArg::Xiidm
             | FormatArg::IidmInput
+            | FormatArg::Jiidm
             | FormatArg::Cgmes
             | FormatArg::PowerWorld
             | FormatArg::PandapowerJson
@@ -580,6 +585,7 @@ impl FormatArg {
             FormatArg::RawxInput => "rawx",
             FormatArg::Xiidm => "xiidm",
             FormatArg::IidmInput => "iidm",
+            FormatArg::Jiidm => "jiidm",
             FormatArg::Cgmes => "cgmes",
             FormatArg::PowerWorld => "powerworld",
             FormatArg::PandapowerJson => "pandapower-json",

--- a/powerio-cli/tests/cli.rs
+++ b/powerio-cli/tests/cli.rs
@@ -537,6 +537,30 @@ fn convert_writes_a_cgmes_profile_directory() {
 }
 
 #[test]
+fn convert_writes_jiidm_and_reads_it_back() {
+    let case = repo_file("tests/data/case9.m");
+    let out = run(&[
+        "convert",
+        case.to_str().unwrap(),
+        "--to",
+        "jiidm",
+        "-o",
+        "-",
+    ]);
+    assert_success(&out);
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.starts_with("{\n  \"version\" : \"1.17\","), "{text}");
+    let out = run_with_stdin(&["summary", "-", "--from", "jiidm"], text.as_bytes());
+    assert_success(&out);
+    let summary = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        summary.contains("\"source_format\": \"jiidm\""),
+        "{summary}"
+    );
+    assert!(summary.contains("\"buses\": 9"), "{summary}");
+}
+
+#[test]
 fn convert_reserves_iidm_and_rawx_for_input() {
     let case = repo_file("tests/data/case9.m");
     for (input_spelling, canonical) in [("iidm", "xiidm"), ("rawx", "psse-rawx")] {

--- a/powerio-tx/src/diagnostics.rs
+++ b/powerio-tx/src/diagnostics.rs
@@ -179,6 +179,7 @@ pub mod codes {
     emit_family!(EMIT_EGRET, "EGRET", "egret JSON");
     emit_family!(EMIT_SURGE, "SURGE", "Surge JSON");
     emit_family!(EMIT_XIIDM, "XIIDM", "XIIDM 1.17 XML");
+    emit_family!(EMIT_JIIDM, "JIIDM", "JIIDM 1.17 JSON");
     emit_family!(EMIT_CGMES, "CGMES", "CGMES 3.0");
     emit_family!(EMIT_UNSUPPORTED, "UNSUPPORTED", "a read only format");
 
@@ -382,7 +383,7 @@ pub mod codes {
 
     /// Every write target's family, in the order [`super::registry`] reports
     /// them.
-    pub const EMIT_FAMILIES: [&EmitFamily; 12] = [
+    pub const EMIT_FAMILIES: [&EmitFamily; 13] = [
         &EMIT_MATPOWER,
         &EMIT_PSSE,
         &EMIT_PSLF,
@@ -393,6 +394,7 @@ pub mod codes {
         &EMIT_EGRET,
         &EMIT_SURGE,
         &EMIT_XIIDM,
+        &EMIT_JIIDM,
         &EMIT_CGMES,
         &EMIT_UNSUPPORTED,
     ];
@@ -422,6 +424,7 @@ impl TargetFormat {
             TargetFormat::EgretJson => &codes::EMIT_EGRET,
             TargetFormat::SurgeJson => &codes::EMIT_SURGE,
             TargetFormat::Xiidm => &codes::EMIT_XIIDM,
+            TargetFormat::Jiidm => &codes::EMIT_JIIDM,
             TargetFormat::Cgmes => &codes::EMIT_CGMES,
             // This transmission layer has no GOC3 problem or OPFData writer.
             // The facade emits a complete GOC3 solution before reaching this

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -3,7 +3,7 @@
 //! Each format module owns its parser and/or serializer: MATPOWER `.m`,
 //! PowerModels JSON, PSS/E `.raw`, PowerWorld `.aux`, egret `ModelData` JSON,
 //! pandapower JSON, PyPSA CSV folders, PSLF `.epc`, PSS/E RAWX 35, PowSybl
-//! XIIDM 1.12 through 1.17, CIM CGMES 2.4.15 and 3.0, GO Challenge 3 JSON,
+//! XIIDM and JIIDM 1.0 through 1.17, CIM CGMES 2.4.15 and 3.0, GO Challenge 3 JSON,
 //! Surge JSON, and
 //! DeepMind OPFData JSON. PowerWorld `.pwb` cases and OPFData JSON are input
 //! only. GO Challenge 3 defines a calculation rather than a bare network, so
@@ -88,7 +88,7 @@ pub(crate) use pslf::write_pslf;
 pub(crate) use psse::write_psse_rev;
 pub(crate) use rawx::write_rawx;
 pub(crate) use surge::write_surge_json;
-pub(crate) use xiidm::write_xiidm;
+pub(crate) use xiidm::{write_jiidm, write_xiidm};
 
 /// A target case format. See [`emit`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +123,8 @@ pub enum TargetFormat {
     DeepMindOpfDataJson,
     /// PowSybl XIIDM XML, version 1.17.
     Xiidm,
+    /// PowSybl JIIDM JSON, version 1.17.
+    Jiidm,
     /// IEC CIM Common Grid Model Exchange Specification profile set.
     Cgmes,
 }
@@ -144,6 +146,7 @@ impl TargetFormat {
             TargetFormat::Matpower => "m",
             TargetFormat::Pslf => "epc",
             TargetFormat::Xiidm => "xiidm",
+            TargetFormat::Jiidm => "jiidm",
             TargetFormat::Cgmes => "xml",
         }
     }
@@ -164,6 +167,7 @@ impl TargetFormat {
             TargetFormat::SurgeJson => "Surge JSON",
             TargetFormat::DeepMindOpfDataJson => "DeepMind OPFData JSON",
             TargetFormat::Xiidm => "XIIDM 1.17 XML",
+            TargetFormat::Jiidm => "JIIDM 1.17 JSON",
             TargetFormat::Cgmes => "CGMES 3.0 profile set",
         }
     }
@@ -186,6 +190,7 @@ impl TargetFormat {
             TargetFormat::SurgeJson => "surge-json",
             TargetFormat::DeepMindOpfDataJson => "opfdata-json",
             TargetFormat::Xiidm => "xiidm",
+            TargetFormat::Jiidm => "jiidm",
             TargetFormat::Cgmes => "cgmes",
         }
     }
@@ -277,8 +282,8 @@ pub fn parse_display_format(name: &str) -> Option<DisplayFormat> {
 /// if unrecognized. Accepts `matpower`/`m`, `powermodels-json`/`powermodels`/`pm`,
 /// `egret-json`/`egret`, `pandapower-json`/`pandapower`/`pp`, `psse`/`raw`,
 /// `powerworld`/`aux`, `pslf`/`epc`, `goc3-json`/`goc3`, and
-/// `surge-json`/`surge`, `opfdata-json`/`opfdata`/`gridopt`, `xiidm`, and
-/// `cgmes`.
+/// `surge-json`/`surge`, `opfdata-json`/`opfdata`/`gridopt`, `xiidm`, `jiidm`,
+/// and `cgmes`.
 /// Case-insensitive. The one place the bindings (Python, C ABI) share, so a new
 /// format means one new arm here, not three. CGMES emits a profile directory;
 /// PyPSA CSV folders, GridFM datasets, and PowerWorld `.pwb` are routed by
@@ -310,6 +315,7 @@ pub fn parse_target_format(name: &str) -> Option<TargetFormat> {
         TransmissionFormat::SurgeJson => TargetFormat::SurgeJson,
         TransmissionFormat::DeepMindOpfDataJson => TargetFormat::DeepMindOpfDataJson,
         TransmissionFormat::Xiidm => TargetFormat::Xiidm,
+        TransmissionFormat::Jiidm => TargetFormat::Jiidm,
         TransmissionFormat::Cgmes => TargetFormat::Cgmes,
         TransmissionFormat::PypsaCsv | TransmissionFormat::Pwb | TransmissionFormat::Gridfm => {
             return None;
@@ -541,6 +547,18 @@ pub fn parse_with_json_class(
         || source
             .primary_buffer()
             .is_ok_and(|buffer| xiidm::looks_like_xiidm(buffer.content_bytes()));
+    let is_jiidm = source.format().is_some_and(|format| {
+        routing::parse_transmission_format(format.as_str()) == Some(TransmissionFormat::Jiidm)
+    }) || std::path::Path::new(source.name())
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("jiidm"))
+        || matches!(
+            json_class,
+            Some(routing::JsonClass::Case(routing::Detection::Known(
+                routing::SourceFormat::Transmission(TransmissionFormat::Jiidm)
+            )))
+        );
     let is_cgmes = source.format().is_some_and(|format| {
         routing::parse_transmission_format(format.as_str()) == Some(TransmissionFormat::Cgmes)
     }) || cgmes::looks_like_profile_set(&source);
@@ -555,6 +573,11 @@ pub fn parse_with_json_class(
                 source.with_format(
                     powerio_core::FormatId::new("psse-rawx")
                         .expect("the canonical RAWX token is valid"),
+                )
+            } else if is_jiidm {
+                source.with_format(
+                    powerio_core::FormatId::new("jiidm")
+                        .expect("the canonical JIIDM token is valid"),
                 )
             } else if is_xiidm {
                 source.with_format(
@@ -717,6 +740,7 @@ fn parse_to_network(
                 Some("rawx") => Some(TargetFormat::PsseRawx),
                 Some("aux") => Some(TargetFormat::PowerWorld),
                 Some("xiidm") => Some(TargetFormat::Xiidm),
+                Some("jiidm") => Some(TargetFormat::Jiidm),
                 Some("xml") if looks_like_xiidm => Some(TargetFormat::Xiidm),
                 Some("xml" | "zip") => Some(TargetFormat::Cgmes),
                 Some("json") => None,
@@ -834,6 +858,7 @@ fn read_source(
             opfdata::parse_opfdata_source(text, name_hint, warnings)
         }
         TargetFormat::Xiidm => xiidm::parse_xiidm_source(text, warnings),
+        TargetFormat::Jiidm => xiidm::parse_jiidm_source(text, warnings),
         TargetFormat::Cgmes => {
             cgmes::parse_text(name_hint.unwrap_or("profile.xml"), text, warnings)
         }
@@ -895,10 +920,12 @@ pub(crate) fn reject_empty_case(net: &BalancedNetwork, format: &'static str) -> 
             || !detailed.dc_lines.is_empty()
             || !detailed.dc_switches.is_empty()
     });
-    let has_empty_xiidm_voltage_level = net.source_format() == SourceFormat::Xiidm
-        && detailed
-            .as_ref()
-            .is_some_and(|detailed| !detailed.voltage_levels.is_empty());
+    let has_empty_xiidm_voltage_level = matches!(
+        net.source_format(),
+        SourceFormat::Xiidm | SourceFormat::Jiidm
+    ) && detailed
+        .as_ref()
+        .is_some_and(|detailed| !detailed.voltage_levels.is_empty());
     if net.buses().is_empty() && !has_dc_equipment && !has_empty_xiidm_voltage_level {
         return Err(Error::FormatRead {
             format,
@@ -917,7 +944,7 @@ pub(crate) fn reject_empty_case(net: &BalancedNetwork, format: &'static str) -> 
 pub const SOURCE_FORMAT_NAMES: &str = "matpower/m, powermodels-json/powermodels/pm, \
      egret-json/egret, psse/raw, psse34, psse35, psse-rawx/rawx, powerworld/aux, \
      pandapower-json/pandapower/pp, pslf/epc, pypsa-csv/pypsa, pwb, goc3-json/goc3, \
-     surge-json/surge, opfdata-json/opfdata/gridopt, xiidm/iidm, cgmes";
+     surge-json/surge, opfdata-json/opfdata/gridopt, xiidm/iidm, jiidm, cgmes";
 
 /// An unrecognized source format token. When the token names a distribution
 /// format (`dss`, `pmd`, `bmopf`), the error points at the distribution
@@ -978,6 +1005,7 @@ fn transmission_json_target(format: TransmissionFormat) -> Result<TargetFormat> 
         TransmissionFormat::SurgeJson => Ok(TargetFormat::SurgeJson),
         TransmissionFormat::DeepMindOpfDataJson => Ok(TargetFormat::DeepMindOpfDataJson),
         TransmissionFormat::PsseRawx => Ok(TargetFormat::PsseRawx),
+        TransmissionFormat::Jiidm => Ok(TargetFormat::Jiidm),
         other => Err(Error::UnknownFormat(format!(
             "JSON classifier returned non-JSON transmission format `{}`",
             other.name()
@@ -1133,6 +1161,7 @@ pub(crate) fn emit_value_text(net: &BalancedNetwork, format: TargetFormat) -> Re
             });
         }
         TargetFormat::Xiidm => write_xiidm(net)?,
+        TargetFormat::Jiidm => write_jiidm(net)?,
         TargetFormat::Cgmes => {
             return Err(Error::WriteUnsupported { format: "cgmes" });
         }
@@ -1220,19 +1249,19 @@ pub fn emit_with_options(
             );
         }
     }
-    if format == TargetFormat::Xiidm
+    if matches!(format, TargetFormat::Xiidm | TargetFormat::Jiidm)
         && options.is_default()
         && let Some(source) = module.source()
         && source
             .format()
             .and_then(|value| parse_target_format(value.as_str()))
-            == Some(TargetFormat::Xiidm)
+            == Some(format)
         && source.acquired_buffers().len() == 1
     {
         let buffer = source.primary_buffer()?;
         let artifact = powerio_core::MemoryArtifact::new(
-            powerio_core::ArtifactPath::new("case.xiidm")
-                .expect("static name is a valid artifact path"),
+            powerio_core::ArtifactPath::new(format!("case.{}", format.extension()))
+                .expect("the format extension names a valid artifact path"),
             buffer.bytes().to_vec(),
         );
         return destination.__commit_artifacts(

--- a/powerio-tx/src/format/routing.rs
+++ b/powerio-tx/src/format/routing.rs
@@ -50,6 +50,7 @@ pub enum TransmissionFormat {
     SurgeJson,
     DeepMindOpfDataJson,
     Xiidm,
+    Jiidm,
     Cgmes,
 }
 
@@ -73,6 +74,7 @@ impl TransmissionFormat {
             Self::SurgeJson => "surge-json",
             Self::DeepMindOpfDataJson => "opfdata-json",
             Self::Xiidm => "xiidm",
+            Self::Jiidm => "jiidm",
             Self::Cgmes => "cgmes",
         }
     }
@@ -151,6 +153,7 @@ pub fn parse_transmission_format(name: &str) -> Option<TransmissionFormat> {
         "goc3" | "goc3json" | "go3" | "gochallenge3" | "c3" => Some(TransmissionFormat::Goc3Json),
         "surge" | "surgejson" => Some(TransmissionFormat::SurgeJson),
         "xiidm" | "iidm" => Some(TransmissionFormat::Xiidm),
+        "jiidm" => Some(TransmissionFormat::Jiidm),
         "cgmes" => Some(TransmissionFormat::Cgmes),
         "opfdata"
         | "opfdatajson"
@@ -237,6 +240,13 @@ impl JsonClass {
 /// Ambiguous means the document contains strong markers from both domains, so
 /// the caller must ask the user for an explicit format.
 pub fn classify_json_text(text: &str) -> JsonClass {
+    // PowSybl JIIDM opens with its `version` key, the same test PowSybl's
+    // importer applies; no other JSON case format starts that way.
+    if super::xiidm::looks_like_jiidm(text) {
+        return JsonClass::Case(Detection::Known(SourceFormat::Transmission(
+            TransmissionFormat::Jiidm,
+        )));
+    }
     // Windows tooling saves JSON with a UTF-8 byte order mark, which
     // serde_json rejects; strip it so a BOM never hides the format.
     let Ok(header) = serde_json::from_str::<JsonHeader>(text.trim_start_matches('\u{feff}')) else {

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -1,4 +1,10 @@
-//! PowSybl XIIDM 1.12 through 1.17 XML reader and 1.17 writer.
+//! PowSybl IIDM reader and writer: XIIDM XML and JIIDM JSON, versions 1.0
+//! through 1.17 on input and 1.17 on output.
+//!
+//! Both encodings describe the same element tree. [`ParsedXiidm`] consumes
+//! that tree as [`TreeEvent`] values, so one element mapping serves the XML
+//! event stream and the JSON document alike. The JIIDM writer converts the
+//! fresh XIIDM 1.17 text to PowSybl's JSON tree layout.
 
 #![allow(
     clippy::format_push_string,
@@ -39,14 +45,22 @@ use crate::network::{
 use crate::{Error, Generator, Result};
 
 const FORMAT: &str = "XIIDM XML";
+const JSON_FORMAT: &str = "JIIDM JSON";
 /// Retained three winding transformer `ratedU0` when it differs from
 /// `ratedU1`: the voltage base the source stated its leg impedances on.
 const XIIDM_RATED_U0_EXTRA: &str = "xiidm_rated_u0";
+/// Identifier of the operational limits group that holds loading limits an
+/// IIDM document older than 1.12 states directly on the equipment. PowSybl
+/// files those limits under the same default group identifier.
+const DEFAULT_OPERATIONAL_LIMITS_GROUP: &str = "DEFAULT";
 
 const NAMESPACE: &str = "http://www.powsybl.org/schema/iidm/1_17";
 const EQUIPMENT_NAMESPACE: &str = "http://www.powsybl.org/schema/iidm/equipment/1_17";
 const NAMESPACE_PREFIX: &str = "http://www.powsybl.org/schema/iidm/";
 const EQUIPMENT_NAMESPACE_PREFIX: &str = "http://www.powsybl.org/schema/iidm/equipment/";
+/// IIDM 1.0 predates the PowSybl domain and declares the iTesla namespace.
+const ITESLA_NAMESPACE_PREFIX: &str = "http://www.itesla_project.eu/schema/iidm/";
+const EXTENSION_NAMESPACE_PREFIX: &str = "http://www.powsybl.org/schema/iidm/ext/";
 const ACTIVE_POWER_CONTROL_NAMESPACE_V1_0: &str =
     "http://www.itesla_project.eu/schema/iidm/ext/active_power_control/1_0";
 const ACTIVE_POWER_CONTROL_NAMESPACE_V1_1: &str =
@@ -63,12 +77,56 @@ const MAX_XIIDM_ELEMENT_DEPTH: usize = 256;
 pub(crate) fn looks_like_xiidm(bytes: &[u8]) -> bool {
     let head = &bytes[..bytes.len().min(16_384)];
     let text = String::from_utf8_lossy(head);
-    (text.contains(NAMESPACE_PREFIX) || text.contains(EQUIPMENT_NAMESPACE_PREFIX))
+    (text.contains(NAMESPACE_PREFIX)
+        || text.contains(EQUIPMENT_NAMESPACE_PREFIX)
+        || text.contains(ITESLA_NAMESPACE_PREFIX))
         && (text.contains(":network") || text.contains("<network"))
 }
 
+/// Whether JSON text is a PowSybl JIIDM document: an object whose first key
+/// is `version` holding a `major.minor` string, which is the test PowSybl's
+/// own JSON importer applies before reading anything else.
+pub(crate) fn looks_like_jiidm(text: &str) -> bool {
+    let rest = text.trim_start_matches('\u{feff}').trim_start();
+    let Some(rest) = rest.strip_prefix('{') else {
+        return false;
+    };
+    let Some(rest) = rest.trim_start().strip_prefix("\"version\"") else {
+        return false;
+    };
+    let Some(rest) = rest.trim_start().strip_prefix(':') else {
+        return false;
+    };
+    let Some(rest) = rest.trim_start().strip_prefix('"') else {
+        return false;
+    };
+    let Some((version, _)) = rest.split_once('"') else {
+        return false;
+    };
+    version.split_once('.').is_some_and(|(major, minor)| {
+        !major.is_empty()
+            && !minor.is_empty()
+            && major.bytes().all(|value| value.is_ascii_digit())
+            && minor.bytes().all(|value| value.is_ascii_digit())
+    })
+}
+
+/// One PowSybl IIDM serialization version. The order is the release order,
+/// so range comparisons select the versions a rule applies to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum XiidmVersion {
+    V1_0,
+    V1_1,
+    V1_2,
+    V1_3,
+    V1_4,
+    V1_5,
+    V1_6,
+    V1_7,
+    V1_8,
+    V1_9,
+    V1_10,
+    V1_11,
     V1_12,
     V1_13,
     V1_14,
@@ -78,20 +136,63 @@ enum XiidmVersion {
 }
 
 impl XiidmVersion {
+    const ALL: [Self; 18] = [
+        Self::V1_0,
+        Self::V1_1,
+        Self::V1_2,
+        Self::V1_3,
+        Self::V1_4,
+        Self::V1_5,
+        Self::V1_6,
+        Self::V1_7,
+        Self::V1_8,
+        Self::V1_9,
+        Self::V1_10,
+        Self::V1_11,
+        Self::V1_12,
+        Self::V1_13,
+        Self::V1_14,
+        Self::V1_15,
+        Self::V1_16,
+        Self::V1_17,
+    ];
+
+    fn minor(self) -> u32 {
+        self as u32
+    }
+
+    /// The version named by a namespace suffix such as `1_12`.
     fn from_suffix(suffix: &str) -> Option<Self> {
-        Some(match suffix {
-            "1_12" => Self::V1_12,
-            "1_13" => Self::V1_13,
-            "1_14" => Self::V1_14,
-            "1_15" => Self::V1_15,
-            "1_16" => Self::V1_16,
-            "1_17" => Self::V1_17,
-            _ => return None,
-        })
+        let (major, minor) = suffix.split_once('_')?;
+        if major != "1" {
+            return None;
+        }
+        let minor: u32 = minor.parse().ok()?;
+        Self::ALL
+            .iter()
+            .copied()
+            .find(|value| value.minor() == minor)
+    }
+
+    /// The version named by a JIIDM `version` value such as `1.12`.
+    fn from_label(label: &str) -> Option<Self> {
+        Self::from_suffix(&label.replacen('.', "_", 1))
     }
 
     fn label(self) -> &'static str {
         match self {
+            Self::V1_0 => "1.0",
+            Self::V1_1 => "1.1",
+            Self::V1_2 => "1.2",
+            Self::V1_3 => "1.3",
+            Self::V1_4 => "1.4",
+            Self::V1_5 => "1.5",
+            Self::V1_6 => "1.6",
+            Self::V1_7 => "1.7",
+            Self::V1_8 => "1.8",
+            Self::V1_9 => "1.9",
+            Self::V1_10 => "1.10",
+            Self::V1_11 => "1.11",
             Self::V1_12 => "1.12",
             Self::V1_13 => "1.13",
             Self::V1_14 => "1.14",
@@ -99,6 +200,22 @@ impl XiidmVersion {
             Self::V1_16 => "1.16",
             Self::V1_17 => "1.17",
         }
+    }
+
+    /// The XML namespace this version declares for a valid network. IIDM 1.0
+    /// belongs to the iTesla domain; every later version to PowSybl's.
+    fn namespace_uri(self) -> String {
+        let prefix = if self == Self::V1_0 {
+            ITESLA_NAMESPACE_PREFIX
+        } else {
+            NAMESPACE_PREFIX
+        };
+        format!("{prefix}1_{}", self.minor())
+    }
+
+    /// Equipment validation level documents exist from 1.7 on.
+    fn supports_equipment_validation(self) -> bool {
+        self >= Self::V1_7
     }
 }
 
@@ -133,17 +250,39 @@ struct XiidmNamespace {
 }
 
 impl XiidmNamespace {
+    /// The version and validation level a namespace URI names, or `None`
+    /// when the URI is not one PowSybl writes: the equipment namespace exists
+    /// from 1.7 on, the iTesla domain names only 1.0, and the PowSybl domain
+    /// names 1.1 and later.
     fn from_uri(uri: &str) -> Option<Self> {
-        let (validation, suffix) =
-            if let Some(suffix) = uri.strip_prefix(EQUIPMENT_NAMESPACE_PREFIX) {
-                (XiidmValidation::Equipment, suffix)
-            } else {
-                (XiidmValidation::Valid, uri.strip_prefix(NAMESPACE_PREFIX)?)
-            };
+        if let Some(suffix) = uri.strip_prefix(EQUIPMENT_NAMESPACE_PREFIX) {
+            let version = XiidmVersion::from_suffix(suffix)?;
+            return version.supports_equipment_validation().then_some(Self {
+                version,
+                validation: XiidmValidation::Equipment,
+            });
+        }
+        let version = if let Some(suffix) = uri.strip_prefix(ITESLA_NAMESPACE_PREFIX) {
+            XiidmVersion::from_suffix(suffix).filter(|version| *version == XiidmVersion::V1_0)?
+        } else {
+            let suffix = uri.strip_prefix(NAMESPACE_PREFIX)?;
+            XiidmVersion::from_suffix(suffix).filter(|version| *version > XiidmVersion::V1_0)?
+        };
         Some(Self {
-            version: XiidmVersion::from_suffix(suffix)?,
-            validation,
+            version,
+            validation: XiidmValidation::Valid,
         })
+    }
+
+    /// The namespace URI PowSybl writes for this version and validation
+    /// level.
+    fn uri(self) -> String {
+        match self.validation {
+            XiidmValidation::Valid => self.version.namespace_uri(),
+            XiidmValidation::Equipment => {
+                format!("{EQUIPMENT_NAMESPACE_PREFIX}1_{}", self.version.minor())
+            }
+        }
     }
 
     fn is_equipment(self) -> bool {
@@ -158,6 +297,7 @@ impl XiidmNamespace {
 fn is_xiidm_namespace_uri(uri: &str) -> bool {
     uri.strip_prefix(EQUIPMENT_NAMESPACE_PREFIX)
         .or_else(|| uri.strip_prefix(NAMESPACE_PREFIX))
+        .or_else(|| uri.strip_prefix(ITESLA_NAMESPACE_PREFIX))
         .is_some_and(|version| {
             let Some((major, minor)) = version.split_once('_') else {
                 return false;
@@ -250,6 +390,9 @@ struct RawBusbarSection {
     id: String,
     voltage_level: String,
     node: i32,
+    /// IIDM 1.0 states the calculated bus voltage magnitude and angle on
+    /// each busbar section instead of on a calculated bus record.
+    legacy_voltage: Option<(f64, f64)>,
 }
 
 #[derive(Clone, Debug)]
@@ -316,6 +459,34 @@ fn tap_tag(tag: &str) -> Option<ActiveTap> {
         _ => return None,
     };
     Some(ActiveTap { kind, winding })
+}
+
+/// The loading limits kind and optional side an element name states:
+/// `currentLimits` inside an operational limits group, or `currentLimits2`
+/// stated directly on equipment as every IIDM version before 1.12 does.
+fn loading_limit_tag(tag: &str) -> Option<(LoadingLimitKind, Option<u8>)> {
+    let (kind, rest) = [
+        ("activePowerLimits", LoadingLimitKind::ActivePower),
+        ("apparentPowerLimits", LoadingLimitKind::ApparentPower),
+        ("currentLimits", LoadingLimitKind::Current),
+    ]
+    .into_iter()
+    .find_map(|(prefix, kind)| tag.strip_prefix(prefix).map(|rest| (kind, rest)))?;
+    match rest {
+        "" => Some((kind, None)),
+        "1" => Some((kind, Some(1))),
+        "2" => Some((kind, Some(2))),
+        "3" => Some((kind, Some(3))),
+        _ => None,
+    }
+}
+
+/// Move an attribute to the name later IIDM versions use for the same
+/// field, when the source states it under its older name.
+fn rename_attribute(attrs: &mut Attrs, from: &str, to: &str) {
+    if let Some(value) = attrs.remove(from) {
+        attrs.entry(to.to_owned()).or_insert(value);
+    }
 }
 
 fn operational_limits_side(tag: &str) -> Option<u8> {
@@ -450,10 +621,23 @@ struct RawLoadingLimits {
 struct RawOperationalLimitsGroup {
     id: String,
     side: u8,
+    /// The group holds loading limits stated directly on the equipment, the
+    /// only form IIDM versions before 1.12 have. Such a group is the selected
+    /// group of its side.
+    implicit: bool,
     properties: BTreeMap<String, String>,
     active_power: Option<RawLoadingLimits>,
     apparent_power: Option<RawLoadingLimits>,
     current: Option<RawLoadingLimits>,
+}
+
+/// The loading limits element currently open: which kind it is and which
+/// equipment group receives its temporary limits.
+#[derive(Clone, Copy, Debug)]
+struct ActiveLoadingLimit {
+    kind: LoadingLimitKind,
+    equipment: usize,
+    group: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -501,6 +685,44 @@ struct Frame {
     component: Option<ComponentId>,
     equipment: Option<usize>,
     ac_dc_converter: Option<RawAcDcConverterIndex>,
+    /// The two boundary line equipment records a tie line older than IIDM
+    /// 1.10 states inline; its side suffixed loading limits belong to them.
+    legacy_tie_sides: Option<[usize; 2]>,
+}
+
+impl Frame {
+    fn new(tag: &str) -> Self {
+        Self {
+            tag: tag.to_owned(),
+            component: None,
+            equipment: None,
+            ac_dc_converter: None,
+            legacy_tie_sides: None,
+        }
+    }
+}
+
+/// The document encoding a tree came from; it names the module's source
+/// format.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum IidmEncoding {
+    #[default]
+    Xml,
+    Json,
+}
+
+/// One node of the IIDM element tree, independent of the encoding that
+/// carried it. XML events and JSON objects both reduce to this sequence:
+/// every element starts with its attributes, may carry text, and ends.
+enum TreeEvent<'a> {
+    Start {
+        tag: &'a str,
+        namespace: Option<&'a str>,
+        attrs: Attrs,
+        empty: bool,
+    },
+    Text(&'a str),
+    End(&'a str),
 }
 
 #[derive(Clone, Debug)]
@@ -512,6 +734,7 @@ struct PendingAlias {
 
 #[derive(Default)]
 struct ParsedXiidm {
+    encoding: IidmEncoding,
     id: Option<String>,
     case_metadata: CaseMetadata,
     namespace: Option<XiidmNamespace>,
@@ -521,8 +744,11 @@ struct ParsedXiidm {
     current_voltage_level: Option<String>,
     current_area: Option<usize>,
     current_tap: Option<ActiveTap>,
-    current_loading_limit: Option<LoadingLimitKind>,
+    current_loading_limit: Option<ActiveLoadingLimit>,
     current_extension_target: Option<String>,
+    /// Depth inside an extension subtree the mapping does not read; the
+    /// events of that subtree are consumed without effect until it closes.
+    skipped_depth: usize,
     frames: Vec<Frame>,
     pending_alias: Option<PendingAlias>,
     ids: HashSet<String>,
@@ -570,7 +796,6 @@ pub(crate) fn parse_xiidm_bytes(
     reader.config_mut().check_end_names = true;
     reader.config_mut().expand_empty_elements = false;
     let mut parsed = ParsedXiidm::default();
-    let mut skipped_extension_depth = 0_usize;
     let mut element_depth = 0_usize;
     let mut encoding_checked = false;
     let mut buffer = Vec::new();
@@ -593,39 +818,19 @@ pub(crate) fn parse_xiidm_bytes(
                         "XIIDM XML exceeds the {MAX_XIIDM_ELEMENT_DEPTH} element nesting limit"
                     )));
                 }
-                if skipped_extension_depth > 0 {
-                    skipped_extension_depth += 1;
-                    buffer.clear();
-                    continue;
-                }
                 let tag = local_name(element.name().as_ref())?;
-                let active_power_control = tag == "activePowerControl"
-                    && ActivePowerControlVersion::from_namespace(namespace.as_deref()).is_some();
-                if parsed.current_extension_target.is_some()
-                    && tag != "extension"
-                    && !active_power_control
-                {
-                    if namespace.as_deref().is_none_or(is_xiidm_namespace_uri) {
-                        return Err(format_error(format!(
-                            "XIIDM model element `{tag}` appears inside an extension"
-                        )));
-                    }
-                    diagnostics.push(
-                        &codes::READ_XIIDM_ELEMENT_UNMAPPED,
-                        format!(
-                            "XIIDM extension element `{tag}` on `{}` is retained only by exact same format emission",
-                            parsed.current_extension_target.as_deref().unwrap_or_default()
-                        ),
-                    );
-                    skipped_extension_depth = 1;
-                    buffer.clear();
-                    continue;
-                }
-                parsed.start(
-                    &tag,
-                    namespace.as_deref(),
-                    attributes(&element, reader.decoder())?,
-                    false,
+                let attrs = if parsed.skipped_depth > 0 {
+                    Attrs::new()
+                } else {
+                    attributes(&element, reader.decoder())?
+                };
+                parsed.consume(
+                    TreeEvent::Start {
+                        tag: &tag,
+                        namespace: namespace.as_deref(),
+                        attrs,
+                        empty: false,
+                    },
                     diagnostics,
                 )?;
             }
@@ -635,70 +840,43 @@ pub(crate) fn parse_xiidm_bytes(
                         "XIIDM XML exceeds the {MAX_XIIDM_ELEMENT_DEPTH} element nesting limit"
                     )));
                 }
-                if skipped_extension_depth > 0 {
-                    buffer.clear();
-                    continue;
-                }
                 let tag = local_name(element.name().as_ref())?;
-                let active_power_control = tag == "activePowerControl"
-                    && ActivePowerControlVersion::from_namespace(namespace.as_deref()).is_some();
-                if parsed.current_extension_target.is_some()
-                    && tag != "extension"
-                    && !active_power_control
-                {
-                    if namespace.as_deref().is_none_or(is_xiidm_namespace_uri) {
-                        return Err(format_error(format!(
-                            "XIIDM model element `{tag}` appears inside an extension"
-                        )));
-                    }
-                    diagnostics.push(
-                        &codes::READ_XIIDM_ELEMENT_UNMAPPED,
-                        format!(
-                            "XIIDM extension element `{tag}` on `{}` is retained only by exact same format emission",
-                            parsed.current_extension_target.as_deref().unwrap_or_default()
-                        ),
-                    );
-                    buffer.clear();
-                    continue;
-                }
-                parsed.start(
-                    &tag,
-                    namespace.as_deref(),
-                    attributes(&element, reader.decoder())?,
-                    true,
+                let attrs = if parsed.skipped_depth > 0 {
+                    Attrs::new()
+                } else {
+                    attributes(&element, reader.decoder())?
+                };
+                parsed.consume(
+                    TreeEvent::Start {
+                        tag: &tag,
+                        namespace: namespace.as_deref(),
+                        attrs,
+                        empty: true,
+                    },
                     diagnostics,
                 )?;
             }
             Event::End(element) => {
-                if skipped_extension_depth > 0 {
-                    skipped_extension_depth -= 1;
-                    element_depth = element_depth.saturating_sub(1);
-                    buffer.clear();
-                    continue;
-                }
-                parsed.end(&local_name(element.name().as_ref())?)?;
+                parsed.consume(
+                    TreeEvent::End(&local_name(element.name().as_ref())?),
+                    diagnostics,
+                )?;
                 element_depth = element_depth.saturating_sub(1);
             }
             Event::Text(value) => {
-                if skipped_extension_depth == 0
-                    && let Some(alias) = &mut parsed.pending_alias
-                {
-                    alias.value.push_str(
-                        &value
-                            .decode()
-                            .map_err(|error| format_error(error.to_string()))?,
-                    );
+                if parsed.skipped_depth == 0 && parsed.pending_alias.is_some() {
+                    let text = value
+                        .decode()
+                        .map_err(|error| format_error(error.to_string()))?;
+                    parsed.consume(TreeEvent::Text(&text), diagnostics)?;
                 }
             }
             Event::CData(value) => {
-                if skipped_extension_depth == 0
-                    && let Some(alias) = &mut parsed.pending_alias
-                {
-                    alias.value.push_str(
-                        &value
-                            .decode()
-                            .map_err(|error| format_error(error.to_string()))?,
-                    );
+                if parsed.skipped_depth == 0 && parsed.pending_alias.is_some() {
+                    let text = value
+                        .decode()
+                        .map_err(|error| format_error(error.to_string()))?;
+                    parsed.consume(TreeEvent::Text(&text), diagnostics)?;
                 }
             }
             Event::DocType(_) | Event::GeneralRef(_) => {
@@ -716,6 +894,396 @@ pub(crate) fn parse_xiidm_bytes(
         buffer.clear();
     }
     parsed.finish(diagnostics)
+}
+
+pub(crate) fn parse_jiidm_source(
+    text: &str,
+    diagnostics: &mut Diagnostics,
+) -> Result<BalancedNetwork> {
+    if text.len() > MAX_XIIDM_BYTES {
+        return Err(format_error(format!(
+            "JIIDM JSON exceeds the {MAX_XIIDM_BYTES} byte input limit"
+        )));
+    }
+    let document: JsonNode = serde_json::from_str(text.trim_start_matches('\u{feff}'))
+        .map_err(|error| format_error(format!("malformed JIIDM JSON: {error}")))?;
+    let JsonNode::Object(root) = &document else {
+        return Err(format_error("JIIDM document is not a JSON object"));
+    };
+    let version_label = json_field_text(root, "version")
+        .ok_or_else(|| format_error("JIIDM document has no string `version`"))?;
+    let mut extension_versions = BTreeMap::new();
+    if let Some((_, JsonNode::Array(entries))) =
+        root.iter().find(|(key, _)| key == "extensionVersions")
+    {
+        for entry in entries {
+            let JsonNode::Object(fields) = entry else {
+                return Err(format_error(
+                    "JIIDM `extensionVersions` entry is not an object",
+                ));
+            };
+            let name = json_field_text(fields, "extensionName")
+                .ok_or_else(|| format_error("JIIDM extension version has no `extensionName`"))?;
+            let version = json_field_text(fields, "version")
+                .ok_or_else(|| format_error("JIIDM extension version has no `version`"))?;
+            extension_versions.insert(name.to_owned(), version.to_owned());
+        }
+    }
+    let mut parsed = ParsedXiidm {
+        encoding: IidmEncoding::Json,
+        ..ParsedXiidm::default()
+    };
+    let namespace = match XiidmVersion::from_label(version_label) {
+        Some(version) => {
+            let equipment = json_field_text(root, "minimumValidationLevel") == Some("EQUIPMENT")
+                && version.supports_equipment_validation();
+            XiidmNamespace {
+                version,
+                validation: if equipment {
+                    XiidmValidation::Equipment
+                } else {
+                    XiidmValidation::Valid
+                },
+            }
+            .uri()
+        }
+        // An unknown version still names a PowSybl namespace, so the root
+        // reader reports it with the same coded diagnostic as XML input.
+        None => format!("{NAMESPACE_PREFIX}{}", version_label.replacen('.', "_", 1)),
+    };
+    let walker = JsonWalker {
+        namespace: &namespace,
+        extension_versions: &extension_versions,
+    };
+    walker.walk(&mut parsed, "network", root, None, 1, diagnostics)?;
+    parsed.finish(diagnostics)
+}
+
+/// Text of a scalar string field in a JSON object.
+fn json_field_text<'a>(fields: &'a [(String, JsonNode)], name: &str) -> Option<&'a str> {
+    fields.iter().find_map(|(key, value)| match value {
+        JsonNode::String(text) if key == name => Some(text.as_str()),
+        _ => None,
+    })
+}
+
+/// A JSON document with object keys in document order. PowSybl reads
+/// attributes before child nodes and elements in sequence, so the order the
+/// document states is the order the tree mapping receives.
+#[derive(Clone, Debug)]
+enum JsonNode {
+    Null,
+    Bool(bool),
+    Number(serde_json::Number),
+    String(String),
+    Array(Vec<JsonNode>),
+    Object(Vec<(String, JsonNode)>),
+}
+
+impl JsonNode {
+    fn is_scalar(&self) -> bool {
+        !matches!(self, Self::Array(_) | Self::Object(_))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for JsonNode {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct NodeVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for NodeVisitor {
+            type Value = JsonNode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a JSON value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::Bool(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::Number(value.into()))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::Number(value.into()))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> std::result::Result<JsonNode, E>
+            where
+                E: serde::de::Error,
+            {
+                serde_json::Number::from_f64(value)
+                    .map(JsonNode::Number)
+                    .ok_or_else(|| E::custom("JSON number is not finite"))
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::String(value.to_owned()))
+            }
+
+            fn visit_string<E>(self, value: String) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::String(value))
+            }
+
+            fn visit_unit<E>(self) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::Null)
+            }
+
+            fn visit_none<E>(self) -> std::result::Result<JsonNode, E> {
+                Ok(JsonNode::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> std::result::Result<JsonNode, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                serde::Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<JsonNode, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut values = Vec::new();
+                while let Some(value) = seq.next_element()? {
+                    values.push(value);
+                }
+                Ok(JsonNode::Array(values))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> std::result::Result<JsonNode, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut entries = Vec::new();
+                while let Some((key, value)) = map.next_entry::<String, JsonNode>()? {
+                    entries.push((key, value));
+                }
+                Ok(JsonNode::Object(entries))
+            }
+        }
+
+        deserializer.deserialize_any(NodeVisitor)
+    }
+}
+
+/// PowSybl's JSON array field names and the element each entry is. Elements
+/// outside this table repeat as plain object fields, as `voltageLevelRef`
+/// does under an area.
+const JIIDM_ARRAY_ELEMENTS: [(&str, &str); 46] = [
+    ("networks", "network"),
+    ("extensions", "extension"),
+    ("switches", "switch"),
+    ("steps", "step"),
+    ("aliases", "alias"),
+    ("areas", "area"),
+    ("batteries", "battery"),
+    ("areaBoundaries", "areaBoundary"),
+    ("buses", "bus"),
+    ("busbarSections", "busbarSection"),
+    ("temporaryLimits", "temporaryLimit"),
+    ("boundaryLines", "boundaryLine"),
+    ("danglingLines", "danglingLine"),
+    ("dcNodes", "dcNode"),
+    ("dcGrounds", "dcGround"),
+    ("dcLines", "dcLine"),
+    ("dcSwitches", "dcSwitch"),
+    ("segments", "segment"),
+    ("generators", "generator"),
+    ("hvdcLines", "hvdcLine"),
+    ("lccConverterStations", "lccConverterStation"),
+    ("lines", "line"),
+    ("lineCommutatedConverters", "lineCommutatedConverter"),
+    ("loads", "load"),
+    ("internalConnections", "internalConnection"),
+    ("overloadManagementSystems", "overloadManagementSystem"),
+    ("properties", "property"),
+    ("points", "point"),
+    ("shunts", "shunt"),
+    ("sections", "section"),
+    ("shuntCompensators", "shuntCompensator"),
+    ("staticVarCompensators", "staticVarCompensator"),
+    ("substations", "substation"),
+    ("threeWindingsTransformers", "threeWindingsTransformer"),
+    ("tieLines", "tieLine"),
+    ("twoWindingsTransformers", "twoWindingsTransformer"),
+    ("voltageAngleLimits", "voltageAngleLimit"),
+    ("voltageLevels", "voltageLevel"),
+    ("fictitiousInjections", "inj"),
+    ("voltageSourceConverters", "voltageSourceConverter"),
+    ("vscConverterStations", "vscConverterStation"),
+    ("grounds", "ground"),
+    ("operationalLimitsGroups", "operationalLimitsGroup"),
+    ("operationalLimitsGroups1", "operationalLimitsGroup1"),
+    ("operationalLimitsGroups2", "operationalLimitsGroup2"),
+    ("operationalLimitsGroups3", "operationalLimitsGroup3"),
+];
+
+fn jiidm_array_element(array: &str) -> Option<&'static str> {
+    JIIDM_ARRAY_ELEMENTS
+        .iter()
+        .find(|(name, _)| *name == array)
+        .map(|(_, element)| *element)
+}
+
+fn jiidm_array_name(element: &str) -> Option<&'static str> {
+    JIIDM_ARRAY_ELEMENTS
+        .iter()
+        .find(|(_, name)| *name == element)
+        .map(|(array, _)| *array)
+}
+
+/// Drives [`ParsedXiidm`] from a JIIDM object tree.
+struct JsonWalker<'a> {
+    namespace: &'a str,
+    extension_versions: &'a BTreeMap<String, String>,
+}
+
+impl JsonWalker<'_> {
+    /// The namespace of an extension element: the versioned active power
+    /// control namespace when the document names a version the reader maps,
+    /// otherwise a PowSybl extension namespace the mapping does not read.
+    fn extension_namespace(&self, name: &str) -> String {
+        let version = self
+            .extension_versions
+            .get(name)
+            .map_or("1.2", String::as_str);
+        if name == "activePowerControl" {
+            match version {
+                "1.0" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_0.to_owned(),
+                "1.1" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_1.to_owned(),
+                "1.2" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_2.to_owned(),
+                _ => {}
+            }
+        }
+        format!(
+            "{EXTENSION_NAMESPACE_PREFIX}{name}/{}",
+            version.replacen('.', "_", 1)
+        )
+    }
+
+    fn walk(
+        &self,
+        parsed: &mut ParsedXiidm,
+        tag: &str,
+        fields: &[(String, JsonNode)],
+        namespace: Option<&str>,
+        depth: usize,
+        diagnostics: &mut Diagnostics,
+    ) -> Result<()> {
+        if depth > MAX_XIIDM_ELEMENT_DEPTH {
+            return Err(format_error(format!(
+                "JIIDM JSON exceeds the {MAX_XIIDM_ELEMENT_DEPTH} element nesting limit"
+            )));
+        }
+        let root = depth == 1;
+        let mut attrs = Attrs::new();
+        let mut content = None;
+        if root {
+            attrs.insert("xmlns:iidm".to_owned(), self.namespace.to_owned());
+        }
+        for (key, value) in fields {
+            if root && (key == "version" || key == "extensionVersions") {
+                continue;
+            }
+            match value {
+                JsonNode::String(text) if key == "content" => content = Some(text.as_str()),
+                JsonNode::Bool(_) | JsonNode::Number(_) | JsonNode::String(_) => {
+                    attrs.insert(key.clone(), json_scalar_text(value));
+                }
+                JsonNode::Array(values)
+                    if !values.is_empty() && values.iter().all(JsonNode::is_scalar) =>
+                {
+                    attrs.insert(key.clone(), json_array_text(values));
+                }
+                JsonNode::Null | JsonNode::Array(_) | JsonNode::Object(_) => {}
+            }
+        }
+        let element_namespace = namespace.unwrap_or(self.namespace);
+        parsed.consume(
+            TreeEvent::Start {
+                tag,
+                namespace: Some(element_namespace),
+                attrs,
+                empty: false,
+            },
+            diagnostics,
+        )?;
+        if let Some(text) = content {
+            parsed.consume(TreeEvent::Text(text), diagnostics)?;
+        }
+        let in_extension = tag == "extension";
+        for (key, value) in fields {
+            let child_namespace = if in_extension {
+                Some(self.extension_namespace(key))
+            } else {
+                namespace.map(str::to_owned)
+            };
+            match value {
+                JsonNode::Object(child) => {
+                    self.walk(
+                        parsed,
+                        key,
+                        child,
+                        child_namespace.as_deref(),
+                        depth + 1,
+                        diagnostics,
+                    )?;
+                }
+                JsonNode::Array(values) if !values.iter().all(JsonNode::is_scalar) => {
+                    let element = jiidm_array_element(key).unwrap_or(key.as_str());
+                    for entry in values {
+                        let JsonNode::Object(child) = entry else {
+                            return Err(format_error(format!(
+                                "JIIDM array `{key}` mixes objects with scalar values"
+                            )));
+                        };
+                        self.walk(
+                            parsed,
+                            element,
+                            child,
+                            child_namespace.as_deref(),
+                            depth + 1,
+                            diagnostics,
+                        )?;
+                    }
+                }
+                _ => {}
+            }
+        }
+        parsed.consume(TreeEvent::End(tag), diagnostics)
+    }
+}
+
+/// The attribute text of a JSON scalar, in the spelling the XML attribute
+/// readers accept.
+fn json_scalar_text(value: &JsonNode) -> String {
+    match value {
+        JsonNode::Bool(value) => value.to_string(),
+        JsonNode::Number(value) => value.to_string(),
+        JsonNode::String(value) => value.clone(),
+        JsonNode::Null | JsonNode::Array(_) | JsonNode::Object(_) => String::new(),
+    }
+}
+
+/// The attribute text of a JSON scalar array: PowSybl's XML writer joins
+/// integer arrays with commas and encodes string arrays as one CSV record,
+/// quoting values that contain a comma, a quote, or a line break.
+fn json_array_text(values: &[JsonNode]) -> String {
+    values
+        .iter()
+        .map(|value| match value {
+            JsonNode::String(text) if text.contains([',', '"', '\n', '\r']) => {
+                format!("\"{}\"", text.replace('"', "\"\""))
+            }
+            other => json_scalar_text(other),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn validate_xml_encoding(
@@ -758,6 +1326,80 @@ fn reject_xml_entities(bytes: &[u8]) -> Result<()> {
 }
 
 impl ParsedXiidm {
+    /// The version of the document being read, once the root network has
+    /// declared it.
+    fn version(&self) -> Option<XiidmVersion> {
+        self.namespace.map(|namespace| namespace.version)
+    }
+
+    fn version_at_most(&self, version: XiidmVersion) -> bool {
+        self.version().is_some_and(|value| value <= version)
+    }
+
+    fn version_at_least(&self, version: XiidmVersion) -> bool {
+        self.version().is_some_and(|value| value >= version)
+    }
+
+    /// Consume one tree event. Elements inside an extension subtree the
+    /// mapping does not read are counted and otherwise ignored until that
+    /// subtree closes; every other event reaches the element mapping.
+    fn consume(&mut self, event: TreeEvent<'_>, diagnostics: &mut Diagnostics) -> Result<()> {
+        match event {
+            TreeEvent::Start {
+                tag,
+                namespace,
+                attrs,
+                empty,
+            } => {
+                if self.skipped_depth > 0 {
+                    if !empty {
+                        self.skipped_depth += 1;
+                    }
+                    return Ok(());
+                }
+                let active_power_control = tag == "activePowerControl"
+                    && ActivePowerControlVersion::from_namespace(namespace).is_some();
+                if self.current_extension_target.is_some()
+                    && tag != "extension"
+                    && !active_power_control
+                {
+                    if namespace.is_none_or(is_xiidm_namespace_uri) {
+                        return Err(format_error(format!(
+                            "XIIDM model element `{tag}` appears inside an extension"
+                        )));
+                    }
+                    diagnostics.push(
+                        &codes::READ_XIIDM_ELEMENT_UNMAPPED,
+                        format!(
+                            "XIIDM extension element `{tag}` on `{}` is retained only by exact same format emission",
+                            self.current_extension_target.as_deref().unwrap_or_default()
+                        ),
+                    );
+                    if !empty {
+                        self.skipped_depth = 1;
+                    }
+                    return Ok(());
+                }
+                self.start(tag, namespace, attrs, empty, diagnostics)
+            }
+            TreeEvent::Text(text) => {
+                if self.skipped_depth == 0
+                    && let Some(alias) = &mut self.pending_alias
+                {
+                    alias.value.push_str(text);
+                }
+                Ok(())
+            }
+            TreeEvent::End(tag) => {
+                if self.skipped_depth > 0 {
+                    self.skipped_depth -= 1;
+                    return Ok(());
+                }
+                self.end(tag)
+            }
+        }
+    }
+
     fn start(
         &mut self,
         tag: &str,
@@ -784,12 +1426,7 @@ impl ParsedXiidm {
                 )));
             }
         }
-        let mut frame = Frame {
-            tag: tag.to_owned(),
-            component: None,
-            equipment: None,
-            ac_dc_converter: None,
-        };
+        let mut frame = Frame::new(tag);
         match tag {
             "network" => {
                 let root = !self.root_seen;
@@ -1045,13 +1682,19 @@ impl ParsedXiidm {
                 let voltage_level = self.require_voltage_level(tag)?;
                 let id = required_text(&attrs, "id")?.to_owned();
                 frame.component = Some(self.register_component("busbar_section", &id, &attrs)?);
+                let legacy_voltage = if self.version_at_most(XiidmVersion::V1_0) {
+                    optional_f64(&attrs, "v")?.zip(optional_f64(&attrs, "angle")?)
+                } else {
+                    None
+                };
                 self.busbar_sections.push(RawBusbarSection {
                     id,
                     voltage_level,
                     node: required_i32(&attrs, "node")?,
+                    legacy_voltage,
                 });
             }
-            "switch" => self.read_switch(&attrs, &mut frame)?,
+            "switch" => self.read_switch(&attrs, &mut frame, diagnostics)?,
             "internalConnection" => self.internal_connections.push(RawInternalConnection {
                 voltage_level: self.require_voltage_level(tag)?,
                 node1: required_i32(&attrs, "node1")?,
@@ -1059,36 +1702,62 @@ impl ParsedXiidm {
             }),
             "load" => self.read_equipment(EquipmentKind::Load, attrs, &mut frame)?,
             "generator" => self.read_equipment(EquipmentKind::Generator, attrs, &mut frame)?,
-            "battery" => self.read_equipment(EquipmentKind::Battery, attrs, &mut frame)?,
-            "shunt"
-                if self
-                    .namespace
-                    .is_some_and(|namespace| namespace.version <= XiidmVersion::V1_15) =>
-            {
-                self.read_equipment(EquipmentKind::Shunt, attrs, &mut frame)?;
+            "battery" => {
+                let mut attrs = attrs;
+                if self.version_at_most(XiidmVersion::V1_7) {
+                    rename_attribute(&mut attrs, "p0", "targetP");
+                    rename_attribute(&mut attrs, "q0", "targetQ");
+                }
+                self.read_equipment(EquipmentKind::Battery, attrs, &mut frame)?;
             }
-            "shuntCompensator"
-                if self
-                    .namespace
-                    .is_some_and(|namespace| namespace.version >= XiidmVersion::V1_16) =>
-            {
+            "shunt" if self.version_at_most(XiidmVersion::V1_15) => {
+                let mut attrs = attrs;
+                let legacy_model = if self.version_at_most(XiidmVersion::V1_2) {
+                    let model = (
+                        0.0,
+                        required_f64(&attrs, "bPerSection")?,
+                        required_u32(&attrs, "maximumSectionCount")?,
+                    );
+                    let section_count = required_u32(&attrs, "currentSectionCount")?;
+                    attrs.remove("bPerSection");
+                    attrs.remove("maximumSectionCount");
+                    attrs.remove("currentSectionCount");
+                    attrs.insert("sectionCount".to_owned(), section_count.to_string());
+                    if self.version_at_most(XiidmVersion::V1_1) {
+                        attrs
+                            .entry("voltageRegulatorOn".to_owned())
+                            .or_insert_with(|| "false".to_owned());
+                    }
+                    Some(model)
+                } else {
+                    None
+                };
+                self.read_equipment(EquipmentKind::Shunt, attrs, &mut frame)?;
+                if let Some(model) = legacy_model {
+                    let equipment = frame.equipment.expect("equipment was read");
+                    self.equipment[equipment].shunt_linear = Some(model);
+                    self.equipment[equipment].shunt_conductance_omitted = true;
+                }
+            }
+            "shuntCompensator" if self.version_at_least(XiidmVersion::V1_16) => {
                 self.read_equipment(EquipmentKind::Shunt, attrs, &mut frame)?;
             }
             "staticVarCompensator" => {
+                let mut attrs = attrs;
+                if self.version_at_most(XiidmVersion::V1_2) {
+                    rename_attribute(&mut attrs, "voltageSetPoint", "voltageSetpoint");
+                    rename_attribute(&mut attrs, "reactivePowerSetPoint", "reactivePowerSetpoint");
+                }
                 self.read_equipment(EquipmentKind::StaticVarCompensator, attrs, &mut frame)?;
             }
-            "boundaryLine"
-                if self
-                    .namespace
-                    .is_some_and(|namespace| namespace.version >= XiidmVersion::V1_16) =>
-            {
+            "boundaryLine" if self.version_at_least(XiidmVersion::V1_16) => {
                 self.read_equipment(EquipmentKind::BoundaryLine, attrs, &mut frame)?;
             }
-            "danglingLine"
-                if self
-                    .namespace
-                    .is_some_and(|namespace| namespace.version <= XiidmVersion::V1_15) =>
-            {
+            "danglingLine" if self.version_at_most(XiidmVersion::V1_15) => {
+                let mut attrs = attrs;
+                if self.version_at_most(XiidmVersion::V1_10) {
+                    rename_attribute(&mut attrs, "ucteXnodeCode", "pairingKey");
+                }
                 self.read_equipment(EquipmentKind::BoundaryLine, attrs, &mut frame)?;
             }
             "shunt" | "shuntCompensator" | "boundaryLine" | "danglingLine" => {
@@ -1113,6 +1782,15 @@ impl ParsedXiidm {
                 self.read_equipment(EquipmentKind::Transformer, attrs, &mut frame)?;
             }
             "threeWindingsTransformer" => {
+                let mut attrs = attrs;
+                // IIDM 1.0 has no `ratedU0`; the leg impedances are stated on
+                // the first winding's rated voltage.
+                if self.version_at_most(XiidmVersion::V1_0)
+                    && !attrs.contains_key("ratedU0")
+                    && let Some(rated_u1) = attrs.get("ratedU1").cloned()
+                {
+                    attrs.insert("ratedU0".to_owned(), rated_u1);
+                }
                 self.read_equipment(EquipmentKind::ThreeWindingTransformer, attrs, &mut frame)?;
             }
             "hvdcLine" => {
@@ -1120,12 +1798,13 @@ impl ParsedXiidm {
                 frame.component = Some(self.register_component("hvdc", &id, &attrs)?);
                 self.hvdc_lines.push(RawHvdcLine { id, attrs });
             }
+            "tieLine" if self.version_at_most(XiidmVersion::V1_9) => {
+                self.read_legacy_tie_line(&attrs, &mut frame, diagnostics)?;
+            }
             "tieLine" => {
                 let id = required_text(&attrs, "id")?.to_owned();
                 frame.component = Some(self.register_component("tie_line", &id, &attrs)?);
-                let modern = self
-                    .namespace
-                    .is_some_and(|namespace| namespace.version >= XiidmVersion::V1_16);
+                let modern = self.version_at_least(XiidmVersion::V1_16);
                 self.tie_lines.push(RawTieLine {
                     id,
                     boundary_line1: required_text(
@@ -1292,6 +1971,14 @@ impl ParsedXiidm {
                     && self
                         .namespace
                         .is_some_and(|namespace| namespace.version <= XiidmVersion::V1_13);
+                // Before 1.12 a ratio tap changer states `targetV` instead of
+                // a regulation mode and value; a stated target means voltage
+                // regulation.
+                let legacy_ratio_target = (active.kind == TapKind::Ratio
+                    && self.version_at_most(XiidmVersion::V1_11))
+                .then(|| optional_f64(&attrs, "targetV"))
+                .transpose()?
+                .flatten();
                 let regulation_mode = if legacy_fixed_phase_tap {
                     diagnostics.push(
                         &codes::READ_XIIDM_VERSION_COMPATIBILITY,
@@ -1302,17 +1989,13 @@ impl ParsedXiidm {
                         ),
                     );
                     Some(TapChangerRegulationMode::Current)
+                } else if legacy_ratio_target.is_some() {
+                    Some(TapChangerRegulationMode::Voltage)
                 } else {
-                    match active.kind {
-                        TapKind::Ratio => attrs
-                            .get("regulationMode")
-                            .map(|mode| parse_tap_regulation_mode(active.kind, mode))
-                            .transpose()?,
-                        TapKind::Phase => attrs
-                            .get("regulationMode")
-                            .map(|mode| parse_tap_regulation_mode(active.kind, mode))
-                            .transpose()?,
-                    }
+                    attrs
+                        .get("regulationMode")
+                        .map(|mode| parse_tap_regulation_mode(active.kind, mode))
+                        .transpose()?
                 };
                 let load_tap_changing_capabilities = match active.kind {
                     TapKind::Phase
@@ -1355,8 +2038,16 @@ impl ParsedXiidm {
                     load_tap_changing_capabilities,
                     regulating,
                     regulation_mode,
-                    regulation_value: optional_f64(&attrs, "regulationValue")?,
-                    target_deadband: optional_f64(&attrs, "targetDeadband")?,
+                    regulation_value: match legacy_ratio_target {
+                        Some(target) => Some(target),
+                        None => optional_f64(&attrs, "regulationValue")?,
+                    },
+                    // IIDM 1.0 and 1.1 allow a regulating tap changer without
+                    // a deadband; PowSybl reads that as a zero deadband.
+                    target_deadband: match optional_f64(&attrs, "targetDeadband")? {
+                        None if regulating && self.version_at_most(XiidmVersion::V1_1) => Some(0.0),
+                        value => value,
+                    },
                     regulation_terminal: None,
                     steps: Vec::new(),
                 };
@@ -1380,30 +2071,77 @@ impl ParsedXiidm {
                     .push(RawOperationalLimitsGroup {
                         id: required_text(&attrs, "id")?.to_owned(),
                         side: operational_limits_side(tag).expect("matched limit group"),
+                        implicit: false,
                         properties: BTreeMap::new(),
                         active_power: None,
                         apparent_power: None,
                         current: None,
                     });
             }
-            "activePowerLimits" | "apparentPowerLimits" | "currentLimits" => {
-                let kind = match tag {
-                    "activePowerLimits" => LoadingLimitKind::ActivePower,
-                    "apparentPowerLimits" => LoadingLimitKind::ApparentPower,
-                    _ => LoadingLimitKind::Current,
-                };
+            tag if loading_limit_tag(tag).is_some() => {
+                let (kind, side) = loading_limit_tag(tag).expect("matched loading limits");
                 let limits = RawLoadingLimits {
                     permanent_limit: optional_f64(&attrs, "permanentLimit")?,
                     permanent_name: attrs.get("permanentLimitName").cloned(),
                     temporary_limits: Vec::new(),
                 };
-                let group = self.current_operational_limits_group_mut()?;
-                match kind {
-                    LoadingLimitKind::ActivePower => group.active_power = Some(limits),
-                    LoadingLimitKind::ApparentPower => group.apparent_power = Some(limits),
-                    LoadingLimitKind::Current => group.current = Some(limits),
+                let parent = self.frames.last();
+                let inside_group =
+                    parent.is_some_and(|frame| operational_limits_side(&frame.tag).is_some());
+                let (equipment, group) = if inside_group {
+                    if side.is_some() {
+                        return Err(format_error(format!(
+                            "loading limits `{tag}` inside an operational limits group must not name a side"
+                        )));
+                    }
+                    let equipment = self.current_equipment()?;
+                    let group = self.equipment[equipment].operational_limits.len() - 1;
+                    (equipment, group)
+                } else if let Some(sides) = parent.and_then(|frame| frame.legacy_tie_sides) {
+                    // A tie line older than IIDM 1.10 states each boundary
+                    // line's limits with that side's suffix.
+                    let side = side.filter(|side| (1..=2).contains(side)).ok_or_else(|| {
+                        format_error(format!(
+                            "tie line loading limits `{tag}` must name side 1 or 2"
+                        ))
+                    })?;
+                    let equipment = sides[usize::from(side - 1)];
+                    (
+                        equipment,
+                        self.implicit_operational_limits_group(equipment, 1),
+                    )
+                } else {
+                    let equipment = self.current_equipment()?;
+                    let side = side.unwrap_or(1);
+                    if side > self.equipment[equipment].kind.terminal_count() {
+                        return Err(format_error(format!(
+                            "loading limits `{tag}` name a side `{}` does not have",
+                            self.equipment[equipment].id
+                        )));
+                    }
+                    (
+                        equipment,
+                        self.implicit_operational_limits_group(equipment, side),
+                    )
+                };
+                frame.equipment = Some(equipment);
+                let target = &mut self.equipment[equipment].operational_limits[group];
+                let slot = match kind {
+                    LoadingLimitKind::ActivePower => &mut target.active_power,
+                    LoadingLimitKind::ApparentPower => &mut target.apparent_power,
+                    LoadingLimitKind::Current => &mut target.current,
+                };
+                if slot.replace(limits).is_some() {
+                    return Err(format_error(format!(
+                        "equipment `{}` states `{tag}` more than once for one operational limits group",
+                        self.equipment[equipment].id
+                    )));
                 }
-                self.current_loading_limit = Some(kind);
+                self.current_loading_limit = Some(ActiveLoadingLimit {
+                    kind,
+                    equipment,
+                    group,
+                });
             }
             "temporaryLimit" if self.current_loading_limit.is_some() => {
                 let limit = RawTemporaryLimit {
@@ -1412,9 +2150,9 @@ impl ParsedXiidm {
                     value: optional_f64(&attrs, "value")?,
                     fictitious: optional_bool(&attrs, "fictitious")?.unwrap_or(false),
                 };
-                let kind = self.current_loading_limit.expect("matched loading limit");
-                let group = self.current_operational_limits_group_mut()?;
-                let limits = match kind {
+                let active = self.current_loading_limit.expect("matched loading limit");
+                let group = &mut self.equipment[active.equipment].operational_limits[active.group];
+                let limits = match active.kind {
                     LoadingLimitKind::ActivePower => group.active_power.as_mut(),
                     LoadingLimitKind::ApparentPower => group.apparent_power.as_mut(),
                     LoadingLimitKind::Current => group.current.as_mut(),
@@ -1465,10 +2203,7 @@ impl ParsedXiidm {
             if tap_tag(tag).is_some() {
                 self.current_tap = None;
             }
-            if matches!(
-                tag,
-                "activePowerLimits" | "apparentPowerLimits" | "currentLimits"
-            ) {
+            if loading_limit_tag(tag).is_some() {
                 self.current_loading_limit = None;
             }
             if tag == "area" {
@@ -1547,18 +2282,18 @@ impl ParsedXiidm {
             diagnostics.push(
                 &codes::PARSE_XIIDM_VERSION_UNSUPPORTED,
                 format!(
-                    "XIIDM namespace `{uri}` is unsupported; PowerIO reads XIIDM 1.12 through 1.17"
+                    "IIDM namespace `{uri}` is unsupported; PowerIO reads IIDM 1.0 through 1.17"
                 ),
             );
             return Err(format_error(format!(
-                "unsupported XIIDM namespace `{uri}`; supported input versions are 1.12 through 1.17"
+                "unsupported IIDM namespace `{uri}`; supported input versions are 1.0 through 1.17"
             )));
         };
         if namespace.version != XiidmVersion::V1_17 {
             diagnostics.push(
                 &codes::READ_XIIDM_VERSION_COMPATIBILITY,
                 format!(
-                    "XIIDM {} input was read; fresh XIIDM output uses 1.17",
+                    "IIDM {} input was read; fresh XIIDM and JIIDM output uses 1.17",
                     namespace.version.label()
                 ),
             );
@@ -1567,13 +2302,21 @@ impl ParsedXiidm {
         let id = required_text(attrs, "id")?.to_owned();
         frame.component = Some(self.register_component("balanced_network", &id, attrs)?);
         self.id = Some(id);
+        // The validation level attribute exists from 1.7 on; every earlier
+        // document is a steady state hypothesis.
+        let minimum_validation_level = if namespace.version.supports_equipment_validation() {
+            required_text(attrs, "minimumValidationLevel")?.to_owned()
+        } else {
+            attrs
+                .get("minimumValidationLevel")
+                .cloned()
+                .unwrap_or_else(|| DEFAULT_VALIDATION_LEVEL.to_owned())
+        };
         self.case_metadata = CaseMetadata {
             case_date: Some(required_text(attrs, "caseDate")?.to_owned()),
-            forecast_distance: Some(required_i32(attrs, "forecastDistance")?),
+            forecast_distance: Some(optional_i32(attrs, "forecastDistance")?.unwrap_or(0)),
             source_model_format: Some(required_text(attrs, "sourceFormat")?.to_owned()),
-            minimum_validation_level: Some(
-                required_text(attrs, "minimumValidationLevel")?.to_owned(),
-            ),
+            minimum_validation_level: Some(minimum_validation_level),
         };
         self.root_seen = true;
         Ok(())
@@ -1604,9 +2347,33 @@ impl ParsedXiidm {
         Ok(())
     }
 
-    fn read_switch(&mut self, attrs: &Attrs, frame: &mut Frame) -> Result<()> {
+    fn read_switch(
+        &mut self,
+        attrs: &Attrs,
+        frame: &mut Frame,
+        diagnostics: &mut Diagnostics,
+    ) -> Result<()> {
         let voltage_level = self.require_voltage_level("switch")?;
         let id = required_text(attrs, "id")?.to_owned();
+        // Versions before 1.8 could write a switch with the same bus or node
+        // at both ends; PowSybl discards such a switch when reading them.
+        if self.version_at_most(XiidmVersion::V1_7) {
+            let same_ends = if attrs.contains_key("bus1") {
+                attrs.get("bus1") == attrs.get("bus2")
+            } else {
+                attrs.get("node1") == attrs.get("node2")
+            };
+            if same_ends {
+                diagnostics.push(
+                    &codes::READ_XIIDM_VERSION_COMPATIBILITY,
+                    format!(
+                        "XIIDM {} switch `{id}` connects one end to itself; PowSybl discards it and so does this reader",
+                        self.namespace.expect("version checked").version.label()
+                    ),
+                );
+                return Ok(());
+            }
+        }
         frame.component = Some(self.register_component("switch", &id, attrs)?);
         let kind = match required_text(attrs, "kind")? {
             "BREAKER" => SwitchKind::Breaker,
@@ -1647,11 +2414,100 @@ impl ParsedXiidm {
         attrs: Attrs,
         frame: &mut Frame,
     ) -> Result<()> {
-        let id = required_text(&attrs, "id")?.to_owned();
-        frame.component = Some(self.register_component(kind.component_type(), &id, &attrs)?);
         let voltage_level = (kind.terminal_count() == 1)
             .then(|| self.require_voltage_level(kind.component_type()))
             .transpose()?;
+        self.read_equipment_in(kind, attrs, frame, voltage_level)
+    }
+
+    /// Read one tie line of IIDM 1.9 or older, which states both boundary
+    /// lines inline: each side's identity, impedance, terminal, and flows
+    /// carry a `_1` or `_2` suffix, and the pairing key is the tie line's
+    /// `ucteXnodeCode`. The two sides become boundary line equipment records
+    /// and the tie line references them as later versions do.
+    fn read_legacy_tie_line(
+        &mut self,
+        attrs: &Attrs,
+        frame: &mut Frame,
+        diagnostics: &mut Diagnostics,
+    ) -> Result<()> {
+        let id = required_text(attrs, "id")?.to_owned();
+        frame.component = Some(self.register_component("tie_line", &id, attrs)?);
+        let pairing_key = attrs.get("ucteXnodeCode").cloned();
+        let mut sides = [0_usize; 2];
+        let mut boundary_ids = [String::new(), String::new()];
+        for side in 1..=2_u8 {
+            let suffix = format!("_{side}");
+            let boundary_id = required_text(attrs, &format!("id{suffix}"))?.to_owned();
+            let voltage_level = required_text(attrs, &format!("voltageLevelId{side}"))?.to_owned();
+            let mut boundary = Attrs::new();
+            boundary.insert("id".to_owned(), boundary_id.clone());
+            if let Some(name) = attrs.get(&format!("name{suffix}")) {
+                boundary.insert("name".to_owned(), name.clone());
+            }
+            if let Some(fictitious) = attrs.get(&format!("fictitious{suffix}")) {
+                boundary.insert("fictitious".to_owned(), fictitious.clone());
+            }
+            boundary.insert("p0".to_owned(), "0".to_owned());
+            boundary.insert("q0".to_owned(), "0".to_owned());
+            for name in ["r", "x"] {
+                boundary.insert(
+                    name.to_owned(),
+                    required_text(attrs, &format!("{name}{suffix}"))?.to_owned(),
+                );
+            }
+            for (name, first, second) in [("g", "g1", "g2"), ("b", "b1", "b2")] {
+                let total = required_f64(attrs, &format!("{first}{suffix}"))?
+                    + required_f64(attrs, &format!("{second}{suffix}"))?;
+                boundary.insert(name.to_owned(), number(total));
+            }
+            if let Some(key) = &pairing_key {
+                boundary.insert("pairingKey".to_owned(), key.clone());
+            }
+            for name in ["bus", "connectableBus", "node", "p", "q"] {
+                if let Some(value) = attrs.get(&format!("{name}{side}")) {
+                    boundary.insert(name.to_owned(), value.clone());
+                }
+            }
+            if attrs.contains_key(&format!("xnodeP{suffix}"))
+                || attrs.contains_key(&format!("xnodeQ{suffix}"))
+            {
+                diagnostics.push(
+                    &codes::READ_XIIDM_FIELD_UNMAPPED,
+                    format!(
+                        "XIIDM tie line `{id}` states boundary flows `xnodeP{suffix}`/`xnodeQ{suffix}`; PowSybl recomputes them from the half lines and fresh output omits them"
+                    ),
+                );
+            }
+            let mut side_frame = Frame::new("danglingLine");
+            self.read_equipment_in(
+                EquipmentKind::BoundaryLine,
+                boundary,
+                &mut side_frame,
+                Some(voltage_level),
+            )?;
+            sides[usize::from(side - 1)] = side_frame.equipment.expect("equipment was read");
+            boundary_ids[usize::from(side - 1)] = boundary_id;
+        }
+        let [boundary_line1, boundary_line2] = boundary_ids;
+        self.tie_lines.push(RawTieLine {
+            id,
+            boundary_line1,
+            boundary_line2,
+        });
+        frame.legacy_tie_sides = Some(sides);
+        Ok(())
+    }
+
+    fn read_equipment_in(
+        &mut self,
+        kind: EquipmentKind,
+        attrs: Attrs,
+        frame: &mut Frame,
+        voltage_level: Option<String>,
+    ) -> Result<()> {
+        let id = required_text(&attrs, "id")?.to_owned();
+        frame.component = Some(self.register_component(kind.component_type(), &id, &attrs)?);
         let equipment_index = self.equipment.len();
         frame.equipment = Some(equipment_index);
         if self
@@ -1867,11 +2723,15 @@ impl ParsedXiidm {
             .last()
             .map(|frame| frame.tag.clone())
             .unwrap_or_default();
-        if matches!(
-            parent.as_str(),
-            "activePowerLimits" | "apparentPowerLimits" | "currentLimits" | "temporaryLimit"
-        ) {
-            let group = self.current_operational_limits_group_mut()?.id.clone();
+        if loading_limit_tag(parent.as_str()).is_some() || parent == "temporaryLimit" {
+            let group = self
+                .current_loading_limit
+                .map(|active| {
+                    self.equipment[active.equipment].operational_limits[active.group]
+                        .id
+                        .clone()
+                })
+                .unwrap_or_default();
             diagnostics.push(
                 &codes::READ_XIIDM_FIELD_UNMAPPED,
                 format!(
@@ -1880,16 +2740,18 @@ impl ParsedXiidm {
             );
             return Ok(());
         }
-        if self.frames.iter().rev().any(|frame| {
-            matches!(
-                frame.tag.as_str(),
-                "operationalLimitsGroup"
-                    | "operationalLimitsGroup1"
-                    | "operationalLimitsGroup2"
-                    | "operationalLimitsGroup3"
-            )
-        }) {
-            self.current_operational_limits_group_mut()?
+        if self
+            .frames
+            .iter()
+            .any(|frame| operational_limits_side(&frame.tag).is_some())
+        {
+            let equipment = self.current_equipment()?;
+            self.equipment[equipment]
+                .operational_limits
+                .last_mut()
+                .ok_or_else(|| {
+                    format_error("operational limits group property has no group parent")
+                })?
                 .properties
                 .insert(name, value);
             return Ok(());
@@ -2031,12 +2893,27 @@ impl ParsedXiidm {
         Ok(())
     }
 
-    fn current_operational_limits_group_mut(&mut self) -> Result<&mut RawOperationalLimitsGroup> {
-        let equipment = self.current_equipment()?;
-        self.equipment[equipment]
-            .operational_limits
-            .last_mut()
-            .ok_or_else(|| format_error("loading limits have no operational limits group parent"))
+    /// The index of the operational limits group that receives loading
+    /// limits stated directly on `equipment` for `side`, created on first
+    /// use.
+    fn implicit_operational_limits_group(&mut self, equipment: usize, side: u8) -> usize {
+        let groups = &mut self.equipment[equipment].operational_limits;
+        if let Some(index) = groups
+            .iter()
+            .position(|group| group.implicit && group.side == side)
+        {
+            return index;
+        }
+        groups.push(RawOperationalLimitsGroup {
+            id: DEFAULT_OPERATIONAL_LIMITS_GROUP.to_owned(),
+            side,
+            implicit: true,
+            properties: BTreeMap::new(),
+            active_power: None,
+            apparent_power: None,
+            current: None,
+        });
+        groups.len() - 1
     }
 
     fn current_tap_mut(&mut self, equipment: usize, active: ActiveTap) -> Result<&mut TapChanger> {
@@ -2123,10 +3000,7 @@ impl ParsedXiidm {
         if tap_tag(tag).is_some() {
             self.current_tap = None;
         }
-        if matches!(
-            tag,
-            "activePowerLimits" | "apparentPowerLimits" | "currentLimits"
-        ) {
+        if loading_limit_tag(tag).is_some() {
             self.current_loading_limit = None;
         }
         let frame = self
@@ -3118,7 +3992,10 @@ fn build_network(parsed: &ParsedXiidm, diagnostics: &mut Diagnostics) -> Result<
         DEFAULT_BASE_MVA,
     );
     *network.case_metadata_mut() = parsed.case_metadata.clone();
-    *network.source_format_mut() = SourceFormat::Xiidm;
+    *network.source_format_mut() = match parsed.encoding {
+        IidmEncoding::Xml => SourceFormat::Xiidm,
+        IidmEncoding::Json => SourceFormat::Jiidm,
+    };
     *network.buses_mut() = buses;
     *network.loads_mut() = loads;
     *network.shunts_mut() = shunts;
@@ -3850,12 +4727,25 @@ impl<'a> BusBuilder<'a> {
                 .get(root)
                 .copied()
                 .cloned()
-                .unwrap_or(RawBus {
-                    id: None,
-                    voltage_level: level.id.clone(),
-                    nodes: group.clone(),
-                    v: None,
-                    angle: None,
+                .unwrap_or_else(|| {
+                    // IIDM 1.0 states the calculated bus voltage on its
+                    // busbar sections; every section of one bus states the
+                    // same value.
+                    let legacy_voltage = self
+                        .parsed
+                        .busbar_sections
+                        .iter()
+                        .filter(|value| {
+                            value.voltage_level == level.id && group.contains(&value.node)
+                        })
+                        .find_map(|value| value.legacy_voltage);
+                    RawBus {
+                        id: None,
+                        voltage_level: level.id.clone(),
+                        nodes: group.clone(),
+                        v: legacy_voltage.map(|(v, _)| v),
+                        angle: legacy_voltage.map(|(_, angle)| angle),
+                    }
                 });
             let local_id = self
                 .parsed
@@ -4557,7 +5447,14 @@ fn selected_operational_limit_group_ids(equipment: &RawEquipment, side: u8) -> R
     if let Some(value) = equipment.attrs.get(&singular_key) {
         return Ok(vec![value.clone()]);
     }
-    Ok(Vec::new())
+    // Limits stated directly on the equipment are the selected limits of
+    // their side.
+    Ok(equipment
+        .operational_limits
+        .iter()
+        .filter(|group| group.implicit && group.side == side)
+        .map(|group| group.id.clone())
+        .collect())
 }
 
 fn parse_operational_limits_group_ids(value: &str) -> Result<Vec<String>> {
@@ -5345,9 +6242,13 @@ fn build_detailed_connectivity(
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    let connectivity_nodes = buses
-        .node_map
-        .iter()
+    // Voltage level then node number: the table order does not depend on
+    // the map's iteration order, so the same network reads the same way from
+    // either encoding and on every run.
+    let mut node_entries = buses.node_map.iter().collect::<Vec<_>>();
+    node_entries.sort_by_key(|(key, _)| *key);
+    let connectivity_nodes = node_entries
+        .into_iter()
         .map(|((voltage_level, node), bus)| {
             Ok(ConnectivityNode {
                 component: node_component_id(voltage_level, *node)?,
@@ -6823,6 +7724,980 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
     write_active_power_control_extensions(network, &|_| true, 2, &mut output)?;
     output.push_str("</iidm:network>\n");
     Ok(TextEmission::new(output, diagnostics))
+}
+
+/// Write the network as PowSybl JIIDM 1.17: the fresh XIIDM 1.17 tree in
+/// PowSybl's JSON layout. Repeated elements become arrays under PowSybl's
+/// plural field names, attributes become typed scalars, and each element's
+/// attributes follow the order PowSybl's sequential JSON reader consumes
+/// them in.
+pub(crate) fn write_jiidm(network: &BalancedNetwork) -> Result<TextEmission> {
+    let emission = write_xiidm(network)?;
+    let text = xiidm_to_jiidm(&emission.text)?;
+    Ok(TextEmission {
+        text,
+        diagnostics: emission.diagnostics,
+        fidelity: emission.fidelity,
+    })
+}
+
+/// One value of the JIIDM output tree. Scalars are stored as their rendered
+/// JSON token.
+enum JsonOut {
+    Scalar(String),
+    Array(Vec<JsonOut>),
+    Object(Vec<(String, JsonOut)>),
+}
+
+/// An XML element under construction while its children are read.
+struct OpenElement {
+    tag: String,
+    attrs: Vec<(String, String)>,
+    namespaces: Vec<String>,
+    content: Option<String>,
+    children: Vec<(String, JsonOut)>,
+}
+
+fn jiidm_emission_error(message: impl Into<String>) -> Error {
+    Error::Emit {
+        format: JSON_FORMAT,
+        message: message.into(),
+    }
+}
+
+fn xiidm_to_jiidm(xml: &str) -> Result<String> {
+    let mut reader = NsReader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    let mut stack: Vec<OpenElement> = Vec::new();
+    let mut root = None;
+    loop {
+        let event = reader
+            .read_event()
+            .map_err(|error| jiidm_emission_error(format!("fresh XIIDM is malformed: {error}")))?;
+        match event {
+            Event::Start(element) => stack.push(open_element(&element, reader.decoder())?),
+            Event::Empty(element) => {
+                let open = open_element(&element, reader.decoder())?;
+                close_element(open, &mut stack, &mut root)?;
+            }
+            Event::End(_) => {
+                let open = stack.pop().ok_or_else(|| {
+                    jiidm_emission_error("fresh XIIDM closes an unopened element")
+                })?;
+                close_element(open, &mut stack, &mut root)?;
+            }
+            Event::Text(text) => {
+                let open = stack.last_mut().ok_or_else(|| {
+                    jiidm_emission_error("fresh XIIDM has text outside an element")
+                })?;
+                let text = text
+                    .decode()
+                    .map_err(|error| jiidm_emission_error(error.to_string()))?;
+                open.content.get_or_insert_with(String::new).push_str(&text);
+            }
+            Event::CData(text) => {
+                let open = stack.last_mut().ok_or_else(|| {
+                    jiidm_emission_error("fresh XIIDM has text outside an element")
+                })?;
+                let text = text
+                    .decode()
+                    .map_err(|error| jiidm_emission_error(error.to_string()))?;
+                open.content.get_or_insert_with(String::new).push_str(&text);
+            }
+            Event::Decl(_) | Event::Comment(_) | Event::PI(_) => {}
+            Event::DocType(_) | Event::GeneralRef(_) => {
+                return Err(jiidm_emission_error(
+                    "fresh XIIDM carries a DTD or entity reference",
+                ));
+            }
+            Event::Eof => break,
+        }
+    }
+    let root = root.ok_or_else(|| jiidm_emission_error("fresh XIIDM has no root element"))?;
+    let mut output = String::new();
+    render_json(&root, 0, &mut output);
+    output.push('\n');
+    Ok(output)
+}
+
+fn open_element(
+    element: &BytesStart<'_>,
+    decoder: quick_xml::encoding::Decoder,
+) -> Result<OpenElement> {
+    let tag = local_name(element.name().as_ref())?;
+    let mut attrs = Vec::new();
+    let mut namespaces = Vec::new();
+    for attribute in element.attributes() {
+        let attribute = attribute.map_err(|error| jiidm_emission_error(error.to_string()))?;
+        let key = std::str::from_utf8(attribute.key.as_ref())
+            .map_err(|error| jiidm_emission_error(error.to_string()))?;
+        let value = attribute
+            .decode_and_unescape_value(decoder)
+            .map_err(|error| jiidm_emission_error(error.to_string()))?
+            .into_owned();
+        if key == "xmlns" || key.starts_with("xmlns:") {
+            namespaces.push(value);
+        } else {
+            attrs.push((local_name(key.as_bytes())?, value));
+        }
+    }
+    Ok(OpenElement {
+        tag,
+        attrs,
+        namespaces,
+        content: None,
+        children: Vec::new(),
+    })
+}
+
+/// Turn a finished element into its JSON object and attach it to its parent:
+/// as one entry of the parent's plural array when PowSybl lists the element,
+/// otherwise as a field named after the element.
+fn close_element(
+    open: OpenElement,
+    stack: &mut [OpenElement],
+    root: &mut Option<JsonOut>,
+) -> Result<()> {
+    let is_root = stack.is_empty();
+    let mut entries = Vec::new();
+    if is_root {
+        entries.push(("version".to_owned(), JsonOut::Scalar(json_string("1.17"))));
+        let extension_versions = open
+            .namespaces
+            .iter()
+            .filter_map(|namespace| {
+                let version = match namespace.as_str() {
+                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_0 => "1.0",
+                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_1 => "1.1",
+                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_2 => "1.2",
+                    _ => return None,
+                };
+                Some(JsonOut::Object(vec![
+                    (
+                        "extensionName".to_owned(),
+                        JsonOut::Scalar(json_string("activePowerControl")),
+                    ),
+                    ("version".to_owned(), JsonOut::Scalar(json_string(version))),
+                ]))
+            })
+            .collect::<Vec<_>>();
+        if !extension_versions.is_empty() {
+            entries.push((
+                "extensionVersions".to_owned(),
+                JsonOut::Array(extension_versions),
+            ));
+        }
+    }
+    let order = jiidm_attribute_order(&open.tag);
+    let rank = |name: &str| {
+        order
+            .iter()
+            .position(|candidate| *candidate == name)
+            .unwrap_or(order.len())
+    };
+    let mut attrs = open.attrs;
+    attrs.sort_by_key(|(name, _)| rank(name));
+    for (name, value) in attrs {
+        let value = jiidm_attribute_value(&open.tag, &name, &value)?;
+        entries.push((name, value));
+    }
+    if let Some(content) = open.content {
+        entries.push(("content".to_owned(), JsonOut::Scalar(json_string(&content))));
+    }
+    entries.extend(open.children);
+    let object = JsonOut::Object(entries);
+    let Some(parent) = stack.last_mut() else {
+        *root = Some(object);
+        return Ok(());
+    };
+    if let Some(array_name) = jiidm_array_name(&open.tag) {
+        if let Some((_, JsonOut::Array(values))) = parent
+            .children
+            .iter_mut()
+            .find(|(name, _)| name == array_name)
+        {
+            values.push(object);
+        } else {
+            parent
+                .children
+                .push((array_name.to_owned(), JsonOut::Array(vec![object])));
+        }
+    } else {
+        parent.children.push((open.tag, object));
+    }
+    Ok(())
+}
+
+const IDENTIFIABLE_ATTRIBUTES: [&str; 3] = ["id", "name", "fictitious"];
+
+/// The attribute order PowSybl's sequential JSON reader consumes for each
+/// element. Attributes the table does not name follow the named ones in
+/// document order.
+fn jiidm_attribute_order(tag: &str) -> &'static [&'static str] {
+    match tag {
+        "network" => &[
+            "id",
+            "caseDate",
+            "forecastDistance",
+            "sourceFormat",
+            "minimumValidationLevel",
+        ],
+        "substation" => &[
+            "id",
+            "name",
+            "fictitious",
+            "country",
+            "tso",
+            "geographicalTags",
+        ],
+        "voltageLevel" => &[
+            "id",
+            "name",
+            "fictitious",
+            "nominalV",
+            "lowVoltageLimit",
+            "highVoltageLimit",
+            "topologyKind",
+        ],
+        "bus" => &[
+            "id",
+            "name",
+            "fictitious",
+            "v",
+            "angle",
+            "fictitiousP0",
+            "fictitiousQ0",
+            "nodes",
+        ],
+        "busbarSection" => &["id", "name", "fictitious", "node"],
+        "switch" => &[
+            "id",
+            "name",
+            "fictitious",
+            "kind",
+            "retained",
+            "open",
+            "node1",
+            "node2",
+            "bus1",
+            "bus2",
+        ],
+        "internalConnection" => &["node1", "node2"],
+        "inj" => &["node", "fictitiousP0", "fictitiousQ0"],
+        "load" => &[
+            "id",
+            "name",
+            "fictitious",
+            "loadType",
+            "p0",
+            "q0",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "generator" => &[
+            "id",
+            "name",
+            "fictitious",
+            "energySource",
+            "minP",
+            "maxP",
+            "ratedS",
+            "voltageRegulatorOn",
+            "targetP",
+            "targetV",
+            "targetQ",
+            "isCondenser",
+            "equivalentLocalTargetV",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "battery" => &[
+            "id",
+            "name",
+            "fictitious",
+            "targetP",
+            "targetQ",
+            "minP",
+            "maxP",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "shuntCompensator" => &[
+            "id",
+            "name",
+            "fictitious",
+            "sectionCount",
+            "solvedSectionCount",
+            "voltageRegulatorOn",
+            "targetV",
+            "targetDeadband",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "staticVarCompensator" => &[
+            "id",
+            "name",
+            "fictitious",
+            "bMin",
+            "bMax",
+            "voltageSetpoint",
+            "reactivePowerSetpoint",
+            "regulationMode",
+            "regulating",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "boundaryLine" => &[
+            "id",
+            "name",
+            "fictitious",
+            "p0",
+            "q0",
+            "r",
+            "x",
+            "g",
+            "b",
+            "generationVoltageRegulationOn",
+            "generationMinP",
+            "generationMaxP",
+            "generationTargetP",
+            "generationTargetV",
+            "generationTargetQ",
+            "node",
+            "bus",
+            "connectableBus",
+            "pairingKey",
+            "p",
+            "q",
+            "selectedOperationalLimitsGroupIds",
+        ],
+        "line" => &[
+            "id",
+            "name",
+            "fictitious",
+            "r",
+            "x",
+            "g1",
+            "b1",
+            "g2",
+            "b2",
+            "voltageLevelId1",
+            "node1",
+            "bus1",
+            "connectableBus1",
+            "voltageLevelId2",
+            "node2",
+            "bus2",
+            "connectableBus2",
+            "p1",
+            "q1",
+            "p2",
+            "q2",
+            "selectedOperationalLimitsGroupIds1",
+            "selectedOperationalLimitsGroupIds2",
+        ],
+        "twoWindingsTransformer" => &[
+            "id",
+            "name",
+            "fictitious",
+            "r",
+            "x",
+            "g",
+            "b",
+            "ratedU1",
+            "ratedU2",
+            "ratedS",
+            "voltageLevelId1",
+            "node1",
+            "bus1",
+            "connectableBus1",
+            "voltageLevelId2",
+            "node2",
+            "bus2",
+            "connectableBus2",
+            "p1",
+            "q1",
+            "p2",
+            "q2",
+            "selectedOperationalLimitsGroupIds1",
+            "selectedOperationalLimitsGroupIds2",
+        ],
+        "threeWindingsTransformer" => &[
+            "id",
+            "name",
+            "fictitious",
+            "r1",
+            "x1",
+            "g1",
+            "b1",
+            "ratedU1",
+            "ratedS1",
+            "r2",
+            "x2",
+            "g2",
+            "b2",
+            "ratedU2",
+            "ratedS2",
+            "r3",
+            "x3",
+            "g3",
+            "b3",
+            "ratedU3",
+            "ratedS3",
+            "ratedU0",
+            "voltageLevelId1",
+            "node1",
+            "bus1",
+            "connectableBus1",
+            "voltageLevelId2",
+            "node2",
+            "bus2",
+            "connectableBus2",
+            "voltageLevelId3",
+            "node3",
+            "bus3",
+            "connectableBus3",
+            "p1",
+            "q1",
+            "p2",
+            "q2",
+            "p3",
+            "q3",
+            "selectedOperationalLimitsGroupIds1",
+            "selectedOperationalLimitsGroupIds2",
+            "selectedOperationalLimitsGroupIds3",
+        ],
+        "ratioTapChanger" | "ratioTapChanger1" | "ratioTapChanger2" | "ratioTapChanger3"
+        | "phaseTapChanger" | "phaseTapChanger1" | "phaseTapChanger2" | "phaseTapChanger3" => &[
+            "regulating",
+            "lowTapPosition",
+            "tapPosition",
+            "solvedTapPosition",
+            "targetDeadband",
+            "loadTapChangingCapabilities",
+            "regulationMode",
+            "regulationValue",
+        ],
+        "step" => &["r", "x", "g", "b", "rho", "alpha"],
+        "terminalRef" | "regulatingTerminal" | "pccTerminal" => &["id", "side", "number"],
+        "minMaxReactiveLimits" => &["minQ", "maxQ"],
+        "point" => &["p", "minQ", "maxQ"],
+        "shuntLinearModel" => &["bPerSection", "gPerSection", "maximumSectionCount"],
+        "section" => &["b", "g"],
+        "exponentialModel" => &["np", "nq"],
+        "zipModel" => &["c0p", "c1p", "c2p", "c0q", "c1q", "c2q"],
+        "operationalLimitsGroup"
+        | "operationalLimitsGroup1"
+        | "operationalLimitsGroup2"
+        | "operationalLimitsGroup3"
+        | "voltageLevelRef"
+        | "boundaryRef"
+        | "extension" => &["id"],
+        "currentLimits" | "activePowerLimits" | "apparentPowerLimits" => {
+            &["permanentLimitName", "permanentLimit"]
+        }
+        "temporaryLimit" => &["name", "acceptableDuration", "value", "fictitious"],
+        "property" => &["name", "value"],
+        "alias" => &["type"],
+        "hvdcLine" => &[
+            "id",
+            "name",
+            "fictitious",
+            "r",
+            "nominalV",
+            "convertersMode",
+            "activePowerSetpoint",
+            "maxP",
+            "converterStation1",
+            "converterStation2",
+        ],
+        "vscConverterStation" => &[
+            "id",
+            "name",
+            "fictitious",
+            "voltageRegulatorOn",
+            "lossFactor",
+            "voltageSetpoint",
+            "reactivePowerSetpoint",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "lccConverterStation" => &[
+            "id",
+            "name",
+            "fictitious",
+            "lossFactor",
+            "powerFactor",
+            "node",
+            "bus",
+            "connectableBus",
+            "p",
+            "q",
+        ],
+        "area" => &["id", "name", "fictitious", "areaType", "interchangeTarget"],
+        "areaBoundary" => &["ac", "type"],
+        "dcNode" => &["id", "name", "fictitious", "nominalV", "v"],
+        "dcGround" => &[
+            "id",
+            "name",
+            "fictitious",
+            "dcNode",
+            "r",
+            "connected",
+            "dcP",
+            "dcI",
+        ],
+        "dcLine" => &[
+            "id",
+            "name",
+            "fictitious",
+            "dcNode1",
+            "dcNode2",
+            "r",
+            "connected1",
+            "connected2",
+            "dcP1",
+            "dcI1",
+            "dcP2",
+            "dcI2",
+        ],
+        "dcSwitch" => &[
+            "id",
+            "name",
+            "fictitious",
+            "dcNode1",
+            "dcNode2",
+            "kind",
+            "open",
+            "r",
+        ],
+        "voltageSourceConverter" => &[
+            "id",
+            "name",
+            "fictitious",
+            "dcNode1",
+            "dcConnected1",
+            "dcNode2",
+            "dcConnected2",
+            "idleLoss",
+            "switchingLoss",
+            "resistiveLoss",
+            "controlMode",
+            "targetP",
+            "targetVdc",
+            "node1",
+            "node2",
+            "bus1",
+            "connectableBus1",
+            "bus2",
+            "connectableBus2",
+            "voltageRegulatorOn",
+            "voltageSetpoint",
+            "reactivePowerSetpoint",
+            "p1",
+            "q1",
+            "p2",
+            "q2",
+            "dcP1",
+            "dcI1",
+            "dcP2",
+            "dcI2",
+        ],
+        "lineCommutatedConverter" => &[
+            "id",
+            "name",
+            "fictitious",
+            "dcNode1",
+            "dcConnected1",
+            "dcNode2",
+            "dcConnected2",
+            "idleLoss",
+            "switchingLoss",
+            "resistiveLoss",
+            "controlMode",
+            "targetP",
+            "targetVdc",
+            "node1",
+            "node2",
+            "bus1",
+            "connectableBus1",
+            "bus2",
+            "connectableBus2",
+            "reactiveModel",
+            "powerFactor",
+            "p1",
+            "q1",
+            "p2",
+            "q2",
+            "dcP1",
+            "dcI1",
+            "dcP2",
+            "dcI2",
+        ],
+        "activePowerControl" => &[
+            "participate",
+            "droop",
+            "participationFactor",
+            "maxTargetP",
+            "minTargetP",
+        ],
+        "tieLine" => &[
+            "id",
+            "name",
+            "fictitious",
+            "boundaryLineId1",
+            "boundaryLineId2",
+        ],
+        "segment" => &["minV", "maxV", "k"],
+        _ => &IDENTIFIABLE_ATTRIBUTES,
+    }
+}
+
+/// The JSON token for one XML attribute, typed the way PowSybl's JSON
+/// reader consumes that attribute: strings, booleans, integers, integer
+/// arrays, string arrays, or numbers. An attribute the table does not know
+/// refuses emission rather than guessing a type PowSybl would reject.
+fn jiidm_attribute_value(tag: &str, name: &str, text: &str) -> Result<JsonOut> {
+    let scalar = |token: String| Ok(JsonOut::Scalar(token));
+    match name {
+        "value" if tag == "property" => return scalar(json_string(text)),
+        "id"
+        | "name"
+        | "country"
+        | "tso"
+        | "kind"
+        | "bus"
+        | "bus1"
+        | "bus2"
+        | "bus3"
+        | "connectableBus"
+        | "connectableBus1"
+        | "connectableBus2"
+        | "connectableBus3"
+        | "voltageLevelId1"
+        | "voltageLevelId2"
+        | "voltageLevelId3"
+        | "topologyKind"
+        | "energySource"
+        | "loadType"
+        | "regulationMode"
+        | "caseDate"
+        | "sourceFormat"
+        | "minimumValidationLevel"
+        | "areaType"
+        | "dcNode"
+        | "dcNode1"
+        | "dcNode2"
+        | "boundaryLineId1"
+        | "boundaryLineId2"
+        | "converterStation1"
+        | "converterStation2"
+        | "convertersMode"
+        | "side"
+        | "number"
+        | "type"
+        | "permanentLimitName"
+        | "pairingKey"
+        | "controlMode"
+        | "reactiveModel" => return scalar(json_string(text)),
+        "open"
+        | "retained"
+        | "fictitious"
+        | "voltageRegulatorOn"
+        | "regulating"
+        | "loadTapChangingCapabilities"
+        | "connected"
+        | "connected1"
+        | "connected2"
+        | "dcConnected1"
+        | "dcConnected2"
+        | "participate"
+        | "generationVoltageRegulationOn"
+        | "isCondenser"
+        | "ac" => {
+            return match text {
+                "true" | "false" => scalar(text.to_owned()),
+                _ => Err(jiidm_emission_error(format!(
+                    "attribute `{name}` on `{tag}` is not a boolean: `{text}`"
+                ))),
+            };
+        }
+        "node"
+        | "node1"
+        | "node2"
+        | "node3"
+        | "forecastDistance"
+        | "tapPosition"
+        | "lowTapPosition"
+        | "solvedTapPosition"
+        | "sectionCount"
+        | "maximumSectionCount"
+        | "acceptableDuration"
+        | "solvedSectionCount" => {
+            return text
+                .parse::<i64>()
+                .map(|value| JsonOut::Scalar(value.to_string()))
+                .map_err(|_| {
+                    jiidm_emission_error(format!(
+                        "attribute `{name}` on `{tag}` is not an integer: `{text}`"
+                    ))
+                });
+        }
+        "nodes" => {
+            let values = text
+                .split(',')
+                .map(|value| {
+                    value
+                        .trim()
+                        .parse::<i64>()
+                        .map(|value| JsonOut::Scalar(value.to_string()))
+                        .map_err(|_| {
+                            jiidm_emission_error(format!(
+                                "attribute `nodes` on `{tag}` is not an integer list: `{text}`"
+                            ))
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            return Ok(JsonOut::Array(values));
+        }
+        "geographicalTags"
+        | "selectedOperationalLimitsGroupIds"
+        | "selectedOperationalLimitsGroupIds1"
+        | "selectedOperationalLimitsGroupIds2"
+        | "selectedOperationalLimitsGroupIds3" => {
+            let values = parse_operational_limits_group_ids(text)?
+                .into_iter()
+                .map(|value| JsonOut::Scalar(json_string(&value)))
+                .collect();
+            return Ok(JsonOut::Array(values));
+        }
+        "r"
+        | "x"
+        | "g"
+        | "b"
+        | "g1"
+        | "b1"
+        | "g2"
+        | "b2"
+        | "g3"
+        | "b3"
+        | "r1"
+        | "x1"
+        | "r2"
+        | "x2"
+        | "r3"
+        | "x3"
+        | "ratedU0"
+        | "ratedU1"
+        | "ratedU2"
+        | "ratedU3"
+        | "ratedS"
+        | "ratedS1"
+        | "ratedS2"
+        | "ratedS3"
+        | "nominalV"
+        | "lowVoltageLimit"
+        | "highVoltageLimit"
+        | "v"
+        | "angle"
+        | "p"
+        | "q"
+        | "p1"
+        | "q1"
+        | "p2"
+        | "q2"
+        | "p3"
+        | "q3"
+        | "p0"
+        | "q0"
+        | "targetP"
+        | "targetQ"
+        | "targetV"
+        | "targetDeadband"
+        | "minP"
+        | "maxP"
+        | "minQ"
+        | "maxQ"
+        | "bMin"
+        | "bMax"
+        | "voltageSetpoint"
+        | "reactivePowerSetpoint"
+        | "activePowerSetpoint"
+        | "permanentLimit"
+        | "rho"
+        | "alpha"
+        | "bPerSection"
+        | "gPerSection"
+        | "np"
+        | "nq"
+        | "c0p"
+        | "c1p"
+        | "c2p"
+        | "c0q"
+        | "c1q"
+        | "c2q"
+        | "interchangeTarget"
+        | "regulationValue"
+        | "lossFactor"
+        | "powerFactor"
+        | "idleLoss"
+        | "switchingLoss"
+        | "resistiveLoss"
+        | "targetVdc"
+        | "dcP"
+        | "dcI"
+        | "dcP1"
+        | "dcI1"
+        | "dcP2"
+        | "dcI2"
+        | "k"
+        | "minV"
+        | "maxV"
+        | "droop"
+        | "participationFactor"
+        | "minTargetP"
+        | "maxTargetP"
+        | "generationMinP"
+        | "generationMaxP"
+        | "generationTargetP"
+        | "generationTargetQ"
+        | "generationTargetV"
+        | "fictitiousP0"
+        | "fictitiousQ0"
+        | "equivalentLocalTargetV"
+        | "value" => {}
+        _ => {
+            return Err(jiidm_emission_error(format!(
+                "attribute `{name}` on `{tag}` has no JIIDM type"
+            )));
+        }
+    }
+    json_number(text).map(JsonOut::Scalar).ok_or_else(|| {
+        jiidm_emission_error(format!(
+            "attribute `{name}` on `{tag}` is not a finite number: `{text}`"
+        ))
+    })
+}
+
+/// The JSON number token for XML attribute text: the text itself when it is
+/// already a JSON number literal, otherwise the shortest decimal that names
+/// the same finite value.
+fn json_number(text: &str) -> Option<String> {
+    let value: f64 = text.parse().ok()?;
+    if !value.is_finite() {
+        return None;
+    }
+    let mut rest = text.strip_prefix('-').unwrap_or(text);
+    let integer = rest.len() - rest.trim_start_matches(|c: char| c.is_ascii_digit()).len();
+    if integer == 0 || (integer > 1 && rest.starts_with('0')) {
+        return Some(value.to_string());
+    }
+    rest = &rest[integer..];
+    if let Some(fraction) = rest.strip_prefix('.') {
+        let digits = fraction.len()
+            - fraction
+                .trim_start_matches(|c: char| c.is_ascii_digit())
+                .len();
+        if digits == 0 {
+            return Some(value.to_string());
+        }
+        rest = &fraction[digits..];
+    }
+    if let Some(exponent) = rest.strip_prefix(['e', 'E']) {
+        let exponent = exponent.strip_prefix(['+', '-']).unwrap_or(exponent);
+        if exponent.is_empty() || !exponent.bytes().all(|byte| byte.is_ascii_digit()) {
+            return Some(value.to_string());
+        }
+        rest = "";
+    }
+    Some(if rest.is_empty() {
+        text.to_owned()
+    } else {
+        value.to_string()
+    })
+}
+
+fn json_string(text: &str) -> String {
+    let mut output = String::with_capacity(text.len() + 2);
+    output.push('"');
+    for character in text.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            control if (control as u32) < 0x20 => {
+                output.push_str(&format!("\\u{:04x}", control as u32));
+            }
+            other => output.push(other),
+        }
+    }
+    output.push('"');
+    output
+}
+
+/// Render a value the way PowSybl's pretty printer lays JIIDM out: two space
+/// indentation, `"key" : value`, and arrays inline as `[ a, b ]`.
+fn render_json(value: &JsonOut, indent: usize, output: &mut String) {
+    match value {
+        JsonOut::Scalar(token) => output.push_str(token),
+        JsonOut::Array(values) => {
+            if values.is_empty() {
+                output.push_str("[ ]");
+                return;
+            }
+            output.push_str("[ ");
+            for (position, value) in values.iter().enumerate() {
+                if position > 0 {
+                    output.push_str(", ");
+                }
+                render_json(value, indent, output);
+            }
+            output.push_str(" ]");
+        }
+        JsonOut::Object(entries) => {
+            if entries.is_empty() {
+                output.push_str("{ }");
+                return;
+            }
+            output.push_str("{\n");
+            for (position, (key, value)) in entries.iter().enumerate() {
+                if position > 0 {
+                    output.push_str(",\n");
+                }
+                for _ in 0..indent + 2 {
+                    output.push(' ');
+                }
+                output.push_str(&json_string(key));
+                output.push_str(" : ");
+                render_json(value, indent + 2, output);
+            }
+            output.push('\n');
+            for _ in 0..indent {
+                output.push(' ');
+            }
+            output.push('}');
+        }
+    }
 }
 
 fn write_subnetwork(
@@ -10461,13 +12336,13 @@ fn injection_solution_attributes(
     }
 }
 
+/// The shortest decimal that reads back to exactly `value`, without an
+/// exponent, so a value survives emission and a second read unchanged.
 fn number(value: f64) -> String {
-    let value = format!("{value:.17}");
-    let value = value.trim_end_matches('0').trim_end_matches('.');
-    if value.is_empty() || value == "-0" {
+    if value == 0.0 {
         "0".to_owned()
     } else {
-        value.to_owned()
+        value.to_string()
     }
 }
 
@@ -11402,14 +13277,14 @@ mod tests {
 
     #[test]
     fn refuses_unverified_xiidm_versions_with_a_structured_diagnostic() {
-        let source = NODE_BREAKER.replace(NAMESPACE, "http://www.powsybl.org/schema/iidm/1_11");
+        let source = NODE_BREAKER.replace(NAMESPACE, "http://www.powsybl.org/schema/iidm/1_18");
         assert!(looks_like_xiidm(source.as_bytes()));
         let mut diagnostics = Diagnostics::new();
         let error = parse_xiidm_source(&source, &mut diagnostics).unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("supported input versions are 1.12 through 1.17")
+                .contains("supported input versions are 1.0 through 1.17")
         );
         assert!(
             diagnostics
@@ -12971,5 +14846,167 @@ mod tests {
         );
         let error = parse_xiidm_source(&nested, &mut Diagnostics::new()).unwrap_err();
         assert!(error.to_string().contains("only one level"));
+    }
+
+    #[test]
+    fn jiidm_is_recognized_by_its_leading_version_field() {
+        assert!(looks_like_jiidm(
+            "{\n  \"version\" : \"1.17\",\n  \"id\" : \"x\"}"
+        ));
+        assert!(looks_like_jiidm("\u{feff}{\"version\":\"1.0\"}"));
+        assert!(!looks_like_jiidm("{\"id\":\"x\",\"version\":\"1.17\"}"));
+        assert!(!looks_like_jiidm("{\"version\":\"3.2.2\"}"));
+        assert!(!looks_like_jiidm("{\"version\":1}"));
+        assert!(!looks_like_jiidm("[{\"version\":\"1.17\"}]"));
+    }
+
+    #[test]
+    fn json_numbers_pass_through_or_shorten() {
+        assert_eq!(json_number("24").as_deref(), Some("24"));
+        assert_eq!(json_number("-9999.99").as_deref(), Some("-9999.99"));
+        assert_eq!(json_number("1.93E-4").as_deref(), Some("1.93E-4"));
+        assert_eq!(json_number("007").as_deref(), Some("7"));
+        assert_eq!(json_number("5.").as_deref(), Some("5"));
+        assert_eq!(json_number(".5").as_deref(), Some("0.5"));
+        assert_eq!(json_number("NaN"), None);
+        assert_eq!(json_number("inf"), None);
+    }
+
+    #[test]
+    fn jiidm_extensions_and_unknown_versions_follow_the_xml_rules() {
+        let document = r#"{
+  "version" : "1.13",
+  "extensionVersions" : [ {
+    "extensionName" : "activePowerControl",
+    "version" : "1.1"
+  } ],
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "voltageLevels" : [ {
+      "id" : "VL",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ { "id" : "B", "v" : 24.5, "angle" : 0.0 } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : 0.0,
+        "maxP" : 100.0,
+        "voltageRegulatorOn" : true,
+        "targetP" : 50.0,
+        "targetV" : 24.5,
+        "bus" : "B",
+        "connectableBus" : "B",
+        "minMaxReactiveLimits" : { "minQ" : -10.0, "maxQ" : 10.0 }
+      } ]
+    } ]
+  } ],
+  "extensions" : [ {
+    "id" : "GEN",
+    "position" : { "feeder" : { "direction" : "BOTTOM", "order" : [ 1, 2 ] } },
+    "activePowerControl" : { "participate" : true, "droop" : 2.0, "participationFactor" : 1.5 }
+  } ]
+}"#;
+        let mut diagnostics = Diagnostics::new();
+        let network = parse_jiidm_source(document, &mut diagnostics).unwrap();
+        assert_eq!(network.source_format(), SourceFormat::Jiidm);
+        assert_eq!(network.buses().len(), 1);
+        let control = network.generators()[0]
+            .active_power_control
+            .as_ref()
+            .unwrap();
+        assert!(control.participate);
+        assert_eq!(control.droop_percent, Some(2.0));
+        assert_eq!(control.participation_factor, Some(1.5));
+        let messages = diagnostics
+            .records()
+            .iter()
+            .map(|diagnostic| format!("{}: {}", diagnostic.code(), diagnostic.message()))
+            .collect::<Vec<_>>();
+        assert!(messages.iter().any(|message| {
+            message.starts_with("READ.XIIDM.ELEMENT_UNMAPPED")
+                && message.contains("`position` on `GEN`")
+        }));
+        assert!(messages.iter().any(|message| {
+            message.starts_with("READ.XIIDM.VERSION.COMPATIBILITY") && message.contains("1.13")
+        }));
+
+        let unsupported = document.replacen("\"version\" : \"1.13\"", "\"version\" : \"1.18\"", 1);
+        let mut diagnostics = Diagnostics::new();
+        let error = parse_jiidm_source(&unsupported, &mut diagnostics).unwrap_err();
+        assert!(error.to_string().contains("1.0 through 1.17"));
+        assert!(
+            diagnostics
+                .records()
+                .iter()
+                .any(|diagnostic| diagnostic.code() == "PARSE.XIIDM.VERSION_UNSUPPORTED")
+        );
+
+        let fresh = write_jiidm(&network).unwrap();
+        assert!(fresh.text.contains("\"extensionVersions\" : [ {"));
+        assert!(
+            fresh
+                .text
+                .contains("\"extensionName\" : \"activePowerControl\"")
+        );
+        let reread = parse_jiidm_source(&fresh.text, &mut Diagnostics::new()).unwrap();
+        assert_eq!(
+            reread.generators()[0].active_power_control,
+            network.generators()[0].active_power_control
+        );
+    }
+
+    #[test]
+    fn pre_1_8_self_connected_switches_and_unregulated_shunts_are_read_as_powsybl_does() {
+        let source = r#"<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_1" id="legacy" caseDate="2019-01-01T00:00:00Z" forecastDistance="0" sourceFormat="test">
+  <iidm:substation id="S" country="FR">
+    <iidm:voltageLevel id="VL" nominalV="380.0" topologyKind="BUS_BREAKER">
+      <iidm:busBreakerTopology>
+        <iidm:bus id="B1"/>
+        <iidm:bus id="B2"/>
+        <iidm:switch id="SELF" kind="BREAKER" retained="true" open="false" bus1="B1" bus2="B1"/>
+        <iidm:switch id="SW" kind="BREAKER" retained="true" open="false" bus1="B1" bus2="B2"/>
+      </iidm:busBreakerTopology>
+      <iidm:generator id="G" energySource="OTHER" minP="0.0" maxP="100.0" voltageRegulatorOn="true" targetP="10.0" targetV="380.0" bus="B1" connectableBus="B1">
+        <iidm:minMaxReactiveLimits minQ="-10.0" maxQ="10.0"/>
+      </iidm:generator>
+      <iidm:shunt id="SH" bPerSection="1.0E-5" maximumSectionCount="2" currentSectionCount="1" bus="B2" connectableBus="B2"/>
+      <iidm:load id="L" loadType="UNDEFINED" p0="5.0" q0="1.0" bus="B2" connectableBus="B2"/>
+    </iidm:voltageLevel>
+  </iidm:substation>
+</iidm:network>"#;
+        let mut diagnostics = Diagnostics::new();
+        let network = parse_xiidm_source(source, &mut diagnostics).unwrap();
+        let switches = network
+            .detailed_connectivity()
+            .as_ref()
+            .unwrap()
+            .switches
+            .iter()
+            .map(|switch| switch.component.local_id().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(switches, vec!["SW".to_owned()]);
+        assert!(diagnostics.records().iter().any(|diagnostic| {
+            diagnostic.code() == "READ.XIIDM.VERSION.COMPATIBILITY"
+                && diagnostic.message().contains("`SELF`")
+        }));
+        let shunt = &network.shunts()[0];
+        assert_eq!(shunt.section_count, Some(1));
+        assert_f64_close(shunt.b, 1.0e-5 * 380.0 * 380.0);
+        assert!(
+            shunt
+                .control
+                .as_ref()
+                .is_none_or(|control| control.mode == SwitchedShuntMode::Locked)
+        );
+        assert!(write_xiidm(&network).unwrap().text.contains(NAMESPACE));
     }
 }

--- a/powerio-tx/src/network.rs
+++ b/powerio-tx/src/network.rs
@@ -1414,9 +1414,12 @@ pub enum SourceFormat {
     /// exact write back to the same format.
     #[serde(rename = "opfdata-json")]
     DeepMindOpfDataJson,
-    /// Read from PowSybl's XIIDM XML grid exchange format, versions 1.12 through 1.17.
+    /// Read from PowSybl's XIIDM XML grid exchange format, versions 1.0 through 1.17.
     #[serde(rename = "xiidm")]
     Xiidm,
+    /// Read from PowSybl's JIIDM JSON grid exchange format, versions 1.0 through 1.17.
+    #[serde(rename = "jiidm")]
+    Jiidm,
     /// Read from a CGMES profile set (2.4.15/CIM16 or 3.0/CIM100).
     #[serde(rename = "cgmes")]
     Cgmes,
@@ -1447,6 +1450,7 @@ impl SourceFormat {
             SourceFormat::SurgeJson => "surge-json",
             SourceFormat::DeepMindOpfDataJson => "opfdata-json",
             SourceFormat::Xiidm => "xiidm",
+            SourceFormat::Jiidm => "jiidm",
             SourceFormat::Cgmes => "cgmes",
         }
     }
@@ -5614,6 +5618,7 @@ mod tests {
             SourceFormat::SurgeJson,
             SourceFormat::DeepMindOpfDataJson,
             SourceFormat::Xiidm,
+            SourceFormat::Jiidm,
             SourceFormat::Cgmes,
         ];
         for f in all {
@@ -5635,6 +5640,7 @@ mod tests {
                 | SourceFormat::SurgeJson
                 | SourceFormat::DeepMindOpfDataJson
                 | SourceFormat::Xiidm
+                | SourceFormat::Jiidm
                 | SourceFormat::Cgmes => {}
             }
             let token = serde_json::to_value(f).unwrap();

--- a/powerio-tx/tests/classify_corpus.rs
+++ b/powerio-tx/tests/classify_corpus.rs
@@ -63,6 +63,42 @@ const EXPECTED: &[(&str, &str, Option<&str>)] = &[
     // metadata object, both beside the CSV folder that carries the case.
     ("pypsa/example/crs.json", "unknown", None),
     ("pypsa/example/meta.json", "unknown", None),
+    // PowSybl JIIDM fixtures use JSON from IIDM 1.11 onward.
+    (
+        "xiidm/powsybl/V1_11/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_12/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_13/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_14/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_15/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_16/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
+    (
+        "xiidm/powsybl/V1_17/eurostag-tutorial1-lf.json",
+        "transmission",
+        Some("jiidm"),
+    ),
 ];
 
 fn data_root() -> PathBuf {

--- a/powerio/src/formats.rs
+++ b/powerio/src/formats.rs
@@ -89,6 +89,8 @@ mod tests {
         assert_eq!(resolve_format("pm").unwrap().token, "powermodels-json");
         assert_eq!(resolve_format("engineering").unwrap().token, "pmd-json");
         assert_eq!(resolve_format("xiidm").unwrap().token, "xiidm");
+        assert_eq!(resolve_format("jiidm").unwrap().token, "jiidm");
+        assert_eq!(resolve_format("jiidm").unwrap().extension, Some("jiidm"));
         assert!(resolve_format("cgmes").unwrap().is_directory);
         assert_eq!(resolve_format("iidm"), None);
         assert_eq!(resolve_format("rawx"), None);

--- a/powerio/tests/format_info.rs
+++ b/powerio/tests/format_info.rs
@@ -11,6 +11,7 @@ fn every_canonical_format_reports_its_artifact_shape() {
         ("psse35", Some("raw"), false, true),
         ("psse-rawx", Some("rawx"), false, true),
         ("xiidm", Some("xiidm"), false, true),
+        ("jiidm", Some("jiidm"), false, true),
         ("cgmes", None, true, true),
         ("powerworld", Some("aux"), false, true),
         ("pandapower-json", Some("json"), false, true),

--- a/powerio/tests/iidm_versions.rs
+++ b/powerio/tests/iidm_versions.rs
@@ -1,0 +1,462 @@
+//! Every PowSybl IIDM serialization version reads to the same network, JIIDM
+//! reads as XIIDM does, and fresh JIIDM reads back to the module it came
+//! from.
+
+mod helpers;
+
+use std::path::PathBuf;
+
+use helpers::{
+    deserialize_module_text, load_balanced_case, load_balanced_memory_named, serialize_module_text,
+};
+use powerio::network::TapChangerRegulationMode;
+use powerio::{BalancedNetwork, Destination, EmittedOutput, SourceFormat};
+
+const VERSIONS: [&str; 18] = [
+    "1_0", "1_1", "1_2", "1_3", "1_4", "1_5", "1_6", "1_7", "1_8", "1_9", "1_10", "1_11", "1_12",
+    "1_13", "1_14", "1_15", "1_16", "1_17",
+];
+const JIIDM_VERSIONS: [&str; 7] = ["1_11", "1_12", "1_13", "1_14", "1_15", "1_16", "1_17"];
+
+fn fixture(version: &str, name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../tests/data/xiidm/powsybl")
+        .join(format!("V{version}"))
+        .join(name)
+}
+
+fn network_document(network: &BalancedNetwork) -> serde_json::Value {
+    let mut document: serde_json::Value =
+        serde_json::from_str(&network.to_json().unwrap()).unwrap();
+    // The encoding a network came from is the one field an XML and a JSON
+    // document of the same network state differently.
+    document
+        .as_object_mut()
+        .unwrap()
+        .remove("source_format")
+        .expect("model JSON names the source format");
+    document
+}
+
+/// Emit `to` from a freshly parsed source. Serializing and deserializing
+/// through PowerIO IR removes the input file content kept for same format
+/// emission, so the writer rebuilds the document from the typed value.
+fn emit_fresh(source: powerio::Source, from: &str, to: &str) -> String {
+    let module = powerio::parse(source, Some(from)).unwrap();
+    let module = deserialize_module_text(&serialize_module_text(&module).unwrap()).unwrap();
+    let emitted = powerio::emit(&module, to, Destination::memory("fresh").unwrap()).unwrap();
+    let EmittedOutput::Memory { mut artifacts } = emitted.into_output() else {
+        panic!("memory destination returned a path output");
+    };
+    String::from_utf8(artifacts.pop().unwrap().into_bytes()).unwrap()
+}
+
+fn emit_memory(network_path: &std::path::Path, from: &str, to: &str) -> String {
+    emit_fresh(powerio::Source::open(network_path).unwrap(), from, to)
+}
+
+fn assert_close(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() <= 1e-9 * expected.abs().max(1.0),
+        "{actual} differs from {expected}"
+    );
+}
+
+/// Sort the terminal table by equipment so the comparison does not depend
+/// on the order fresh output lists equipment within a voltage level.
+fn normalize_document(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, item) in map.iter_mut() {
+                if key == "terminals"
+                    && let serde_json::Value::Array(terminals) = item
+                {
+                    terminals.sort_by_cached_key(|terminal| {
+                        format!("{}/{}", terminal["equipment"], terminal["terminal"])
+                    });
+                }
+                normalize_document(item);
+            }
+        }
+        serde_json::Value::Array(values) => values.iter_mut().for_each(normalize_document),
+        _ => {}
+    }
+}
+
+/// Compare two network documents, allowing the rounding a unit conversion
+/// to ohms and back introduces in fresh output.
+fn assert_documents_close(actual: &serde_json::Value, expected: &serde_json::Value, path: &str) {
+    match (actual, expected) {
+        (serde_json::Value::Number(a), serde_json::Value::Number(b)) => {
+            let (a, b) = (a.as_f64().unwrap(), b.as_f64().unwrap());
+            assert!(
+                (a - b).abs() <= 1e-12 * a.abs().max(b.abs()).max(1.0),
+                "{path}: {a} differs from {b}"
+            );
+        }
+        (serde_json::Value::Array(a), serde_json::Value::Array(b)) => {
+            assert_eq!(a.len(), b.len(), "{path}: array length");
+            for (index, (x, y)) in a.iter().zip(b).enumerate() {
+                assert_documents_close(x, y, &format!("{path}[{index}]"));
+            }
+        }
+        (serde_json::Value::Object(a), serde_json::Value::Object(b)) => {
+            assert_eq!(
+                a.keys().collect::<Vec<_>>(),
+                b.keys().collect::<Vec<_>>(),
+                "{path}: keys"
+            );
+            for (key, x) in a {
+                assert_documents_close(x, &b[key], &format!("{path}/{key}"));
+            }
+        }
+        _ => assert_eq!(actual, expected, "{path}"),
+    }
+}
+
+/// The solved eurostag network as every version states it: the same element
+/// counts and the same electrical values.
+#[test]
+fn every_iidm_version_reads_the_same_network() {
+    let reference = load_balanced_case(fixture("1_17", "eurostag-tutorial1-lf.xml"), None).unwrap();
+    let reference_document = network_document(&reference.network);
+    for version in VERSIONS {
+        let parsed = load_balanced_case(fixture(version, "eurostag-tutorial1-lf.xml"), None)
+            .unwrap_or_else(|error| panic!("IIDM {version}: {error}"));
+        let network = &parsed.network;
+        assert_eq!(network.source_format(), SourceFormat::Xiidm, "{version}");
+        assert_eq!(network.buses().len(), 4, "{version}");
+        assert_eq!(network.branches().len(), 4, "{version}");
+        assert_eq!(network.generators().len(), 1, "{version}");
+        assert_eq!(network.loads().len(), 1, "{version}");
+        let generator_bus = network.generators()[0].bus;
+        let bus = network
+            .buses()
+            .iter()
+            .find(|bus| bus.id == generator_bus)
+            .unwrap();
+        assert_close(bus.vm, 24.500_000_610_351_563 / 24.0);
+        assert_close(bus.va, 2.325_976_371_765_136_7);
+        assert_close(network.generators()[0].pg, 607.0);
+        assert_close(network.loads()[0].p, 600.0);
+        let detailed = network.detailed_connectivity().as_ref().unwrap();
+        let tap = detailed
+            .tap_changers
+            .iter()
+            .find(|tap| tap.transformer.local_id() == "NHV2_NLOAD")
+            .unwrap_or_else(|| panic!("IIDM {version} lost the ratio tap changer"));
+        assert_eq!(tap.tap_position, Some(1), "{version}");
+        assert_eq!(
+            tap.regulation_mode,
+            Some(TapChangerRegulationMode::Voltage),
+            "{version}"
+        );
+        assert_eq!(tap.regulation_value, Some(158.0), "{version}");
+        assert!(tap.regulating, "{version}");
+        assert_eq!(tap.steps.len(), 3, "{version}");
+        assert_eq!(
+            network_document(network),
+            reference_document,
+            "IIDM {version} reads to a different network than 1.17"
+        );
+        let compatibility = parsed
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code() == "READ.XIIDM.VERSION.COMPATIBILITY")
+            .count();
+        assert_eq!(compatibility, usize::from(version != "1_17"), "{version}");
+    }
+}
+
+/// PowSybl's JSON layout of a network reads to the same balanced network as
+/// its XML layout, in every version PowSybl ships both for.
+#[test]
+fn jiidm_reads_as_the_matching_xiidm_document() {
+    for version in JIIDM_VERSIONS {
+        let xml = load_balanced_case(fixture(version, "eurostag-tutorial1-lf.xml"), None).unwrap();
+        let json = load_balanced_case(fixture(version, "eurostag-tutorial1-lf.json"), None)
+            .unwrap_or_else(|error| panic!("JIIDM {version}: {error}"));
+        assert_eq!(
+            json.network.source_format(),
+            SourceFormat::Jiidm,
+            "{version}"
+        );
+        assert_eq!(
+            network_document(&json.network),
+            network_document(&xml.network),
+            "JIIDM {version} differs from XIIDM {version}"
+        );
+        let xml_codes = xml
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code().to_owned())
+            .collect::<Vec<_>>();
+        let json_codes = json
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(json_codes, xml_codes, "{version}");
+    }
+    let xml = load_balanced_case(fixture("1_17", "fictitiousSwitchRef.xml"), None).unwrap();
+    let json = load_balanced_case(fixture("1_17", "fictitiousSwitchRef.jiidm"), None).unwrap();
+    assert_eq!(
+        network_document(&json.network),
+        network_document(&xml.network)
+    );
+    let oldest = load_balanced_case(fixture("1_11", "fictitiousSwitchRef.jiidm"), None).unwrap();
+    assert_eq!(oldest.network.source_format(), SourceFormat::Jiidm);
+    assert_eq!(oldest.network.buses().len(), xml.network.buses().len());
+    assert_eq!(
+        oldest.network.branches().len(),
+        xml.network.branches().len()
+    );
+    assert!(
+        oldest
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code() == "READ.XIIDM.VERSION.COMPATIBILITY")
+    );
+}
+
+/// A `.json` source is recognized as JIIDM without a declared format.
+#[test]
+fn bare_json_is_classified_as_jiidm() {
+    let text = std::fs::read_to_string(fixture("1_17", "eurostag-tutorial1-lf.json")).unwrap();
+    let parsed = load_balanced_memory_named(&text, "jiidm", Some("network.json")).unwrap();
+    assert_eq!(parsed.network.source_format(), SourceFormat::Jiidm);
+    let source = powerio::Source::from_memory("network.json", text.into_bytes()).unwrap();
+    let module = powerio::parse(source, None).unwrap();
+    assert_eq!(
+        module
+            .source()
+            .unwrap()
+            .format()
+            .map(powerio::FormatId::as_str),
+        Some("jiidm")
+    );
+}
+
+/// Fresh JIIDM is PowSybl's 1.17 layout and reads back to the module it was
+/// written from; fresh XIIDM from either encoding is the same document.
+#[test]
+fn fresh_jiidm_reads_back_to_the_same_module() {
+    for name in ["eurostag-tutorial1-lf.xml", "fictitiousSwitchRef.xml"] {
+        let path = fixture("1_17", name);
+        let original = load_balanced_case(&path, None).unwrap();
+        let jiidm = emit_memory(&path, "xiidm", "jiidm");
+        assert!(
+            jiidm.starts_with("{\n  \"version\" : \"1.17\",\n"),
+            "{name}"
+        );
+        let reread = load_balanced_memory_named(&jiidm, "jiidm", Some("fresh.jiidm")).unwrap();
+        assert_eq!(
+            reread.network.source_format(),
+            SourceFormat::Jiidm,
+            "{name}"
+        );
+        let mut reread_document = network_document(&reread.network);
+        let mut original_document = network_document(&original.network);
+        normalize_document(&mut reread_document);
+        normalize_document(&mut original_document);
+        assert_documents_close(&reread_document, &original_document, name);
+        let fresh_xiidm_from_xml = emit_memory(&path, "xiidm", "xiidm");
+        let fresh_xiidm_from_json = emit_fresh(
+            powerio::Source::from_memory("fresh.jiidm", jiidm.into_bytes()).unwrap(),
+            "jiidm",
+            "xiidm",
+        );
+        assert_eq!(fresh_xiidm_from_json, fresh_xiidm_from_xml, "{name}");
+    }
+}
+
+/// The JIIDM element and attribute order matches the PowSybl fixture for the
+/// same network, which is what PowSybl's sequential JSON reader requires.
+#[test]
+fn fresh_jiidm_follows_the_powsybl_field_order() {
+    fn key_orders(value: &serde_json::Value, path: &str, out: &mut Vec<(String, Vec<String>)>) {
+        let serde_json::Value::Object(map) = value else {
+            return;
+        };
+        let scalar_keys = map
+            .iter()
+            .filter(|(_, item)| match item {
+                serde_json::Value::Array(values) => values.iter().all(|v| !v.is_object()),
+                other => !other.is_object(),
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        out.push((path.to_owned(), scalar_keys));
+        for (key, item) in map {
+            match item {
+                serde_json::Value::Object(_) => key_orders(item, &format!("{path}/{key}"), out),
+                serde_json::Value::Array(values) => {
+                    for entry in values.iter().filter(|entry| entry.is_object()) {
+                        key_orders(entry, &format!("{path}/{key}[]"), out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    for name in ["eurostag-tutorial1-lf", "fictitiousSwitchRef"] {
+        let xml_path = fixture("1_17", &format!("{name}.xml"));
+        let json_name = if name == "fictitiousSwitchRef" {
+            format!("{name}.jiidm")
+        } else {
+            format!("{name}.json")
+        };
+        let reference: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(fixture("1_17", &json_name)).unwrap())
+                .unwrap();
+        let fresh: serde_json::Value =
+            serde_json::from_str(&emit_memory(&xml_path, "xiidm", "jiidm")).unwrap();
+        let mut reference_orders = Vec::new();
+        key_orders(&reference, "", &mut reference_orders);
+        let mut fresh_orders = Vec::new();
+        key_orders(&fresh, "", &mut fresh_orders);
+        assert_eq!(fresh_orders.len(), reference_orders.len(), "{name}");
+        for ((fresh_path, fresh_keys), (reference_path, reference_keys)) in
+            fresh_orders.iter().zip(&reference_orders)
+        {
+            assert_eq!(fresh_path, reference_path, "{name}");
+            let common_fresh = fresh_keys
+                .iter()
+                .filter(|key| reference_keys.contains(key))
+                .collect::<Vec<_>>();
+            let common_reference = reference_keys
+                .iter()
+                .filter(|key| fresh_keys.contains(key))
+                .collect::<Vec<_>>();
+            assert_eq!(common_fresh, common_reference, "{name}: {fresh_path}");
+        }
+    }
+}
+
+/// The IIDM 1.0 forms of shunts, static VAR compensators, and batteries map
+/// to the same tables as the 1.17 forms.
+#[test]
+fn iidm_1_0_legacy_injection_forms_map_to_the_current_tables() {
+    let shunt = load_balanced_case(fixture("1_0", "nonLinearShuntRoundTripRef.xml"), None)
+        .unwrap()
+        .network;
+    assert_eq!(shunt.shunts().len(), 1);
+    assert_close(shunt.shunts()[0].b, 1.0e-5 * 380.0 * 380.0);
+    assert_eq!(shunt.shunts()[0].section_count, Some(1));
+
+    let svc = load_balanced_case(fixture("1_0", "staticVarCompensatorRoundTripRef.xml"), None)
+        .unwrap()
+        .network;
+    assert_eq!(svc.static_var_compensators().len(), 1);
+    assert_close(svc.static_var_compensators()[0].voltage_setpoint_kv, 390.0);
+    assert!(svc.static_var_compensators()[0].regulating);
+
+    let battery = load_balanced_case(fixture("1_0", "batteryRoundTripRef.xml"), None)
+        .unwrap()
+        .network;
+    let storage = battery.storage();
+    assert_eq!(storage.len(), 2);
+    let second = storage
+        .iter()
+        .find(|item| item.uid.as_deref() == Some("BAT2"))
+        .unwrap();
+    assert_close(second.ps, 100.0);
+    assert_close(second.qs, 200.0);
+}
+
+/// The IIDM 1.0 forms of three winding transformers, inline tie lines, and
+/// busbar section voltages map to the same tables as the 1.17 forms.
+#[test]
+fn iidm_1_0_legacy_branch_forms_map_to_the_current_tables() {
+    let transformer = load_balanced_case(
+        fixture("1_0", "threeWindingsTransformerRoundTripRef.xml"),
+        None,
+    )
+    .unwrap();
+    let network = &transformer.network;
+    assert_eq!(network.transformers_3w().len(), 1);
+    let detailed = network.detailed_connectivity().as_ref().unwrap();
+    let taps = detailed
+        .tap_changers
+        .iter()
+        .filter(|tap| tap.transformer.local_id() == "3WT")
+        .collect::<Vec<_>>();
+    assert_eq!(taps.len(), 2);
+    assert!(
+        taps.iter()
+            .all(|tap| tap.regulation_mode == Some(TapChangerRegulationMode::Voltage))
+    );
+    let limits = detailed
+        .operational_limit_groups
+        .iter()
+        .filter(|group| group.equipment.local_id() == "3WT")
+        .collect::<Vec<_>>();
+    assert_eq!(limits.len(), 3);
+    assert!(
+        limits
+            .iter()
+            .all(|group| group.selected && group.id == "DEFAULT")
+    );
+    assert_eq!(
+        limits
+            .iter()
+            .map(|group| group.current_limits.as_ref().unwrap().permanent_limit)
+            .collect::<Vec<_>>(),
+        vec![Some(1000.0), Some(100.0), Some(10.0)]
+    );
+
+    let tie = load_balanced_case(fixture("1_0", "tl-loading-limits.xml"), None).unwrap();
+    let detailed = tie.network.detailed_connectivity().as_ref().unwrap();
+    assert_eq!(detailed.tie_lines.len(), 2);
+    assert_eq!(detailed.boundary_lines.len(), 4);
+    assert!(
+        detailed
+            .boundary_lines
+            .iter()
+            .all(|line| matches!(line.pairing_key.as_deref(), Some("X1" | "X2")))
+    );
+    let first_half = detailed
+        .boundary_lines
+        .iter()
+        .find(|line| line.component.local_id() == "NHV1_NHV2_1.1")
+        .unwrap();
+    assert_close(first_half.resistance_ohm, 1.5);
+    assert_close(first_half.susceptance_siemens, 2.0 * 9.65e-5);
+    let half_limits = detailed
+        .operational_limit_groups
+        .iter()
+        .filter(|group| group.equipment.local_id().starts_with("NHV1_NHV2_1."))
+        .collect::<Vec<_>>();
+    assert_eq!(half_limits.len(), 2);
+    assert!(half_limits.iter().all(|group| {
+        group.selected
+            && group.current_limits.as_ref().unwrap().permanent_limit == Some(350.0)
+            && group
+                .current_limits
+                .as_ref()
+                .unwrap()
+                .temporary_limits
+                .len()
+                == 2
+    }));
+    assert!(
+        tie.diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message().contains("xnodeP_1"))
+    );
+
+    let node_breaker = load_balanced_case(fixture("1_0", "fictitiousSwitchRef.xml"), None)
+        .unwrap()
+        .network;
+    let current = load_balanced_case(fixture("1_17", "fictitiousSwitchRef.xml"), None)
+        .unwrap()
+        .network;
+    assert_eq!(node_breaker.buses().len(), current.buses().len());
+    let bus = node_breaker
+        .buses()
+        .iter()
+        .find(|bus| bus.uid.as_deref() == Some("D"))
+        .unwrap();
+    assert_close(bus.vm, 234.40912 / 225.0);
+}

--- a/python/powerio/__init__.pyi
+++ b/python/powerio/__init__.pyi
@@ -839,6 +839,7 @@ class BalancedNetwork:
         "goc3-json",
         "surge-json",
         "xiidm",
+        "jiidm",
         "cgmes",
     ]
     n_buses: int

--- a/python/powerio/_powerio.pyi
+++ b/python/powerio/_powerio.pyi
@@ -109,6 +109,9 @@ class _BalancedNetwork:
         "pypsa-csv",
         "goc3-json",
         "surge-json",
+        "xiidm",
+        "jiidm",
+        "cgmes",
     ]: ...
     @property
     def n_buses(self) -> int: ...

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -2461,6 +2461,9 @@ def test_source_format_stubs_cover_every_variant():
         "gridfm",
         "in-memory",
         "normalized",
+        "xiidm",
+        "jiidm",
+        "cgmes",
     ]
     root = Path(__file__).resolve().parents[1] / "powerio"
     for stub in ("__init__.pyi", "_powerio.pyi"):

--- a/tests/data/xiidm/powsybl/README.md
+++ b/tests/data/xiidm/powsybl/README.md
@@ -1,0 +1,21 @@
+# PowSybl IIDM serialization fixtures
+
+Every file under `V1_<minor>/` is copied unchanged from the PowSybl Core
+repository (`https://github.com/powsybl/powsybl-core`, commit
+`a795bfac3c`), directory
+`iidm/iidm-serde/src/test/resources/V1_<minor>/`. PowSybl Core is licensed
+under the Mozilla Public License 2.0 (`MPL-2.0`); the files carry no
+ENTSO-E data.
+
+| File | Versions | Purpose |
+| --- | --- | --- |
+| `eurostag-tutorial1-lf.xml` | 1.0 to 1.17 | The same solved four bus network written by PowSybl in every XIIDM version: two substations, a generator, a load, two lines, and two transformers with a voltage regulating ratio tap changer. |
+| `eurostag-tutorial1-lf.json` | 1.11 to 1.17 | The same network as PowSybl JIIDM JSON. |
+| `fictitiousSwitchRef.xml`, `fictitiousSwitchRef.jiidm` | 1.0, 1.11, 1.17 | A node breaker network with busbar sections, switches, calculated buses, a phase tap changer, and operational limits. IIDM 1.0 states the bus voltages on the busbar sections. |
+| Battery reference | 1.0 | Batteries with the `p0`/`q0` attribute names IIDM used before 1.8. |
+| Nonlinear shunt reference | 1.0 | A shunt with `bPerSection`, `maximumSectionCount`, and `currentSectionCount` stated on the element, as every version before 1.3 does. |
+| Static VAR compensator reference | 1.0 | A static VAR compensator with the `voltageSetPoint` spelling IIDM used before 1.3. |
+| Three winding transformer reference | 1.0 | A three winding transformer without `ratedU0`, with leg 2 and 3 ratio tap changers regulating `targetV`, and with current limits stated directly on the element. |
+| `tl-loading-limits.xml` | 1.0 | Tie lines in the inline form IIDM used before 1.10, with current limits per side. |
+
+No file was edited. Each file is smaller than 20 KiB.

--- a/tests/data/xiidm/powsybl/V1_0/batteryRoundTripRef.xml
+++ b/tests/data/xiidm/powsybl/V1_0/batteryRoundTripRef.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" geographicalTags="A" tso="R">
+        <iidm:voltageLevel id="VLGEN" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" geographicalTags="B" tso="R">
+        <iidm:voltageLevel id="VLBAT" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NBAT"/>
+            </iidm:busBreakerTopology>
+            <iidm:battery id="BAT" p0="9999.99" q0="9999.99" minP="-9999.99" maxP="9999.99" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:battery>
+            <iidm:battery id="BAT2" p0="100.0" q0="200.0" minP="-200.0" maxP="200.0" bus="NBAT" connectableBus="NBAT" p="-605.0" q="-225.0">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:battery>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NBAT" connectableBus="NBAT"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" voltageLevelId1="VLGEN" voltageLevelId2="VLBAT" bus1="NGEN" connectableBus1="NGEN" bus2="NBAT" connectableBus2="NBAT" r="3.0" x="33.0" g1="0.0"  b1="1.93E-4" g2="0.0" b2="1.93E-4"/>
+    <iidm:line id="NHV1_NHV2_2" voltageLevelId1="VLGEN" voltageLevelId2="VLBAT" bus1="NGEN" connectableBus1="NGEN" bus2="NBAT" connectableBus2="NBAT" r="3.0" x="33.0" g1="0.0"  b1="1.93E-4" g2="0.0" b2="1.93E-4"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_0/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/fictitiousSwitchRef.xml
+++ b/tests/data/xiidm/powsybl/V1_0/fictitiousSwitchRef.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="fictitious" caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology nodeCount="5">
+                <iidm:busbarSection id="D" name="E" node="0" v="234.40912" angle="0.0"/>
+                <iidm:switch id="F" name="G" kind="DISCONNECTOR" retained="false" open="false" fictitious="true" node1="0" node2="1"/>
+                <iidm:switch id="H" name="I" kind="DISCONNECTOR" retained="false" open="false" fictitious="true" node1="0" node2="3"/>
+                <iidm:switch id="J" name="K" kind="BREAKER" retained="true" open="false" fictitious="true" node1="1" node2="2"/>
+                <iidm:switch id="L" name="M" kind="BREAKER" retained="true" open="false" fictitious="true" node1="3" node2="4"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology nodeCount="23">
+                <iidm:busbarSection id="O" name="E" node="0" v="236.44736" angle="15.250391"/>
+                <iidm:busbarSection id="P" name="Q" node="1" v="236.44736" angle="15.250391"/>
+                <iidm:switch id="R" name="S" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="19"/>
+                <iidm:switch id="T" name="U" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="17"/>
+                <iidm:switch id="V" name="W" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="21"/>
+                <iidm:switch id="X" name="Y" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="11"/>
+                <iidm:switch id="Z" name="AA" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="13"/>
+                <iidm:switch id="AB" name="AC" kind="DISCONNECTOR" retained="false" open="false" node1="0" node2="15"/>
+                <iidm:switch id="AD" name="AE" kind="DISCONNECTOR" retained="false" open="true" node1="0" node2="8"/>
+                <iidm:switch id="AF" name="AG" kind="DISCONNECTOR" retained="false" open="true" fictitious="true" node1="0" node2="2"/>
+                <iidm:switch id="AH" name="AI" kind="DISCONNECTOR" retained="false" open="false" node1="7" node2="0"/>
+                <iidm:switch id="AJ" name="AK" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="6"/>
+                <iidm:switch id="AL" name="AM" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="19"/>
+                <iidm:switch id="AN" name="AO" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="17"/>
+                <iidm:switch id="AP" name="AQ" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="21"/>
+                <iidm:switch id="AR" name="AS" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="11"/>
+                <iidm:switch id="AT" name="AU" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="13"/>
+                <iidm:switch id="AV" name="AW" kind="DISCONNECTOR" retained="false" open="true" node1="1" node2="15"/>
+                <iidm:switch id="AX" name="AY" kind="DISCONNECTOR" retained="false" open="false" node1="1" node2="8"/>
+                <iidm:switch id="AZ" name="BA" kind="DISCONNECTOR" retained="false" open="true" fictitious="true" node1="1" node2="2"/>
+                <iidm:switch id="BB" name="BC" kind="BREAKER" retained="true" open="true" fictitious="true" node1="2" node2="3"/>
+                <iidm:switch id="BD" name="BE" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:switch id="BF" name="BG" kind="DISCONNECTOR" retained="false" open="false" node1="3" node2="5"/>
+                <iidm:switch id="BH" name="BI" kind="DISCONNECTOR" retained="false" open="true" node1="9" node2="3"/>
+                <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" node1="6" node2="7"/>
+                <iidm:switch id="BL" name="BM" kind="BREAKER" retained="true" open="false" node1="8" node2="9"/>
+                <iidm:switch id="BN" name="BO" kind="DISCONNECTOR" retained="false" open="false" node1="9" node2="10"/>
+                <iidm:switch id="BP" name="BQ" kind="BREAKER" retained="true" open="true" node1="11" node2="12"/>
+                <iidm:switch id="BR" name="BS" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
+                <iidm:switch id="BT" name="BU" kind="BREAKER" retained="true" open="false" node1="15" node2="16"/>
+                <iidm:switch id="BV" name="BW" kind="BREAKER" retained="true" open="false" node1="17" node2="18"/>
+                <iidm:switch id="BX" name="BY" kind="BREAKER" retained="true" open="false" node1="19" node2="20"/>
+                <iidm:switch id="BZ" name="CA" kind="BREAKER" retained="true" open="false" node1="21" node2="22"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="12">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0" targetV="0.0" targetQ="0.0" node="14">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true" targetP="21.789589" targetV="236.44736" targetQ="-20.701546" node="16" p="-21.789589" q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" node="4" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" node="18" p="8.455854" q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" node="20" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249" q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" g="0.0" b="3.2E-5" ratedU1="225.0" ratedU2="225.0" node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N">
+            <iidm:phaseTapChanger lowTapPosition="0" tapPosition="22" regulationMode="CURRENT_LIMITER" regulationValue="930.6667" regulating="false">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" g="0.0" b="0.0" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" g="0.0" b="0.0" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" g="0.0" b="0.0" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" g="0.0" b="0.0" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" g="0.0" b="0.0" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" g="0.0" b="0.0" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" g="0.0" b="0.0" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" g="0.0" b="0.0" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" g="0.0" b="0.0" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" g="0.0" b="0.0" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" g="0.0" b="0.0" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" g="0.0" b="0.0" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" g="0.0" b="0.0" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" g="0.0" b="0.0" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" g="0.0" b="0.0" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" g="0.0" b="0.0" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits1 permanentLimit="931.0"/>
+            <iidm:currentLimits2 permanentLimit="931.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="CJ" r="0.009999999" x="0.100000024" g1="0.0" b1="0.0" g2="0.0" b2="0.0" node1="4" voltageLevelId1="C" node2="5" voltageLevelId2="N">
+        <iidm:currentLimits1 permanentLimit="931.0"/>
+        <iidm:currentLimits2 permanentLimit="931.0">
+            <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+            <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+        </iidm:currentLimits2>
+    </iidm:line>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/nonLinearShuntRoundTripRef.xml
+++ b/tests/data/xiidm/powsybl/V1_0/nonLinearShuntRoundTripRef.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="shuntTestCase" caseDate="2019-09-30T16:29:18.263+02:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:shunt id="SHUNT" bPerSection="1.0E-5" maximumSectionCount="1" currentSectionCount="1" bus="B1" connectableBus="B1">
+                <iidm:property name="test" value="test"/>
+            </iidm:shunt>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="220.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="100.0" q0="50.0" bus="B2" connectableBus="B2"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/staticVarCompensatorRoundTripRef.xml
+++ b/tests/data/xiidm/powsybl/V1_0/staticVarCompensatorRoundTripRef.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="svcTestCase" caseDate="2016-06-29T14:54:03.427+02:00" forecastDistance="0" sourceFormat="code">
+    <iidm:substation id="S1" country="FR">
+        <iidm:voltageLevel id="VL1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B1"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="G1" energySource="OTHER" minP="50.0" maxP="150.0" voltageRegulatorOn="true" targetP="100.0" targetV="400.0" bus="B1" connectableBus="B1">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/> <!--min max value-->
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="S2" country="FR">
+        <iidm:voltageLevel id="VL2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="B2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="L2" loadType="UNDEFINED" p0="100.0" q0="50.0" bus="B2" connectableBus="B2"/>
+            <iidm:staticVarCompensator id="SVC2" bMin="2.0E-4" bMax="8.0E-4" voltageSetPoint="390.0" regulationMode="VOLTAGE" bus="B2" connectableBus="B2">
+                <iidm:property name="test" value="test"/>
+            </iidm:staticVarCompensator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="L1" r="4.0" x="200.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/threeWindingsTransformerRoundTripRef.xml
+++ b/tests/data/xiidm/powsybl/V1_0/threeWindingsTransformerRoundTripRef.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="three-windings-transformer" caseDate="2018-03-05T13:30:30.486+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="SUBSTATION" country="FR">
+        <iidm:voltageLevel id="VL_132" nominalV="132.0" lowVoltageLimit="118.8" highVoltageLimit="145.2" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_132" v="133.584" angle="-9.62"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN_132" energySource="OTHER" minP="0.0" maxP="140.0" voltageRegulatorOn="true" targetP="7.2" targetV="135.0" bus="BUS_132" connectableBus="BUS_132">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_33" nominalV="33.0" lowVoltageLimit="29.7" highVoltageLimit="36.3" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_33" v="34.881" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_33" loadType="UNDEFINED" p0="11.2" q0="7.5" bus="BUS_33" connectableBus="BUS_33" p="11.2" q="7.5"/>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VL_11" nominalV="11.0" lowVoltageLimit="9.9" highVoltageLimit="12.1" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BUS_11" v="11.781" angle="-15.24"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD_11" loadType="UNDEFINED" p0="0.0" q0="-10.6" bus="BUS_11" connectableBus="BUS_11" p="0.0" q="-10.6"/>
+        </iidm:voltageLevel>
+        <iidm:threeWindingsTransformer id="3WT" r1="17.424" x1="1.7424" g1="0.00573921028466483" b1="5.73921028466483E-4" ratedU1="132.0" r2="1.089" x2="0.1089" ratedU2="33.0" r3="0.121" x3="0.0121" ratedU3="11.0" bus1="BUS_132" connectableBus1="BUS_132" voltageLevelId1="VL_132" bus2="BUS_33" connectableBus2="BUS_33" voltageLevelId2="VL_33" bus3="BUS_11" connectableBus3="BUS_11" voltageLevelId3="VL_11">
+            <iidm:ratioTapChanger2 lowTapPosition="0" tapPosition="2" loadTapChangingCapabilities="true" regulating="true" targetV="33.0">
+                <iidm:terminalRef id="LOAD_33"/>
+                <iidm:step r="0.9801" x="0.09801" g="0.08264462809917356" b="0.008264462809917356" rho="0.9"/>
+                <iidm:step r="1.089" x="0.1089" g="0.09182736455463728" b="0.009182736455463728" rho="1.0"/>
+                <iidm:step r="1.1979" x="0.11979" g="0.10101010101010101" b="0.0101010101010101" rho="1.1"/>
+            </iidm:ratioTapChanger2>
+            <iidm:ratioTapChanger3 lowTapPosition="0" tapPosition="0" loadTapChangingCapabilities="true" regulating="false" targetV="11.0">
+                <iidm:terminalRef id="LOAD_11"/>
+                <iidm:step r="0.1089" x="0.01089" g="0.8264462809917356" b="0.08264462809917356" rho="0.9"/>
+                <iidm:step r="0.121" x="0.0121" g="0.8264462809917356" b="0.08264462809917356" rho="1.0"/>
+                <iidm:step r="0.1331" x="0.01331" g="0.9090909090909092" b="0.09090909090909093" rho="1.1"/>
+            </iidm:ratioTapChanger3>
+            <iidm:currentLimits1 permanentLimit="1000.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="1200.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="1400.0"/>
+            </iidm:currentLimits1>
+            <iidm:currentLimits2 permanentLimit="100.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="120.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="140.0"/>
+            </iidm:currentLimits2>
+            <iidm:currentLimits3 permanentLimit="10.0">
+                <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="12.0"/>
+                <iidm:temporaryLimit name="10'" acceptableDuration="600" value="14.0"/>
+            </iidm:currentLimits3>
+        </iidm:threeWindingsTransformer>
+    </iidm:substation>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_0/tl-loading-limits.xml
+++ b/tests/data/xiidm/powsybl/V1_0/tl-loading-limits.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:tieLine id="NHV1_NHV2_1" ucteXnodeCode="X1" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906" id_1="NHV1_NHV2_1.1" r_1="1.5" x_1="16.5" g1_1="0.0" b1_1="9.65E-5" g2_1="0.0" b2_1="9.65E-5" xnodeP_1="-301.43898434342725" xnodeQ_1="-118.89616773372641" id_2="NHV1_NHV2_1.2" r_2="1.5" x_2="16.5" g1_2="0.0" b1_2="9.65E-5" g2_2="0.0" b2_2="9.65E-5" xnodeP_2="301.43897577958876" xnodeQ_2="118.89616087695104">
+        <iidm:currentLimits1 permanentLimit="350.0">
+            <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="370.0"/>
+            <iidm:temporaryLimit name="10'" acceptableDuration="600" value="380.0"/>
+        </iidm:currentLimits1>
+        <iidm:currentLimits2 permanentLimit="350.0">
+            <iidm:temporaryLimit name="20'" acceptableDuration="1200" value="370.0"/>
+            <iidm:temporaryLimit name="10'" acceptableDuration="600" value="380.0"/>
+        </iidm:currentLimits2>
+    </iidm:tieLine>
+    <iidm:tieLine id="NHV1_NHV2_2" ucteXnodeCode="X2" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906" id_1="NHV1_NHV2_2.1" r_1="1.5" x_1="16.5" g1_1="0.0" b1_1="9.65E-5" g2_1="0.0" b2_1="9.65E-5" xnodeP_1="-301.43898434342725" xnodeQ_1="-118.89616773372641" id_2="NHV1_NHV2_2.2" r_2="1.5" x_2="16.5" g1_2="0.0" b1_2="9.65E-5" g2_2="0.0" b2_2="9.65E-5" xnodeP_2="301.43897577958876" xnodeQ_2="118.89616087695104"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_1/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_1/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_1" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_10/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_10/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_11/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_11/eurostag-tutorial1-lf.json
@@ -1,0 +1,199 @@
+{
+  "version" : "1.11",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "targetV" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_11/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_11/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_11" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_11/fictitiousSwitchRef.jiidm
+++ b/tests/data/xiidm/powsybl/V1_11/fictitiousSwitchRef.jiidm
@@ -1,0 +1,729 @@
+{
+  "version" : "1.11",
+  "id" : "fictitious",
+  "caseDate" : "2017-06-25T17:43:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "A",
+    "country" : "FR",
+    "voltageLevels" : [ {
+      "id" : "C",
+      "nominalV" : 225.0,
+      "lowVoltageLimit" : 0.0,
+      "topologyKind" : "NODE_BREAKER",
+      "nodeBreakerTopology" : {
+        "busbarSections" : [ {
+          "id" : "D",
+          "name" : "E",
+          "node" : 0
+        } ],
+        "switches" : [ {
+          "id" : "F",
+          "name" : "G",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 0,
+          "node2" : 1
+        }, {
+          "id" : "H",
+          "name" : "I",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 0,
+          "node2" : 3
+        }, {
+          "id" : "J",
+          "name" : "K",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 2
+        }, {
+          "id" : "L",
+          "name" : "M",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 3,
+          "node2" : 4
+        } ],
+        "buses" : [ {
+          "v" : 234.40912,
+          "angle" : 0.0,
+          "nodes" : [ 0, 1, 2, 3, 4 ]
+        } ]
+      }
+    }, {
+      "id" : "N",
+      "nominalV" : 225.0,
+      "lowVoltageLimit" : 220.0,
+      "highVoltageLimit" : 245.00002,
+      "topologyKind" : "NODE_BREAKER",
+      "nodeBreakerTopology" : {
+        "busbarSections" : [ {
+          "id" : "O",
+          "name" : "E",
+          "node" : 0
+        }, {
+          "id" : "P",
+          "name" : "Q",
+          "node" : 1
+        } ],
+        "switches" : [ {
+          "id" : "R",
+          "name" : "S",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 19
+        }, {
+          "id" : "T",
+          "name" : "U",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 17
+        }, {
+          "id" : "V",
+          "name" : "W",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 21
+        }, {
+          "id" : "X",
+          "name" : "Y",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 11
+        }, {
+          "id" : "Z",
+          "name" : "AA",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 13
+        }, {
+          "id" : "AB",
+          "name" : "AC",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 0,
+          "node2" : 15
+        }, {
+          "id" : "AD",
+          "name" : "AE",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 8
+        }, {
+          "id" : "AF",
+          "name" : "AG",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 0,
+          "node2" : 2
+        }, {
+          "id" : "AH",
+          "name" : "AI",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 7,
+          "node2" : 0
+        }, {
+          "id" : "AJ",
+          "name" : "AK",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 6
+        }, {
+          "id" : "AL",
+          "name" : "AM",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 19
+        }, {
+          "id" : "AN",
+          "name" : "AO",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 17
+        }, {
+          "id" : "AP",
+          "name" : "AQ",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 21
+        }, {
+          "id" : "AR",
+          "name" : "AS",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 1,
+          "node2" : 11
+        }, {
+          "id" : "AT",
+          "name" : "AU",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 1,
+          "node2" : 13
+        }, {
+          "id" : "AV",
+          "name" : "AW",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 1,
+          "node2" : 15
+        }, {
+          "id" : "AX",
+          "name" : "AY",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 8
+        }, {
+          "id" : "AZ",
+          "name" : "BA",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 1,
+          "node2" : 2
+        }, {
+          "id" : "BB",
+          "name" : "BC",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 2,
+          "node2" : 3
+        }, {
+          "id" : "BD",
+          "name" : "BE",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 3,
+          "node2" : 4
+        }, {
+          "id" : "BF",
+          "name" : "BG",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 3,
+          "node2" : 5
+        }, {
+          "id" : "BH",
+          "name" : "BI",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : true,
+          "node1" : 9,
+          "node2" : 3
+        }, {
+          "id" : "BJ",
+          "name" : "BK",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 6,
+          "node2" : 7
+        }, {
+          "id" : "BL",
+          "name" : "BM",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 8,
+          "node2" : 9
+        }, {
+          "id" : "BN",
+          "name" : "BO",
+          "kind" : "DISCONNECTOR",
+          "retained" : false,
+          "open" : false,
+          "node1" : 9,
+          "node2" : 10
+        }, {
+          "id" : "BP",
+          "name" : "BQ",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 11,
+          "node2" : 12
+        }, {
+          "id" : "BR",
+          "name" : "BS",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 13,
+          "node2" : 14
+        }, {
+          "id" : "BT",
+          "name" : "BU",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 15,
+          "node2" : 16
+        }, {
+          "id" : "BV",
+          "name" : "BW",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 17,
+          "node2" : 18
+        }, {
+          "id" : "BX",
+          "name" : "BY",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 19,
+          "node2" : 20
+        }, {
+          "id" : "BZ",
+          "name" : "CA",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 21,
+          "node2" : 22
+        } ],
+        "buses" : [ {
+          "v" : 236.44736,
+          "angle" : 15.250391,
+          "nodes" : [ 0, 1, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22 ]
+        } ]
+      },
+      "generators" : [ {
+        "id" : "CB",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 70.0,
+        "voltageRegulatorOn" : false,
+        "targetP" : 0.0,
+        "targetV" : 0.0,
+        "targetQ" : 0.0,
+        "node" : 12,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -59.3,
+            "maxQ" : 60.0
+          }, {
+            "p" : 70.0,
+            "minQ" : -54.55,
+            "maxQ" : 46.25
+          } ]
+        }
+      }, {
+        "id" : "CC",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 80.0,
+        "voltageRegulatorOn" : false,
+        "targetP" : 0.0,
+        "targetV" : 0.0,
+        "targetQ" : 0.0,
+        "node" : 14,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -56.8,
+            "maxQ" : 57.4
+          }, {
+            "p" : 80.0,
+            "minQ" : -53.514,
+            "maxQ" : 36.4
+          } ]
+        }
+      }, {
+        "id" : "CD",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 35.0,
+        "voltageRegulatorOn" : true,
+        "targetP" : 21.789589,
+        "targetV" : 236.44736,
+        "targetQ" : -20.701546,
+        "node" : 16,
+        "p" : -21.789589,
+        "q" : 20.693394,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -20.6,
+            "maxQ" : 18.1
+          }, {
+            "p" : 35.0,
+            "minQ" : -21.725,
+            "maxQ" : 6.3500004
+          } ]
+        }
+      } ],
+      "loads" : [ {
+        "id" : "CE",
+        "loadType" : "UNDEFINED",
+        "p0" : -72.18689,
+        "q0" : 50.168945,
+        "node" : 4,
+        "p" : -72.18689,
+        "q" : 50.168945
+      }, {
+        "id" : "CF",
+        "loadType" : "UNDEFINED",
+        "p0" : 8.455854,
+        "q0" : -23.695925,
+        "node" : 18,
+        "p" : 8.455854,
+        "q" : -23.695925
+      }, {
+        "id" : "CG",
+        "loadType" : "UNDEFINED",
+        "p0" : 90.39911,
+        "q0" : -51.96869,
+        "node" : 20,
+        "p" : 90.39911,
+        "q" : -51.96869
+      }, {
+        "id" : "CH",
+        "loadType" : "UNDEFINED",
+        "p0" : -5.102249,
+        "q0" : 4.9081216,
+        "node" : 22,
+        "p" : -5.102249,
+        "q" : 4.9081216
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "CI",
+      "r" : 2.0,
+      "x" : 14.745,
+      "g" : 0.0,
+      "b" : 3.2E-5,
+      "ratedU1" : 225.0,
+      "ratedU2" : 225.0,
+      "voltageLevelId1" : "C",
+      "node1" : 2,
+      "voltageLevelId2" : "N",
+      "node2" : 10,
+      "phaseTapChanger" : {
+        "regulating" : false,
+        "lowTapPosition" : 0,
+        "tapPosition" : 22,
+        "regulationMode" : "CURRENT_LIMITER",
+        "regulationValue" : 930.6667,
+        "terminalRef" : {
+          "id" : "CI",
+          "side" : "ONE"
+        },
+        "steps" : [ {
+          "r" : 39.78473,
+          "x" : 39.784725,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -42.8
+        }, {
+          "r" : 31.720245,
+          "x" : 31.720242,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -40.18
+        }, {
+          "r" : 23.655737,
+          "x" : 23.655735,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -37.54
+        }, {
+          "r" : 16.263271,
+          "x" : 16.263268,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -34.9
+        }, {
+          "r" : 9.542847,
+          "x" : 9.542842,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -32.26
+        }, {
+          "r" : 3.4944773,
+          "x" : 3.4944773,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -29.6
+        }, {
+          "r" : -1.8818557,
+          "x" : -1.8818527,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -26.94
+        }, {
+          "r" : -7.258195,
+          "x" : -7.2581954,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -24.26
+        }, {
+          "r" : -11.962485,
+          "x" : -11.962484,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -21.58
+        }, {
+          "r" : -15.994745,
+          "x" : -15.994745,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -18.9
+        }, {
+          "r" : -19.354952,
+          "x" : -19.354952,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -16.22
+        }, {
+          "r" : -22.043127,
+          "x" : -22.043129,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -13.52
+        }, {
+          "r" : -24.73129,
+          "x" : -24.731287,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -10.82
+        }, {
+          "r" : -26.747417,
+          "x" : -26.747417,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -8.12
+        }, {
+          "r" : -28.091503,
+          "x" : -28.091503,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -5.42
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : -2.7
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 0.0
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 2.7
+        }, {
+          "r" : -28.091503,
+          "x" : -28.091503,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 5.42
+        }, {
+          "r" : -26.747417,
+          "x" : -26.747417,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 8.12
+        }, {
+          "r" : -24.73129,
+          "x" : -24.731287,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 10.82
+        }, {
+          "r" : -22.043127,
+          "x" : -22.043129,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 13.52
+        }, {
+          "r" : -19.354952,
+          "x" : -19.354952,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 16.22
+        }, {
+          "r" : -15.994745,
+          "x" : -15.994745,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 18.9
+        }, {
+          "r" : -11.962485,
+          "x" : -11.962484,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 21.58
+        }, {
+          "r" : -7.258195,
+          "x" : -7.2581954,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 24.26
+        }, {
+          "r" : -1.8818557,
+          "x" : -1.8818527,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 26.94
+        }, {
+          "r" : 3.4944773,
+          "x" : 3.4944773,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 29.6
+        }, {
+          "r" : 9.542847,
+          "x" : 9.542842,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 32.26
+        }, {
+          "r" : 16.263271,
+          "x" : 16.263268,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 34.9
+        }, {
+          "r" : 23.655737,
+          "x" : 23.655735,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 37.54
+        }, {
+          "r" : 31.720245,
+          "x" : 31.720242,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 40.18
+        }, {
+          "r" : 39.78473,
+          "x" : 39.784725,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0,
+          "alpha" : 42.8
+        } ]
+      },
+      "currentLimits1" : {
+        "permanentLimit" : 931.0
+      },
+      "currentLimits2" : {
+        "permanentLimit" : 931.0
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "CJ",
+    "r" : 0.009999999,
+    "x" : 0.100000024,
+    "g1" : 0.0,
+    "b1" : 0.0,
+    "g2" : 0.0,
+    "b2" : 0.0,
+    "voltageLevelId1" : "C",
+    "node1" : 4,
+    "voltageLevelId2" : "N",
+    "node2" : 5,
+    "currentLimits1" : {
+      "permanentLimit" : 931.0
+    },
+    "currentLimits2" : {
+      "permanentLimit" : 931.0,
+      "temporaryLimits" : [ {
+        "name" : "IST",
+        "value" : 1640.0,
+        "fictitious" : true
+      }, {
+        "name" : "IT1",
+        "acceptableDuration" : 60
+      } ]
+    }
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_12/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_12/eurostag-tutorial1-lf.json
@@ -1,0 +1,200 @@
+{
+  "version" : "1.12",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_12/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_12/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_13/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_13/eurostag-tutorial1-lf.json
@@ -1,0 +1,200 @@
+{
+  "version" : "1.13",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_13/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_13/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_13" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_14/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_14/eurostag-tutorial1-lf.json
@@ -1,0 +1,200 @@
+{
+  "version" : "1.14",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_14/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_14/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_14" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_15/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_15/eurostag-tutorial1-lf.json
@@ -1,0 +1,200 @@
+{
+  "version" : "1.15",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_15/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_15/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_15" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_16/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_16/eurostag-tutorial1-lf.json
@@ -1,0 +1,200 @@
+{
+  "version" : "1.16",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "g" : 0.0,
+      "b" : 0.0,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "lowTapPosition" : 0,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 0.8505666905244191
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.0006666666666666
+        }, {
+          "r" : 0.0,
+          "x" : 0.0,
+          "g" : 0.0,
+          "b" : 0.0,
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "g1" : 0.0,
+    "b1" : 1.93E-4,
+    "g2" : 0.0,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_16/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_16/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_16" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_17/eurostag-tutorial1-lf.json
+++ b/tests/data/xiidm/powsybl/V1_17/eurostag-tutorial1-lf.json
@@ -1,0 +1,179 @@
+{
+  "version" : "1.17",
+  "id" : "sim1",
+  "caseDate" : "2013-01-15T18:45:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "P1",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "A" ],
+    "voltageLevels" : [ {
+      "id" : "VLGEN",
+      "nominalV" : 24.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NGEN",
+          "v" : 24.500000610351563,
+          "angle" : 2.3259763717651367
+        } ]
+      },
+      "generators" : [ {
+        "id" : "GEN",
+        "energySource" : "OTHER",
+        "minP" : -9999.99,
+        "maxP" : 9999.99,
+        "voltageRegulatorOn" : true,
+        "targetP" : 607.0,
+        "targetV" : 24.5,
+        "targetQ" : 301.0,
+        "bus" : "NGEN",
+        "connectableBus" : "NGEN",
+        "p" : -605.558349609375,
+        "q" : -225.2825164794922,
+        "minMaxReactiveLimits" : {
+          "minQ" : -9999.99,
+          "maxQ" : 9999.99
+        }
+      } ]
+    }, {
+      "id" : "VLHV1",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV1",
+          "v" : 402.1428451538086,
+          "angle" : 0.0
+        } ]
+      }
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NGEN_NHV1",
+      "r" : 0.26658461538461536,
+      "x" : 11.104492831516762,
+      "ratedU1" : 24.0,
+      "ratedU2" : 400.0,
+      "voltageLevelId1" : "VLGEN",
+      "bus1" : "NGEN",
+      "connectableBus1" : "NGEN",
+      "voltageLevelId2" : "VLHV1",
+      "bus2" : "NHV1",
+      "connectableBus2" : "NHV1",
+      "p1" : 605.558349609375,
+      "q1" : 225.2825164794922,
+      "p2" : -604.8909301757812,
+      "q2" : -197.48046875
+    } ]
+  }, {
+    "id" : "P2",
+    "country" : "FR",
+    "tso" : "RTE",
+    "geographicalTags" : [ "B" ],
+    "voltageLevels" : [ {
+      "id" : "VLHV2",
+      "nominalV" : 380.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NHV2",
+          "v" : 389.9526763916016,
+          "angle" : -3.5063576698303223
+        } ]
+      }
+    }, {
+      "id" : "VLLOAD",
+      "nominalV" : 150.0,
+      "topologyKind" : "BUS_BREAKER",
+      "busBreakerTopology" : {
+        "buses" : [ {
+          "id" : "NLOAD",
+          "v" : 147.57861328125,
+          "angle" : -9.614486694335938
+        } ]
+      },
+      "loads" : [ {
+        "id" : "LOAD",
+        "loadType" : "UNDEFINED",
+        "p0" : 600.0,
+        "q0" : 200.0,
+        "bus" : "NLOAD",
+        "connectableBus" : "NLOAD",
+        "p" : 600.0,
+        "q" : 200.0
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "NHV2_NLOAD",
+      "r" : 0.04724999999999999,
+      "x" : 4.049724365620455,
+      "ratedU1" : 400.0,
+      "ratedU2" : 158.0,
+      "voltageLevelId1" : "VLHV2",
+      "bus1" : "NHV2",
+      "connectableBus1" : "NHV2",
+      "voltageLevelId2" : "VLLOAD",
+      "bus2" : "NLOAD",
+      "connectableBus2" : "NLOAD",
+      "p1" : 600.8677978515625,
+      "q1" : 274.3769836425781,
+      "p2" : -600.0,
+      "q2" : -200.0,
+      "ratioTapChanger" : {
+        "regulating" : true,
+        "tapPosition" : 1,
+        "targetDeadband" : 0.0,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "VOLTAGE",
+        "regulationValue" : 158.0,
+        "terminalRef" : {
+          "id" : "NHV2_NLOAD",
+          "side" : "TWO"
+        },
+        "steps" : [ {
+          "rho" : 0.8505666905244191
+        }, {
+          "rho" : 1.0006666666666666
+        }, {
+          "rho" : 1.150766642808914
+        } ]
+      }
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "NHV1_NHV2_1",
+    "r" : 3.0,
+    "x" : 33.0,
+    "b1" : 1.93E-4,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  }, {
+    "id" : "NHV1_NHV2_2",
+    "r" : 3.0,
+    "x" : 33.0,
+    "b1" : 1.93E-4,
+    "b2" : 1.93E-4,
+    "voltageLevelId1" : "VLHV1",
+    "bus1" : "NHV1",
+    "connectableBus1" : "NHV1",
+    "voltageLevelId2" : "VLHV2",
+    "bus2" : "NHV2",
+    "connectableBus2" : "NHV2",
+    "p1" : 302.4440612792969,
+    "q1" : 98.74027252197266,
+    "p2" : -300.43389892578125,
+    "q2" : -137.18849182128906
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_17/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_17/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger tapPosition="1" loadTapChangingCapabilities="true" regulating="true" regulationMode="VOLTAGE" regulationValue="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step rho="0.8505666905244191"/>
+                <iidm:step rho="1.0006666666666666"/>
+                <iidm:step rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" b1="1.93E-4" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" b1="1.93E-4" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_17/fictitiousSwitchRef.jiidm
+++ b/tests/data/xiidm/powsybl/V1_17/fictitiousSwitchRef.jiidm
@@ -1,0 +1,651 @@
+{
+  "version" : "1.17",
+  "id" : "fictitious",
+  "caseDate" : "2017-06-25T17:43:00.000+01:00",
+  "forecastDistance" : 0,
+  "sourceFormat" : "test",
+  "minimumValidationLevel" : "STEADY_STATE_HYPOTHESIS",
+  "substations" : [ {
+    "id" : "A",
+    "country" : "FR",
+    "voltageLevels" : [ {
+      "id" : "C",
+      "nominalV" : 225.0,
+      "lowVoltageLimit" : 0.0,
+      "topologyKind" : "NODE_BREAKER",
+      "nodeBreakerTopology" : {
+        "busbarSections" : [ {
+          "id" : "D",
+          "name" : "E",
+          "node" : 0
+        } ],
+        "switches" : [ {
+          "id" : "F",
+          "name" : "G",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 0,
+          "node2" : 1
+        }, {
+          "id" : "H",
+          "name" : "I",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 0,
+          "node2" : 3
+        }, {
+          "id" : "J",
+          "name" : "K",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 1,
+          "node2" : 2
+        }, {
+          "id" : "L",
+          "name" : "M",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 3,
+          "node2" : 4
+        } ],
+        "buses" : [ {
+          "v" : 234.40912,
+          "angle" : 0.0,
+          "nodes" : [ 0, 1, 2, 3, 4 ]
+        } ]
+      }
+    }, {
+      "id" : "N",
+      "nominalV" : 225.0,
+      "lowVoltageLimit" : 220.0,
+      "highVoltageLimit" : 245.00002,
+      "topologyKind" : "NODE_BREAKER",
+      "nodeBreakerTopology" : {
+        "busbarSections" : [ {
+          "id" : "O",
+          "name" : "E",
+          "node" : 0
+        }, {
+          "id" : "P",
+          "name" : "Q",
+          "node" : 1
+        } ],
+        "switches" : [ {
+          "id" : "R",
+          "name" : "S",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 19
+        }, {
+          "id" : "T",
+          "name" : "U",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 17
+        }, {
+          "id" : "V",
+          "name" : "W",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 21
+        }, {
+          "id" : "X",
+          "name" : "Y",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 11
+        }, {
+          "id" : "Z",
+          "name" : "AA",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 13
+        }, {
+          "id" : "AB",
+          "name" : "AC",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 0,
+          "node2" : 15
+        }, {
+          "id" : "AD",
+          "name" : "AE",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 8
+        }, {
+          "id" : "AF",
+          "name" : "AG",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 0,
+          "node2" : 2
+        }, {
+          "id" : "AH",
+          "name" : "AI",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 7,
+          "node2" : 0
+        }, {
+          "id" : "AJ",
+          "name" : "AK",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 1,
+          "node2" : 6
+        }, {
+          "id" : "AL",
+          "name" : "AM",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 1,
+          "node2" : 19
+        }, {
+          "id" : "AN",
+          "name" : "AO",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 1,
+          "node2" : 17
+        }, {
+          "id" : "AP",
+          "name" : "AQ",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 1,
+          "node2" : 21
+        }, {
+          "id" : "AR",
+          "name" : "AS",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 1,
+          "node2" : 11
+        }, {
+          "id" : "AT",
+          "name" : "AU",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 1,
+          "node2" : 13
+        }, {
+          "id" : "AV",
+          "name" : "AW",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 1,
+          "node2" : 15
+        }, {
+          "id" : "AX",
+          "name" : "AY",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 1,
+          "node2" : 8
+        }, {
+          "id" : "AZ",
+          "name" : "BA",
+          "fictitious" : true,
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 1,
+          "node2" : 2
+        }, {
+          "id" : "BB",
+          "name" : "BC",
+          "fictitious" : true,
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 2,
+          "node2" : 3
+        }, {
+          "id" : "BD",
+          "name" : "BE",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 3,
+          "node2" : 4
+        }, {
+          "id" : "BF",
+          "name" : "BG",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 3,
+          "node2" : 5
+        }, {
+          "id" : "BH",
+          "name" : "BI",
+          "kind" : "DISCONNECTOR",
+          "open" : true,
+          "node1" : 9,
+          "node2" : 3
+        }, {
+          "id" : "BJ",
+          "name" : "BK",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 6,
+          "node2" : 7
+        }, {
+          "id" : "BL",
+          "name" : "BM",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 8,
+          "node2" : 9
+        }, {
+          "id" : "BN",
+          "name" : "BO",
+          "kind" : "DISCONNECTOR",
+          "open" : false,
+          "node1" : 9,
+          "node2" : 10
+        }, {
+          "id" : "BP",
+          "name" : "BQ",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 11,
+          "node2" : 12
+        }, {
+          "id" : "BR",
+          "name" : "BS",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : true,
+          "node1" : 13,
+          "node2" : 14
+        }, {
+          "id" : "BT",
+          "name" : "BU",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 15,
+          "node2" : 16
+        }, {
+          "id" : "BV",
+          "name" : "BW",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 17,
+          "node2" : 18
+        }, {
+          "id" : "BX",
+          "name" : "BY",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 19,
+          "node2" : 20
+        }, {
+          "id" : "BZ",
+          "name" : "CA",
+          "kind" : "BREAKER",
+          "retained" : true,
+          "open" : false,
+          "node1" : 21,
+          "node2" : 22
+        } ],
+        "buses" : [ {
+          "v" : 236.44736,
+          "angle" : 15.250391,
+          "nodes" : [ 0, 1, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22 ]
+        } ]
+      },
+      "generators" : [ {
+        "id" : "CB",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 70.0,
+        "voltageRegulatorOn" : false,
+        "targetP" : 0.0,
+        "targetV" : 0.0,
+        "targetQ" : 0.0,
+        "node" : 12,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -59.3,
+            "maxQ" : 60.0
+          }, {
+            "p" : 70.0,
+            "minQ" : -54.55,
+            "maxQ" : 46.25
+          } ]
+        }
+      }, {
+        "id" : "CC",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 80.0,
+        "voltageRegulatorOn" : false,
+        "targetP" : 0.0,
+        "targetV" : 0.0,
+        "targetQ" : 0.0,
+        "node" : 14,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -56.8,
+            "maxQ" : 57.4
+          }, {
+            "p" : 80.0,
+            "minQ" : -53.514,
+            "maxQ" : 36.4
+          } ]
+        }
+      }, {
+        "id" : "CD",
+        "energySource" : "HYDRO",
+        "minP" : 0.0,
+        "maxP" : 35.0,
+        "voltageRegulatorOn" : true,
+        "targetP" : 21.789589,
+        "targetV" : 236.44736,
+        "targetQ" : -20.701546,
+        "node" : 16,
+        "p" : -21.789589,
+        "q" : 20.693394,
+        "reactiveCapabilityCurve" : {
+          "points" : [ {
+            "p" : 0.0,
+            "minQ" : -20.6,
+            "maxQ" : 18.1
+          }, {
+            "p" : 35.0,
+            "minQ" : -21.725,
+            "maxQ" : 6.3500004
+          } ]
+        }
+      } ],
+      "loads" : [ {
+        "id" : "CE",
+        "loadType" : "UNDEFINED",
+        "p0" : -72.18689,
+        "q0" : 50.168945,
+        "node" : 4,
+        "p" : -72.18689,
+        "q" : 50.168945
+      }, {
+        "id" : "CF",
+        "loadType" : "UNDEFINED",
+        "p0" : 8.455854,
+        "q0" : -23.695925,
+        "node" : 18,
+        "p" : 8.455854,
+        "q" : -23.695925
+      }, {
+        "id" : "CG",
+        "loadType" : "UNDEFINED",
+        "p0" : 90.39911,
+        "q0" : -51.96869,
+        "node" : 20,
+        "p" : 90.39911,
+        "q" : -51.96869
+      }, {
+        "id" : "CH",
+        "loadType" : "UNDEFINED",
+        "p0" : -5.102249,
+        "q0" : 4.9081216,
+        "node" : 22,
+        "p" : -5.102249,
+        "q" : 4.9081216
+      } ]
+    } ],
+    "twoWindingsTransformers" : [ {
+      "id" : "CI",
+      "r" : 2.0,
+      "x" : 14.745,
+      "b" : 3.2E-5,
+      "ratedU1" : 225.0,
+      "ratedU2" : 225.0,
+      "voltageLevelId1" : "C",
+      "node1" : 2,
+      "voltageLevelId2" : "N",
+      "node2" : 10,
+      "selectedOperationalLimitsGroupIds1" : [ "DEFAULT" ],
+      "selectedOperationalLimitsGroupIds2" : [ "DEFAULT" ],
+      "phaseTapChanger" : {
+        "regulating" : false,
+        "tapPosition" : 22,
+        "loadTapChangingCapabilities" : true,
+        "regulationMode" : "CURRENT_LIMITER",
+        "regulationValue" : 930.6667,
+        "terminalRef" : {
+          "id" : "CI",
+          "side" : "ONE"
+        },
+        "steps" : [ {
+          "r" : 39.78473,
+          "x" : 39.784725,
+          "rho" : 1.0,
+          "alpha" : -42.8
+        }, {
+          "r" : 31.720245,
+          "x" : 31.720242,
+          "rho" : 1.0,
+          "alpha" : -40.18
+        }, {
+          "r" : 23.655737,
+          "x" : 23.655735,
+          "rho" : 1.0,
+          "alpha" : -37.54
+        }, {
+          "r" : 16.263271,
+          "x" : 16.263268,
+          "rho" : 1.0,
+          "alpha" : -34.9
+        }, {
+          "r" : 9.542847,
+          "x" : 9.542842,
+          "rho" : 1.0,
+          "alpha" : -32.26
+        }, {
+          "r" : 3.4944773,
+          "x" : 3.4944773,
+          "rho" : 1.0,
+          "alpha" : -29.6
+        }, {
+          "r" : -1.8818557,
+          "x" : -1.8818527,
+          "rho" : 1.0,
+          "alpha" : -26.94
+        }, {
+          "r" : -7.258195,
+          "x" : -7.2581954,
+          "rho" : 1.0,
+          "alpha" : -24.26
+        }, {
+          "r" : -11.962485,
+          "x" : -11.962484,
+          "rho" : 1.0,
+          "alpha" : -21.58
+        }, {
+          "r" : -15.994745,
+          "x" : -15.994745,
+          "rho" : 1.0,
+          "alpha" : -18.9
+        }, {
+          "r" : -19.354952,
+          "x" : -19.354952,
+          "rho" : 1.0,
+          "alpha" : -16.22
+        }, {
+          "r" : -22.043127,
+          "x" : -22.043129,
+          "rho" : 1.0,
+          "alpha" : -13.52
+        }, {
+          "r" : -24.73129,
+          "x" : -24.731287,
+          "rho" : 1.0,
+          "alpha" : -10.82
+        }, {
+          "r" : -26.747417,
+          "x" : -26.747417,
+          "rho" : 1.0,
+          "alpha" : -8.12
+        }, {
+          "r" : -28.091503,
+          "x" : -28.091503,
+          "rho" : 1.0,
+          "alpha" : -5.42
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "rho" : 1.0,
+          "alpha" : -2.7
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "rho" : 1.0,
+          "alpha" : 0.0
+        }, {
+          "r" : -28.763538,
+          "x" : -28.763536,
+          "rho" : 1.0,
+          "alpha" : 2.7
+        }, {
+          "r" : -28.091503,
+          "x" : -28.091503,
+          "rho" : 1.0,
+          "alpha" : 5.42
+        }, {
+          "r" : -26.747417,
+          "x" : -26.747417,
+          "rho" : 1.0,
+          "alpha" : 8.12
+        }, {
+          "r" : -24.73129,
+          "x" : -24.731287,
+          "rho" : 1.0,
+          "alpha" : 10.82
+        }, {
+          "r" : -22.043127,
+          "x" : -22.043129,
+          "rho" : 1.0,
+          "alpha" : 13.52
+        }, {
+          "r" : -19.354952,
+          "x" : -19.354952,
+          "rho" : 1.0,
+          "alpha" : 16.22
+        }, {
+          "r" : -15.994745,
+          "x" : -15.994745,
+          "rho" : 1.0,
+          "alpha" : 18.9
+        }, {
+          "r" : -11.962485,
+          "x" : -11.962484,
+          "rho" : 1.0,
+          "alpha" : 21.58
+        }, {
+          "r" : -7.258195,
+          "x" : -7.2581954,
+          "rho" : 1.0,
+          "alpha" : 24.26
+        }, {
+          "r" : -1.8818557,
+          "x" : -1.8818527,
+          "rho" : 1.0,
+          "alpha" : 26.94
+        }, {
+          "r" : 3.4944773,
+          "x" : 3.4944773,
+          "rho" : 1.0,
+          "alpha" : 29.6
+        }, {
+          "r" : 9.542847,
+          "x" : 9.542842,
+          "rho" : 1.0,
+          "alpha" : 32.26
+        }, {
+          "r" : 16.263271,
+          "x" : 16.263268,
+          "rho" : 1.0,
+          "alpha" : 34.9
+        }, {
+          "r" : 23.655737,
+          "x" : 23.655735,
+          "rho" : 1.0,
+          "alpha" : 37.54
+        }, {
+          "r" : 31.720245,
+          "x" : 31.720242,
+          "rho" : 1.0,
+          "alpha" : 40.18
+        }, {
+          "r" : 39.78473,
+          "x" : 39.784725,
+          "rho" : 1.0,
+          "alpha" : 42.8
+        } ]
+      },
+      "operationalLimitsGroups1" : [ {
+        "id" : "DEFAULT",
+        "currentLimits" : {
+          "permanentLimit" : 931.0
+        }
+      } ],
+      "operationalLimitsGroups2" : [ {
+        "id" : "DEFAULT",
+        "currentLimits" : {
+          "permanentLimit" : 931.0
+        }
+      } ]
+    } ]
+  } ],
+  "lines" : [ {
+    "id" : "CJ",
+    "r" : 0.009999999,
+    "x" : 0.100000024,
+    "voltageLevelId1" : "C",
+    "node1" : 4,
+    "voltageLevelId2" : "N",
+    "node2" : 5,
+    "selectedOperationalLimitsGroupIds1" : [ "DEFAULT" ],
+    "selectedOperationalLimitsGroupIds2" : [ "DEFAULT" ],
+    "operationalLimitsGroups1" : [ {
+      "id" : "DEFAULT",
+      "currentLimits" : {
+        "permanentLimit" : 931.0
+      }
+    } ],
+    "operationalLimitsGroups2" : [ {
+      "id" : "DEFAULT",
+      "currentLimits" : {
+        "permanentLimit" : 931.0,
+        "temporaryLimits" : [ {
+          "name" : "IST",
+          "value" : 1640.0,
+          "fictitious" : true
+        }, {
+          "name" : "IT1",
+          "acceptableDuration" : 60
+        } ]
+      }
+    } ]
+  } ]
+}

--- a/tests/data/xiidm/powsybl/V1_17/fictitiousSwitchRef.xml
+++ b/tests/data/xiidm/powsybl/V1_17/fictitiousSwitchRef.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="fictitious"
+              caseDate="2017-06-25T17:43:00.000+01:00" forecastDistance="0" sourceFormat="test"
+              minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="A" country="FR">
+        <iidm:voltageLevel id="C" nominalV="225.0" lowVoltageLimit="0.0" topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="D" name="E" node="0"/>
+                <iidm:switch id="F" name="G" kind="DISCONNECTOR" open="false" fictitious="true"
+                             node1="0" node2="1"/>
+                <iidm:switch id="H" name="I" kind="DISCONNECTOR" open="false" fictitious="true"
+                             node1="0" node2="3"/>
+                <iidm:switch id="J" name="K" kind="BREAKER" retained="true" open="false" fictitious="true" node1="1"
+                             node2="2"/>
+                <iidm:switch id="L" name="M" kind="BREAKER" retained="true" open="false" fictitious="true" node1="3"
+                             node2="4"/>
+                <iidm:bus v="234.40912" angle="0.0" nodes="0,1,2,3,4"/>
+            </iidm:nodeBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="N" nominalV="225.0" lowVoltageLimit="220.0" highVoltageLimit="245.00002"
+                           topologyKind="NODE_BREAKER">
+            <iidm:nodeBreakerTopology>
+                <iidm:busbarSection id="O" name="E" node="0"/>
+                <iidm:busbarSection id="P" name="Q" node="1"/>
+                <iidm:switch id="R" name="S" kind="DISCONNECTOR" open="true" node1="0" node2="19"/>
+                <iidm:switch id="T" name="U" kind="DISCONNECTOR" open="true" node1="0" node2="17"/>
+                <iidm:switch id="V" name="W" kind="DISCONNECTOR" open="true" node1="0" node2="21"/>
+                <iidm:switch id="X" name="Y" kind="DISCONNECTOR" open="true" node1="0" node2="11"/>
+                <iidm:switch id="Z" name="AA" kind="DISCONNECTOR" open="true" node1="0" node2="13"/>
+                <iidm:switch id="AB" name="AC" kind="DISCONNECTOR" open="false" node1="0" node2="15"/>
+                <iidm:switch id="AD" name="AE" kind="DISCONNECTOR" open="true" node1="0" node2="8"/>
+                <iidm:switch id="AF" name="AG" kind="DISCONNECTOR" open="true" fictitious="true"
+                             node1="0" node2="2"/>
+                <iidm:switch id="AH" name="AI" kind="DISCONNECTOR" open="false" node1="7" node2="0"/>
+                <iidm:switch id="AJ" name="AK" kind="DISCONNECTOR" open="false" node1="1" node2="6"/>
+                <iidm:switch id="AL" name="AM" kind="DISCONNECTOR" open="false" node1="1" node2="19"/>
+                <iidm:switch id="AN" name="AO" kind="DISCONNECTOR" open="false" node1="1" node2="17"/>
+                <iidm:switch id="AP" name="AQ" kind="DISCONNECTOR" open="false" node1="1" node2="21"/>
+                <iidm:switch id="AR" name="AS" kind="DISCONNECTOR" open="true" node1="1" node2="11"/>
+                <iidm:switch id="AT" name="AU" kind="DISCONNECTOR" open="true" node1="1" node2="13"/>
+                <iidm:switch id="AV" name="AW" kind="DISCONNECTOR" open="true" node1="1" node2="15"/>
+                <iidm:switch id="AX" name="AY" kind="DISCONNECTOR" open="false" node1="1" node2="8"/>
+                <iidm:switch id="AZ" name="BA" kind="DISCONNECTOR" open="true" fictitious="true"
+                             node1="1" node2="2"/>
+                <iidm:switch id="BB" name="BC" kind="BREAKER" retained="true" open="true" fictitious="true" node1="2"
+                             node2="3"/>
+                <iidm:switch id="BD" name="BE" kind="BREAKER" retained="true" open="false" node1="3" node2="4"/>
+                <iidm:switch id="BF" name="BG" kind="DISCONNECTOR" open="false" node1="3" node2="5"/>
+                <iidm:switch id="BH" name="BI" kind="DISCONNECTOR" open="true" node1="9" node2="3"/>
+                <iidm:switch id="BJ" name="BK" kind="BREAKER" retained="true" open="false" node1="6" node2="7"/>
+                <iidm:switch id="BL" name="BM" kind="BREAKER" retained="true" open="false" node1="8" node2="9"/>
+                <iidm:switch id="BN" name="BO" kind="DISCONNECTOR" open="false" node1="9" node2="10"/>
+                <iidm:switch id="BP" name="BQ" kind="BREAKER" retained="true" open="true" node1="11" node2="12"/>
+                <iidm:switch id="BR" name="BS" kind="BREAKER" retained="true" open="true" node1="13" node2="14"/>
+                <iidm:switch id="BT" name="BU" kind="BREAKER" retained="true" open="false" node1="15" node2="16"/>
+                <iidm:switch id="BV" name="BW" kind="BREAKER" retained="true" open="false" node1="17" node2="18"/>
+                <iidm:switch id="BX" name="BY" kind="BREAKER" retained="true" open="false" node1="19" node2="20"/>
+                <iidm:switch id="BZ" name="CA" kind="BREAKER" retained="true" open="false" node1="21" node2="22"/>
+                <iidm:bus v="236.44736" angle="15.250391" nodes="0,1,6,7,8,9,10,15,16,17,18,19,20,21,22"/>
+            </iidm:nodeBreakerTopology>
+            <iidm:generator id="CB" energySource="HYDRO" minP="0.0" maxP="70.0" voltageRegulatorOn="false" targetP="0.0"
+                            targetV="0.0" targetQ="0.0" node="12">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-59.3" maxQ="60.0"/>
+                    <iidm:point p="70.0" minQ="-54.55" maxQ="46.25"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CC" energySource="HYDRO" minP="0.0" maxP="80.0" voltageRegulatorOn="false" targetP="0.0"
+                            targetV="0.0" targetQ="0.0" node="14">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-56.8" maxQ="57.4"/>
+                    <iidm:point p="80.0" minQ="-53.514" maxQ="36.4"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:generator id="CD" energySource="HYDRO" minP="0.0" maxP="35.0" voltageRegulatorOn="true"
+                            targetP="21.789589" targetV="236.44736" targetQ="-20.701546" node="16" p="-21.789589"
+                            q="20.693394">
+                <iidm:reactiveCapabilityCurve>
+                    <iidm:point p="0.0" minQ="-20.6" maxQ="18.1"/>
+                    <iidm:point p="35.0" minQ="-21.725" maxQ="6.3500004"/>
+                </iidm:reactiveCapabilityCurve>
+            </iidm:generator>
+            <iidm:load id="CE" loadType="UNDEFINED" p0="-72.18689" q0="50.168945" node="4" p="-72.18689" q="50.168945"/>
+            <iidm:load id="CF" loadType="UNDEFINED" p0="8.455854" q0="-23.695925" node="18" p="8.455854"
+                       q="-23.695925"/>
+            <iidm:load id="CG" loadType="UNDEFINED" p0="90.39911" q0="-51.96869" node="20" p="90.39911" q="-51.96869"/>
+            <iidm:load id="CH" loadType="UNDEFINED" p0="-5.102249" q0="4.9081216" node="22" p="-5.102249"
+                       q="4.9081216"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="CI" r="2.0" x="14.745" b="3.2E-5" ratedU1="225.0" ratedU2="225.0"
+                                     node1="2" voltageLevelId1="C" node2="10" voltageLevelId2="N"
+                                     selectedOperationalLimitsGroupIds1="DEFAULT" selectedOperationalLimitsGroupIds2="DEFAULT">
+            <iidm:phaseTapChanger tapPosition="22" loadTapChangingCapabilities="true" regulationMode="CURRENT_LIMITER"
+                                  regulationValue="930.6667" regulating="false">
+                <iidm:terminalRef id="CI" side="ONE"/>
+                <iidm:step r="39.78473" x="39.784725" rho="1.0" alpha="-42.8"/>
+                <iidm:step r="31.720245" x="31.720242" rho="1.0" alpha="-40.18"/>
+                <iidm:step r="23.655737" x="23.655735" rho="1.0" alpha="-37.54"/>
+                <iidm:step r="16.263271" x="16.263268" rho="1.0" alpha="-34.9"/>
+                <iidm:step r="9.542847" x="9.542842" rho="1.0" alpha="-32.26"/>
+                <iidm:step r="3.4944773" x="3.4944773" rho="1.0" alpha="-29.6"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" rho="1.0" alpha="-26.94"/>
+                <iidm:step r="-7.258195" x="-7.2581954" rho="1.0" alpha="-24.26"/>
+                <iidm:step r="-11.962485" x="-11.962484" rho="1.0" alpha="-21.58"/>
+                <iidm:step r="-15.994745" x="-15.994745" rho="1.0" alpha="-18.9"/>
+                <iidm:step r="-19.354952" x="-19.354952" rho="1.0" alpha="-16.22"/>
+                <iidm:step r="-22.043127" x="-22.043129" rho="1.0" alpha="-13.52"/>
+                <iidm:step r="-24.73129" x="-24.731287" rho="1.0" alpha="-10.82"/>
+                <iidm:step r="-26.747417" x="-26.747417" rho="1.0" alpha="-8.12"/>
+                <iidm:step r="-28.091503" x="-28.091503" rho="1.0" alpha="-5.42"/>
+                <iidm:step r="-28.763538" x="-28.763536" rho="1.0" alpha="-2.7"/>
+                <iidm:step r="-28.763538" x="-28.763536" rho="1.0" alpha="0.0"/>
+                <iidm:step r="-28.763538" x="-28.763536" rho="1.0" alpha="2.7"/>
+                <iidm:step r="-28.091503" x="-28.091503" rho="1.0" alpha="5.42"/>
+                <iidm:step r="-26.747417" x="-26.747417" rho="1.0" alpha="8.12"/>
+                <iidm:step r="-24.73129" x="-24.731287" rho="1.0" alpha="10.82"/>
+                <iidm:step r="-22.043127" x="-22.043129" rho="1.0" alpha="13.52"/>
+                <iidm:step r="-19.354952" x="-19.354952" rho="1.0" alpha="16.22"/>
+                <iidm:step r="-15.994745" x="-15.994745" rho="1.0" alpha="18.9"/>
+                <iidm:step r="-11.962485" x="-11.962484" rho="1.0" alpha="21.58"/>
+                <iidm:step r="-7.258195" x="-7.2581954" rho="1.0" alpha="24.26"/>
+                <iidm:step r="-1.8818557" x="-1.8818527" rho="1.0" alpha="26.94"/>
+                <iidm:step r="3.4944773" x="3.4944773" rho="1.0" alpha="29.6"/>
+                <iidm:step r="9.542847" x="9.542842" rho="1.0" alpha="32.26"/>
+                <iidm:step r="16.263271" x="16.263268" rho="1.0" alpha="34.9"/>
+                <iidm:step r="23.655737" x="23.655735" rho="1.0" alpha="37.54"/>
+                <iidm:step r="31.720245" x="31.720242" rho="1.0" alpha="40.18"/>
+                <iidm:step r="39.78473" x="39.784725" rho="1.0" alpha="42.8"/>
+            </iidm:phaseTapChanger>
+            <iidm:operationalLimitsGroup1 id="DEFAULT">
+                <iidm:currentLimits permanentLimit="931.0"/>
+            </iidm:operationalLimitsGroup1>
+            <iidm:operationalLimitsGroup2 id="DEFAULT">
+                <iidm:currentLimits permanentLimit="931.0"/>
+            </iidm:operationalLimitsGroup2>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="CJ" r="0.009999999" x="0.100000024" node1="4" voltageLevelId1="C"
+               node2="5" voltageLevelId2="N" selectedOperationalLimitsGroupIds1="DEFAULT" selectedOperationalLimitsGroupIds2="DEFAULT">
+        <iidm:operationalLimitsGroup1 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0"/>
+        </iidm:operationalLimitsGroup1>
+        <iidm:operationalLimitsGroup2 id="DEFAULT">
+            <iidm:currentLimits permanentLimit="931.0">
+                <iidm:temporaryLimit name="IST" value="1640.0" fictitious="true"/>
+                <iidm:temporaryLimit name="IT1" acceptableDuration="60"/>
+            </iidm:currentLimits>
+        </iidm:operationalLimitsGroup2>
+    </iidm:line>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_2/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_2/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_2" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_3/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_3/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_3" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_4/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_4/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_4" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_5/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_5/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_6/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_6/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_6" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_7/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_7/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_7" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_8/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_8/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_8" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>

--- a/tests/data/xiidm/powsybl/V1_9/eurostag-tutorial1-lf.xml
+++ b/tests/data/xiidm/powsybl/V1_9/eurostag-tutorial1-lf.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+</iidm:network>


### PR DESCRIPTION
## Summary

- read XIIDM and JIIDM 1.0 through 1.17 with revision-specific namespaces and fields
- write JIIDM 1.17 through the shared IIDM element mapping
- check supported revisions with PowSybl cases and the pinned interoperability gate


## Testing

- cargo test -p powerio-tx -p powerio -p powerio-cli
- RUSTUP_TOOLCHAIN=1.98.0 cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- Python format-list test
- mdbook build docs
- PowSybl gate: 54,147 assertions

Closes #462
