### PR TITLE
Calculate CGMES topology when TP is absent

### DIFF
--- a/.github/workflows/powsybl.yml
+++ b/.github/workflows/powsybl.yml
@@ -46,6 +46,13 @@ jobs:
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/CGMES_v2.4.15_MiniGridTestConfiguration_Boundary_v3
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_BaseCase_Complete_v3.0.0
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0
+          cgmes/cgmes-conformity/src/main/resources/cgmes3-test-models/MicroGrid
+          iidm/iidm-serde/src/test/resources/V1_12/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources/V1_13/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources/V1_14/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources/V1_15/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources/V1_16/threeWindingsTransformerToBeEstimated.xiidm
+          iidm/iidm-serde/src/test/resources/V1_17/threeWindingsTransformerToBeEstimated.xiidm
           psse/psse-converter/src/test/resources/remoteControl.xiidm
           psse/psse-converter/src/test/resources/twoTerminalDc.xiidm
           psse/psse-converter/src/test/resources/five_bus_nodeBreaker_rev35.xiidm

--- a/.github/workflows/powsybl.yml
+++ b/.github/workflows/powsybl.yml
@@ -42,6 +42,10 @@ jobs:
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-2/MicroGrid/Type2_T2/CGMES_v2.4.15_MicroGridTestConfiguration_T2_Assembled_Complete_v2
           cgmes/cgmes-conformity/src/main/resources/conformity/cas-3-data-3.0.2/MicroGrid/BaseCase/MicroGrid-BaseCase-Merged
           iidm/iidm-serde/src/test/resources
+          cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/CGMES_v2.4.15_MiniGridTestConfiguration_BaseCase_Complete_v3
+          cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/CGMES_v2.4.15_MiniGridTestConfiguration_Boundary_v3
+          cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_BaseCase_Complete_v3.0.0
+          cgmes/cgmes-conformity/src/main/resources/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0
           psse/psse-converter/src/test/resources/remoteControl.xiidm
           psse/psse-converter/src/test/resources/twoTerminalDc.xiidm
           psse/psse-converter/src/test/resources/five_bus_nodeBreaker_rev35.xiidm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,22 @@ XIIDM output stays 1.17. The XIIDM element mapping now reads one tree
 representation produced by either the XML or JSON reader. In the PowSybl
 gate, PyPowSybl reads PowerIO's JIIDM output and PowerIO reads PyPowSybl's.
 
+CGMES sets without `TopologicalNode` data now read when their declared
+profiles describe node breaker equipment (CGMES 2.4.15 EquipmentOperation,
+or CGMES 3.0 CoreEquipment with `ConnectivityNode` data), matching PowSybl.
+The reader calculates buses as connected components of the
+`ConnectivityNode` graph joined by closed, in-service switches. SSH
+`Switch.open` takes precedence over EQ `Switch.normalOpen`. Each calculated
+bus takes the name of a busbar section on it and a UUIDv5 identity derived
+from the joined `ConnectivityNode` mRIDs, without inventing a source
+`TopologicalNode` mRID. `READ.CGMES.TOPOLOGY_CALCULATED` reports the
+calculation, and `READ.CGMES.CONNECTIVITY_INSUFFICIENT` names missing data
+when a set has neither `TopologicalNode` data nor calculable connectivity.
+Bay containers resolve to their voltage level, and a `TopologicalNode` whose
+container holds none of its `ConnectivityNode` data follows those nodes. The
+PowSybl gate compares calculated bus assignments for the MiniGrid, SmallGrid,
+and CGMES 3.0 MicroGrid node breaker sets with PyPowSybl.
+
 ## 0.10.0
 
 PowerIO 0.10 is the public beta of the 1.0 API. API corrections may land before 1.0.0 as downstream integrations exercise the new design.

--- a/docs/src/format-fidelity.md
+++ b/docs/src/format-fidelity.md
@@ -143,10 +143,55 @@ parse warning that hides the cause.
   `http://iec.ch/TC57/CIM100-European#` (IEC 61970-600-1/-2:2021). Both use
   the IEC 61970-552 CIMXML instance syntax: `rdf:ID` defines a record,
   `rdf:about` extends one, and `md:FullModel` heads each profile document.
-  EQ and TP are required;
+  EQ is required;
   SSH, SV, and boundary profile data are used when present. SSH assignments
   take precedence over SV observations; an SV shunt section count that differs
-  from the SSH assignment is reported and not retained. Each document's
+  from the SSH assignment is reported and not retained. A set with
+  TopologicalNode data reads one bus per `TopologicalNode`, and that data
+  wins even for node breaker equipment, so source TopologicalNode identities
+  survive. A set without TopologicalNode data reads when its declared profile
+  URIs describe node breaker equipment, the selection PowSybl makes in
+  [`CgmesModelTripleStore.computeIsNodeBreaker`](https://github.com/powsybl/powsybl-core/blob/0939bfcc2c0c094de907dc818dd688b4cbfb7281/cgmes/cgmes-model/src/main/java/com/powsybl/cgmes/model/triplestore/CgmesModelTripleStore.java#L168-L184): every CGMES 2.4.15 document
+  that declares EquipmentCore also declares EquipmentOperation (and every
+  EquipmentBoundary document declares EquipmentBoundaryOperation), or the EQ
+  is CGMES 3.0 CoreEquipment with ConnectivityNode records. The buses are
+  then the connected components of the ConnectivityNode graph joined by
+  switches that are closed and in service, the graph PowSybl's
+  [`NodeMapping`](https://github.com/powsybl/powsybl-core/blob/0939bfcc2c0c094de907dc818dd688b4cbfb7281/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/NodeMapping.java)
+  and [`SwitchConversion`](https://github.com/powsybl/powsybl-core/blob/0939bfcc2c0c094de907dc818dd688b4cbfb7281/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/elements/SwitchConversion.java)
+  hand to IIDM. A switch is open when SSH
+  `Switch.open` says so, else when EQ `Switch.normalOpen` says so, else
+  closed; SV `SvStatus.inService`, else SSH `Equipment.inService`, decides
+  service status, which CGMES defines as availability for topology
+  processing (PowSybl 7.3 reads only the switch position; the official sets
+  contain no closed switch out of service, so both rules agree there). A
+  terminal is connected unless SSH `ACDCTerminal.connected` is false; a
+  disconnected terminal leaves its equipment on the bus of its
+  ConnectivityNode with the equipment out of service, where PowSybl inserts
+  a fictitious open switch. Each bus takes the nominal voltage of its nodes'
+  VoltageLevel (a Bay resolves to its VoltageLevel); a node in a Line
+  container takes the base voltage of attached conducting equipment or
+  transformer ends, and a node no terminal references gets no bus. A bus is
+  named after a BusbarSection on it, else its first ConnectivityNode, and
+  its identity is the UUIDv5 under PowerIO's CGMES namespace of the sorted
+  ConnectivityNode mRIDs it joins, so the same nodes always yield the same
+  mRID and no source TopologicalNode mRID is invented; the `bus_breaker_buses`
+  table stays empty and `calculated_buses` lists the nodes of each bus.
+  `READ.CGMES.TOPOLOGY_CALCULATED` (a remark) states the bus, node, and
+  switch counts and the identity rule; `READ.CGMES.CONNECTIVITY_INSUFFICIENT`
+  (an error) names the missing data when a set has neither TopologicalNode
+  records nor calculable connectivity, such as a bus branch EQ without TP.
+  Limits of the calculated topology: SvVoltage observations reference
+  TopologicalNodes, so bus voltages keep their defaults and
+  `READ.CGMES.RECORD_UNMAPPED` counts the observations; no TopologicalIsland
+  names an angle reference, so the reference bus comes from
+  `referencePriority`, an external injection, or the largest machine; a
+  closed switch between two voltage levels joins its nodes into one bus
+  placed in the first node's level, as PowSybl merges those levels; a 2.4.15
+  junction terminal in EQ_BD names no ConnectivityNode and is recorded as
+  disconnected without TP_BD; and PowSybl's bus view omits a component with
+  no busbar section and fewer than two feeders while PowerIO keeps every
+  component as a bus, so bus counts differ by those components. Each document's
   `Model.modelingAuthoritySet` is read for the boundary and state variable
   authority checks, reported, and not retained; fresh output states PowerIO's
   own modeling authority. A source can be an

--- a/evals/powsybl/README.md
+++ b/evals/powsybl/README.md
@@ -231,6 +231,36 @@ fresh SV profile. The CGMES 2.4.15 Type 2 set has an SV profile with power flow
 and voltage observations but no SvStatus records, so it has no source service
 flags to compare.
 
+Three node breaker sets from the pinned checkout check CGMES import without
+a TP profile: the CGMES 2.4.15 MiniGrid and SmallGrid node breaker base
+cases with their EQ_BD and TP_BD documents under
+`conformity/cas-1.1.3-data-4.0.3`, and the CGMES 3.0 MicroGrid under
+`cgmes3-test-models`. The gate stages each set twice, as shipped and without
+its TP and TP_BD documents, reads both with PowerIO, and emits fresh CGMES
+from the calculated topology. It requires exactly one
+`READ.CGMES.TOPOLOGY_CALCULATED` remark with the pinned bus, ConnectivityNode,
+closed switch, and open switch counts (13 buses from 103 nodes and 90 closed
+switches; 118 from 1225 and 1107; 16 from 42 with 25 closed and 1 open), an
+empty `bus_breaker_buses` table, one `calculated_buses` record per bus, a
+bus `uid` equal to the UUIDv5 under the PowerIO CGMES namespace of
+`calculated-bus:` followed by the sorted ConnectivityNode mRIDs of that
+record, and no bus identity equal to a ConnectivityNode mRID. It then keys
+every connected terminal of PowSybl's bus view by its CGMES terminal alias
+and requires the grouping of those terminals into buses to equal PowerIO's
+grouping through `terminals[].node` and `connectivity_nodes[].calculated_bus`:
+47 shared terminals in 11 buses, 617 in 115, and 49 in 11. The MiniGrid and
+SmallGrid calculated groupings also equal the ConnectivityNode grouping their
+shipped TP states. The CGMES 3.0 MicroGrid TP, dated later than its SSH,
+separates the ends of breaker `5f5d40ae-d52d-4631-9285-b3ceefff784c` that the
+SSH closes; PowSybl follows the SSH position and so does the calculated
+topology, so that grouping is pinned as differing from the shipped TP (18
+buses against 16). Finally PowSybl loads the fresh CGMES emitted from each
+calculated topology, must reach `STEADY_STATE_HYPOTHESIS`, and must group the
+shared terminals as the official set does (38, 557, and 49 shared terminals;
+12, 118, and 16 fresh bus view buses). PowSybl's bus view omits a component
+with no busbar section and fewer than two feeders, so its bus counts stay
+below PowerIO's.
+
 The two XIIDM inputs use exact source and fresh identity sets. The gate compares
 voltage levels, calculated buses, lines, two winding transformers, generators,
 loads, shunts, operational limits, and ratio tap changer rows and steps. The

--- a/evals/powsybl/check_outputs.py
+++ b/evals/powsybl/check_outputs.py
@@ -127,6 +127,67 @@ VSC_TARGET_Q = {
     "76eeb38f-a3ef-4444-9c65-6cb46a7a94da": -40.0,
 }
 
+# Node breaker sets read without their TP documents. Each entry pins the
+# calculated topology remark, the bus identity rule, the bus partition of the
+# terminals PowSybl's bus view shares with PowerIO, the TP partition of the
+# official set, and PowSybl's view of the fresh CGMES emitted from the
+# calculated topology.
+CGMES_NODE_BREAKER_CASES = {
+    "mini-grid-node-breaker": {
+        "label": "CGMES 2.4.15 MiniGrid node breaker",
+        "namespace": CIM16,
+        "calculated_buses": 13,
+        "connectivity_nodes": 103,
+        "closed_switches": 90,
+        "open_switches": 0,
+        "unreferenced_nodes": 0,
+        "unmapped_sv_voltages": 13,
+        "shared_terminals": 47,
+        "shared_buses": 11,
+        "topological_node_buses": 13,
+        "topological_node_partition_matches": True,
+        "fresh_buses": 12,
+        "fresh_shared_terminals": 38,
+    },
+    "small-grid-node-breaker": {
+        "label": "CGMES 2.4.15 SmallGrid node breaker",
+        "namespace": CIM16,
+        "calculated_buses": 118,
+        "connectivity_nodes": 1225,
+        "closed_switches": 1107,
+        "open_switches": 0,
+        "unreferenced_nodes": 0,
+        "unmapped_sv_voltages": 118,
+        "shared_terminals": 617,
+        "shared_buses": 115,
+        "topological_node_buses": 118,
+        "topological_node_partition_matches": True,
+        "fresh_buses": 118,
+        "fresh_shared_terminals": 557,
+    },
+    # The shipped TP of this set (dated 2323Z) separates the ends of closed
+    # breaker B1 `5f5d40ae-d52d-4631-9285-b3ceefff784c` that its SSH (dated
+    # 1930Z) closes. PowSybl's node breaker import follows the SSH switch
+    # positions, and so does PowerIO's calculated topology; the TP partition
+    # therefore has two more buses than the calculated one.
+    "micro-grid-cgmes3": {
+        "label": "CGMES 3.0 MicroGrid node breaker",
+        "namespace": CIM100,
+        "calculated_buses": 16,
+        "connectivity_nodes": 42,
+        "closed_switches": 25,
+        "open_switches": 1,
+        "unreferenced_nodes": 1,
+        "unmapped_sv_voltages": 17,
+        "shared_terminals": 49,
+        "shared_buses": 11,
+        "topological_node_buses": 18,
+        "topological_node_partition_matches": False,
+        "fresh_buses": 16,
+        "fresh_shared_terminals": 49,
+    },
+}
+
 CGMES_30_SOURCE_COUNTS = {
     "buses": 10,
     "lines": 3,
@@ -1253,6 +1314,255 @@ def check_cgmes_projection(
         f"{label}: a source load mRID is missing from fresh output",
     )
     print(f"{label}: source counts={source_counts}; fresh projection counts={fresh_counts}")
+
+
+def component_local_id(component: Any) -> str:
+    return str(component["local_id"]) if isinstance(component, dict) else str(component)
+
+
+def ir_terminal_buses(stored: dict[str, Any]) -> dict[str, int]:
+    """Terminal mRID -> calculated bus for every PowerIO IR terminal whose
+    ConnectivityNode maps to a bus."""
+    detailed = stored["value"]["data"]["detailed_connectivity"]
+    bus_of_node = {
+        component_local_id(node["component"]): node.get("calculated_bus")
+        for node in detailed["connectivity_nodes"]
+    }
+    assignments: dict[str, int] = {}
+    for terminal in detailed["terminals"]:
+        node = terminal.get("node")
+        component = terminal.get("component")
+        if node is None or component is None:
+            continue
+        bus = bus_of_node.get(component_local_id(node))
+        if bus is not None:
+            assignments[component_local_id(component)] = int(bus)
+    return assignments
+
+
+def ir_node_partition(stored: dict[str, Any]) -> set[frozenset[str]]:
+    """The ConnectivityNode identities grouped by calculated bus."""
+    groups: dict[int, set[str]] = {}
+    for node in stored["value"]["data"]["detailed_connectivity"]["connectivity_nodes"]:
+        bus = node.get("calculated_bus")
+        if bus is not None:
+            groups.setdefault(int(bus), set()).add(component_local_id(node["component"]))
+    return {frozenset(nodes) for nodes in groups.values()}
+
+
+def powsybl_terminal_buses(network: pp.network.Network, label: str) -> dict[str, str]:
+    """Terminal mRID -> bus view bus for every connected terminal of the
+    equipment PowSybl's CGMES import aliases with its CGMES terminal."""
+    terminal_of_side: dict[tuple[str, int], str] = {}
+    for element_id, row in network.get_aliases().iterrows():
+        alias_type = str(row["alias_type"])
+        prefix = "CGMES.Terminal"
+        if alias_type.startswith(prefix) and alias_type[len(prefix):] in ("", "1", "2", "3"):
+            side = int(alias_type[len(prefix):] or "1")
+            terminal_of_side[(str(element_id), side)] = str(row["alias"])
+    frames = (
+        (network.get_lines(), 2),
+        (network.get_2_windings_transformers(), 2),
+        (network.get_3_windings_transformers(), 3),
+        (network.get_generators(), 1),
+        (network.get_loads(), 1),
+        (network.get_shunt_compensators(), 1),
+        (network.get_static_var_compensators(), 1),
+        (network.get_busbar_sections(), 1),
+    )
+    assignments: dict[str, str] = {}
+    for frame, sides in frames:
+        for element_id, row in frame.iterrows():
+            for side in range(1, sides + 1):
+                suffix = "" if sides == 1 else str(side)
+                if not bool(row[f"connected{suffix}"]):
+                    continue
+                bus = row[f"bus{suffix}_id"]
+                if not isinstance(bus, str) or bus == "":
+                    continue
+                mrid = terminal_of_side.get((str(element_id), side))
+                require(
+                    mrid is not None,
+                    f"{label}: {element_id} side {side} has no CGMES terminal alias",
+                )
+                assignments[str(mrid)] = bus
+    return assignments
+
+
+def bus_partition(
+    assignments: dict[str, Any],
+    terminals: set[str],
+) -> set[frozenset[str]]:
+    groups: dict[Any, set[str]] = {}
+    for terminal in terminals:
+        groups.setdefault(assignments[terminal], set()).add(terminal)
+    return {frozenset(members) for members in groups.values()}
+
+
+def check_cgmes_calculated_topology(
+    case: dict[str, Any],
+    official_path: Path,
+    official_ir_path: Path,
+    calculated_ir_path: Path,
+    fresh_path: Path,
+) -> None:
+    label = str(case["label"])
+    require_cim_namespace(official_path, str(case["namespace"]), f"official {label}")
+    official = load_checked(official_path, f"official {label}")
+    calculated_ir = json.loads(calculated_ir_path.read_text(encoding="utf-8"))
+    official_ir = json.loads(official_ir_path.read_text(encoding="utf-8"))
+
+    remarks = [
+        diagnostic["message"]
+        for diagnostic in calculated_ir["diagnostics"]
+        if diagnostic["code"] == "READ.CGMES.TOPOLOGY_CALCULATED"
+    ]
+    require(len(remarks) == 1, f"{label}: expected one topology calculation remark")
+    expected_prefix = (
+        f"no TopologicalNode data: {case['calculated_buses']} calculated bus(es) joined "
+        f"{case['connectivity_nodes']} ConnectivityNode(s) through "
+        f"{case['closed_switches']} closed switch(es); "
+        f"{case['open_switches']} open switch(es) separate nodes"
+    )
+    require(
+        remarks[0].startswith(expected_prefix),
+        f"{label}: unexpected calculation remark: {remarks[0]}",
+    )
+    require(
+        "more than one connectivity container" not in remarks[0],
+        f"{label}: a calculated bus spans connectivity containers",
+    )
+    unreferenced = int(case["unreferenced_nodes"])
+    require(
+        (f"{unreferenced} ConnectivityNode(s) outside any VoltageLevel" in remarks[0])
+        == (unreferenced > 0),
+        f"{label}: unexpected unreferenced node count in remark: {remarks[0]}",
+    )
+    require(
+        remarks[0].endswith(
+            "bus identities are UUIDv5 values derived from the joined ConnectivityNode "
+            "mRIDs, not source TopologicalNode mRIDs"
+        ),
+        f"{label}: the remark does not state the identity rule",
+    )
+    require(
+        not any(
+            diagnostic["code"] == "READ.CGMES.CONNECTIVITY_INSUFFICIENT"
+            for diagnostic in calculated_ir["diagnostics"]
+        ),
+        f"{label}: the calculated set was reported as insufficient",
+    )
+    unmapped_prefix = (
+        f"{case['unmapped_sv_voltages']} SvVoltage record(s) observe TopologicalNode identities"
+    )
+    require(
+        any(
+            diagnostic["code"] == "READ.CGMES.RECORD_UNMAPPED"
+            and diagnostic["message"].startswith(unmapped_prefix)
+            for diagnostic in calculated_ir["diagnostics"]
+        ),
+        f"{label}: unmapped SvVoltage count changed",
+    )
+
+    data = calculated_ir["value"]["data"]
+    detailed = data["detailed_connectivity"]
+    require(
+        not detailed["bus_breaker_buses"],
+        f"{label}: the calculated topology claims source TopologicalNode records",
+    )
+    require(
+        len(data["buses"]) == int(case["calculated_buses"])
+        and len(detailed["calculated_buses"]) == len(data["buses"]),
+        f"{label}: {len(data['buses'])} buses and {len(detailed['calculated_buses'])} calculated bus records",
+    )
+    node_ids = {
+        component_local_id(node["component"]) for node in detailed["connectivity_nodes"]
+    }
+    nodes_of_bus = {
+        int(record["calculated_bus"]): sorted(
+            component_local_id(node) for node in record["nodes"]
+        )
+        for record in detailed["calculated_buses"]
+    }
+    for bus in data["buses"]:
+        expected_uid = str(
+            uuid.uuid5(
+                CGMES_UUID_NAMESPACE,
+                "calculated-bus:" + ",".join(nodes_of_bus[int(bus["id"])]),
+            )
+        )
+        require(
+            bus["uid"] == expected_uid,
+            f"{label}: bus {bus['id']} identity {bus['uid']} is not derived from its nodes",
+        )
+        require(
+            bus["uid"] not in node_ids,
+            f"{label}: bus {bus['id']} reuses a ConnectivityNode identity",
+        )
+
+    calculated_assignments = ir_terminal_buses(calculated_ir)
+    official_assignments = powsybl_terminal_buses(official, f"official {label}")
+    require(
+        set(official_assignments) <= set(calculated_assignments),
+        f"{label}: PowSybl bus view terminals are missing from the calculated topology: "
+        f"{sorted(set(official_assignments) - set(calculated_assignments))[:5]}",
+    )
+    shared = set(official_assignments) & set(calculated_assignments)
+    require(
+        len(shared) == int(case["shared_terminals"]),
+        f"{label}: {len(shared)} shared terminals, expected {case['shared_terminals']}",
+    )
+    calculated_partition = bus_partition(calculated_assignments, shared)
+    official_partition = bus_partition(official_assignments, shared)
+    require(
+        calculated_partition == official_partition,
+        f"{label}: terminal to bus assignment differs from PowSybl; PowerIO only "
+        f"{[sorted(group) for group in calculated_partition - official_partition][:3]}, "
+        f"PowSybl only {[sorted(group) for group in official_partition - calculated_partition][:3]}",
+    )
+    require(
+        len(calculated_partition) == int(case["shared_buses"]),
+        f"{label}: {len(calculated_partition)} shared buses, expected {case['shared_buses']}",
+    )
+
+    topological_partition = ir_node_partition(official_ir)
+    node_partition = ir_node_partition(calculated_ir)
+    require(
+        len(topological_partition) == int(case["topological_node_buses"]),
+        f"{label}: {len(topological_partition)} TopologicalNode buses in the official set",
+    )
+    if bool(case["topological_node_partition_matches"]):
+        require(
+            topological_partition == node_partition,
+            f"{label}: calculated buses differ from the official TopologicalNode grouping",
+        )
+    else:
+        require(
+            topological_partition != node_partition,
+            f"{label}: the official TopologicalNode grouping unexpectedly matches",
+        )
+
+    fresh = load_checked(fresh_path, f"fresh {label}")
+    fresh_assignments = powsybl_terminal_buses(fresh, f"fresh {label}")
+    fresh_shared = set(fresh_assignments) & set(official_assignments)
+    require(
+        len(fresh_shared) == int(case["fresh_shared_terminals"]),
+        f"{label}: {len(fresh_shared)} fresh shared terminals, expected {case['fresh_shared_terminals']}",
+    )
+    require(
+        bus_partition(fresh_assignments, fresh_shared)
+        == bus_partition(official_assignments, fresh_shared),
+        f"{label}: fresh CGMES bus assignment differs from PowSybl's official view",
+    )
+    require(
+        len(fresh.get_buses()) == int(case["fresh_buses"]),
+        f"{label}: PowSybl sees {len(fresh.get_buses())} fresh buses, expected {case['fresh_buses']}",
+    )
+    print(
+        f"{label}: calculated buses={case['calculated_buses']}, shared terminals={len(shared)}, "
+        f"shared buses={len(calculated_partition)}, PowSybl bus view={len(official.get_buses())}, "
+        f"fresh bus view={len(fresh.get_buses())}"
+    )
 
 
 def same_missing_value(source_value: Any, fresh_value: Any) -> bool:
@@ -4678,6 +4988,16 @@ def main() -> None:
             output_dir / f"powsybl-cgmes-{version}.emit.log",
             CIM16 if version == "2415" else CIM100,
             f"PowSybl CGMES {version}",
+        )
+
+    node_breaker_dir = output_dir / "node-breaker"
+    for stem, case in CGMES_NODE_BREAKER_CASES.items():
+        check_cgmes_calculated_topology(
+            case,
+            node_breaker_dir / f"{stem}-official",
+            node_breaker_dir / f"{stem}-official.pio.json",
+            node_breaker_dir / f"{stem}-calculated.pio.json",
+            node_breaker_dir / f"{stem}-calculated-fresh",
         )
 
     for version, (relative_path, expected_sha256) in XIIDM_VERSION_FIXTURES.items():

--- a/evals/powsybl/run.sh
+++ b/evals/powsybl/run.sh
@@ -25,6 +25,12 @@ two_substations_source="$powsybl_core/psse/psse-converter/src/test/resources/two
 node_breaker_source="$powsybl_core/psse/psse-model-test/src/main/resources/five_bus_nodeBreaker_rev35.raw"
 node_breaker_xiidm_source="$powsybl_core/psse/psse-converter/src/test/resources/five_bus_nodeBreaker_rev35.xiidm"
 xiidm_serde_root="$powsybl_core/iidm/iidm-serde/src/test/resources"
+cgmes_conformity_root="$powsybl_core/cgmes/cgmes-conformity/src/main/resources"
+mini_grid_node_breaker_source="$cgmes_conformity_root/conformity/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/CGMES_v2.4.15_MiniGridTestConfiguration_BaseCase_Complete_v3"
+mini_grid_node_breaker_bd_source="$cgmes_conformity_root/conformity/cas-1.1.3-data-4.0.3/MiniGrid/NodeBreaker/CGMES_v2.4.15_MiniGridTestConfiguration_Boundary_v3"
+small_grid_node_breaker_source="$cgmes_conformity_root/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_BaseCase_Complete_v3.0.0"
+small_grid_node_breaker_bd_source="$cgmes_conformity_root/conformity/cas-1.1.3-data-4.0.3/SmallGrid/NodeBreaker/CGMES_v2.4.15_SmallGridTestConfiguration_Boundary_v3.0.0"
+micro_grid_cgmes3_source="$cgmes_conformity_root/cgmes3-test-models/MicroGrid"
 
 for source in \
     "$cgmes_2415_source" \
@@ -36,7 +42,12 @@ for source in \
     "$ieee_30_bus_32_source" \
     "$two_substations_source" \
     "$node_breaker_source" \
-    "$node_breaker_xiidm_source"; do
+    "$node_breaker_xiidm_source" \
+    "$mini_grid_node_breaker_source" \
+    "$mini_grid_node_breaker_bd_source" \
+    "$small_grid_node_breaker_source" \
+    "$small_grid_node_breaker_bd_source" \
+    "$micro_grid_cgmes3_source"; do
     if [[ ! -e "$source" ]]; then
         echo "missing PowSybl reference case: $source" >&2
         exit 1
@@ -130,6 +141,52 @@ fresh_emit "$powsybl_inputs/powsybl-cgmes-2415.zip" \
     cgmes cgmes powsybl-cgmes-2415 "$output_dir/powsybl-cgmes-2415"
 fresh_emit "$powsybl_inputs/powsybl-cgmes-30.zip" \
     cgmes cgmes powsybl-cgmes-30 "$output_dir/powsybl-cgmes-30"
+
+# Node breaker sets are read twice: the official documents as shipped, and a
+# copy without the TP and TP_BD documents whose buses PowerIO calculates.
+node_breaker_dir="$output_dir/node-breaker"
+stage_cgmes_documents() {
+    local target=$1 mode=$2
+    shift 2
+    mkdir -p "$target"
+    local source file
+    for source in "$@"; do
+        for file in "$source"/*.xml; do
+            case "$mode:$(basename "$file")" in
+                without-tp:*_TP_*|without-tp:*TP_BD*) ;;
+                *) cp "$file" "$target/" ;;
+            esac
+        done
+    done
+}
+run_logged() {
+    local log=$1
+    shift
+    if ! "$@" 2> "$log"; then
+        sed -n '1,$p' "$log" >&2
+        return 1
+    fi
+}
+calculated_topology() {
+    local stem=$1
+    shift
+    stage_cgmes_documents "$node_breaker_dir/$stem-official" with-tp "$@"
+    stage_cgmes_documents "$node_breaker_dir/$stem-without-tp" without-tp "$@"
+    run_logged "$node_breaker_dir/$stem-official.log" "$powerio_binary" serialize \
+        "$node_breaker_dir/$stem-official" --from cgmes \
+        -o "$node_breaker_dir/$stem-official.pio.json"
+    run_logged "$node_breaker_dir/$stem-calculated.log" "$powerio_binary" serialize \
+        "$node_breaker_dir/$stem-without-tp" --from cgmes \
+        -o "$node_breaker_dir/$stem-calculated.pio.json"
+    run_logged "$node_breaker_dir/$stem-calculated-fresh.log" "$powerio_binary" convert \
+        "$node_breaker_dir/$stem-calculated.pio.json" --to cgmes \
+        -o "$node_breaker_dir/$stem-calculated-fresh"
+}
+calculated_topology mini-grid-node-breaker \
+    "$mini_grid_node_breaker_source" "$mini_grid_node_breaker_bd_source"
+calculated_topology small-grid-node-breaker \
+    "$small_grid_node_breaker_source" "$small_grid_node_breaker_bd_source"
+calculated_topology micro-grid-cgmes3 "$micro_grid_cgmes3_source"
 
 "$python_binary" "$repository_root/evals/powsybl/check_outputs.py" \
     "$output_dir" "$powsybl_core"

--- a/powerio-tx/src/diagnostics.rs
+++ b/powerio-tx/src/diagnostics.rs
@@ -231,6 +231,11 @@ pub mod codes {
             "a value absent from the CGMES profile set was defaulted";
         READ_CGMES_VALUE_APPROXIMATED = "READ.CGMES.VALUE_APPROXIMATED", Warning,
             "a CGMES value was represented through an explicit approximation";
+        READ_CGMES_TOPOLOGY_CALCULATED = "READ.CGMES.TOPOLOGY_CALCULATED", Remark,
+            "the set carries no TopologicalNode data, so buses were calculated from ConnectivityNodes and switch positions";
+        READ_CGMES_CONNECTIVITY_INSUFFICIENT = "READ.CGMES.CONNECTIVITY_INSUFFICIENT", Error,
+            "the set carries neither TopologicalNode data nor enough connectivity to calculate buses",
+            category = Parse;
         READ_PANDAPOWER_VALUE_INFERRED = "READ.PANDAPOWER.VALUE_INFERRED", Warning,
             "a value pandapower does not store was reconstructed on a declared convention";
         READ_PANDAPOWER_TABLE_UNSUPPORTED = "READ.PANDAPOWER.TABLE_UNSUPPORTED", Warning,

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -33,7 +33,7 @@ use std::path::{Component, Path};
 
 use powerio_core::{ArtifactPath, DiagnosticInfo, MemoryArtifact, Source};
 
-use crate::diagnostics::Diagnostics;
+use crate::diagnostics::{Diagnostics, codes};
 use crate::network::BalancedNetwork;
 use crate::{Error, Result};
 
@@ -145,11 +145,22 @@ pub(crate) fn parse_source(
     let name = Path::new(source.name())
         .file_stem()
         .and_then(|stem| stem.to_str());
-    let parsed = read::read_cgmes_documents(documents, name)?;
-    for diagnostic in parsed.warnings {
+    read_documents(documents, name, diagnostics)
+}
+
+/// Read the documents, handing every diagnostic to `diagnostics` whether or
+/// not the read succeeds, so a coded refusal reaches the caller with its error.
+fn read_documents(
+    documents: Vec<(String, String)>,
+    name: Option<&str>,
+    diagnostics: &mut Diagnostics,
+) -> Result<BalancedNetwork> {
+    let mut warnings = CgmesDiagnostics::new(&codes::READ_CGMES_RECORD_UNMAPPED);
+    let result = read::read_cgmes_documents_into(documents, name, &mut warnings);
+    for diagnostic in warnings {
         diagnostics.push(diagnostic.info, diagnostic.message);
     }
-    Ok(parsed.network)
+    result
 }
 
 pub(crate) fn parse_text(
@@ -158,11 +169,11 @@ pub(crate) fn parse_text(
     diagnostics: &mut Diagnostics,
 ) -> Result<BalancedNetwork> {
     reject_unsafe_xml(text.as_bytes())?;
-    let parsed = read::read_cgmes_documents(vec![(name.to_string(), text.to_string())], None)?;
-    for diagnostic in parsed.warnings {
-        diagnostics.push(diagnostic.info, diagnostic.message);
-    }
-    Ok(parsed.network)
+    read_documents(
+        vec![(name.to_string(), text.to_string())],
+        None,
+        diagnostics,
+    )
 }
 
 fn acquire_documents(source: &Source) -> Result<Vec<(String, String)>> {

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -6220,16 +6220,55 @@ mod tests {
         }));
     }
 
+    /// The document without its ConnectivityNode elements and without the
+    /// terminal references to them.
+    fn strip_connectivity_nodes(text: &str) -> String {
+        let mut stripped = String::new();
+        let mut inside_node = false;
+        for line in text.lines() {
+            if line.contains("<cim:ConnectivityNode rdf:ID=") {
+                inside_node = true;
+            }
+            if !inside_node && !line.contains("Terminal.ConnectivityNode") {
+                stripped.push_str(line);
+                stripped.push('\n');
+            }
+            if line.contains("</cim:ConnectivityNode>") {
+                inside_node = false;
+            }
+        }
+        stripped
+    }
+
     #[test]
     fn missing_profiles_malformed_xml_and_dangling_references_are_refused() {
         let output = write::write_cgmes(&network(), CgmesVersion::V3_0).unwrap();
-        let eq_only = output
+        // A CGMES 3.0 EQ carries ConnectivityNodes, so it reads without TP
+        // through calculated buses; stripping those nodes leaves nothing to
+        // calculate from.
+        let eq_only: Vec<(String, String)> = output
             .files
             .iter()
             .filter(|(name, _)| name.ends_with("_EQ.xml"))
             .cloned()
             .collect();
-        assert!(read::read_cgmes_documents(eq_only, Some("missing-tp")).is_err());
+        let calculated = read::read_cgmes_documents(eq_only.clone(), Some("missing-tp")).unwrap();
+        assert_eq!(calculated.network.buses().len(), 2);
+        assert!(calculated.warnings.iter().any(|warning| {
+            warning.info.code == crate::diagnostics::codes::READ_CGMES_TOPOLOGY_CALCULATED.code
+        }));
+        let without_nodes = eq_only
+            .into_iter()
+            .map(|(name, text)| (name, strip_connectivity_nodes(&text)))
+            .collect();
+        let error = read::read_cgmes_documents(without_nodes, Some("missing-tp"))
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(
+            error.contains("the set declares no TP profile data"),
+            "{error}"
+        );
 
         assert!(xml::parse_cimxml("<rdf:RDF><cim:TopologicalNode>").is_err());
 
@@ -6268,5 +6307,205 @@ mod tests {
             })
             .collect();
         assert!(read::read_cgmes_documents(duplicate, Some("duplicate")).is_err());
+    }
+
+    const NODE_BREAKER_EQ: &str =
+        include_str!("../../../../tests/data/cgmes/node-breaker/NodeBreaker_EQ.xml");
+    const NODE_BREAKER_SSH: &str =
+        include_str!("../../../../tests/data/cgmes/node-breaker/NodeBreaker_SSH.xml");
+
+    fn node_breaker_documents() -> Vec<(String, String)> {
+        vec![
+            (
+                "NodeBreaker_EQ.xml".to_string(),
+                NODE_BREAKER_EQ.to_string(),
+            ),
+            (
+                "NodeBreaker_SSH.xml".to_string(),
+                NODE_BREAKER_SSH.to_string(),
+            ),
+        ]
+    }
+
+    fn bus_named<'a>(network: &'a BalancedNetwork, name: &str) -> &'a Bus {
+        network
+            .buses()
+            .iter()
+            .find(|bus| bus.name.as_deref() == Some(name))
+            .unwrap_or_else(|| panic!("no bus named {name}"))
+    }
+
+    fn load_with_uid<'a>(network: &'a BalancedNetwork, uid: &str) -> &'a Load {
+        network
+            .loads()
+            .iter()
+            .find(|load| load.uid.as_deref() == Some(uid))
+            .unwrap_or_else(|| panic!("no load {uid}"))
+    }
+
+    #[test]
+    fn node_breaker_set_without_tp_calculates_buses_from_switch_positions() {
+        let parsed =
+            read::read_cgmes_documents(node_breaker_documents(), Some("node-breaker")).unwrap();
+        let network = &parsed.network;
+        assert_eq!(network.buses().len(), 3);
+        let bb1 = bus_named(network, "BB1");
+        let n3 = bus_named(network, "N3");
+        let bb2 = bus_named(network, "BB2");
+        assert_eq!(bb1.kind, BusType::Ref);
+        assert!(
+            network
+                .buses()
+                .iter()
+                .all(|bus| (bus.base_kv - 110.0).abs() < 1e-12)
+        );
+
+        assert_eq!(
+            load_with_uid(network, "ec000000-0000-4000-8000-000000000001").bus,
+            bb1.id
+        );
+        assert_eq!(
+            load_with_uid(network, "ec000000-0000-4000-8000-000000000002").bus,
+            n3.id
+        );
+        let disconnected = load_with_uid(network, "ec000000-0000-4000-8000-000000000003");
+        assert_eq!(disconnected.bus, bb2.id);
+        assert!(!disconnected.in_service);
+        assert_eq!(network.generators()[0].bus, bb1.id);
+        assert_eq!(
+            (network.branches()[0].from, network.branches()[0].to),
+            (bb1.id, bb2.id)
+        );
+        assert_eq!(network.switches().len(), 1);
+        let open = &network.switches()[0];
+        assert_eq!((open.from, open.to, open.closed), (bb1.id, n3.id, false));
+
+        // Identities derive from the joined ConnectivityNode mRIDs: valid
+        // UUIDs, never a node's own mRID, and identical on every read.
+        for bus in network.buses() {
+            let uid = bus.uid.as_deref().unwrap();
+            assert!(uuid::Uuid::parse_str(uid).is_ok());
+            assert!(!uid.starts_with("c0000000"));
+        }
+        let again =
+            read::read_cgmes_documents(node_breaker_documents(), Some("node-breaker")).unwrap();
+        let uids = |network: &BalancedNetwork| {
+            network
+                .buses()
+                .iter()
+                .map(|bus| bus.uid.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(uids(network), uids(&again.network));
+
+        let detailed = network.detailed_connectivity().as_deref().unwrap();
+        assert!(detailed.bus_breaker_buses.is_empty());
+        assert_eq!(detailed.calculated_buses.len(), 3);
+        let joined = detailed
+            .calculated_buses
+            .iter()
+            .find(|bus| bus.calculated_bus == bb1.id)
+            .unwrap();
+        // N2 sits in a Bay, which resolves to VL1 like N1.
+        assert_eq!(joined.nodes.len(), 2);
+        assert_eq!(
+            joined.voltage_level.local_id(),
+            "a1000000-0000-4000-8000-000000000001"
+        );
+        assert!(
+            detailed
+                .voltage_levels
+                .iter()
+                .all(|level| level.topology_kind == TopologyKind::NodeBreaker)
+        );
+        let vl1 = detailed
+            .voltage_levels
+            .iter()
+            .find(|level| level.component.local_id() == "a1000000-0000-4000-8000-000000000001")
+            .unwrap();
+        assert_eq!(vl1.buses, vec![bb1.id, n3.id]);
+        assert!(parsed.warnings.iter().any(|warning| {
+            warning.info.code == crate::diagnostics::codes::READ_CGMES_TOPOLOGY_CALCULATED.code
+                && warning.contains(
+                    "3 calculated bus(es) joined 5 ConnectivityNode(s) through 2 closed switch(es); 1 open switch(es)",
+                )
+        }));
+    }
+
+    #[test]
+    fn node_breaker_ssh_switch_position_closes_the_disconnector() {
+        let closed = node_breaker_documents()
+            .into_iter()
+            .map(|(name, text)| {
+                if name.ends_with("_SSH.xml") {
+                    (
+                        name,
+                        text.replace(
+                            "<cim:Switch.open>true</cim:Switch.open>",
+                            "<cim:Switch.open>false</cim:Switch.open>",
+                        ),
+                    )
+                } else {
+                    (name, text)
+                }
+            })
+            .collect();
+        let parsed = read::read_cgmes_documents(closed, Some("closed")).unwrap();
+        assert_eq!(parsed.network.buses().len(), 2);
+        assert!(parsed.network.switches().is_empty());
+        let bb1 = bus_named(&parsed.network, "BB1").id;
+        assert_eq!(
+            parsed
+                .network
+                .loads()
+                .iter()
+                .filter(|load| load.bus == bb1)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn node_breaker_set_without_connectivity_is_refused_with_the_missing_data_named() {
+        let bus_branch = node_breaker_documents()
+            .into_iter()
+            .map(|(name, text)| {
+                (
+                    name,
+                    text.replace(
+                        "    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>\n",
+                        "",
+                    ),
+                )
+            })
+            .collect();
+        let mut warnings =
+            CgmesDiagnostics::new(&crate::diagnostics::codes::READ_CGMES_RECORD_UNMAPPED);
+        let error = read::read_cgmes_documents_into(bus_branch, Some("bus-branch"), &mut warnings)
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("the set declares no TP profile data"));
+        assert!(error.contains("bus branch equipment"));
+        assert!(warnings.iter().any(|warning| {
+            warning.info.code
+                == crate::diagnostics::codes::READ_CGMES_CONNECTIVITY_INSUFFICIENT.code
+        }));
+
+        let without_nodes = node_breaker_documents()
+            .into_iter()
+            .map(|(name, text)| {
+                if name.ends_with("_EQ.xml") {
+                    (name, strip_connectivity_nodes(&text))
+                } else {
+                    (name, text)
+                }
+            })
+            .collect();
+        let error = read::read_cgmes_documents(without_nodes, Some("no-nodes"))
+            .err()
+            .unwrap()
+            .to_string();
+        assert!(error.contains("define no ConnectivityNode records"));
     }
 }

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -6340,7 +6340,7 @@ mod tests {
             .loads()
             .iter()
             .find(|load| load.uid.as_deref() == Some(uid))
-            .unwrap_or_else(|| panic!("no load {uid}"))
+            .unwrap_or_else(|| panic!("no load with the requested identifier"))
     }
 
     #[test]

--- a/powerio-tx/src/format/cgmes/read.rs
+++ b/powerio-tx/src/format/cgmes/read.rs
@@ -1,10 +1,15 @@
 //! Merged CGMES profiles into a [`BalancedNetwork`].
 //!
-//! `TopologicalNode` is the bus. Terminals tie conducting equipment to nodes
-//! (directly in 2.4.15 TP; through `ConnectivityNode.TopologicalNode` in
-//! 3.0). SSH carries the operating point (`p`/`q`, switch position, tap steps,
+//! `TopologicalNode` is the bus when the set carries TP data. Terminals tie
+//! conducting equipment to nodes (directly in 2.4.15 TP; through
+//! `ConnectivityNode.TopologicalNode` in 3.0). Without TopologicalNode data
+//! a node breaker set (EquipmentOperation in 2.4.15, any CGMES 3.0 EQ with
+//! ConnectivityNodes) has its buses calculated: the connected components of
+//! the ConnectivityNode graph joined by closed, in service switches, the same
+//! selection PowSybl's `CgmesModelTripleStore.computeIsNodeBreaker` makes.
+//! SSH carries the operating point (`p`/`q`, switch position, tap steps,
 //! sections); SV supplies solved voltage, tap, and terminal power values.
-//! Missing SSH degrades gracefully — vendor exports like the CIGRE MV set
+//! Missing SSH degrades gracefully; vendor exports like the CIGRE MV set
 //! ship EQ/TP/SV only, so element `p`/`q` falls back to the terminal's
 //! `SvPowerFlow`.
 //!
@@ -14,6 +19,7 @@
 
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write as _;
 
 use powerio_core::ComponentId;
 
@@ -41,6 +47,7 @@ const FMT: &str = "CGMES";
 /// CGMES has no system MVA base; every per-unit value lands on this one.
 const SYSTEM_MVA: f64 = 100.0;
 
+#[cfg(test)]
 pub(crate) struct Parsed {
     pub(crate) network: BalancedNetwork,
     pub(crate) warnings: CgmesDiagnostics,
@@ -665,8 +672,19 @@ fn describe_property_value(value: &PropValue) -> String {
     }
 }
 
+/// Where the balanced buses come from.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BusSource {
+    /// One bus per `TopologicalNode` record.
+    TopologicalNodes,
+    /// One bus per connected component of `ConnectivityNode` records joined
+    /// by closed, in service switches.
+    Calculated,
+}
+
 /// Terminal wiring: equipment → its terminals (sequence order), terminal →
-/// topological node, and the terminal SSH connection value.
+/// bus node (the topological node, or the connectivity node when buses are
+/// calculated), and the terminal SSH connection value.
 struct Wiring {
     of_equipment: HashMap<String, Vec<String>>,
     node_of: HashMap<String, String>,
@@ -674,7 +692,7 @@ struct Wiring {
 }
 
 impl Wiring {
-    fn build(store: &Store) -> Wiring {
+    fn build(store: &Store, topology: BusSource) -> Wiring {
         let mut of_equipment: HashMap<String, Vec<(f64, String)>> = HashMap::new();
         let mut node_of = HashMap::new();
         let mut connected = HashMap::new();
@@ -690,13 +708,14 @@ impl Wiring {
                     .push((seq, id.to_string()));
             }
             // 2.4.15 TP links the terminal itself; 3.0 links through the
-            // connectivity node. Either way the terminal lands on a TN.
-            let tn = store.refv(id, "Terminal.TopologicalNode").or_else(|| {
-                let cn = store.refv(id, "Terminal.ConnectivityNode")?;
-                store.refv(cn, "ConnectivityNode.TopologicalNode")
-            });
-            if let Some(tn) = tn {
-                node_of.insert(id.to_string(), tn.to_string());
+            // connectivity node. Either way the terminal lands on a TN. A
+            // calculated topology keys buses by the connectivity node.
+            let node = match topology {
+                BusSource::TopologicalNodes => terminal_topological_node(store, id),
+                BusSource::Calculated => store.refv(id, "Terminal.ConnectivityNode"),
+            };
+            if let Some(node) = node {
+                node_of.insert(id.to_string(), node.to_string());
             }
             if let Some(is_connected) = store.boolean(id, "ACDCTerminal.connected") {
                 connected.insert(id.to_string(), is_connected);
@@ -733,11 +752,24 @@ impl Wiring {
     }
 }
 
+/// One calculated bus: the connectivity nodes it joins, in definition order,
+/// and the voltage level or other connectivity container they resolve to.
+struct CalculatedGroup {
+    bus: BusId,
+    container: String,
+    nodes: Vec<String>,
+}
+
 /// Everything the element builders share.
 struct Mapper<'a> {
     store: &'a Store,
+    topology: BusSource,
     wiring: Wiring,
-    bus_of_tn: HashMap<String, BusId>,
+    /// Bus node identity (topological node, or connectivity node when the
+    /// topology is calculated) → balanced bus.
+    bus_of_node: HashMap<String, BusId>,
+    /// The calculated buses, empty when TopologicalNode records supplied them.
+    calculated: Vec<CalculatedGroup>,
     kv_of: HashMap<BusId, f64>,
     /// Terminal → solved SvPowerFlow (p, q), the SSH fallback.
     sv_flow: HashMap<String, (f64, f64)>,
@@ -750,8 +782,17 @@ struct Mapper<'a> {
 impl Mapper<'_> {
     fn bus_of_equipment_terminal(&mut self, equipment: &str, index: usize) -> Option<BusId> {
         let terminal = self.wiring.terminals(equipment).get(index)?.clone();
-        let tn = self.wiring.node(&terminal)?.to_string();
-        self.bus_of_tn.get(tn.as_str()).copied()
+        let node = self.wiring.node(&terminal)?.to_string();
+        self.bus_of_node.get(node.as_str()).copied()
+    }
+
+    /// The balanced bus a topological node maps to; `None` when the topology
+    /// was calculated, because the set then defines no topological nodes.
+    fn bus_of_topological_node(&self, topological_node: &str) -> Option<BusId> {
+        match self.topology {
+            BusSource::TopologicalNodes => self.bus_of_node.get(topological_node).copied(),
+            BusSource::Calculated => None,
+        }
     }
 
     fn kv(&self, bus: BusId) -> f64 {
@@ -832,12 +873,28 @@ impl Mapper<'_> {
 }
 
 /// Read already acquired CGMES XML profile documents as one case.
-#[allow(clippy::too_many_lines)] // profile classification and merge share one ordered pass
+///
+/// Diagnostics collected before a failure are dropped with it; callers that
+/// must keep them use [`read_cgmes_documents_into`].
+#[cfg(test)]
 pub(crate) fn read_cgmes_documents(
     documents: Vec<(String, String)>,
     name_hint: Option<&str>,
 ) -> Result<Parsed> {
     let mut warnings = CgmesDiagnostics::new(&codes::READ_CGMES_RECORD_UNMAPPED);
+    let network = read_cgmes_documents_into(documents, name_hint, &mut warnings)?;
+    Ok(Parsed { network, warnings })
+}
+
+/// Read already acquired CGMES XML profile documents as one case, appending
+/// every diagnostic to `warnings`, including the coded refusal that precedes
+/// an error.
+#[allow(clippy::too_many_lines)] // profile classification and merge share one ordered pass
+pub(crate) fn read_cgmes_documents_into(
+    documents: Vec<(String, String)>,
+    name_hint: Option<&str>,
+    warnings: &mut CgmesDiagnostics,
+) -> Result<BalancedNetwork> {
     let mut store = Store {
         objects: Vec::new(),
         by_id: HashMap::new(),
@@ -849,6 +906,7 @@ pub(crate) fn read_cgmes_documents(
     let mut skipped: Vec<String> = Vec::new();
     let mut has_eq = false;
     let mut has_tp = false;
+    let mut model_profiles: Vec<Vec<String>> = Vec::new();
 
     for (name, text) in documents {
         let doc = parse_cimxml(&text)?;
@@ -859,7 +917,7 @@ pub(crate) fn read_cgmes_documents(
                 }
             }
         }
-        warn_full_model_fields(&name, doc.header.as_ref(), &mut warnings);
+        warn_full_model_fields(&name, doc.header.as_ref(), warnings);
         if let Some(header) = doc.header.as_ref() {
             if let Some(value) = header.scenario_time.as_ref() {
                 if scenario_time
@@ -896,12 +954,14 @@ pub(crate) fn read_cgmes_documents(
             continue;
         }
         if let Some(header) = doc.header.as_ref() {
-            has_eq |= header.profiles.iter().any(|profile| {
-                profile.contains("/EquipmentCore/") || profile.contains("/CIM/CoreEquipment")
-            });
+            has_eq |= header
+                .profiles
+                .iter()
+                .any(|profile| is_equipment_core(profile));
             has_tp |= header.profiles.iter().any(|profile| {
                 profile.contains("/Topology/") || profile.contains("/CIM/Topology-")
             });
+            model_profiles.push(header.profiles.clone());
         }
         store.merge(doc)?;
     }
@@ -927,37 +987,134 @@ pub(crate) fn read_cgmes_documents(
             });
         }
     };
-    validate_critical_references(&store)?;
+    let topology = if store.of_class("TopologicalNode").next().is_some() {
+        BusSource::TopologicalNodes
+    } else {
+        BusSource::Calculated
+    };
+    validate_critical_references(&store, topology)?;
     if !skipped.is_empty() {
         for summary in skipped {
             warnings.push(summary);
         }
     }
-    if !has_eq || !has_tp {
-        let missing = match (has_eq, has_tp) {
-            (false, false) => "EQ and TP",
-            (false, true) => "EQ",
-            (true, false) => "TP",
-            (true, true) => unreachable!(),
-        };
+    if !has_eq {
         return Err(Error::FormatRead {
             format: FMT,
-            message: format!("CGMES profile set is missing required {missing} profile data"),
+            message: "CGMES profile set is missing required EQ profile data".into(),
         });
     }
+    if topology == BusSource::Calculated {
+        check_calculable_connectivity(&store, &model_profiles, has_tp, warnings)?;
+    }
 
-    let network = build(
+    build(
         &store,
         version,
+        topology,
         description,
         scenario_time,
         name_hint,
-        &mut warnings,
-    )?;
-    Ok(Parsed { network, warnings })
+        warnings,
+    )
 }
 
-fn validate_critical_references(store: &Store) -> Result<()> {
+fn is_equipment_core(profile: &str) -> bool {
+    profile.contains("/EquipmentCore/") || profile.contains("/CIM/CoreEquipment")
+}
+
+fn is_equipment_operation(profile: &str) -> bool {
+    profile.contains("/EquipmentOperation/") || profile.contains("/CIM/Operation")
+}
+
+/// PowSybl's CGMES 3 equipment test: the profile URI starts with the
+/// CoreEquipment-EU namespace and its version is 3.0 or later.
+fn is_cgmes3_equipment_core(profile: &str) -> bool {
+    const PREFIX: &str = "http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/";
+    const FIRST: &str = "http://iec.ch/TC57/ns/CIM/CoreEquipment-EU/3.0";
+    profile.starts_with(PREFIX) && profile >= FIRST
+}
+
+/// Whether the declared profile URIs describe a node breaker set, following
+/// PowSybl's `CgmesModelTripleStore.computeIsNodeBreaker`: every CGMES 3
+/// equipment document is node breaker once ConnectivityNodes exist; a CGMES
+/// 2.4.15 set is node breaker only when each document declaring EquipmentCore
+/// also declares EquipmentOperation, and each document declaring
+/// EquipmentBoundary also declares EquipmentBoundaryOperation.
+fn declares_node_breaker(model_profiles: &[Vec<String>], store: &Store) -> bool {
+    let has_connectivity_nodes = store.of_class("ConnectivityNode").next().is_some();
+    let all_cgmes3 = model_profiles
+        .iter()
+        .flatten()
+        .all(|profile| !is_equipment_core(profile) || is_cgmes3_equipment_core(profile));
+    if all_cgmes3 && has_connectivity_nodes {
+        return true;
+    }
+    model_profiles.iter().all(|profiles| {
+        let core = profiles.iter().any(|profile| is_equipment_core(profile));
+        let operation = profiles
+            .iter()
+            .any(|profile| is_equipment_operation(profile));
+        let bd = profiles
+            .iter()
+            .any(|profile| profile.contains("/EquipmentBoundary/"));
+        let bd_operation = profiles
+            .iter()
+            .any(|profile| profile.contains("/EquipmentBoundaryOperation/"));
+        (!core || operation) && (!bd || bd_operation)
+    })
+}
+
+/// Refuse a set without TopologicalNode data unless it declares node breaker
+/// equipment whose terminals reference ConnectivityNodes; the refusal names
+/// the missing data.
+fn check_calculable_connectivity(
+    store: &Store,
+    model_profiles: &[Vec<String>],
+    has_tp: bool,
+    warnings: &mut CgmesDiagnostics,
+) -> Result<()> {
+    let topology_state = if has_tp {
+        "the TP profile data defines no TopologicalNode records"
+    } else {
+        "the set declares no TP profile data"
+    };
+    let node_count = store.of_class("ConnectivityNode").count();
+    let terminal_count = store.of_class("Terminal").count();
+    let connected_terminal_count = store
+        .of_class("Terminal")
+        .filter(|terminal| store.refv(terminal, "Terminal.ConnectivityNode").is_some())
+        .count();
+    let missing = if !declares_node_breaker(model_profiles, store) {
+        Some(format!(
+            "the declared profiles describe bus branch equipment (no EquipmentOperation or CGMES 3 CoreEquipment profile with ConnectivityNodes), so nothing states which terminals share a bus; the set has {node_count} ConnectivityNode record(s)"
+        ))
+    } else if node_count == 0 {
+        Some("the node breaker profiles define no ConnectivityNode records".to_string())
+    } else if connected_terminal_count == 0 {
+        Some(format!(
+            "none of the {terminal_count} Terminal record(s) references a ConnectivityNode"
+        ))
+    } else {
+        None
+    };
+    if let Some(missing) = missing {
+        let message = format!(
+            "{topology_state} and buses cannot be calculated: {missing}; a TP profile, or an EQ profile with ConnectivityNode connectivity and switch positions, is required"
+        );
+        warnings.push_as(
+            &codes::READ_CGMES_CONNECTIVITY_INSUFFICIENT,
+            message.clone(),
+        );
+        return Err(Error::FormatRead {
+            format: FMT,
+            message,
+        });
+    }
+    Ok(())
+}
+
+fn validate_critical_references(store: &Store, topology: BusSource) -> Result<()> {
     const REQUIRED: [&str; 33] = [
         "Terminal.ConductingEquipment",
         "Terminal.TopologicalNode",
@@ -1007,6 +1164,12 @@ fn validate_critical_references(store: &Store) -> Result<()> {
                     ),
                 });
             };
+            // An SV profile kept without its TP profile observes topological
+            // nodes the set never defines; those observations are counted
+            // and left unmapped when the buses are calculated.
+            if topology == BusSource::Calculated && property == "SvVoltage.TopologicalNode" {
+                continue;
+            }
             if !store.contains(target) {
                 return Err(Error::FormatRead {
                     format: FMT,
@@ -1100,20 +1263,18 @@ const CONSUMED: &[&str] = &[
     "Junction",
 ];
 
-#[allow(clippy::too_many_lines)] // the element families map in one ordered pass
-fn build(
-    store: &Store,
-    version: CgmesVersion,
-    description: Option<String>,
-    scenario_time: Option<String>,
-    name_hint: Option<&str>,
-    warnings: &mut CgmesDiagnostics,
-) -> Result<BalancedNetwork> {
-    let wiring = Wiring::build(store);
+/// The balanced buses and the node and voltage indexes built with them.
+struct BusTable {
+    buses: Vec<Bus>,
+    bus_of_node: HashMap<String, BusId>,
+    kv_of: HashMap<BusId, f64>,
+    calculated: Vec<CalculatedGroup>,
+}
 
-    // Buses from TopologicalNode, ids in definition order.
+/// Buses from TopologicalNode records, ids in definition order.
+fn buses_from_topological_nodes(store: &Store) -> Result<BusTable> {
     let mut buses = Vec::new();
-    let mut bus_of_tn = HashMap::new();
+    let mut bus_of_node = HashMap::new();
     let mut kv_of = HashMap::new();
     for (i, tn) in store.of_class("TopologicalNode").enumerate() {
         let id = BusId(i + 1);
@@ -1145,21 +1306,371 @@ fn build(
         bus.name = Some(store.name(tn));
         bus.uid = Some(tn.to_string());
         buses.push(bus);
-        bus_of_tn.insert(tn.to_string(), id);
+        bus_of_node.insert(tn.to_string(), id);
         kv_of.insert(id, kv);
     }
+    Ok(BusTable {
+        buses,
+        bus_of_node,
+        kv_of,
+        calculated: Vec::new(),
+    })
+}
+
+/// The switch position that decides whether a switch conducts: the SSH
+/// `Switch.open` assignment, else the EQ `Switch.normalOpen` default, else
+/// closed. PowSybl's `SwitchConversion.update` applies the same precedence.
+fn switch_is_open(store: &Store, switch: &str) -> bool {
+    store
+        .boolean(switch, "Switch.open")
+        .or_else(|| store.boolean(switch, "Switch.normalOpen"))
+        .unwrap_or(false)
+}
+
+/// The service status a topology processor reads: the SV `SvStatus.inService`
+/// observation, else the SSH `Equipment.inService` assignment, else in
+/// service. CGMES defines `Equipment.inService` as availability for topology
+/// processing, so a switch out of service never joins its nodes.
+fn switch_in_service(store: &Store, switch: &str, sv_status: &HashMap<String, bool>) -> bool {
+    sv_status
+        .get(switch)
+        .copied()
+        .or_else(|| store.boolean(switch, "Equipment.inService"))
+        .unwrap_or(true)
+}
+
+/// The nominal voltage of a calculated bus: its container's `VoltageLevel`
+/// base voltage, else the base voltage stated by conducting equipment or a
+/// transformer end attached to one of its nodes.
+fn calculated_bus_kv(store: &Store, container: &str, nodes: &[String]) -> Option<f64> {
+    if store.class_of(container) == Some("VoltageLevel")
+        && let Some(kv) = store
+            .refv(container, "VoltageLevel.BaseVoltage")
+            .and_then(|base| store.f(base, "BaseVoltage.nominalVoltage"))
+    {
+        return Some(kv);
+    }
+    let node_set: BTreeSet<&str> = nodes.iter().map(String::as_str).collect();
+    store
+        .of_class("Terminal")
+        .filter(|terminal| {
+            store
+                .refv(terminal, "Terminal.ConnectivityNode")
+                .is_some_and(|node| node_set.contains(node))
+        })
+        .find_map(|terminal| {
+            let equipment = store.refv(terminal, "Terminal.ConductingEquipment")?;
+            let stated = store
+                .refv(equipment, "ConductingEquipment.BaseVoltage")
+                .and_then(|base| store.f(base, "BaseVoltage.nominalVoltage"));
+            if stated.is_some() {
+                return stated;
+            }
+            store.of_class("PowerTransformerEnd").find_map(|end| {
+                (store.refv(end, "TransformerEnd.Terminal") == Some(terminal))
+                    .then(|| {
+                        store
+                            .refv(end, "TransformerEnd.BaseVoltage")
+                            .and_then(|base| store.f(base, "BaseVoltage.nominalVoltage"))
+                            .or_else(|| store.f(end, "PowerTransformerEnd.ratedU"))
+                    })
+                    .flatten()
+            })
+        })
+}
+
+/// The deterministic identity of a calculated bus: UUIDv5 under PowerIO's
+/// CGMES namespace over the sorted connectivity node identities it joins, so
+/// the same nodes always yield the same bus mRID and never a source
+/// TopologicalNode mRID.
+fn calculated_bus_uid(nodes: &[String]) -> String {
+    let namespace = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, b"https://powerio.dev/cgmes");
+    let mut sorted: Vec<&str> = nodes.iter().map(String::as_str).collect();
+    sorted.sort_unstable();
+    let name = format!("calculated-bus:{}", sorted.join(","));
+    uuid::Uuid::new_v5(&namespace, name.as_bytes()).to_string()
+}
+
+/// Buses as the connected components of ConnectivityNodes joined by closed,
+/// in service switches; ids in first node definition order. PowSybl's node
+/// breaker import builds the same graph (`NodeMapping`, `SwitchConversion`)
+/// and lets IIDM compute the buses from it.
+#[allow(clippy::too_many_lines)] // one pass joins nodes, names buses, and reports the result
+fn calculate_buses(
+    store: &Store,
+    wiring: &Wiring,
+    sv_status: &HashMap<String, bool>,
+    warnings: &mut CgmesDiagnostics,
+) -> Result<BusTable> {
+    let nodes: Vec<&str> = store.of_class("ConnectivityNode").collect();
+    let index: HashMap<&str, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(position, node)| (*node, position))
+        .collect();
+    let mut union = crate::format::union_find::UnionFind::new(nodes.len());
+    let mut closed = 0usize;
+    let mut open = 0usize;
+    let mut out_of_service = 0usize;
+    let mut unplaced = 0usize;
+    for class in SWITCH_CLASSES {
+        for switch in store.of_class(class) {
+            let terminals = wiring.terminals(switch);
+            let (Some(first), Some(second)) = (terminals.first(), terminals.get(1)) else {
+                unplaced += 1;
+                continue;
+            };
+            let ends = (
+                store
+                    .refv(first, "Terminal.ConnectivityNode")
+                    .and_then(|node| index.get(node)),
+                store
+                    .refv(second, "Terminal.ConnectivityNode")
+                    .and_then(|node| index.get(node)),
+            );
+            let (Some(first), Some(second)) = ends else {
+                unplaced += 1;
+                continue;
+            };
+            if switch_is_open(store, switch) {
+                open += 1;
+            } else if !switch_in_service(store, switch, sv_status) {
+                out_of_service += 1;
+            } else {
+                closed += 1;
+                union.union(*first, *second);
+            }
+        }
+    }
+
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    let mut group_of_root: HashMap<usize, usize> = HashMap::new();
+    for position in 0..nodes.len() {
+        let root = union.find(position);
+        let group = *group_of_root.entry(root).or_insert_with(|| {
+            groups.push(Vec::new());
+            groups.len() - 1
+        });
+        groups[group].push(position);
+    }
+
+    let busbar_names: HashMap<&str, String> = store
+        .of_class("BusbarSection")
+        .filter_map(|busbar| {
+            let terminal = wiring.terminals(busbar).first()?;
+            let node = store.refv(terminal, "Terminal.ConnectivityNode")?;
+            Some((node, store.name(busbar)))
+        })
+        .collect();
+
+    let referenced: BTreeSet<&str> = store
+        .of_class("Terminal")
+        .filter_map(|terminal| store.refv(terminal, "Terminal.ConnectivityNode"))
+        .collect();
+    let mut buses = Vec::new();
+    let mut bus_of_node = HashMap::new();
+    let mut kv_of = HashMap::new();
+    let mut calculated = Vec::new();
+    let mut split_levels = 0usize;
+    let mut unreferenced: Vec<String> = Vec::new();
+    for members in &groups {
+        let member_ids: Vec<String> = members
+            .iter()
+            .map(|member| nodes[*member].to_string())
+            .collect();
+        let container = member_ids
+            .iter()
+            .find_map(|node| connectivity_node_container(store, node))
+            .ok_or_else(|| Error::FormatRead {
+                format: FMT,
+                message: format!(
+                    "ConnectivityNode `{}` has no ConnectivityNode.ConnectivityNodeContainer reference, so its calculated bus has no voltage level",
+                    member_ids[0]
+                ),
+            })?
+            .to_string();
+        let Some(kv) = calculated_bus_kv(store, &container, &member_ids) else {
+            if member_ids
+                .iter()
+                .all(|node| !referenced.contains(node.as_str()))
+            {
+                // An EQ_BD tie point no terminal of this set references (the
+                // EQ_BD lists every interconnection) states no voltage and
+                // connects nothing; PowSybl converts no node for it either.
+                unreferenced.push(member_ids[0].clone());
+                continue;
+            }
+            return Err(Error::FormatRead {
+                format: FMT,
+                message: format!(
+                    "calculated bus for ConnectivityNode `{}` has no nominal voltage: its container `{container}` is not a VoltageLevel with a BaseVoltage and no attached conducting equipment states a BaseVoltage",
+                    member_ids[0]
+                ),
+            });
+        };
+        if kv <= 0.0 {
+            return Err(Error::FormatRead {
+                format: FMT,
+                message: format!(
+                    "calculated bus for ConnectivityNode `{}` has nonpositive nominal voltage {kv} kV",
+                    member_ids[0]
+                ),
+            });
+        }
+        let id = BusId(buses.len() + 1);
+        let (own, foreign): (Vec<String>, Vec<String>) = member_ids
+            .iter()
+            .cloned()
+            .partition(|node| connectivity_node_container(store, node) == Some(container.as_str()));
+        if !foreign.is_empty() {
+            split_levels += 1;
+            warnings.push_as(
+                &codes::READ_CGMES_VALUE_APPROXIMATED,
+                format!(
+                    "calculated bus {id} joins ConnectivityNodes from more than one container through closed switches; it is placed in `{container}` and the {} node(s) from other containers (sample `{}`) map to it without a calculated bus record listing them",
+                    foreign.len(),
+                    foreign[0]
+                ),
+            );
+        }
+        let mut bus = Bus::new(id, BusType::Pq, kv);
+        bus.name = Some(
+            member_ids
+                .iter()
+                .find_map(|node| busbar_names.get(node.as_str()).cloned())
+                .unwrap_or_else(|| store.name(&member_ids[0])),
+        );
+        bus.uid = Some(calculated_bus_uid(&member_ids));
+        buses.push(bus);
+        for node in &member_ids {
+            bus_of_node.insert(node.clone(), id);
+        }
+        kv_of.insert(id, kv);
+        calculated.push(CalculatedGroup {
+            bus: id,
+            container,
+            nodes: own,
+        });
+    }
+
+    let mut summary = format!(
+        "no TopologicalNode data: {} calculated bus(es) joined {} ConnectivityNode(s) through {closed} closed switch(es); {open} open switch(es) separate nodes",
+        buses.len(),
+        nodes.len()
+    );
+    if out_of_service > 0 {
+        let _ = write!(
+            summary,
+            "; {out_of_service} closed switch(es) out of service (SvStatus or Equipment.inService false) separate nodes"
+        );
+    }
+    if unplaced > 0 {
+        let _ = write!(
+            summary,
+            "; {unplaced} switch(es) without two ConnectivityNode terminals join nothing"
+        );
+    }
+    if split_levels > 0 {
+        let _ = write!(
+            summary,
+            "; {split_levels} bus(es) span more than one connectivity container"
+        );
+    }
+    if !unreferenced.is_empty() {
+        let _ = write!(
+            summary,
+            "; {} ConnectivityNode(s) outside any VoltageLevel that no terminal references (sample `{}`) got no bus",
+            unreferenced.len(),
+            unreferenced[0]
+        );
+    }
+    summary.push_str(
+        "; bus identities are UUIDv5 values derived from the joined ConnectivityNode mRIDs, not source TopologicalNode mRIDs",
+    );
+    warnings.push_as(&codes::READ_CGMES_TOPOLOGY_CALCULATED, summary);
+    Ok(BusTable {
+        buses,
+        bus_of_node,
+        kv_of,
+        calculated,
+    })
+}
+
+/// Conducting equipment → solved service status from SV `SvStatus` records.
+fn read_sv_status(store: &Store) -> Result<HashMap<String, bool>> {
+    let mut sv_status = HashMap::new();
+    for status in store.of_class("SvStatus") {
+        let equipment = store
+            .refv(status, "SvStatus.ConductingEquipment")
+            .ok_or_else(|| Error::FormatRead {
+                format: FMT,
+                message: format!(
+                    "SvStatus {} has no SvStatus.ConductingEquipment reference",
+                    store.name(status)
+                ),
+            })?;
+        let in_service =
+            store
+                .boolean(status, "SvStatus.inService")
+                .ok_or_else(|| Error::FormatRead {
+                    format: FMT,
+                    message: format!(
+                        "SvStatus {} has no boolean SvStatus.inService value",
+                        store.name(status)
+                    ),
+                })?;
+        if let Some(previous) = sv_status.insert(equipment.to_string(), in_service)
+            && previous != in_service
+        {
+            return Err(Error::FormatRead {
+                format: FMT,
+                message: format!(
+                    "conducting equipment {} has conflicting SvStatus.inService values",
+                    store.name(equipment)
+                ),
+            });
+        }
+    }
+    Ok(sv_status)
+}
+
+#[allow(clippy::too_many_lines)] // the element families map in one ordered pass
+fn build(
+    store: &Store,
+    version: CgmesVersion,
+    topology: BusSource,
+    description: Option<String>,
+    scenario_time: Option<String>,
+    name_hint: Option<&str>,
+    warnings: &mut CgmesDiagnostics,
+) -> Result<BalancedNetwork> {
+    let wiring = Wiring::build(store, topology);
+    let sv_status = read_sv_status(store)?;
+
+    let BusTable {
+        mut buses,
+        bus_of_node,
+        kv_of,
+        calculated,
+    } = match topology {
+        BusSource::TopologicalNodes => buses_from_topological_nodes(store)?,
+        BusSource::Calculated => calculate_buses(store, &wiring, &sv_status, warnings)?,
+    };
     if buses.is_empty() {
         return Err(Error::FormatRead {
             format: FMT,
-            message: "no TopologicalNode records; the bus-branch reader needs the TP \
-                      part of the set (node-breaker collapse is follow-up work)"
-                .into(),
+            message: "the set defines no TopologicalNode and no ConnectivityNode records, so it has no buses".into(),
         });
     }
+    let bus_of_topological_node = |topological_node: &str| match topology {
+        BusSource::TopologicalNodes => bus_of_node.get(topological_node).copied(),
+        BusSource::Calculated => None,
+    };
 
     // SV voltage values onto the buses. Equal duplicate observations are
     // harmless; different observations for one topological node are ambiguous.
     let mut sv_voltage = HashMap::new();
+    let mut unmapped_sv_voltages = 0usize;
     for sv in store.of_class("SvVoltage") {
         let Some(topological_node) = store.refv(sv, "SvVoltage.TopologicalNode") else {
             continue;
@@ -1175,7 +1686,10 @@ fn build(
                 ),
             });
         }
-        let Some(bus) = bus_of_tn.get(topological_node) else {
+        let Some(bus) = bus_of_topological_node(topological_node) else {
+            if topology == BusSource::Calculated {
+                unmapped_sv_voltages += 1;
+            }
             continue;
         };
         let bus = &mut buses[bus.0 - 1];
@@ -1185,6 +1699,14 @@ fn build(
         if let Some(angle) = observation.1 {
             bus.va = angle;
         }
+    }
+    if unmapped_sv_voltages > 0 {
+        warnings.push_as(
+            &codes::READ_CGMES_RECORD_UNMAPPED,
+            format!(
+                "{unmapped_sv_voltages} SvVoltage record(s) observe TopologicalNode identities the set does not define; the calculated buses keep their default voltage because no TP data ties those observations to ConnectivityNodes"
+            ),
+        );
     }
     for topological_node in store.of_class("TopologicalNode") {
         if let Some((sv_voltage, sv_authority, container_authority)) =
@@ -1252,44 +1774,12 @@ fn build(
             )),
         }
     }
-    let mut sv_status = HashMap::new();
-    for status in store.of_class("SvStatus") {
-        let equipment = store
-            .refv(status, "SvStatus.ConductingEquipment")
-            .ok_or_else(|| Error::FormatRead {
-                format: FMT,
-                message: format!(
-                    "SvStatus {} has no SvStatus.ConductingEquipment reference",
-                    store.name(status)
-                ),
-            })?;
-        let in_service =
-            store
-                .boolean(status, "SvStatus.inService")
-                .ok_or_else(|| Error::FormatRead {
-                    format: FMT,
-                    message: format!(
-                        "SvStatus {} has no boolean SvStatus.inService value",
-                        store.name(status)
-                    ),
-                })?;
-        if let Some(previous) = sv_status.insert(equipment.to_string(), in_service)
-            && previous != in_service
-        {
-            return Err(Error::FormatRead {
-                format: FMT,
-                message: format!(
-                    "conducting equipment {} has conflicting SvStatus.inService values",
-                    store.name(equipment)
-                ),
-            });
-        }
-    }
-
     let mut mapper = Mapper {
         store,
+        topology,
         wiring,
-        bus_of_tn,
+        bus_of_node,
+        calculated,
         kv_of,
         sv_flow,
         sv_status,
@@ -1311,9 +1801,9 @@ fn build(
     for island in store.of_class("TopologicalIsland") {
         if let Some(bus) = store
             .refv(island, "TopologicalIsland.AngleRefTopologicalNode")
-            .and_then(|tn| mapper.bus_of_tn.get(tn))
+            .and_then(|tn| mapper.bus_of_topological_node(tn))
         {
-            reference = Some(*bus);
+            reference = Some(bus);
             break;
         }
     }
@@ -1432,27 +1922,79 @@ fn component_type(class: &str) -> &'static str {
     }
 }
 
+/// The connectivity container a node or equipment container resolves to: a
+/// `Bay` stands in for its `Bay.VoltageLevel`, because PowerIO's topology
+/// records name voltage levels rather than bays; every other container (a
+/// `VoltageLevel`, a `Line`, a `Substation`) is itself.
+fn resolve_container<'a>(store: &'a Store, container: &'a str) -> &'a str {
+    if store.class_of(container) == Some("Bay") {
+        store
+            .refv(container, "Bay.VoltageLevel")
+            .unwrap_or(container)
+    } else {
+        container
+    }
+}
+
+fn connectivity_node_container<'a>(store: &'a Store, node: &str) -> Option<&'a str> {
+    store
+        .refv(node, "ConnectivityNode.ConnectivityNodeContainer")
+        .map(|container| resolve_container(store, container))
+}
+
+fn topological_node_container<'a>(store: &'a Store, node: &str) -> Option<&'a str> {
+    store
+        .refv(node, "TopologicalNode.ConnectivityNodeContainer")
+        .map(|container| resolve_container(store, container))
+}
+
 fn equipment_voltage_level<'a>(store: &'a Store, equipment: &str) -> Option<&'a str> {
     store
         .refv(equipment, "Equipment.EquipmentContainer")
+        .map(|container| resolve_container(store, container))
         .filter(|container| store.class_of(container) == Some("VoltageLevel"))
 }
 
+/// The container a terminal's topology record names: its connectivity node's
+/// container, else its topological node's, else the container of its
+/// conducting equipment (a junction terminal in a 2.4.15 EQ_BD has no
+/// ConnectivityNode and, without TP_BD, no TopologicalNode either).
 fn terminal_voltage_level<'a>(store: &'a Store, terminal: &str) -> Option<&'a str> {
     if let Some(node) = store.refv(terminal, "Terminal.ConnectivityNode") {
-        return store.refv(node, "ConnectivityNode.ConnectivityNodeContainer");
+        return connectivity_node_container(store, node);
     }
     if let Some(node) = store.refv(terminal, "Terminal.TopologicalNode") {
-        return store.refv(node, "TopologicalNode.ConnectivityNodeContainer");
+        return topological_node_level(store, node);
     }
     store
         .refv(terminal, "Terminal.ConductingEquipment")
-        .and_then(|equipment| equipment_voltage_level(store, equipment))
+        .and_then(|equipment| store.refv(equipment, "Equipment.EquipmentContainer"))
+        .map(|container| resolve_container(store, container))
+}
+
+/// The container a TopologicalNode's topology records name. A TopologicalNode
+/// whose own container holds none of its ConnectivityNodes (a TP_BD
+/// TopologicalNode names one Line while its EQ_BD node names another)
+/// follows the nodes' container, because one bus belongs to one container.
+fn topological_node_level<'a>(store: &'a Store, topological_node: &str) -> Option<&'a str> {
+    let own = topological_node_container(store, topological_node)?;
+    let mut members = store.of_class("ConnectivityNode").filter(|node| {
+        store.refv(node, "ConnectivityNode.TopologicalNode") == Some(topological_node)
+    });
+    let Some(first) = members.next() else {
+        return Some(own);
+    };
+    if connectivity_node_container(store, first) == Some(own)
+        || members.any(|node| connectivity_node_container(store, node) == Some(own))
+    {
+        return Some(own);
+    }
+    connectivity_node_container(store, first).or(Some(own))
 }
 
 fn terminal_nominal_kv(mapper: &Mapper<'_>, terminal: &str) -> Option<f64> {
     if let Some(node) = mapper.wiring.node(terminal)
-        && let Some(bus) = mapper.bus_of_tn.get(node)
+        && let Some(bus) = mapper.bus_of_node.get(node)
     {
         return Some(mapper.kv(*bus));
     }
@@ -1688,16 +2230,22 @@ fn build_detailed_connectivity(
                 .refv(id, "VoltageLevel.BaseVoltage")
                 .and_then(|base| store.f(base, "BaseVoltage.nominalVoltage"))
                 .unwrap_or(0.0);
-            let has_nodes = store.of_class("ConnectivityNode").any(|node| {
-                store.refv(node, "ConnectivityNode.ConnectivityNodeContainer") == Some(id)
-            });
-            let mut buses = store
-                .of_class("TopologicalNode")
-                .filter(|node| {
-                    store.refv(node, "TopologicalNode.ConnectivityNodeContainer") == Some(id)
-                })
-                .filter_map(|node| mapper.bus_of_tn.get(node).copied())
-                .collect::<Vec<_>>();
+            let has_nodes = store
+                .of_class("ConnectivityNode")
+                .any(|node| connectivity_node_container(store, node) == Some(id));
+            let mut buses = match mapper.topology {
+                BusSource::TopologicalNodes => store
+                    .of_class("TopologicalNode")
+                    .filter(|node| topological_node_container(store, node) == Some(id))
+                    .filter_map(|node| mapper.bus_of_node.get(node).copied())
+                    .collect::<Vec<_>>(),
+                BusSource::Calculated => mapper
+                    .calculated
+                    .iter()
+                    .filter(|group| group.container == id)
+                    .map(|group| group.bus)
+                    .collect::<Vec<_>>(),
+            };
             buses.sort_unstable();
             buses.dedup();
             Ok(VoltageLevel {
@@ -1722,7 +2270,13 @@ fn build_detailed_connectivity(
 
     let mut connectivity_nodes = Vec::new();
     for id in store.of_class("ConnectivityNode") {
-        if let Some(level) = store.refv(id, "ConnectivityNode.ConnectivityNodeContainer") {
+        if let Some(level) = connectivity_node_container(store, id) {
+            let calculated_bus = match mapper.topology {
+                BusSource::TopologicalNodes => store
+                    .refv(id, "ConnectivityNode.TopologicalNode")
+                    .and_then(|node| mapper.bus_of_node.get(node).copied()),
+                BusSource::Calculated => mapper.bus_of_node.get(id).copied(),
+            };
             connectivity_nodes.push(ConnectivityNode {
                 component: component_id("connectivity_node", id)?,
                 voltage_level: component_id(
@@ -1730,16 +2284,14 @@ fn build_detailed_connectivity(
                     level,
                 )?,
                 node_number: None,
-                calculated_bus: store
-                    .refv(id, "ConnectivityNode.TopologicalNode")
-                    .and_then(|node| mapper.bus_of_tn.get(node).copied()),
+                calculated_bus,
             });
         }
     }
 
     let mut bus_breaker_buses = Vec::new();
     for id in store.of_class("TopologicalNode") {
-        if let Some(level) = store.refv(id, "TopologicalNode.ConnectivityNodeContainer") {
+        if let Some(level) = topological_node_level(store, id) {
             let (voltage_kv, angle_degrees) = solved_voltage(store, id);
             bus_breaker_buses.push(BusBreakerBus {
                 component: component_id("bus", id)?,
@@ -1747,7 +2299,7 @@ fn build_detailed_connectivity(
                     component_type(store.class_of(level).unwrap_or("")),
                     level,
                 )?,
-                calculated_bus: mapper.bus_of_tn.get(id).copied(),
+                calculated_bus: mapper.bus_of_topological_node(id),
                 voltage_kv,
                 angle_degrees,
             });
@@ -1755,32 +2307,70 @@ fn build_detailed_connectivity(
     }
 
     let mut calculated_buses = Vec::new();
-    for id in store.of_class("TopologicalNode") {
-        let (Some(level), Some(calculated_bus)) = (
-            store.refv(id, "TopologicalNode.ConnectivityNodeContainer"),
-            mapper.bus_of_tn.get(id).copied(),
-        ) else {
-            continue;
-        };
-        let nodes = store
-            .of_class("ConnectivityNode")
-            .filter(|node| store.refv(node, "ConnectivityNode.TopologicalNode") == Some(id))
-            .map(|node| component_id("connectivity_node", node))
-            .collect::<Result<Vec<_>>>()?;
-        if nodes.is_empty() {
-            continue;
+    match mapper.topology {
+        BusSource::TopologicalNodes => {
+            for id in store.of_class("TopologicalNode") {
+                let (Some(own_level), Some(level), Some(calculated_bus)) = (
+                    topological_node_container(store, id),
+                    topological_node_level(store, id),
+                    mapper.bus_of_topological_node(id),
+                ) else {
+                    continue;
+                };
+                let members = store
+                    .of_class("ConnectivityNode")
+                    .filter(|node| store.refv(node, "ConnectivityNode.TopologicalNode") == Some(id))
+                    .collect::<Vec<_>>();
+                if members.is_empty() {
+                    continue;
+                }
+                if level != own_level {
+                    mapper.warnings.push_as(
+                        &codes::READ_CGMES_VALUE_APPROXIMATED,
+                        format!(
+                            "TopologicalNode `{id}` is contained by `{own_level}` while its ConnectivityNodes are contained by `{level}`; the topology records follow the ConnectivityNodes"
+                        ),
+                    );
+                }
+                // One record names one container, so nodes joined from another
+                // container map to the bus without being listed.
+                let nodes = members
+                    .iter()
+                    .filter(|node| connectivity_node_container(store, node) == Some(level))
+                    .map(|node| component_id("connectivity_node", node))
+                    .collect::<Result<Vec<_>>>()?;
+                let (voltage_kv, angle_degrees) = solved_voltage(store, id);
+                calculated_buses.push(CalculatedBus {
+                    voltage_level: component_id(
+                        component_type(store.class_of(level).unwrap_or("")),
+                        level,
+                    )?,
+                    calculated_bus,
+                    nodes,
+                    voltage_kv,
+                    angle_degrees,
+                });
+            }
         }
-        let (voltage_kv, angle_degrees) = solved_voltage(store, id);
-        calculated_buses.push(CalculatedBus {
-            voltage_level: component_id(
-                component_type(store.class_of(level).unwrap_or("")),
-                level,
-            )?,
-            calculated_bus,
-            nodes,
-            voltage_kv,
-            angle_degrees,
-        });
+        BusSource::Calculated => {
+            for group in &mapper.calculated {
+                let nodes = group
+                    .nodes
+                    .iter()
+                    .map(|node| component_id("connectivity_node", node))
+                    .collect::<Result<Vec<_>>>()?;
+                calculated_buses.push(CalculatedBus {
+                    voltage_level: component_id(
+                        component_type(store.class_of(&group.container).unwrap_or("")),
+                        &group.container,
+                    )?,
+                    calculated_bus: group.bus,
+                    nodes,
+                    voltage_kv: None,
+                    angle_degrees: None,
+                });
+            }
+        }
     }
 
     let mut synthesized_busbar_nodes = HashMap::new();
@@ -1802,10 +2392,8 @@ fn build_detailed_connectivity(
                 ));
                 continue;
             };
-            let Some(topological_level) = store.refv(
-                topological_node,
-                "TopologicalNode.ConnectivityNodeContainer",
-            ) else {
+            let Some(topological_level) = topological_node_container(store, topological_node)
+            else {
                 mapper.warnings.push(format!(
                     "BusbarSection {} has no unambiguous VoltageLevel through TopologicalNode {} and was skipped",
                     store.name(id),
@@ -1813,7 +2401,7 @@ fn build_detailed_connectivity(
                 ));
                 continue;
             };
-            let Some(calculated_bus) = mapper.bus_of_tn.get(topological_node).copied() else {
+            let Some(calculated_bus) = mapper.bus_of_topological_node(topological_node) else {
                 mapper.warnings.push(format!(
                     "BusbarSection {} TopologicalNode {} has no calculated bus and was skipped",
                     store.name(id),
@@ -1861,6 +2449,7 @@ fn build_detailed_connectivity(
         .collect::<Result<Vec<_>>>()?;
 
     let mut terminals = Vec::new();
+    let mut unplaced_terminals: Vec<String> = Vec::new();
     for id in store.of_class("Terminal") {
         let Some(equipment) = store.refv(id, "Terminal.ConductingEquipment") else {
             continue;
@@ -1874,6 +2463,19 @@ fn build_detailed_connectivity(
             .unwrap_or(1.0);
         let terminal = u8::try_from(sequence as u64).unwrap_or(u8::MAX);
         let bus = store.refv(id, "Terminal.TopologicalNode");
+        let node = store
+            .refv(id, "Terminal.ConnectivityNode")
+            .map(|value| component_id("connectivity_node", value))
+            .transpose()?
+            .or_else(|| synthesized_busbar_nodes.get(id).cloned());
+        let stated_connected = store.boolean(id, "ACDCTerminal.connected").unwrap_or(true);
+        // A terminal that names neither a ConnectivityNode nor a
+        // TopologicalNode (a 2.4.15 EQ_BD junction terminal read without
+        // TP_BD) sits on no bus, so its record states no connection.
+        let unplaced = node.is_none() && bus.is_none();
+        if unplaced && stated_connected {
+            unplaced_terminals.push(id.to_string());
+        }
         let solved_power = mapper.sv_flow.get(id).copied();
         terminals.push(Terminal {
             component: Some(component_id("terminal", id)?),
@@ -1888,15 +2490,21 @@ fn build_detailed_connectivity(
             )?,
             bus: bus.map(|value| component_id("bus", value)).transpose()?,
             connectable_bus: bus.map(|value| component_id("bus", value)).transpose()?,
-            node: store
-                .refv(id, "Terminal.ConnectivityNode")
-                .map(|value| component_id("connectivity_node", value))
-                .transpose()?
-                .or_else(|| synthesized_busbar_nodes.get(id).cloned()),
-            connected: store.boolean(id, "ACDCTerminal.connected").unwrap_or(true),
+            node,
+            connected: stated_connected && !unplaced,
             active_power_mw: solved_power.map(|value| value.0),
             reactive_power_mvar: solved_power.map(|value| value.1),
         });
+    }
+    if !unplaced_terminals.is_empty() {
+        mapper.warnings.push_as(
+            &codes::READ_CGMES_RECORD_UNMAPPED,
+            format!(
+                "{} connected terminal(s) (sample `{}`) reference neither a ConnectivityNode nor a TopologicalNode, so nothing places them on a bus; their records state no connection",
+                unplaced_terminals.len(),
+                unplaced_terminals[0]
+            ),
+        );
     }
 
     let mut switches = Vec::new();
@@ -3948,7 +4556,7 @@ fn apply_regulation(
         .flatten();
     let regulated = terminal
         .and_then(|t| mapper.wiring.node(t))
-        .and_then(|tn| mapper.bus_of_tn.get(tn))
+        .and_then(|tn| mapper.bus_of_node.get(tn))
         .copied();
     if let Some(bus) = regulated {
         if let Some(target) = regulating_control_target_kv(store, control, mapper.warnings)
@@ -4138,7 +4746,7 @@ fn shunt_control(
     let regulated_bus = regulation
         .and_then(|control| store.refv(control, "RegulatingControl.Terminal"))
         .and_then(|terminal| mapper.wiring.node(terminal))
-        .and_then(|node| mapper.bus_of_tn.get(node))
+        .and_then(|node| mapper.bus_of_node.get(node))
         .copied();
     let regulated_kv = regulated_bus.map_or(1.0, |bus| mapper.kv(bus));
     let scale_to_kv = regulation.map_or(1.0, |control| {
@@ -4214,16 +4822,13 @@ fn read_switches(mapper: &mut Mapper<'_>) -> Vec<Switch> {
                 continue;
             };
             if from == to {
-                // Closed inside one topological node: already collapsed by
-                // the topology processor that produced TP.
+                // Closed inside one bus: the topology processor that produced
+                // TP, or the calculated topology, already joined its ends.
                 internal += 1;
                 continue;
             }
             let store = mapper.store;
-            let open = store
-                .boolean(id, "Switch.open")
-                .or_else(|| store.boolean(id, "Switch.normalOpen"))
-                .unwrap_or(false);
+            let open = switch_is_open(store, id);
             let mut switch = Switch::new(from, to, !open);
             switch.current_rating = store.f(id, "Switch.ratedCurrent");
             switch.uid = Some(id.to_string());
@@ -4231,10 +4836,14 @@ fn read_switches(mapper: &mut Mapper<'_>) -> Vec<Switch> {
         }
     }
     if internal > 0 {
+        let bus_kind = match mapper.topology {
+            BusSource::TopologicalNodes => "topological node",
+            BusSource::Calculated => "calculated bus",
+        };
         mapper.warnings.push_as(
             &codes::READ_CGMES_VALUE_APPROXIMATED,
             format!(
-                "{internal} switch(es) internal to one topological node are represented \
+                "{internal} switch(es) internal to one {bus_kind} are represented \
              by the topology itself"
             ),
         );
@@ -4412,7 +5021,7 @@ fn read_two_winding_transformer(
         store
             .refv(end, "TransformerEnd.Terminal")
             .and_then(|terminal| mapper.wiring.node(terminal))
-            .and_then(|node| mapper.bus_of_tn.get(node))
+            .and_then(|node| mapper.bus_of_node.get(node))
             .copied()
     };
     let (Some(from), Some(to)) = (end_terminal(end1), end_terminal(end2)) else {
@@ -4606,7 +5215,7 @@ fn transformer_end_buses(
         let Some(bus) = mapper
             .wiring
             .node(&terminal)
-            .and_then(|node| mapper.bus_of_tn.get(node))
+            .and_then(|node| mapper.bus_of_node.get(node))
             .copied()
         else {
             mapper.warnings.push(format!(

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -62,6 +62,7 @@ mod pypsa;
 mod rawx;
 pub mod routing;
 mod surge;
+mod union_find;
 mod xiidm;
 
 pub use powerworld::{PwdDisplay, PwdSubstation};

--- a/powerio-tx/src/format/union_find.rs
+++ b/powerio-tx/src/format/union_find.rs
@@ -1,0 +1,36 @@
+//! Disjoint set forest over dense indices, used to join topology nodes into
+//! calculated buses.
+
+pub(crate) struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    pub(crate) fn new(len: usize) -> Self {
+        Self {
+            parent: (0..len).collect(),
+        }
+    }
+
+    /// The representative of `value`'s set, compressing the visited chain.
+    pub(crate) fn find(&mut self, value: usize) -> usize {
+        let parent = self.parent[value];
+        if parent == value {
+            value
+        } else {
+            let root = self.find(parent);
+            self.parent[value] = root;
+            root
+        }
+    }
+
+    /// Merge the sets containing `first` and `second`; the representative of
+    /// `first`'s set stays the representative.
+    pub(crate) fn union(&mut self, first: usize, second: usize) {
+        let first = self.find(first);
+        let second = self.find(second);
+        if first != second {
+            self.parent[second] = first;
+        }
+    }
+}

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -24,6 +24,7 @@ use quick_xml::name::ResolveResult;
 
 use crate::diagnostics::{Diagnostics, codes};
 use crate::format::TextEmission;
+use crate::format::union_find::UnionFind;
 use crate::network::{
     AcDcConverterControlMode, ActivePowerControl, Area, BalancedNetwork, BoundaryLine,
     BoundaryLineGeneration, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet,
@@ -6419,37 +6420,6 @@ fn detailed_endpoint(voltage_level: &str, endpoint: &RawEndpoint) -> Result<Topo
             voltage_level,
             *node,
         )?)),
-    }
-}
-
-struct UnionFind {
-    parent: Vec<usize>,
-}
-
-impl UnionFind {
-    fn new(len: usize) -> Self {
-        Self {
-            parent: (0..len).collect(),
-        }
-    }
-
-    fn find(&mut self, value: usize) -> usize {
-        let parent = self.parent[value];
-        if parent == value {
-            value
-        } else {
-            let root = self.find(parent);
-            self.parent[value] = root;
-            root
-        }
-    }
-
-    fn union(&mut self, first: usize, second: usize) {
-        let first = self.find(first);
-        let second = self.find(second);
-        if first != second {
-            self.parent[second] = first;
-        }
     }
 }
 

--- a/powerio/tests/cgmes.rs
+++ b/powerio/tests/cgmes.rs
@@ -1,4 +1,7 @@
-use powerio::{Destination, EmittedOutput, Fidelity, OutputLayout, PioValue, Source, emit, parse};
+use powerio::{
+    Destination, EmittedOutput, Fidelity, OutputLayout, PioValue, Source, deserialize, emit, parse,
+    serialize,
+};
 use std::io::{Cursor, Write};
 
 #[test]
@@ -33,6 +36,74 @@ fn facade_emits_and_parses_a_cgmes_profile_directory() {
         panic!("a memory destination returned paths");
     };
     assert_eq!(artifacts.len(), 4);
+}
+
+#[test]
+fn facade_calculates_node_breaker_buses_without_a_tp_profile() {
+    let directory = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../tests/data/cgmes/node-breaker"
+    );
+    let module = parse(Source::open(directory).unwrap(), None)
+        .expect("a node breaker EQ and SSH set parses without TP");
+    let PioValue::BalancedNetwork(network) = &module.value else {
+        panic!("CGMES must produce a balanced network");
+    };
+    assert_eq!(network.buses().len(), 3);
+    let remark = module
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code() == "READ.CGMES.TOPOLOGY_CALCULATED")
+        .expect("the calculated topology is reported");
+    assert!(remark.message().contains("3 calculated bus(es)"));
+    let uids: Vec<Option<String>> = network.buses().iter().map(|bus| bus.uid.clone()).collect();
+    assert!(uids.iter().all(Option::is_some));
+
+    // PowerIO IR carries no retained source, so emission from it is fresh.
+    let stored = serialize(&module, Destination::memory("module").unwrap())
+        .expect("the calculated topology serializes");
+    let EmittedOutput::Memory { artifacts: stored } = stored.into_output() else {
+        panic!("a memory destination returned paths")
+    };
+    let restored =
+        deserialize(Source::from_memory("module.pio.json", stored[0].bytes().to_vec()).unwrap())
+            .expect("the stored module deserializes");
+    let fresh = emit(&restored, "cgmes", Destination::memory("fresh").unwrap())
+        .expect("a calculated topology emits fresh CGMES");
+    assert_eq!(fresh.fidelity(), Fidelity::Canonical);
+    let EmittedOutput::Memory { artifacts } = fresh.into_output() else {
+        panic!("a memory destination returned paths")
+    };
+    assert_eq!(artifacts.len(), 4);
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    for artifact in artifacts {
+        writer
+            .start_file(
+                artifact.name().as_str(),
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        writer.write_all(artifact.bytes()).unwrap();
+    }
+    let zip_bytes = writer.finish().unwrap().into_inner();
+    let reparsed = parse(Source::from_memory("fresh.zip", zip_bytes).unwrap(), None)
+        .expect("the fresh profile set, now with TP, parses");
+    let PioValue::BalancedNetwork(reparsed_network) = &reparsed.value else {
+        panic!("CGMES must produce a balanced network");
+    };
+    assert_eq!(reparsed_network.buses().len(), 3);
+    let reparsed_uids: Vec<Option<String>> = reparsed_network
+        .buses()
+        .iter()
+        .map(|bus| bus.uid.clone())
+        .collect();
+    assert_eq!(reparsed_uids, uids);
+    assert!(
+        reparsed
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code() != "READ.CGMES.TOPOLOGY_CALCULATED")
+    );
 }
 
 #[test]

--- a/powerio/tests/cgmes.rs
+++ b/powerio/tests/cgmes.rs
@@ -46,7 +46,7 @@ fn facade_calculates_node_breaker_buses_without_a_tp_profile() {
     );
     let module = parse(Source::open(directory).unwrap(), None)
         .expect("a node breaker EQ and SSH set parses without TP");
-    let PioValue::BalancedNetwork(network) = &module.value else {
+    let PioValue::BalancedNetwork(network) = &module.value() else {
         panic!("CGMES must produce a balanced network");
     };
     assert_eq!(network.buses().len(), 3);
@@ -88,7 +88,7 @@ fn facade_calculates_node_breaker_buses_without_a_tp_profile() {
     let zip_bytes = writer.finish().unwrap().into_inner();
     let reparsed = parse(Source::from_memory("fresh.zip", zip_bytes).unwrap(), None)
         .expect("the fresh profile set, now with TP, parses");
-    let PioValue::BalancedNetwork(reparsed_network) = &reparsed.value else {
+    let PioValue::BalancedNetwork(reparsed_network) = &reparsed.value() else {
         panic!("CGMES must produce a balanced network");
     };
     assert_eq!(reparsed_network.buses().len(), 3);

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -44,6 +44,13 @@ cases. Provenance and per-directory licenses in `dist/README.md`.
 Tool generated fixtures with regeneration scripts and license notes in their
 own READMEs (`pandapower/README.md`, `pypsa/README.md`).
 
+## `cgmes/`
+
+Hand written CGMES documents original to this repository under its code
+license. `cgmes/node-breaker/` is a CGMES 2.4.15 EQ and SSH set without a TP
+profile; `cgmes/node-breaker/README.md` describes its equipment and the
+calculated buses it exercises. No ENTSO-E conformity data is vendored.
+
 ## `psse/` and `egret/`
 
 Original to this repository: the PSS/E RAW files are hand written minimal

--- a/tests/data/cgmes/node-breaker/NodeBreaker_EQ.xml
+++ b/tests/data/cgmes/node-breaker/NodeBreaker_EQ.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:6e0b7c5a-1b2f-4c1d-9a3e-000000000001">
+    <md:Model.scenarioTime>2026-01-01T00:00:00</md:Model.scenarioTime>
+    <md:Model.created>2026-01-01T00:00:00</md:Model.created>
+    <md:Model.description>PowerIO synthetic node breaker equipment set without a TP profile</md:Model.description>
+    <md:Model.version>1</md:Model.version>
+    <md:Model.profile>http://entsoe.eu/CIM/EquipmentCore/3/1</md:Model.profile>
+    <md:Model.profile>http://entsoe.eu/CIM/EquipmentOperation/3/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://powerio.dev/tests</md:Model.modelingAuthoritySet>
+  </md:FullModel>
+  <cim:BaseVoltage rdf:ID="_b1100000-0000-4000-8000-000000000110">
+    <cim:IdentifiedObject.name>110 kV</cim:IdentifiedObject.name>
+    <cim:BaseVoltage.nominalVoltage>110</cim:BaseVoltage.nominalVoltage>
+  </cim:BaseVoltage>
+  <cim:GeographicalRegion rdf:ID="_9e000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>REGION</cim:IdentifiedObject.name>
+  </cim:GeographicalRegion>
+  <cim:SubGeographicalRegion rdf:ID="_9e000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>SUBREGION</cim:IdentifiedObject.name>
+    <cim:SubGeographicalRegion.Region rdf:resource="#_9e000000-0000-4000-8000-000000000001" />
+  </cim:SubGeographicalRegion>
+  <cim:Substation rdf:ID="_5a000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>S1</cim:IdentifiedObject.name>
+    <cim:Substation.Region rdf:resource="#_9e000000-0000-4000-8000-000000000002" />
+  </cim:Substation>
+  <cim:VoltageLevel rdf:ID="_a1000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>VL1</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_5a000000-0000-4000-8000-000000000001" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:VoltageLevel>
+  <cim:VoltageLevel rdf:ID="_a1000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>VL2</cim:IdentifiedObject.name>
+    <cim:VoltageLevel.Substation rdf:resource="#_5a000000-0000-4000-8000-000000000001" />
+    <cim:VoltageLevel.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:VoltageLevel>
+  <cim:Bay rdf:ID="_ba000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>BAY1</cim:IdentifiedObject.name>
+    <cim:Bay.VoltageLevel rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+  </cim:Bay>
+  <cim:Line rdf:ID="_11000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>LINE1</cim:IdentifiedObject.name>
+  </cim:Line>
+  <cim:ConnectivityNode rdf:ID="_c0000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>N1</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_c0000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>N2</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_ba000000-0000-4000-8000-000000000001" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_c0000000-0000-4000-8000-000000000003">
+    <cim:IdentifiedObject.name>N3</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_c0000000-0000-4000-8000-000000000004">
+    <cim:IdentifiedObject.name>N4</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_a1000000-0000-4000-8000-000000000002" />
+  </cim:ConnectivityNode>
+  <cim:ConnectivityNode rdf:ID="_c0000000-0000-4000-8000-000000000005">
+    <cim:IdentifiedObject.name>N5</cim:IdentifiedObject.name>
+    <cim:ConnectivityNode.ConnectivityNodeContainer rdf:resource="#_a1000000-0000-4000-8000-000000000002" />
+  </cim:ConnectivityNode>
+  <cim:BusbarSection rdf:ID="_bb000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>BB1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>BB1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000001" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_bb000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:BusbarSection rdf:ID="_bb000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>BB2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000002" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:BusbarSection>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>BB2_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000004" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_bb000000-0000-4000-8000-000000000002" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_5b000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>BRK1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_ba000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>true</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000011">
+    <cim:IdentifiedObject.name>BRK1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000001" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5b000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000012">
+    <cim:IdentifiedObject.name>BRK1_T2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000002" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5b000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:Disconnector rdf:ID="_5d000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>DSC1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Disconnector>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000021">
+    <cim:IdentifiedObject.name>DSC1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000002" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5d000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000022">
+    <cim:IdentifiedObject.name>DSC1_T2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000003" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5d000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:Breaker rdf:ID="_5b000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>BRK2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000002" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+    <cim:Switch.normalOpen>false</cim:Switch.normalOpen>
+    <cim:Switch.retained>false</cim:Switch.retained>
+  </cim:Breaker>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000031">
+    <cim:IdentifiedObject.name>BRK2_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000004" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5b000000-0000-4000-8000-000000000002" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000032">
+    <cim:IdentifiedObject.name>BRK2_T2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000005" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5b000000-0000-4000-8000-000000000002" />
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:ID="_ec000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>L1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_ba000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:EnergyConsumer>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000041">
+    <cim:IdentifiedObject.name>L1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000002" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ec000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:ID="_ec000000-0000-4000-8000-000000000002">
+    <cim:IdentifiedObject.name>L2</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:EnergyConsumer>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000042">
+    <cim:IdentifiedObject.name>L2_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000003" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ec000000-0000-4000-8000-000000000002" />
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:ID="_ec000000-0000-4000-8000-000000000003">
+    <cim:IdentifiedObject.name>L3</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000002" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+  </cim:EnergyConsumer>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000043">
+    <cim:IdentifiedObject.name>L3_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000005" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ec000000-0000-4000-8000-000000000003" />
+  </cim:Terminal>
+  <cim:ThermalGeneratingUnit rdf:ID="_6e000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>GU1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_5a000000-0000-4000-8000-000000000001" />
+    <cim:GeneratingUnit.initialP>30</cim:GeneratingUnit.initialP>
+    <cim:GeneratingUnit.maxOperatingP>100</cim:GeneratingUnit.maxOperatingP>
+    <cim:GeneratingUnit.minOperatingP>0</cim:GeneratingUnit.minOperatingP>
+  </cim:ThermalGeneratingUnit>
+  <cim:SynchronousMachine rdf:ID="_5e000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>G1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_a1000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+    <cim:RotatingMachine.ratedS>100</cim:RotatingMachine.ratedS>
+    <cim:RotatingMachine.GeneratingUnit rdf:resource="#_6e000000-0000-4000-8000-000000000001" />
+    <cim:SynchronousMachine.maxQ>50</cim:SynchronousMachine.maxQ>
+    <cim:SynchronousMachine.minQ>-50</cim:SynchronousMachine.minQ>
+    <cim:SynchronousMachine.type rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineKind.generator" />
+  </cim:SynchronousMachine>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000051">
+    <cim:IdentifiedObject.name>G1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000001" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_5e000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:ACLineSegment rdf:ID="_ac000000-0000-4000-8000-000000000001">
+    <cim:IdentifiedObject.name>LINE1</cim:IdentifiedObject.name>
+    <cim:Equipment.EquipmentContainer rdf:resource="#_11000000-0000-4000-8000-000000000001" />
+    <cim:ConductingEquipment.BaseVoltage rdf:resource="#_b1100000-0000-4000-8000-000000000110" />
+    <cim:ACLineSegment.r>1.21</cim:ACLineSegment.r>
+    <cim:ACLineSegment.x>6.05</cim:ACLineSegment.x>
+    <cim:ACLineSegment.bch>0.0000412</cim:ACLineSegment.bch>
+    <cim:ACLineSegment.gch>0</cim:ACLineSegment.gch>
+  </cim:ACLineSegment>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000061">
+    <cim:IdentifiedObject.name>LINE1_T1</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>1</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000001" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ac000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+  <cim:Terminal rdf:ID="_1e000000-0000-4000-8000-000000000062">
+    <cim:IdentifiedObject.name>LINE1_T2</cim:IdentifiedObject.name>
+    <cim:ACDCTerminal.sequenceNumber>2</cim:ACDCTerminal.sequenceNumber>
+    <cim:Terminal.ConnectivityNode rdf:resource="#_c0000000-0000-4000-8000-000000000004" />
+    <cim:Terminal.ConductingEquipment rdf:resource="#_ac000000-0000-4000-8000-000000000001" />
+  </cim:Terminal>
+</rdf:RDF>

--- a/tests/data/cgmes/node-breaker/NodeBreaker_SSH.xml
+++ b/tests/data/cgmes/node-breaker/NodeBreaker_SSH.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <md:FullModel rdf:about="urn:uuid:6e0b7c5a-1b2f-4c1d-9a3e-000000000002">
+    <md:Model.scenarioTime>2026-01-01T00:00:00</md:Model.scenarioTime>
+    <md:Model.created>2026-01-01T00:00:00</md:Model.created>
+    <md:Model.description>PowerIO synthetic node breaker equipment set without a TP profile</md:Model.description>
+    <md:Model.version>1</md:Model.version>
+    <md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.modelingAuthoritySet>http://powerio.dev/tests</md:Model.modelingAuthoritySet>
+    <md:Model.DependentOn rdf:resource="urn:uuid:6e0b7c5a-1b2f-4c1d-9a3e-000000000001" />
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000001">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000002">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000011">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000012">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000021">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000022">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000031">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000032">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000041">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000042">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000043">
+    <cim:ACDCTerminal.connected>false</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000051">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000061">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1e000000-0000-4000-8000-000000000062">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Breaker rdf:about="#_5b000000-0000-4000-8000-000000000001">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:Disconnector rdf:about="#_5d000000-0000-4000-8000-000000000001">
+    <cim:Switch.open>true</cim:Switch.open>
+  </cim:Disconnector>
+  <cim:Breaker rdf:about="#_5b000000-0000-4000-8000-000000000002">
+    <cim:Switch.open>false</cim:Switch.open>
+  </cim:Breaker>
+  <cim:EnergyConsumer rdf:about="#_ec000000-0000-4000-8000-000000000001">
+    <cim:EnergyConsumer.p>10</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>2</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_ec000000-0000-4000-8000-000000000002">
+    <cim:EnergyConsumer.p>5</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>1</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_ec000000-0000-4000-8000-000000000003">
+    <cim:EnergyConsumer.p>8</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>3</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:SynchronousMachine rdf:about="#_5e000000-0000-4000-8000-000000000001">
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+    <cim:RotatingMachine.p>-30</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-5</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.referencePriority>1</cim:SynchronousMachine.referencePriority>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator" />
+  </cim:SynchronousMachine>
+</rdf:RDF>

--- a/tests/data/cgmes/node-breaker/README.md
+++ b/tests/data/cgmes/node-breaker/README.md
@@ -1,0 +1,27 @@
+# CGMES node breaker fixture without a TP profile
+
+`NodeBreaker_EQ.xml` and `NodeBreaker_SSH.xml` are hand written CGMES 2.4.15
+(CIM16) documents original to this repository under its code license. The EQ
+document declares the EquipmentCore and EquipmentOperation profiles and no TP
+document exists, so the reader calculates the buses from the ConnectivityNode
+graph and the switch positions.
+
+The equipment:
+
+- substation `S1` with voltage levels `VL1` and `VL2` on the 110 kV base
+  voltage; bay `BAY1` inside `VL1` contains node `N2`, breaker `BRK1`, and
+  load `L1`;
+- connectivity nodes `N1`, `N2`, `N3` in `VL1` and `N4`, `N5` in `VL2`;
+- busbar sections `BB1` at `N1` and `BB2` at `N4`;
+- breaker `BRK1` between `N1` and `N2`, closed in SSH;
+- disconnector `DSC1` between `N2` and `N3`, `normalOpen` false in EQ but
+  open in SSH, so the SSH position wins and `N3` is a bus of its own;
+- breaker `BRK2` between `N4` and `N5`, closed in SSH;
+- loads `L1` at `N2`, `L2` at `N3`, and `L3` at `N5`, whose terminal is
+  disconnected in SSH;
+- generator `G1` at `N1` with generating unit `GU1`;
+- line `LINE1` from `N1` to `N4`.
+
+The expected calculation view has three buses: `{N1, N2}` named after `BB1`,
+`{N3}`, and `{N4, N5}` named after `BB2`. Closing `DSC1` in SSH merges the
+first two.


### PR DESCRIPTION
## Summary

- calculate balanced buses from ConnectivityNodes and closed, in-service switches when a node breaker set has no TP data
- preserve declared connectivity identities, derive stable calculated-bus identities, and report calculated or insufficient topology with coded diagnostics
- compare terminal groupings with pinned PowSybl MiniGrid, SmallGrid, and MicroGrid cases
- document the profile, switch-position, connection, container, and identity rules with pinned PowSybl source citations


## Testing

- cargo test -p powerio-tx -p powerio -p powerio-cli
- RUSTUP_TOOLCHAIN=1.98.0 cargo clippy --all-targets -- -D warnings
- cargo fmt --all -- --check
- Python format-list test
- mdbook build docs
- PowSybl gate: 56,034 assertions

Closes #458
