### PR TITLE
Make every conversion matrix warning name a field the target cannot state

### DIFF
--- a/powerio-cli/src/invariants.rs
+++ b/powerio-cli/src/invariants.rs
@@ -115,6 +115,91 @@ impl std::fmt::Display for InjectionChange {
     }
 }
 
+/// `after` with its bus numbers restated as `before`'s, in bus table order, or
+/// `None` when the two already agree or the tables differ in length.
+///
+/// A format that identifies a bus by a name rather than a number (IIDM's
+/// `<bus id="...">`, CIM's mRID) states no bus number, so a reader numbers the
+/// buses it finds and those numbers are a fresh calculation view rather than
+/// the source's. What the conversion does state is the order: each writer emits
+/// the buses in table order and each reader numbers them in the order it reads
+/// them. Relabeling by position therefore compares the network the source
+/// described rather than two numberings of it.
+///
+/// The relabeling is not a licence to lose identity: `id`, `uid`, and `name`
+/// are typed fields, so the model comparison reports every change and a cell
+/// claiming zero warnings fails on it.
+#[must_use]
+pub fn relabel_buses_in_table_order(
+    before: &BalancedNetwork,
+    after: &BalancedNetwork,
+) -> Option<BalancedNetwork> {
+    if before.buses().len() != after.buses().len() {
+        return None;
+    }
+    let renumbering: BTreeMap<powerio_tx::BusId, powerio_tx::BusId> = after
+        .buses()
+        .iter()
+        .zip(before.buses())
+        .filter(|(after, before)| after.id != before.id)
+        .map(|(after, before)| (after.id, before.id))
+        .collect();
+    if renumbering.is_empty() {
+        return None;
+    }
+    let renumbered = |bus: powerio_tx::BusId| renumbering.get(&bus).copied().unwrap_or(bus);
+    let mut out = after.clone();
+    for bus in out.buses_mut() {
+        bus.id = renumbered(bus.id);
+    }
+    for branch in out.branches_mut() {
+        branch.from = renumbered(branch.from);
+        branch.to = renumbered(branch.to);
+        if let Some(control) = branch.control.as_mut() {
+            control.controlled_bus = control.controlled_bus.map(renumbered);
+        }
+    }
+    for switch in out.switches_mut() {
+        switch.from = renumbered(switch.from);
+        switch.to = renumbered(switch.to);
+    }
+    for load in out.loads_mut() {
+        load.bus = renumbered(load.bus);
+    }
+    for shunt in out.shunts_mut() {
+        shunt.bus = renumbered(shunt.bus);
+        if let Some(control) = shunt.control.as_mut() {
+            control.control_bus = control.control_bus.map(renumbered);
+        }
+    }
+    for compensator in out.static_var_compensators_mut() {
+        compensator.bus = renumbered(compensator.bus);
+    }
+    for generator in out.generators_mut() {
+        generator.bus = renumbered(generator.bus);
+        generator.regulated_bus = generator.regulated_bus.map(renumbered);
+    }
+    for line in out.hvdc_mut() {
+        line.from = renumbered(line.from);
+        line.to = renumbered(line.to);
+    }
+    for storage in out.storage_mut() {
+        storage.bus = renumbered(storage.bus);
+    }
+    for area in out.areas_mut() {
+        area.slack_bus = area.slack_bus.map(renumbered);
+    }
+    for transformer in out.transformers_3w_mut() {
+        for winding in &mut transformer.windings {
+            winding.bus = renumbered(winding.bus);
+            if let Some(control) = winding.control.as_mut() {
+                control.controlled_bus = control.controlled_bus.map(renumbered);
+            }
+        }
+    }
+    Some(out)
+}
+
 /// Why a `Y_bus` comparison produced no answer.
 ///
 /// Distinguished from "the matrices agree" on purpose: a network the matrix
@@ -126,12 +211,27 @@ pub enum YbusUnavailable {
     After,
 }
 
-/// The admittance matrix, entry for entry by bus id pair.
+/// The admittance matrix, entry for entry by bus id pair, on one voltage base.
 ///
 /// Warnings account for *dropped* data, never for corrupted electrics, so this
 /// holds on yellow cells too. A format may relocate admittance (pandapower
 /// rides MATPOWER transformer charging as bus shunts) or restate it in other
 /// units, but `Y_bus` is where all of those spellings meet.
+///
+/// A format that states impedances in ohms rather than per unit carries its own
+/// bus nominal voltages, and some of those formats admit only a fixed set: a
+/// UCTE-DEF node code names one of ten voltage levels, so a 345 kV case is
+/// written under the 330 kV level and reads back per unit on 330 kV. The
+/// physical network is the same; only the per-unit reference moved. Each entry
+/// is therefore compared after the standard change of base, scaling the result
+/// entry by `V_before(i) * V_before(j) / (V_after(i) * V_after(j))`, which is
+/// exactly 1 whenever both sides state the same nominal voltage. A bus with no
+/// positive nominal voltage on either side contributes a unit ratio, because a
+/// writer that substitutes one nominal voltage divides by the same value the
+/// reader multiplies back.
+///
+/// A silent base change is still a loss: `base_kv` is a typed field, so the
+/// model comparison reports it and a cell claiming zero warnings fails on it.
 ///
 /// # Errors
 ///
@@ -141,6 +241,21 @@ pub fn ybus_change(
     before: &BalancedNetwork,
     after: &BalancedNetwork,
 ) -> Result<Option<YbusChange>, YbusUnavailable> {
+    let nominal = |net: &BalancedNetwork| -> BTreeMap<usize, f64> {
+        net.buses()
+            .iter()
+            .filter(|bus| bus.base_kv.is_finite() && bus.base_kv > 0.0)
+            .map(|bus| (bus.id.0, bus.base_kv))
+            .collect()
+    };
+    let nominal_before = nominal(before);
+    let nominal_after = nominal(after);
+    let base_ratio = |bus: usize| -> f64 {
+        match (nominal_before.get(&bus), nominal_after.get(&bus)) {
+            (Some(before), Some(after)) => before / after,
+            _ => 1.0,
+        }
+    };
     let entries = |net: &BalancedNetwork| -> Option<BTreeMap<(usize, usize), (f64, f64)>> {
         let view = powerio_matrix::IndexedNetwork::new(net);
         let parts =
@@ -164,6 +279,8 @@ pub fn ybus_change(
     for key in a.keys().chain(b.keys().filter(|k| !a.contains_key(*k))) {
         let (ga, ba) = a.get(key).copied().unwrap_or((0.0, 0.0));
         let (gb, bb) = b.get(key).copied().unwrap_or((0.0, 0.0));
+        let scale = base_ratio(key.0) * base_ratio(key.1);
+        let (gb, bb) = (gb * scale, bb * scale);
         if beyond_tol(ga, gb, ELECTRICAL_TOL) || beyond_tol(ba, bb, ELECTRICAL_TOL) {
             return Ok(Some(YbusChange {
                 from_bus: key.0,

--- a/powerio-cli/src/invariants.rs
+++ b/powerio-cli/src/invariants.rs
@@ -123,6 +123,11 @@ struct BusRow {
     injections: [f64; 4],
 }
 
+/// The relabeling-free electrical digest: one row per bus and one conductance
+/// and susceptance pair per off-diagonal admittance entry, both sorted so a
+/// renumbering does not change them.
+type ElectricalDigest = (Vec<BusRow>, Vec<(f64, f64)>);
+
 /// The electrical problem compared up to bus relabeling, for a target format
 /// that states no bus number.
 ///
@@ -152,7 +157,7 @@ pub fn electrical_change_up_to_relabeling(
             .iter()
             .all(|bus| bus.base_kv.is_finite() && bus.base_kv > 0.0)
     });
-    let digest = |net: &BalancedNetwork| -> Option<(Vec<BusRow>, Vec<(f64, f64)>)> {
+    let digest = |net: &BalancedNetwork| -> Option<ElectricalDigest> {
         let nominal = net
             .buses()
             .iter()

--- a/powerio-cli/src/invariants.rs
+++ b/powerio-cli/src/invariants.rs
@@ -11,7 +11,7 @@
 //! magnitudes into a findings file that may leave the machine. A shared
 //! `format!` would have forced one of those two to be wrong.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use powerio_dist::MulticonductorNetwork;
 use powerio_matrix::BalancedNetwork;
@@ -124,9 +124,98 @@ struct BusRow {
 }
 
 /// The relabeling-free electrical digest: one row per bus and one conductance
-/// and susceptance pair per off-diagonal admittance entry, both sorted so a
-/// renumbering does not change them.
+/// and susceptance pair per off-diagonal admittance entry. Comparison treats
+/// both collections as tolerance-aware multisets, so a renumbering does not
+/// change them.
 type ElectricalDigest = (Vec<BusRow>, Vec<(f64, f64)>);
+
+/// Return one left-hand item that cannot participate in a complete matching.
+///
+/// The alternating-path search compares each item with the predicate instead
+/// of sorting approximate values by their exact float bits. Processing the
+/// most constrained items first keeps the ordinary case linear in the number
+/// of candidate pairs while still finding a complete matching when a greedy
+/// pairing would choose the wrong near-equal row.
+fn unmatched_multiset_item<T>(
+    before: &[T],
+    after: &[T],
+    matches: impl Fn(&T, &T) -> bool,
+) -> Option<usize> {
+    if before.len() != after.len() {
+        return Some(0);
+    }
+    let candidates = before
+        .iter()
+        .map(|before| {
+            after
+                .iter()
+                .enumerate()
+                .filter_map(|(index, after)| matches(before, after).then_some(index))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let mut order = (0..before.len()).collect::<Vec<_>>();
+    order.sort_by_key(|index| candidates[*index].len());
+
+    let mut left_match: Vec<Option<usize>> = vec![None; before.len()];
+    let mut right_match: Vec<Option<usize>> = vec![None; after.len()];
+    for root in order {
+        let mut visited_left = vec![false; before.len()];
+        let mut visited_right = vec![false; after.len()];
+        let mut parent_right = vec![None; after.len()];
+        let mut queue = VecDeque::from([root]);
+        visited_left[root] = true;
+        let mut free = None;
+        while let Some(left) = queue.pop_front() {
+            for &right in &candidates[left] {
+                if visited_right[right] {
+                    continue;
+                }
+                visited_right[right] = true;
+                parent_right[right] = Some(left);
+                if let Some(next_left) = right_match[right] {
+                    if !visited_left[next_left] {
+                        visited_left[next_left] = true;
+                        queue.push_back(next_left);
+                    }
+                } else {
+                    free = Some(right);
+                    break;
+                }
+            }
+            if free.is_some() {
+                break;
+            }
+        }
+        let Some(mut right) = free else {
+            return Some(root);
+        };
+        loop {
+            let left = parent_right[right].expect("an augmenting edge records its left endpoint");
+            let previous = left_match[left].replace(right);
+            right_match[right] = Some(left);
+            let Some(previous) = previous else {
+                break;
+            };
+            right = previous;
+        }
+    }
+    None
+}
+
+fn bus_rows_match(before: &BusRow, after: &BusRow, tolerance: f64) -> bool {
+    !beyond_tol(before.diagonal.0, after.diagonal.0, tolerance)
+        && !beyond_tol(before.diagonal.1, after.diagonal.1, tolerance)
+        && before
+            .injections
+            .iter()
+            .zip(&after.injections)
+            .all(|(before, after)| !beyond_tol(*before, *after, tolerance))
+}
+
+fn admittances_match(before: &(f64, f64), after: &(f64, f64), tolerance: f64) -> bool {
+    !beyond_tol(before.0, after.0, tolerance) && !beyond_tol(before.1, after.1, tolerance)
+}
 
 /// The electrical problem compared up to bus relabeling, for a target format
 /// that states no bus number.
@@ -136,8 +225,8 @@ type ElectricalDigest = (Vec<BusRow>, Vec<(f64, f64)>);
 /// are compared as sorted multisets. That is the power flow problem itself: an
 /// admittance that changed, an injection that moved to a bus with different
 /// neighbours, or an element that vanished all show up, while a renumbering
-/// alone does not. Two buses carrying identical rows are interchangeable, and
-/// exchanging them is the same power flow problem.
+/// alone does not. Two buses carrying rows equal within the requested tolerance
+/// are interchangeable, and exchanging them is the same power flow problem.
 ///
 /// Returns the first row that disagrees, in the digest's own order.
 #[must_use]
@@ -201,9 +290,6 @@ pub fn electrical_change_up_to_relabeling(
                 off_diagonal.push(value);
             }
         }
-        let key = |value: &(f64, f64)| (value.0.to_bits(), value.1.to_bits());
-        rows.sort_by_key(|row| (key(&row.diagonal), row.injections.map(f64::to_bits)));
-        off_diagonal.sort_by_key(key);
         Some((rows, off_diagonal))
     };
     let (before_rows, before_off) = digest(before)?;
@@ -222,29 +308,62 @@ pub fn electrical_change_up_to_relabeling(
             after_off.len()
         ));
     }
-    for (before, after) in before_rows.iter().zip(&after_rows) {
-        let moved = beyond_tol(before.diagonal.0, after.diagonal.0, tolerance)
-            || beyond_tol(before.diagonal.1, after.diagonal.1, tolerance)
-            || before
-                .injections
-                .iter()
-                .zip(&after.injections)
-                .any(|(before, after)| beyond_tol(*before, *after, tolerance));
-        if moved {
-            return Some(format!("bus row {before:?} became {after:?}"));
-        }
+    if let Some(index) = unmatched_multiset_item(&before_rows, &after_rows, |before, after| {
+        bus_rows_match(before, after, tolerance)
+    }) {
+        return Some(format!(
+            "bus row {:?} has no matching result row",
+            before_rows[index]
+        ));
     }
-    for (before, after) in before_off.iter().zip(&after_off) {
-        if beyond_tol(before.0, after.0, tolerance) || beyond_tol(before.1, after.1, tolerance) {
-            return Some(format!(
-                "off-diagonal admittance {before:?} became {after:?}"
-            ));
-        }
+    if let Some(index) = unmatched_multiset_item(&before_off, &after_off, |before, after| {
+        admittances_match(before, after, tolerance)
+    }) {
+        return Some(format!(
+            "off-diagonal admittance {:?} has no matching result entry",
+            before_off[index]
+        ));
     }
     None
 }
 
-/// Why a `Y_bus` comparison produced no answer./// Why a `Y_bus` comparison produced no answer.
+#[cfg(test)]
+mod relabeling_tests {
+    use super::{BusRow, bus_rows_match, unmatched_multiset_item};
+
+    #[test]
+    fn near_equal_rows_pair_by_all_electrical_values() {
+        let before = [
+            BusRow {
+                diagonal: (1.0, 0.0),
+                injections: [0.0; 4],
+            },
+            BusRow {
+                diagonal: (1.000_001, 0.0),
+                injections: [5.0, 0.0, 0.0, 0.0],
+            },
+        ];
+        let after = [
+            BusRow {
+                diagonal: (1.0, 0.0),
+                injections: [5.0, 0.0, 0.0, 0.0],
+            },
+            BusRow {
+                diagonal: (1.000_001, 0.0),
+                injections: [0.0; 4],
+            },
+        ];
+
+        assert_eq!(
+            unmatched_multiset_item(&before, &after, |before, after| {
+                bus_rows_match(before, after, 1e-3)
+            }),
+            None
+        );
+    }
+}
+
+/// Why a `Y_bus` comparison produced no answer.
 ///
 /// Distinguished from "the matrices agree" on purpose: a network the matrix
 /// builder refuses is a conversion failure, and reporting it as agreement is

--- a/powerio-cli/src/invariants.rs
+++ b/powerio-cli/src/invariants.rs
@@ -115,92 +115,131 @@ impl std::fmt::Display for InjectionChange {
     }
 }
 
-/// `after` with its bus numbers restated as `before`'s, in bus table order, or
-/// `None` when the two already agree or the tables differ in length.
-///
-/// A format that identifies a bus by a name rather than a number (IIDM's
-/// `<bus id="...">`, CIM's mRID) states no bus number, so a reader numbers the
-/// buses it finds and those numbers are a fresh calculation view rather than
-/// the source's. What the conversion does state is the order: each writer emits
-/// the buses in table order and each reader numbers them in the order it reads
-/// them. Relabeling by position therefore compares the network the source
-/// described rather than two numberings of it.
-///
-/// The relabeling is not a licence to lose identity: `id`, `uid`, and `name`
-/// are typed fields, so the model comparison reports every change and a cell
-/// claiming zero warnings fails on it.
-#[must_use]
-pub fn relabel_buses_in_table_order(
-    before: &BalancedNetwork,
-    after: &BalancedNetwork,
-) -> Option<BalancedNetwork> {
-    if before.buses().len() != after.buses().len() {
-        return None;
-    }
-    let renumbering: BTreeMap<powerio_tx::BusId, powerio_tx::BusId> = after
-        .buses()
-        .iter()
-        .zip(before.buses())
-        .filter(|(after, before)| after.id != before.id)
-        .map(|(after, before)| (after.id, before.id))
-        .collect();
-    if renumbering.is_empty() {
-        return None;
-    }
-    let renumbered = |bus: powerio_tx::BusId| renumbering.get(&bus).copied().unwrap_or(bus);
-    let mut out = after.clone();
-    for bus in out.buses_mut() {
-        bus.id = renumbered(bus.id);
-    }
-    for branch in out.branches_mut() {
-        branch.from = renumbered(branch.from);
-        branch.to = renumbered(branch.to);
-        if let Some(control) = branch.control.as_mut() {
-            control.controlled_bus = control.controlled_bus.map(renumbered);
-        }
-    }
-    for switch in out.switches_mut() {
-        switch.from = renumbered(switch.from);
-        switch.to = renumbered(switch.to);
-    }
-    for load in out.loads_mut() {
-        load.bus = renumbered(load.bus);
-    }
-    for shunt in out.shunts_mut() {
-        shunt.bus = renumbered(shunt.bus);
-        if let Some(control) = shunt.control.as_mut() {
-            control.control_bus = control.control_bus.map(renumbered);
-        }
-    }
-    for compensator in out.static_var_compensators_mut() {
-        compensator.bus = renumbered(compensator.bus);
-    }
-    for generator in out.generators_mut() {
-        generator.bus = renumbered(generator.bus);
-        generator.regulated_bus = generator.regulated_bus.map(renumbered);
-    }
-    for line in out.hvdc_mut() {
-        line.from = renumbered(line.from);
-        line.to = renumbered(line.to);
-    }
-    for storage in out.storage_mut() {
-        storage.bus = renumbered(storage.bus);
-    }
-    for area in out.areas_mut() {
-        area.slack_bus = area.slack_bus.map(renumbered);
-    }
-    for transformer in out.transformers_3w_mut() {
-        for winding in &mut transformer.windings {
-            winding.bus = renumbered(winding.bus);
-            if let Some(control) = winding.control.as_mut() {
-                control.controlled_bus = control.controlled_bus.map(renumbered);
-            }
-        }
-    }
-    Some(out)
+/// One bus row of the relabeling-free electrical digest: the bus's own
+/// admittance and its injections.
+#[derive(Debug, Clone, PartialEq)]
+struct BusRow {
+    diagonal: (f64, f64),
+    injections: [f64; 4],
 }
 
-/// Why a `Y_bus` comparison produced no answer.
+/// The electrical problem compared up to bus relabeling, for a target format
+/// that states no bus number.
+///
+/// Every bus contributes its diagonal admittance and its four injection
+/// columns, every branch its off-diagonal admittance, and the two collections
+/// are compared as sorted multisets. That is the power flow problem itself: an
+/// admittance that changed, an injection that moved to a bus with different
+/// neighbours, or an element that vanished all show up, while a renumbering
+/// alone does not. Two buses carrying identical rows are interchangeable, and
+/// exchanging them is the same power flow problem.
+///
+/// Returns the first row that disagrees, in the digest's own order.
+#[must_use]
+pub fn electrical_change_up_to_relabeling(
+    before: &BalancedNetwork,
+    after: &BalancedNetwork,
+    tolerance: f64,
+) -> Option<String> {
+    // Where every bus states a nominal voltage, the digest holds physical
+    // admittance: a format that admits only a fixed set of voltage levels
+    // writes a 345 kV case under the 330 kV level, and the per-unit values move
+    // with the base while the network does not. Where a bus states none, the
+    // writer divided by the same substituted nominal voltage the reader
+    // multiplies back, so the per-unit values are the comparable ones.
+    let physical = [before, after].iter().all(|net| {
+        net.buses()
+            .iter()
+            .all(|bus| bus.base_kv.is_finite() && bus.base_kv > 0.0)
+    });
+    let digest = |net: &BalancedNetwork| -> Option<(Vec<BusRow>, Vec<(f64, f64)>)> {
+        let nominal = net
+            .buses()
+            .iter()
+            .map(|bus| (bus.id.0, bus.base_kv))
+            .collect::<BTreeMap<_, _>>();
+        let scale = |from: usize, to: usize| -> f64 {
+            if !physical {
+                return 1.0;
+            }
+            let voltage = |bus: usize| nominal.get(&bus).copied().unwrap_or(1.0);
+            net.base_mva() / (voltage(from) * voltage(to))
+        };
+        let view = powerio_matrix::IndexedNetwork::new(net);
+        let parts =
+            powerio_matrix::calc_admittance_matrix(&view, &powerio_matrix::BuildOptions::default())
+                .ok()?;
+        let mut entries = BTreeMap::<(usize, usize), (f64, f64)>::new();
+        for (value, (i, j)) in &parts.g {
+            entries
+                .entry((view.bus_id(i).0, view.bus_id(j).0))
+                .or_insert((0.0, 0.0))
+                .0 = *value;
+        }
+        for (value, (i, j)) in &parts.b {
+            entries
+                .entry((view.bus_id(i).0, view.bus_id(j).0))
+                .or_insert((0.0, 0.0))
+                .1 = *value;
+        }
+        let injections = per_bus(net, true);
+        let mut rows = Vec::new();
+        let mut off_diagonal = Vec::new();
+        for ((from, to), value) in entries {
+            let value = (value.0 * scale(from, to), value.1 * scale(from, to));
+            if from == to {
+                rows.push(BusRow {
+                    diagonal: value,
+                    injections: injections.get(&from).copied().unwrap_or_default(),
+                });
+            } else {
+                off_diagonal.push(value);
+            }
+        }
+        let key = |value: &(f64, f64)| (value.0.to_bits(), value.1.to_bits());
+        rows.sort_by_key(|row| (key(&row.diagonal), row.injections.map(f64::to_bits)));
+        off_diagonal.sort_by_key(key);
+        Some((rows, off_diagonal))
+    };
+    let (before_rows, before_off) = digest(before)?;
+    let (after_rows, after_off) = digest(after)?;
+    if before_rows.len() != after_rows.len() {
+        return Some(format!(
+            "{} bus admittance row(s) became {}",
+            before_rows.len(),
+            after_rows.len()
+        ));
+    }
+    if before_off.len() != after_off.len() {
+        return Some(format!(
+            "{} off-diagonal admittance entr(ies) became {}",
+            before_off.len(),
+            after_off.len()
+        ));
+    }
+    for (before, after) in before_rows.iter().zip(&after_rows) {
+        let moved = beyond_tol(before.diagonal.0, after.diagonal.0, tolerance)
+            || beyond_tol(before.diagonal.1, after.diagonal.1, tolerance)
+            || before
+                .injections
+                .iter()
+                .zip(&after.injections)
+                .any(|(before, after)| beyond_tol(*before, *after, tolerance));
+        if moved {
+            return Some(format!("bus row {before:?} became {after:?}"));
+        }
+    }
+    for (before, after) in before_off.iter().zip(&after_off) {
+        if beyond_tol(before.0, after.0, tolerance) || beyond_tol(before.1, after.1, tolerance) {
+            return Some(format!(
+                "off-diagonal admittance {before:?} became {after:?}"
+            ));
+        }
+    }
+    None
+}
+
+/// Why a `Y_bus` comparison produced no answer./// Why a `Y_bus` comparison produced no answer.
 ///
 /// Distinguished from "the matrices agree" on purpose: a network the matrix
 /// builder refuses is a conversion failure, and reporting it as agreement is
@@ -240,6 +279,22 @@ pub enum YbusUnavailable {
 pub fn ybus_change(
     before: &BalancedNetwork,
     after: &BalancedNetwork,
+) -> Result<Option<YbusChange>, YbusUnavailable> {
+    ybus_change_within(before, after, ELECTRICAL_TOL)
+}
+
+/// [`ybus_change`] under a stated relative tolerance, for a format that states
+/// each value in a fixed width field and so cannot return more digits than the
+/// field holds.
+///
+/// # Errors
+///
+/// Returns [`YbusUnavailable`] when either side has no buildable admittance
+/// matrix.
+pub fn ybus_change_within(
+    before: &BalancedNetwork,
+    after: &BalancedNetwork,
+    tolerance: f64,
 ) -> Result<Option<YbusChange>, YbusUnavailable> {
     let nominal = |net: &BalancedNetwork| -> BTreeMap<usize, f64> {
         net.buses()
@@ -281,7 +336,7 @@ pub fn ybus_change(
         let (gb, bb) = b.get(key).copied().unwrap_or((0.0, 0.0));
         let scale = base_ratio(key.0) * base_ratio(key.1);
         let (gb, bb) = (gb * scale, bb * scale);
-        if beyond_tol(ga, gb, ELECTRICAL_TOL) || beyond_tol(ba, bb, ELECTRICAL_TOL) {
+        if beyond_tol(ga, gb, tolerance) || beyond_tol(ba, bb, tolerance) {
             return Ok(Some(YbusChange {
                 from_bus: key.0,
                 to_bus: key.1,
@@ -315,11 +370,29 @@ pub fn injection_change(
     before: &BalancedNetwork,
     after: &BalancedNetwork,
 ) -> Option<InjectionChange> {
-    let change = first_moved(&per_bus(before, true), &per_bus(after, true), AC_INJECTIONS)?;
+    injection_change_within(before, after, ELECTRICAL_TOL)
+}
+
+/// [`injection_change`] under a stated relative tolerance, for a format that
+/// states each value in a fixed width field and so cannot return more digits
+/// than the field holds.
+#[must_use]
+pub fn injection_change_within(
+    before: &BalancedNetwork,
+    after: &BalancedNetwork,
+    tolerance: f64,
+) -> Option<InjectionChange> {
+    let change = first_moved(
+        &per_bus(before, true),
+        &per_bus(after, true),
+        AC_INJECTIONS,
+        tolerance,
+    )?;
     let status_only = first_moved(
         &per_bus(before, false),
         &per_bus(after, false),
         AC_INJECTIONS,
+        tolerance,
     )
     .is_none();
     Some(InjectionChange {
@@ -414,11 +487,13 @@ pub fn dc_terminal_change(
         &per_bus_dc(before, true),
         &per_bus_dc(after, true),
         DC_TERMINALS,
+        ELECTRICAL_TOL,
     )?;
     let status_only = first_moved(
         &per_bus_dc(before, false),
         &per_bus_dc(after, false),
         DC_TERMINALS,
+        ELECTRICAL_TOL,
     )
     .is_none();
     Some(InjectionChange {
@@ -436,12 +511,13 @@ fn first_moved<const N: usize>(
     a: &BTreeMap<usize, [f64; N]>,
     b: &BTreeMap<usize, [f64; N]>,
     quantities: [Injection; N],
+    tolerance: f64,
 ) -> Option<InjectionChange> {
     for key in a.keys().chain(b.keys().filter(|k| !a.contains_key(*k))) {
         let x = a.get(key).copied().unwrap_or([0.0; N]);
         let y = b.get(key).copied().unwrap_or([0.0; N]);
         for (i, quantity) in quantities.into_iter().enumerate() {
-            if beyond_tol(x[i], y[i], ELECTRICAL_TOL) {
+            if beyond_tol(x[i], y[i], tolerance) {
                 return Some(InjectionChange {
                     bus: *key,
                     quantity,
@@ -522,6 +598,28 @@ pub struct TransmissionCore {
 
 fn milli(x: f64) -> i64 {
     (x * 1e3).round() as i64
+}
+
+impl TransmissionCore {
+    /// Whether two cores state the same case under a relative tolerance on the
+    /// power totals.
+    ///
+    /// Element counts are compared exactly. A format that states each value in
+    /// a fixed width field returns fewer digits than the total carries, so the
+    /// totals are compared within `tolerance`.
+    #[must_use]
+    pub fn agrees_within(&self, other: &Self, tolerance: f64) -> bool {
+        let totals = |core: &Self| [core.load_p, core.load_q, core.gen_p, core.base_mva];
+        self.buses == other.buses
+            && self.branches == other.branches
+            && self.generators == other.generators
+            && self.loads == other.loads
+            && self.shunts == other.shunts
+            && totals(self)
+                .into_iter()
+                .zip(totals(other))
+                .all(|(before, after)| !beyond_tol(before as f64, after as f64, tolerance))
+    }
 }
 
 #[must_use]

--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -9,22 +9,19 @@
 //! is a target column: the balanced case formats, the PowSybl and ENTSO-E
 //! exchange formats (XIIDM, JIIDM, CGMES, UCTE-DEF), the dataset directories
 //! (PyPSA CSV, GridFM Parquet), PowerIO's own network document, and the three
-//! read only sources (IEEE CDF, GO Challenge 3, DeepMind OPFData). That is
-//! nineteen rows and sixteen columns, which no PR comment renders readably as
-//! one table, so the columns are grouped by what the formats are for and each
-//! group keeps every source row. The grouping changes the layout and not the
-//! cells: every source is still run into every target.
+//! read only sources (PSS/E RAW revision 32, IEEE CDF, GO Challenge 3, and
+//! DeepMind OPFData). That is twenty rows and sixteen columns, which no PR
+//! comment renders readably as one table, so the columns are grouped by what
+//! the formats are for and each group keeps every source row. The grouping
+//! changes the layout and not the cells: every source is still run into every
+//! target.
 //!
-//! Two parse only inputs are named here rather than run. A revision 32 `.raw`
-//! row is the next one to land, and both vendored version 32 exports currently
-//! fail three checks rather than reporting a loss: the XIIDM and JIIDM cells
-//! fail to read back because the writer takes its detailed connectivity path
-//! for a network whose detailed record states no voltage level and emits no
-//! hierarchy at all; the MATPOWER, pandapower, GridFM, and UCTE cells change
-//! the element counts (a shunt, a generator, a branch). A `.pwb` row waits on
-//! the same vintage work: the export this repository vendors states no located
-//! bus type, so the case reaches a dataset target with no reference bus and
-//! cannot be written at all.
+//! One parse only input is named here rather than run. The only vendored
+//! PowerWorld `.pwb` export states no located bus type, so its network has no
+//! reference bus. GridFM requires exactly one reference bus and therefore
+//! cannot write that source; a PWB row cannot satisfy the all-target contract
+//! until a redistributable fixture states a slack bus or the binary record
+//! carrying that designation is understood.
 //!
 //! A geographic layer is a `powerio.GeoLayer` rather than a network, and no
 //! grid exchange format states a standalone layer, so it has its own one cell
@@ -458,7 +455,7 @@ struct MatrixReport {
     /// column indices it renders. Every table keeps every source row, so the
     /// split changes only how the same cells are laid out.
     groups: Vec<(&'static str, Vec<usize>)>,
-    case_count: usize,
+    coverage: &'static str,
     cells: Vec<Vec<Cell>>,
     failures: Vec<String>,
 }
@@ -531,7 +528,7 @@ fn silent_loss_note(cell: &Cell) -> String {
 fn write_matrix_section(markdown: &mut String, title: &str, report: &MatrixReport) {
     writeln!(markdown, "### {title}").unwrap();
     writeln!(markdown).unwrap();
-    writeln!(markdown, "{} cases per source row.", report.case_count).unwrap();
+    writeln!(markdown, "{}", report.coverage).unwrap();
     for (group, columns) in &report.groups {
         if columns.is_empty() {
             continue;
@@ -715,7 +712,7 @@ fn code_object_name(text: &str) -> String {
 }
 
 /// Which table a target column renders in. One table of every source against
-/// every target is 18 rows by 16 columns, which no PR comment renders
+/// every target is 20 rows by 16 columns, which no PR comment renders
 /// readably, so the columns are grouped by what the formats are for and every
 /// group keeps every source row. No cell is dropped by the grouping.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -799,7 +796,7 @@ const fn read_only(
 /// Every 1.0 transmission format. The writable ones are both source rows and
 /// target columns, in this order; the read only ones are source rows only and
 /// come last, so a target column index indexes this array directly.
-const TRANSMISSION_FORMATS: [TransmissionFormat; 19] = [
+const TRANSMISSION_FORMATS: [TransmissionFormat; 20] = [
     transmission("MATPOWER .m", "matpower", Emission::Document, Family::Case),
     transmission(
         "PowerModels JSON",
@@ -855,6 +852,12 @@ const TRANSMISSION_FORMATS: [TransmissionFormat; 19] = [
         "model-json",
         Emission::ModelJson,
         Family::Dataset,
+    ),
+    read_only(
+        "PSS/E .raw 32",
+        "psse",
+        Family::Case,
+        "psse/ExampleVersion32_exported.raw",
     ),
     read_only(
         "IEEE CDF",
@@ -1082,7 +1085,17 @@ fn transmission_targets() -> impl Iterator<Item = (usize, TransmissionFormat)> {
 // - `GO Challenge 3 JSON` is a new source row. A problem statement parses as
 //   the security constrained commitment it states, and the row runs the
 //   network that problem is stated on into every target.
-const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 19] = [
+// - `PSS/E .raw 32` is a new read-only source row over PowSybl's eight-bus
+//   export. Its two source warnings are the unmodeled OWNER and ZONE sections.
+//   Target-specific warnings name area attributes, switched-shunt and tap
+//   control, the self-loop UCTE cannot state, and each target's synthesized
+//   defaults. The electrical and core invariants hold after reducing the
+//   source to records the target format actually defines.
+// - MATPOWER carries only aggregate bus GS/BS values. Two IIDM payload cases
+//   contain switched shunt controls, so the XIIDM, JIIDM, and CGMES source
+//   rows each add two warnings in the MATPOWER column rather than silently
+//   discarding the control records.
+const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 20] = [
     [0, 1, 15, 15, 18, 7, 15, 23, 14, 76, 76, 64, 48, 15, 27, 0], // MATPOWER .m
     [0, 0, 15, 15, 17, 6, 14, 22, 13, 75, 75, 63, 47, 14, 27, 0], // PowerModels JSON
     [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 19, 35, 9, 32, 0],        // PSS/E .raw 33
@@ -1092,9 +1105,9 @@ const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 19] = [
     [1, 1, 8, 8, 9, 1, 2, 1, 8, 62, 62, 43, 59, 9, 28, 1],        // pandapower JSON
     [0, 0, 9, 9, 12, 0, 7, 0, 7, 73, 73, 43, 42, 9, 27, 0],       // Surge JSON
     [0, 0, 1, 1, 1, 0, 4, 3, 0, 44, 44, 18, 34, 8, 32, 0],        // PSLF .epc
-    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // XIIDM 1.17
-    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // JIIDM 1.17
-    [7, 7, 74, 327, 7, 7, 8, 7, 7, 50, 50, 19, 58, 14, 39, 7],    // CGMES 3.0
+    [9, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // XIIDM 1.17
+    [9, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // JIIDM 1.17
+    [9, 7, 74, 327, 7, 7, 8, 7, 7, 50, 50, 19, 58, 14, 39, 7],    // CGMES 3.0
     [
         25, 19, 13, 13, 25, 19, 13, 19, 25, 49, 49, 26, 13, 19, 37, 7,
     ], // UCTE-DEF .uct
@@ -1103,6 +1116,7 @@ const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 19] = [
         28, 27, 35, 35, 35, 27, 30, 27, 33, 95, 95, 64, 67, 33, 54, 27,
     ], // GridFM Parquet
     [0, 1, 15, 15, 18, 7, 15, 23, 14, 76, 76, 64, 48, 15, 27, 0], // model JSON
+    [4, 3, 2, 2, 3, 3, 4, 3, 5, 16, 16, 11, 10, 5, 8, 2],         // PSS/E .raw 32
     [7, 7, 6, 6, 7, 7, 8, 7, 7, 14, 14, 10, 14, 8, 12, 6],        // IEEE CDF
     [5, 4, 7, 7, 8, 4, 7, 4, 6, 9, 9, 9, 14, 8, 7, 1],            // GO Challenge 3 JSON
     [3, 2, 5, 5, 5, 3, 4, 2, 4, 33, 33, 10, 32, 5, 8, 2],         // DeepMind OPFData JSON
@@ -1175,7 +1189,7 @@ fn run_transmission_matrix() -> MatrixReport {
         sources,
         targets,
         groups,
-        case_count: TRANSMISSION_CASES.len(),
+        coverage: "Six generated cases per writable source row; one vendored case per read-only source row.",
         cells,
         failures,
     }
@@ -1422,6 +1436,39 @@ fn network_a_target_holds(
     if matches!(target.token, "xiidm" | "jiidm") {
         return network_iidm_holds(network);
     }
+    if target.token == "matpower" || target.token == "gridfm" {
+        let mut held = network.clone();
+        let mut merged = BTreeMap::<powerio_tx::BusId, powerio_tx::Shunt>::new();
+        for shunt in held.shunts().iter().filter(|shunt| shunt.in_service) {
+            let aggregate = merged
+                .entry(shunt.bus)
+                .or_insert_with(|| powerio_tx::Shunt::new(shunt.bus, 0.0, 0.0));
+            aggregate.g += shunt.g;
+            aggregate.b += shunt.b;
+        }
+        *held.shunts_mut() = merged.into_values().collect();
+        return held;
+    }
+    if target.token == "pandapower-json" {
+        let mut held = network.clone();
+        let generator_buses = held
+            .generators()
+            .iter()
+            .map(|generator| generator.bus)
+            .collect::<std::collections::HashSet<_>>();
+        let empty_references = held
+            .buses()
+            .iter()
+            .filter(|bus| {
+                bus.kind == powerio_tx::BusType::Ref && !generator_buses.contains(&bus.id)
+            })
+            .map(|bus| bus.id)
+            .collect::<Vec<_>>();
+        for bus in empty_references {
+            held.generators_mut().push(powerio_tx::Generator::new(bus));
+        }
+        return held;
+    }
     if target.token != "ucte" {
         return network.clone();
     }
@@ -1432,6 +1479,8 @@ fn network_a_target_holds(
     // one bus state one generation.
     let mut held = network.clone();
     held.shunts_mut().clear();
+    held.branches_mut()
+        .retain(|branch| branch.from != branch.to);
     for generator in held.generators_mut() {
         if !generator.in_service {
             generator.in_service = true;
@@ -1453,6 +1502,20 @@ fn network_a_target_holds(
         }
     }
     *held.generators_mut() = merged;
+    let generator_buses = held
+        .generators()
+        .iter()
+        .map(|generator| generator.bus)
+        .collect::<std::collections::HashSet<_>>();
+    let empty_references = held
+        .buses()
+        .iter()
+        .filter(|bus| bus.kind == powerio_tx::BusType::Ref && !generator_buses.contains(&bus.id))
+        .map(|bus| bus.id)
+        .collect::<Vec<_>>();
+    for bus in empty_references {
+        held.generators_mut().push(powerio_tx::Generator::new(bus));
+    }
     held
 }
 
@@ -1603,7 +1666,7 @@ fn run_geo_layer_matrix() -> MatrixReport {
         sources: vec![SOURCE],
         targets: vec![TARGET],
         groups: vec![("Into the geographic layer document", vec![0])],
-        case_count: 1,
+        coverage: "One case per source row.",
         cells: vec![vec![cell]],
         failures,
     }
@@ -1700,7 +1763,7 @@ fn run_distribution_matrix() -> MatrixReport {
         sources: formats.clone(),
         targets: formats,
         groups,
-        case_count: DISTRIBUTION_CASES.len(),
+        coverage: "Seven cases per source row.",
         cells,
         failures,
     }

--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -3,6 +3,32 @@
 //! generator of the PR comment; the notes here are for whoever works on a
 //! cell next.
 //!
+//! # What the tables cover
+//!
+//! Every format PowerIO 1.0 reads is a source row and every format it writes
+//! is a target column: the balanced case formats, the PowSybl and ENTSO-E
+//! exchange formats (XIIDM, JIIDM, CGMES, UCTE-DEF), the dataset directories
+//! (PyPSA CSV, GridFM Parquet), PowerIO's own network document, and the two
+//! read only sources (IEEE CDF, DeepMind OPFData). That is eighteen rows and
+//! sixteen columns, which no PR comment renders readably as one table, so the
+//! columns are grouped by what the formats are for and each group keeps every
+//! source row. The grouping changes the layout and not the cells: every source
+//! is still run into every target.
+//!
+//! A geographic layer is a `powerio.GeoLayer` rather than a network, and no
+//! grid exchange format states a standalone layer, so it has its own one cell
+//! table instead of a row here.
+//!
+//! # The rule a nonzero cell states
+//!
+//! A nonzero cell means the target format cannot carry what the source stated,
+//! and every warning names the field or record it cannot carry: on the write
+//! and readback legs a field of the target format, and on the source parse
+//! leg, whose warnings every cell of that row shares, what the source document
+//! itself leaves unstated. A warning that named a writer PowerIO could extend
+//! instead of a limit of the format would be a defect in this table, not a
+//! yellow cell.
+//!
 //! # What a cell asserts
 //!
 //! Each cell runs source parse → target write → target readback over every
@@ -18,6 +44,18 @@
 //!    yellow cells too; together they pin the power flow problem itself
 //!    (same `Y_bus`, same injections, same solution), which is the cheap,
 //!    dependency-free stand-in for cross-validating an AC solve.
+//!
+//!    Three allowances, each a property of a target format rather than of a
+//!    writer, and each stated at its own site: a format that identifies a bus
+//!    by a name rather than a number states no bus number, so the comparison
+//!    falls back to the same problem up to bus relabeling
+//!    (`electrical_change_up_to_relabeling`); a format that states each value
+//!    in a fixed width field returns fewer digits than the value carries
+//!    (`electrical_tolerance`); and a format with no record for an element
+//!    changes the problem by dropping it, so the comparison runs against the
+//!    network the format can hold (`network_a_target_holds`). Every one of
+//!    them names a record or field absent from the target's own definition,
+//!    and the writer reports the same loss as a warning.
 //! 4. **Lossless means lossless** — a cell claiming green (zero warnings)
 //!    must leave the full typed model bit-identical (to a last-ulp float
 //!    tolerance), field for field, extras included. A cell that is silent
@@ -79,6 +117,12 @@
 //! its DC vocabulary — inventing field names would fake a green. dss deck
 //! tokens (`vminpu`, `pf`, source `MVAsc`) and BMOPF named terminals have no
 //! slots in their neighbors; those rows stay honestly yellow.
+//!
+//! The `→ CGMES 3.0` column is an order of magnitude above every other, for
+//! one reason: a CGMES profile set identifies every object by an mRID and
+//! states its class, container, and limit types as objects of their own, so a
+//! case format that states none of that has a field dropped per object rather
+//! than per file. The counts are per object because the losses are.
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
@@ -87,11 +131,11 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use powerio::BalancedNetwork;
 use powerio_cli::invariants::{
-    DistributionCore, TransmissionCore, YbusUnavailable, distribution_core, distribution_value,
-    injection_change, model_diffs, transmission_core, transmission_value, ybus_change,
+    DistributionCore, YbusUnavailable, distribution_core, distribution_value,
+    electrical_change_up_to_relabeling, injection_change_within, model_diffs, transmission_core,
+    transmission_value, ybus_change_within,
 };
 use powerio_dist::{DistTargetFormat, MulticonductorNetwork};
-use powerio_tx::TargetFormat;
 
 const REPORT_ENV: &str = "POWERIO_CONVERSION_MATRIX_REPORT";
 const DETAILS_ENV: &str = "POWERIO_CONVERSION_MATRIX_DETAILS";
@@ -142,14 +186,96 @@ fn text_emission(
     })
 }
 
-fn emit_transmission_value(
+/// One emitted case, held where the format's reader takes it from.
+enum Emitted {
+    /// One document, read back from memory.
+    Document(String),
+    /// A directory of documents, read back from the temporary directory this
+    /// value owns.
+    Directory(tempfile::TempDir),
+}
+
+struct TransmissionEmission {
+    emitted: Emitted,
+    diagnostics: Vec<String>,
+}
+
+/// Write `network` as `format` through the facade, which is the operation a
+/// caller has: one token selects the writer, and a directory format writes its
+/// inventory rather than one document.
+fn emit_transmission(
     network: &BalancedNetwork,
-    target: TargetFormat,
-) -> Result<TextEmission, String> {
+    format: TransmissionFormat,
+) -> Result<TransmissionEmission, String> {
+    if format.emission == Emission::ModelJson {
+        let text = network.to_json().map_err(|err| err.to_string())?;
+        return Ok(TransmissionEmission {
+            emitted: Emitted::Document(text),
+            diagnostics: Vec::new(),
+        });
+    }
     let module = powerio_core::PioModule::new(network.clone());
+    if format.emission == Emission::Directory {
+        let directory = tempfile::tempdir().map_err(|err| err.to_string())?;
+        let result = powerio::emit(
+            &module,
+            format.token,
+            powerio_core::Destination::path(directory.path().join(DIRECTORY_CASE_NAME)),
+        )
+        .map_err(|err| err.to_string())?;
+        let diagnostics = powerio_core::render_diagnostics(result.diagnostics());
+        return Ok(TransmissionEmission {
+            emitted: Emitted::Directory(directory),
+            diagnostics,
+        });
+    }
     let destination = powerio_core::Destination::memory("case").map_err(|err| err.to_string())?;
-    let result = powerio_tx::emit(&module, target, destination).map_err(|err| err.to_string())?;
-    text_emission(result, None)
+    let result =
+        powerio::emit(&module, format.token, destination).map_err(|err| err.to_string())?;
+    let diagnostics = powerio_core::render_diagnostics(result.diagnostics());
+    let powerio_core::EmittedOutput::Memory { mut artifacts } = result.into_output() else {
+        return Err("a memory destination returned path output".to_owned());
+    };
+    let artifact = artifacts
+        .pop()
+        .filter(|_| artifacts.is_empty())
+        .ok_or_else(|| "a one document format returned several artifacts".to_owned())?;
+    let text = String::from_utf8(artifact.into_bytes())
+        .map_err(|err| format!("emitted text is not UTF-8: {err}"))?;
+    Ok(TransmissionEmission {
+        emitted: Emitted::Document(text),
+        diagnostics,
+    })
+}
+
+/// The directory name a directory format writes under, inside a temporary
+/// directory that holds nothing else.
+const DIRECTORY_CASE_NAME: &str = "case";
+
+/// Read one emitted case back as its own format.
+fn parse_transmission_emitted(
+    emitted: &Emitted,
+    format: TransmissionFormat,
+) -> Result<ParsedTransmission, String> {
+    match emitted {
+        Emitted::Document(text) if format.emission == Emission::ModelJson => {
+            let network = BalancedNetwork::from_json(text).map_err(|err| err.to_string())?;
+            Ok(ParsedTransmission {
+                network,
+                warnings: Vec::new(),
+            })
+        }
+        Emitted::Document(text) => {
+            let source = powerio_core::Source::from_memory("<memory>", text.as_bytes().to_vec())
+                .map_err(|err| err.to_string())?;
+            parse_transmission_source(source, format.token)
+        }
+        Emitted::Directory(directory) => {
+            let source = powerio_core::Source::open(directory.path().join(DIRECTORY_CASE_NAME))
+                .map_err(|err| err.to_string())?;
+            parse_transmission_source(source, format.token)
+        }
+    }
 }
 
 fn emit_distribution_module(
@@ -221,9 +347,11 @@ struct Report {
 fn build_report() -> Report {
     let transmission = run_transmission_matrix();
     let distribution = run_distribution_matrix();
+    let geo = run_geo_layer_matrix();
     let mut failures = Vec::new();
     failures.extend(transmission.failures.clone());
     failures.extend(distribution.failures.clone());
+    failures.extend(geo.failures.clone());
 
     let mut markdown = String::new();
     writeln!(markdown, "{REPORT_MARKER}").unwrap();
@@ -235,6 +363,12 @@ fn build_report() -> Report {
     writeln!(
         markdown,
         "Cells show `X/Y`: observed warnings / expected warnings. Counts include source parse, target write, and target readback."
+    )
+    .unwrap();
+    writeln!(markdown).unwrap();
+    writeln!(
+        markdown,
+        "A nonzero cell means the target format cannot carry what the source stated, and every warning names the field or record it cannot carry. A write or readback warning names a field of the target format; a source parse warning, which every cell of that row shares, names what the source document itself leaves unstated. A warning that named a writer PowerIO could extend instead of a limit of the format would be a defect in this table."
     )
     .unwrap();
     writeln!(markdown).unwrap();
@@ -262,6 +396,14 @@ fn build_report() -> Report {
     write_matrix_section(&mut markdown, "Transmission", &transmission);
     writeln!(markdown).unwrap();
     write_matrix_section(&mut markdown, "Distribution", &distribution);
+    writeln!(markdown).unwrap();
+    write_matrix_section(&mut markdown, "Geographic layer", &geo);
+    writeln!(markdown).unwrap();
+    writeln!(
+        markdown,
+        "A geographic layer is a `powerio.GeoLayer`, not a network: no grid exchange format states a standalone layer, so the layer has its own table rather than a row of the network matrix. Its source is the substation coordinates of a vendored PowerWorld auxiliary file."
+    )
+    .unwrap();
 
     let mut details_markdown = String::new();
     writeln!(details_markdown, "{DETAILS_MARKER}").unwrap();
@@ -287,6 +429,8 @@ fn build_report() -> Report {
     write_warning_summary(&mut details_markdown, "Transmission", &transmission);
     writeln!(details_markdown).unwrap();
     write_warning_summary(&mut details_markdown, "Distribution", &distribution);
+    writeln!(details_markdown).unwrap();
+    write_warning_summary(&mut details_markdown, "Geographic layer", &geo);
 
     Report {
         markdown,
@@ -299,6 +443,10 @@ fn build_report() -> Report {
 struct MatrixReport {
     sources: Vec<&'static str>,
     targets: Vec<&'static str>,
+    /// Target columns split into tables, each entry a table title and the
+    /// column indices it renders. Every table keeps every source row, so the
+    /// split changes only how the same cells are laid out.
+    groups: Vec<(&'static str, Vec<usize>)>,
     case_count: usize,
     cells: Vec<Vec<Cell>>,
     failures: Vec<String>,
@@ -372,24 +520,31 @@ fn silent_loss_note(cell: &Cell) -> String {
 fn write_matrix_section(markdown: &mut String, title: &str, report: &MatrixReport) {
     writeln!(markdown, "### {title}").unwrap();
     writeln!(markdown).unwrap();
-    writeln!(markdown, "{} cases.", report.case_count).unwrap();
-    writeln!(markdown).unwrap();
-    write!(markdown, "| Source ↓ / target → |").unwrap();
-    for format in &report.targets {
-        write!(markdown, " {format} |").unwrap();
-    }
-    writeln!(markdown).unwrap();
-    write!(markdown, "| --- |").unwrap();
-    for _ in &report.targets {
-        write!(markdown, " --- |").unwrap();
-    }
-    writeln!(markdown).unwrap();
-    for (source, row) in report.sources.iter().zip(&report.cells) {
-        write!(markdown, "| {source} |").unwrap();
-        for cell in row {
-            write!(markdown, " {} |", cell_summary(cell)).unwrap();
+    writeln!(markdown, "{} cases per source row.", report.case_count).unwrap();
+    for (group, columns) in &report.groups {
+        if columns.is_empty() {
+            continue;
         }
         writeln!(markdown).unwrap();
+        writeln!(markdown, "#### {group}").unwrap();
+        writeln!(markdown).unwrap();
+        write!(markdown, "| Source ↓ / target → |").unwrap();
+        for column in columns {
+            write!(markdown, " {} |", report.targets[*column]).unwrap();
+        }
+        writeln!(markdown).unwrap();
+        write!(markdown, "| --- |").unwrap();
+        for _ in columns {
+            write!(markdown, " --- |").unwrap();
+        }
+        writeln!(markdown).unwrap();
+        for (source, row) in report.sources.iter().zip(&report.cells) {
+            write!(markdown, "| {source} |").unwrap();
+            for column in columns {
+                write!(markdown, " {} |", cell_summary(&row[*column])).unwrap();
+            }
+            writeln!(markdown).unwrap();
+        }
     }
 }
 
@@ -548,55 +703,171 @@ fn code_object_name(text: &str) -> String {
     text.to_string()
 }
 
+/// Which table a target column renders in. One table of every source against
+/// every target is 18 rows by 16 columns, which no PR comment renders
+/// readably, so the columns are grouped by what the formats are for and every
+/// group keeps every source row. No cell is dropped by the grouping.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Family {
+    /// Balanced case formats: one document stating one network.
+    Case,
+    /// The PowSybl and ENTSO-E exchange formats, which state absolute units.
+    Exchange,
+    /// Dataset directories and PowerIO's own network document.
+    Dataset,
+}
+
+impl Family {
+    const ALL: [Self; 3] = [Self::Case, Self::Exchange, Self::Dataset];
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::Case => "Into a case format",
+            Self::Exchange => "Into an exchange format",
+            Self::Dataset => "Into a dataset directory or the network document",
+        }
+    }
+}
+
+/// How a format's output is produced and read back.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Emission {
+    /// One document, emitted and read back in memory.
+    Document,
+    /// A directory of documents whose identity is the directory, so it is
+    /// emitted into and read back from a temporary directory.
+    Directory,
+    /// `BalancedNetwork`'s own JSON document. It is a network serialization
+    /// rather than a case format, so it has no format token to emit through.
+    ModelJson,
+    /// A read only format: a source row and no target column.
+    ReadOnly,
+}
+
 #[derive(Clone, Copy)]
 struct TransmissionFormat {
     name: &'static str,
     token: &'static str,
-    target: TargetFormat,
+    emission: Emission,
+    family: Family,
+    /// The vendored case a read only source parses. Every other source's
+    /// payloads are the MATPOWER cases written into that format first.
+    fixture: Option<&'static str>,
 }
 
-const TRANSMISSION_FORMATS: [TransmissionFormat; 8] = [
+const fn transmission(
+    name: &'static str,
+    token: &'static str,
+    emission: Emission,
+    family: Family,
+) -> TransmissionFormat {
     TransmissionFormat {
-        name: "MATPOWER .m",
-        token: "matpower",
-        target: TargetFormat::Matpower,
-    },
+        name,
+        token,
+        emission,
+        family,
+        fixture: None,
+    }
+}
+
+const fn read_only(
+    name: &'static str,
+    token: &'static str,
+    family: Family,
+    fixture: &'static str,
+) -> TransmissionFormat {
     TransmissionFormat {
-        name: "PowerModels JSON",
-        token: "powermodels-json",
-        target: TargetFormat::PowerModelsJson,
-    },
-    TransmissionFormat {
-        name: "PSS/E .raw",
-        token: "psse",
-        target: TargetFormat::Psse { rev: 33 },
-    },
-    TransmissionFormat {
-        name: "PowerWorld .aux",
-        token: "powerworld",
-        target: TargetFormat::PowerWorld,
-    },
-    TransmissionFormat {
-        name: "egret JSON",
-        token: "egret-json",
-        target: TargetFormat::EgretJson,
-    },
-    TransmissionFormat {
-        name: "pandapower JSON",
-        token: "pandapower-json",
-        target: TargetFormat::PandapowerJson,
-    },
-    TransmissionFormat {
-        name: "Surge JSON",
-        token: "surge-json",
-        target: TargetFormat::SurgeJson,
-    },
-    TransmissionFormat {
-        name: "PSLF .epc",
-        token: "pslf",
-        target: TargetFormat::Pslf,
-    },
+        name,
+        token,
+        emission: Emission::ReadOnly,
+        family,
+        fixture: Some(fixture),
+    }
+}
+
+/// Every 1.0 transmission format. The writable ones are both source rows and
+/// target columns, in this order; the read only ones are source rows only and
+/// come last, so a target column index indexes this array directly.
+const TRANSMISSION_FORMATS: [TransmissionFormat; 18] = [
+    transmission("MATPOWER .m", "matpower", Emission::Document, Family::Case),
+    transmission(
+        "PowerModels JSON",
+        "powermodels-json",
+        Emission::Document,
+        Family::Case,
+    ),
+    transmission("PSS/E .raw 33", "psse", Emission::Document, Family::Case),
+    transmission(
+        "PSS/E RAWX 35",
+        "psse-rawx",
+        Emission::Document,
+        Family::Case,
+    ),
+    transmission(
+        "PowerWorld .aux",
+        "powerworld",
+        Emission::Document,
+        Family::Case,
+    ),
+    transmission("egret JSON", "egret-json", Emission::Document, Family::Case),
+    transmission(
+        "pandapower JSON",
+        "pandapower-json",
+        Emission::Document,
+        Family::Case,
+    ),
+    transmission("Surge JSON", "surge-json", Emission::Document, Family::Case),
+    transmission("PSLF .epc", "pslf", Emission::Document, Family::Case),
+    transmission("XIIDM 1.17", "xiidm", Emission::Document, Family::Exchange),
+    transmission("JIIDM 1.17", "jiidm", Emission::Document, Family::Exchange),
+    transmission("CGMES 3.0", "cgmes", Emission::Directory, Family::Exchange),
+    transmission(
+        "UCTE-DEF .uct",
+        "ucte",
+        Emission::Document,
+        Family::Exchange,
+    ),
+    transmission(
+        "PyPSA CSV",
+        "pypsa-csv",
+        Emission::Directory,
+        Family::Dataset,
+    ),
+    transmission(
+        "GridFM Parquet",
+        "gridfm",
+        Emission::Directory,
+        Family::Dataset,
+    ),
+    transmission(
+        "model JSON",
+        "model-json",
+        Emission::ModelJson,
+        Family::Dataset,
+    ),
+    read_only(
+        "IEEE CDF",
+        "ieee-cdf",
+        Family::Case,
+        "ieee-cdf/ieee14cdf.txt",
+    ),
+    read_only(
+        "DeepMind OPFData JSON",
+        "opfdata-json",
+        Family::Dataset,
+        "opfdataset/example_0.json",
+    ),
 ];
+
+/// The number of writable formats, which is the number of target columns.
+const TRANSMISSION_TARGETS: usize = 16;
+
+fn transmission_targets() -> impl Iterator<Item = (usize, TransmissionFormat)> {
+    TRANSMISSION_FORMATS
+        .into_iter()
+        .enumerate()
+        .filter(|(_, format)| format.emission != Emission::ReadOnly)
+}
 
 // The `→ PSLF .epc` column drops by 5 on every source whose buses carry no base
 // kV: the generator voltage setpoint now rides the bus `vsched` column, which is
@@ -710,18 +981,74 @@ const TRANSMISSION_FORMATS: [TransmissionFormat; 8] = [
 // carries that classification so XIIDM can preserve it. MATPOWER's legacy
 // `mpc.areas` table has only the area number and reference bus, so the PSS/E
 // source row's MATPOWER cell adds one declared field drop.
-const TRANSMISSION_WARNING_BASELINE: [[usize; 8]; 8] = [
-    [0, 1, 15, 15, 7, 15, 23, 14],
-    [0, 0, 15, 14, 6, 14, 22, 13],
-    [1, 1, 0, 2, 1, 3, 1, 2],
-    [0, 0, 0, 0, 0, 2, 0, 0],
-    [0, 0, 9, 9, 0, 8, 1, 7],
-    [1, 1, 8, 8, 1, 2, 1, 8],
-    [0, 0, 9, 9, 0, 7, 0, 7],
-    [0, 0, 1, 1, 0, 4, 3, 0],
+// Rows are sources and columns are targets, both in `TRANSMISSION_FORMATS`
+// order. Each cell sums the source parse, target write, and target readback
+// warnings over the six MATPOWER cases, or over the one vendored case a read
+// only source parses.
+//
+// The eight formats this table already held keep the counts recorded above,
+// except where a fix named in this file's history changed them. The eight
+// columns added here are new counts, derived by running the matrix and
+// attributing each one to its warning texts in the details report:
+//
+// - The `→ PSS/E RAWX 35` column matches `→ PSS/E .raw 33` wherever the two
+//   revisions state the same fields, and differs where revision 35 states
+//   more: a RAWX file carries branch names and twelve rating sets, and the
+//   revision 33 record layout carries neither.
+// - The `→ XIIDM 1.17` and `→ JIIDM 1.17` columns state, per case, the fields
+//   IIDM has no attribute for (generator and DC line dispatch cost, angle
+//   bounds, area swing bus and tolerance, the reverse power bound) and the
+//   values IIDM requires and a case format leaves unstated (the case date,
+//   the forecast distance, the source format, the validation level, and the
+//   substation and voltage level hierarchy the writer derives from buses).
+//   JIIDM adds twelve per file: the JSON writer states one finding per
+//   attribute it shortens, where the XML writer states none.
+// - The `→ CGMES 3.0` column is the largest by an order of magnitude, and for
+//   one reason: a CGMES profile set identifies every object by an mRID and
+//   states its class, container, and limit types as objects of their own, so a
+//   case format that states none of that has a field dropped per object rather
+//   than per file.
+// - The `→ UCTE-DEF .uct` column states the ten voltage levels a node code
+//   admits, the node code itself, the absent shunt and cost records, and the
+//   50 Hz synchronous area frequency.
+// - The `→ PyPSA CSV` column states the reactive limits, capability columns,
+//   and rating sets a PyPSA component CSV has no column for.
+// - The `→ GridFM Parquet` column states what the gridfm schema omits (HVDC,
+//   storage, areas, bus names, rate_b/rate_c, generator mbase and ramp limits,
+//   startup and shutdown costs) and the per bus load folding its table shape
+//   forces.
+// - The `→ model JSON` column is zero for every source but one: the network
+//   document states the whole typed model, so nothing is dropped. The
+//   pandapower row's single warning is its own parse declaring the absolute
+//   cost level a `pwl_cost` table leaves unstated.
+// - The `IEEE CDF` and `DeepMind OPFData JSON` rows parse one vendored case
+//   each, so their counts are per case rather than per six.
+const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 18] = [
+    [0, 1, 15, 15, 15, 7, 15, 23, 14, 76, 76, 301, 48, 15, 27, 0], // MATPOWER .m
+    [0, 0, 15, 15, 14, 6, 14, 22, 13, 75, 75, 300, 47, 14, 27, 0], // PowerModels JSON
+    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 256, 35, 9, 32, 0],        // PSS/E .raw 33
+    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 256, 35, 9, 32, 0],        // PSS/E RAWX 35
+    [0, 0, 0, 0, 0, 0, 2, 0, 0, 37, 37, 251, 33, 7, 32, 0],        // PowerWorld .aux
+    [0, 0, 9, 9, 9, 0, 8, 1, 7, 74, 74, 280, 42, 9, 27, 0],        // egret JSON
+    [1, 1, 8, 8, 8, 1, 2, 1, 8, 62, 62, 209, 59, 9, 28, 1],        // pandapower JSON
+    [0, 0, 9, 9, 9, 0, 7, 0, 7, 73, 73, 280, 42, 9, 27, 0],        // Surge JSON
+    [0, 0, 1, 1, 1, 0, 4, 3, 0, 44, 44, 255, 34, 8, 32, 0],        // PSLF .epc
+    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 354, 66, 15, 38, 6],     // XIIDM 1.17
+    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 354, 66, 15, 38, 6],     // JIIDM 1.17
+    [
+        244, 244, 311, 564, 244, 244, 245, 244, 244, 287, 287, 419, 295, 251, 276, 244,
+    ], // CGMES 3.0
+    [
+        30, 19, 18, 18, 30, 24, 18, 19, 30, 49, 49, 256, 13, 24, 37, 7,
+    ], // UCTE-DEF .uct
+    [0, 6, 14, 14, 14, 6, 9, 6, 12, 76, 76, 211, 44, 0, 27, 0],    // PyPSA CSV
+    [
+        28, 27, 35, 35, 35, 27, 30, 27, 33, 95, 95, 227, 67, 33, 54, 27,
+    ], // GridFM Parquet
+    [0, 1, 15, 15, 15, 7, 15, 23, 14, 76, 76, 301, 48, 15, 27, 0], // model JSON
+    [7, 7, 6, 6, 7, 7, 8, 7, 7, 14, 14, 36, 14, 8, 12, 6],         // IEEE CDF
+    [3, 2, 5, 5, 5, 3, 4, 2, 4, 33, 33, 59, 32, 5, 8, 2],          // DeepMind OPFData JSON
 ];
-
-const DEEPMIND_OPFDATA_WARNING_BASELINE: [usize; 8] = [3, 2, 5, 5, 3, 4, 2, 4];
 
 const TRANSMISSION_CASES: [(&str, &str); 6] = [
     ("case9", "case9.m"),
@@ -736,25 +1063,36 @@ struct TransmissionPayload {
     label: &'static str,
     network: BalancedNetwork,
     parse_warnings: Vec<String>,
-    core: TransmissionCore,
 }
 
 fn run_transmission_matrix() -> MatrixReport {
-    let mut sources: Vec<_> = TRANSMISSION_FORMATS.iter().map(|fmt| fmt.name).collect();
-    let targets = TRANSMISSION_FORMATS.iter().map(|fmt| fmt.name).collect();
+    let sources = TRANSMISSION_FORMATS.iter().map(|fmt| fmt.name).collect();
+    let targets = transmission_targets().map(|(_, fmt)| fmt.name).collect();
+    let groups = Family::ALL
+        .into_iter()
+        .map(|family| {
+            let columns = transmission_targets()
+                .enumerate()
+                .filter(|(_, (_, format))| format.family == family)
+                .map(|(column, _)| column)
+                .collect();
+            (family.title(), columns)
+        })
+        .collect();
     let mut cells = Vec::new();
     let mut failures = Vec::new();
 
     for (source_idx, source) in TRANSMISSION_FORMATS.iter().enumerate() {
         let payloads = transmission_payloads(*source);
         let mut row = Vec::new();
-        for (target_idx, target) in TRANSMISSION_FORMATS.iter().enumerate() {
+        for (column, (target_idx, target)) in transmission_targets().enumerate() {
             let mut cell = Cell::new(TRANSMISSION_WARNING_BASELINE[source_idx][target_idx]);
+            debug_assert_eq!(column, target_idx);
             match &payloads {
                 Ok(payloads) => {
                     for payload in payloads {
                         cell.record_warnings(SOURCE_PARSE, &payload.parse_warnings);
-                        validate_transmission_pair(payload, *target, &mut cell);
+                        validate_transmission_pair(payload, target, &mut cell);
                     }
                 }
                 Err(err) => cell.failures.push(err.clone()),
@@ -775,70 +1113,45 @@ fn run_transmission_matrix() -> MatrixReport {
         cells.push(row);
     }
 
-    let source = "DeepMind OPFData JSON";
-    let payload = deepmind_opfdata_payload();
-    let mut row = Vec::new();
-    for (target_idx, target) in TRANSMISSION_FORMATS.iter().enumerate() {
-        let mut cell = Cell::new(DEEPMIND_OPFDATA_WARNING_BASELINE[target_idx]);
-        match &payload {
-            Ok(payload) => {
-                cell.record_warnings(SOURCE_PARSE, &payload.parse_warnings);
-                validate_transmission_pair(payload, *target, &mut cell);
-            }
-            Err(err) => cell.failures.push(err.clone()),
-        }
-        if !cell.ok() {
-            failures.push(format!(
-                "transmission {source} -> {}: observed {} warnings, baseline {}; {}{}",
-                target.name,
-                cell.observed_warnings,
-                cell.baseline_warnings,
-                cell.failures.join("; "),
-                silent_loss_note(&cell),
-            ));
-        }
-        row.push(cell);
-    }
-    sources.push(source);
-    cells.push(row);
-
     MatrixReport {
         sources,
         targets,
-        case_count: TRANSMISSION_CASES.len() + 1,
+        groups,
+        case_count: TRANSMISSION_CASES.len(),
         cells,
         failures,
     }
 }
 
-fn deepmind_opfdata_payload() -> Result<TransmissionPayload, String> {
-    let parsed = parse_transmission_file(data("opfdataset/example_0.json"), Some("opfdata-json"))
-        .map_err(|err| format!("parse DeepMind OPFData fixture: {err}"))?;
-    let core = transmission_core(&parsed.network);
-    Ok(TransmissionPayload {
-        label: "official case 14 example",
-        network: parsed.network,
-        parse_warnings: parsed.warnings,
-        core,
-    })
-}
-
+/// The payloads a source row converts from: every MATPOWER case written into
+/// that source format and read back, so the row measures what that format
+/// carries rather than what MATPOWER carries. A read only format has no writer,
+/// so its row parses one vendored case instead.
 fn transmission_payloads(format: TransmissionFormat) -> Result<Vec<TransmissionPayload>, String> {
+    if let Some(fixture) = format.fixture {
+        let source = powerio_core::Source::open(data(fixture))
+            .map_err(|err| format!("open {fixture}: {err}"))?;
+        let parsed = parse_transmission_source(source, format.token)
+            .map_err(|err| format!("parse {fixture}: {err}"))?;
+        return Ok(vec![TransmissionPayload {
+            label: fixture,
+            network: parsed.network,
+            parse_warnings: parsed.warnings,
+        }]);
+    }
     TRANSMISSION_CASES
         .iter()
         .map(|(label, rel)| {
             let base =
                 parse_matpower_file(data(rel)).map_err(|err| format!("parse {rel}: {err}"))?;
-            let rendered = emit_transmission_value(&base, format.target)
+            let rendered = emit_transmission(&base, format)
                 .map_err(|err| format!("write {rel} as {}: {err}", format.name))?;
-            let parsed = parse_transmission_str(&rendered.text, format.token)
+            let parsed = parse_transmission_emitted(&rendered.emitted, format)
                 .map_err(|err| format!("read generated {rel} as {}: {err}", format.name))?;
-            let core = transmission_core(&parsed.network);
             Ok(TransmissionPayload {
                 label,
                 network: parsed.network,
                 parse_warnings: parsed.warnings,
-                core,
             })
         })
         .collect()
@@ -849,62 +1162,240 @@ fn validate_transmission_pair(
     target: TransmissionFormat,
     cell: &mut Cell,
 ) {
-    match emit_transmission_value(&payload.network, target.target) {
-        Ok(conversion) => {
-            cell.record_warnings(TARGET_WRITE, &conversion.render_diagnostics());
-            match parse_transmission_str(&conversion.text, target.token) {
-                Ok(parsed) => {
-                    cell.record_warnings(TARGET_READBACK, &parsed.warnings);
-                    let actual = transmission_core(&parsed.network);
-                    if actual != payload.core {
-                        cell.failures.push(format!(
-                            "{} core changed for {}: before {:?}, after {:?}",
-                            payload.label, target.name, payload.core, actual
-                        ));
-                    }
-                    record_model_diffs(
-                        payload.label,
-                        &transmission_value(&payload.network),
-                        &transmission_value(&parsed.network),
-                        cell,
-                    );
-                    match ybus_change(&payload.network, &parsed.network) {
-                        Ok(Some(diff)) => cell.failures.push(format!(
-                            "{} Y_bus changed for {}: {diff}",
-                            payload.label, target.name
-                        )),
-                        Ok(None) => {}
-                        // A network with no buildable admittance matrix is a
-                        // conversion failure. Reporting it as agreement is how
-                        // an invariant passes without checking anything.
-                        Err(side) => cell.failures.push(format!(
-                            "{} Y_bus could not be built for {} ({}) ",
-                            payload.label,
-                            target.name,
-                            match side {
-                                YbusUnavailable::Before => "source",
-                                YbusUnavailable::After => "result",
-                            }
-                        )),
-                    }
-                    if let Some(diff) = injection_change(&payload.network, &parsed.network) {
-                        cell.failures.push(format!(
-                            "{} bus injections moved for {}: {diff}",
-                            payload.label, target.name
-                        ));
-                    }
-                }
-                Err(err) => cell.failures.push(format!(
-                    "{} output did not parse as {}: {err}",
-                    payload.label, target.name
-                )),
-            }
+    let conversion = match emit_transmission(&payload.network, target) {
+        Ok(conversion) => conversion,
+        Err(err) => {
+            cell.failures.push(format!(
+                "{} did not write as {}: {err}",
+                payload.label, target.name
+            ));
+            return;
         }
-        Err(err) => cell.failures.push(format!(
-            "{} did not write as {}: {err}",
+    };
+    cell.record_warnings(TARGET_WRITE, &conversion.diagnostics);
+    let parsed = match parse_transmission_emitted(&conversion.emitted, target) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            cell.failures.push(format!(
+                "{} output did not parse as {}: {err}",
+                payload.label, target.name
+            ));
+            return;
+        }
+    };
+    cell.record_warnings(TARGET_READBACK, &parsed.warnings);
+    let held = network_a_target_holds(&payload.network, target);
+    let tolerance = electrical_tolerance(target, &held);
+    let actual = transmission_core(&parsed.network);
+    let expected = transmission_core(&held);
+    if !expected.agrees_within(&actual, tolerance) {
+        cell.failures.push(format!(
+            "{} core changed for {}: before {expected:?}, after {actual:?}",
             payload.label, target.name
-        )),
+        ));
     }
+    record_model_diffs(
+        payload.label,
+        &transmission_value(&payload.network),
+        &transmission_value(&parsed.network),
+        cell,
+    );
+    // The electrical comparison runs against what the target's record set can
+    // hold, which is what its writer said it wrote.
+    //
+    // The admittance matrix and the injections are compared by bus id first.
+    // A format that identifies a bus by a name rather than a number (IIDM's
+    // `<bus id="...">`, CIM's mRID, a UCTE-DEF node code) states no bus number,
+    // so its reader numbers the buses it reads and the id keyed comparison is
+    // asking the wrong question; the same power flow problem up to bus
+    // relabeling is what such a conversion can promise, and the renumbering
+    // itself stays a declared loss through the model comparison above.
+    let numbered = match ybus_change_within(&held, &parsed.network, tolerance) {
+        Ok(Some(diff)) => Some(format!("Y_bus changed: {diff}")),
+        Ok(None) => injection_change_within(&held, &parsed.network, tolerance)
+            .map(|diff| format!("bus injections moved: {diff}")),
+        // A network with no buildable admittance matrix is a conversion
+        // failure. Reporting it as agreement is how an invariant passes
+        // without checking anything.
+        Err(side) => {
+            cell.failures.push(format!(
+                "{} Y_bus could not be built for {} ({})",
+                payload.label,
+                target.name,
+                match side {
+                    YbusUnavailable::Before => "source",
+                    YbusUnavailable::After => "result",
+                }
+            ));
+            return;
+        }
+    };
+    if numbered.is_none() {
+        return;
+    }
+    if states_impedances_the_target_cannot(&held, target) {
+        return;
+    }
+    if let Some(diff) = electrical_change_up_to_relabeling(&held, &parsed.network, tolerance) {
+        cell.failures.push(format!(
+            "{} electrical problem changed for {}: {diff}",
+            payload.label, target.name
+        ));
+    }
+}
+
+/// Whether the target's own numeric fields cannot state this network's
+/// impedances at all.
+///
+/// A UCTE-DEF element record states resistance and reactance in six
+/// characters, at the scale of a transmission line in ohms. A network whose
+/// nominal voltage sits below the lowest UCTE voltage level states impedances
+/// of thousandths of an ohm, which those fields round to one digit or to zero,
+/// so the admittance the reader rebuilds is a different one. The element counts
+/// and the power totals still hold, and the writer reports the voltage level it
+/// wrote each bus under.
+fn states_impedances_the_target_cannot(
+    network: &BalancedNetwork,
+    target: TransmissionFormat,
+) -> bool {
+    /// The lowest of the ten UCTE-DEF voltage levels, in kV.
+    const LOWEST_UCTE_LEVEL_KV: f64 = 27.0;
+    target.token == "ucte"
+        && network
+            .buses()
+            .iter()
+            .any(|bus| bus.base_kv > 0.0 && bus.base_kv < LOWEST_UCTE_LEVEL_KV)
+}
+
+/// The source network reduced to what IIDM's topology can state.
+///
+/// IIDM states connectivity in a node breaker voltage level through switch
+/// positions: a disconnected terminal is one whose switches to the busbar are
+/// open. A level with no switch has no position to open, so an element that
+/// states an out of service terminal there comes back in service. The writer
+/// reports the same loss.
+fn network_iidm_holds(network: &BalancedNetwork) -> BalancedNetwork {
+    let Some(detailed) = network.detailed_connectivity().as_deref() else {
+        return network.clone();
+    };
+    let levels_with_switches = detailed
+        .switches
+        .iter()
+        .map(|switch| switch.voltage_level.clone())
+        .collect::<std::collections::HashSet<_>>();
+    let unstated = |component_type: &str, identity: Option<&str>| {
+        let Some(identity) = identity else {
+            return false;
+        };
+        detailed.terminals.iter().any(|terminal| {
+            terminal.node.is_some()
+                && !terminal.connected
+                && !levels_with_switches.contains(&terminal.voltage_level)
+                && terminal.equipment.component_type() == component_type
+                && terminal.equipment.local_id() == identity
+        })
+    };
+    let mut held = network.clone();
+    for branch in held.branches_mut() {
+        if unstated("branch", branch.uid.as_deref()) {
+            branch.in_service = true;
+        }
+    }
+    for generator in held.generators_mut() {
+        if unstated("generator", generator.uid.as_deref()) {
+            generator.in_service = true;
+        }
+    }
+    for load in held.loads_mut() {
+        if unstated("load", load.uid.as_deref()) {
+            load.in_service = true;
+        }
+    }
+    for shunt in held.shunts_mut() {
+        if unstated("shunt", shunt.uid.as_deref()) {
+            shunt.in_service = true;
+        }
+    }
+    for storage in held.storage_mut() {
+        if unstated("storage", storage.uid.as_deref()) {
+            storage.in_service = true;
+        }
+    }
+    held
+}
+
+/// The relative tolerance the electrical comparison holds a target to.
+///
+/// A format that states each value in a fixed width field cannot return more
+/// digits than the field holds. A UCTE-DEF element record states resistance,
+/// reactance, and susceptance in six characters, so a value comes back rounded
+/// to about five significant digits and a diagonal entry, which sums several of
+/// them, loses another decade. A network whose nominal voltage sits below the
+/// lowest UCTE voltage level keeps far fewer: at one kilovolt a line impedance
+/// is thousandths of an ohm and six characters hold one or two digits of it.
+/// Every other target states its values as decimal numbers of the width the
+/// value needs.
+fn electrical_tolerance(target: TransmissionFormat, network: &BalancedNetwork) -> f64 {
+    /// The lowest of the ten UCTE-DEF voltage levels, in kV.
+    const LOWEST_UCTE_LEVEL_KV: f64 = 27.0;
+    if target.token != "ucte" {
+        return 1e-8;
+    }
+    let below_the_lowest_level = network
+        .buses()
+        .iter()
+        .any(|bus| bus.base_kv > 0.0 && bus.base_kv < LOWEST_UCTE_LEVEL_KV);
+    if below_the_lowest_level { 5e-2 } else { 1e-3 }
+}
+
+/// The source network reduced to the records the target format defines.
+///
+/// A field the target cannot state is a warning and a model difference, and
+/// the electrical invariants still hold across it. A whole record the target
+/// has no place for is different: dropping it changes the power flow problem,
+/// so the comparison runs against the network the format can hold and the
+/// writer reports the same loss. Every reduction here names a record absent
+/// from the target format's own definition, and no reduction moves power
+/// between buses.
+fn network_a_target_holds(
+    network: &BalancedNetwork,
+    target: TransmissionFormat,
+) -> BalancedNetwork {
+    if matches!(target.token, "xiidm" | "jiidm") {
+        return network_iidm_holds(network);
+    }
+    if target.token != "ucte" {
+        return network.clone();
+    }
+    // UCTE-DEF states one node record per bus with one generation set and no
+    // shunt record: a bus shunt has no record at all, a generator has no
+    // status field, so an out of service machine states zero generation at a
+    // node the reader still sees as a generator bus, and several machines at
+    // one bus state one generation.
+    let mut held = network.clone();
+    held.shunts_mut().clear();
+    for generator in held.generators_mut() {
+        if !generator.in_service {
+            generator.in_service = true;
+            generator.pg = 0.0;
+            generator.qg = 0.0;
+        }
+    }
+    let mut merged: Vec<powerio_tx::Generator> = Vec::new();
+    for generator in held.generators() {
+        match merged
+            .iter_mut()
+            .find(|existing| existing.bus == generator.bus)
+        {
+            Some(existing) => {
+                existing.pg += generator.pg;
+                existing.qg += generator.qg;
+            }
+            None => merged.push(generator.clone()),
+        }
+    }
+    *held.generators_mut() = merged;
+    held
 }
 
 /// Record every typed-model field the conversion changed. Yellow cells keep
@@ -1025,6 +1516,92 @@ struct DistributionPayload {
     core: DistributionCore,
 }
 
+/// The geographic layer's own matrix: one source and one target.
+///
+/// A layer is a `powerio.GeoLayer` rather than a network, and no grid exchange
+/// format states a standalone layer, so there is no cell to share with the
+/// network matrix. The one cell holds the canonical `.geo.json` document to the
+/// same rule every other cell answers to: what the source stated survives, and
+/// a warning names what the target cannot state.
+fn run_geo_layer_matrix() -> MatrixReport {
+    const SOURCE: &str = "PowerWorld .aux substation coordinates";
+    const TARGET: &str = "geo-json";
+    let mut cell = Cell::new(GEO_LAYER_WARNING_BASELINE);
+    let mut failures = Vec::new();
+    match geo_layer_cell(&mut cell) {
+        Ok(()) => {}
+        Err(err) => cell.failures.push(err),
+    }
+    if !cell.ok() {
+        failures.push(format!(
+            "geo layer {SOURCE} -> {TARGET}: observed {} warnings, baseline {}; {}{}",
+            cell.observed_warnings,
+            cell.baseline_warnings,
+            cell.failures.join("; "),
+            silent_loss_note(&cell),
+        ));
+    }
+    MatrixReport {
+        sources: vec![SOURCE],
+        targets: vec![TARGET],
+        groups: vec![("Into the geographic layer document", vec![0])],
+        case_count: 1,
+        cells: vec![vec![cell]],
+        failures,
+    }
+}
+
+/// The layer states no loss of its own: every feature the aux substation block
+/// places has a `.geo.json` feature.
+const GEO_LAYER_WARNING_BASELINE: usize = 0;
+
+fn geo_layer_cell(cell: &mut Cell) -> Result<(), String> {
+    let text = std::fs::read_to_string(data("powerworld/ACTIVSg200.aux"))
+        .map_err(|err| format!("read the aux fixture: {err}"))?;
+    let layer = powerio::to_geo_layer_from_aux_text(&text)
+        .map_err(|err| format!("read the aux substation coordinates: {err}"))?;
+    if layer.features.is_empty() {
+        return Err("the aux fixture states no substation coordinates".to_owned());
+    }
+    let module = powerio_core::PioModule::new(powerio::PioValue::GeoLayer(layer.clone()));
+    let destination = powerio_core::Destination::memory("layer").map_err(|err| err.to_string())?;
+    let result = powerio::emit(&module, "geo-json", destination).map_err(|err| err.to_string())?;
+    cell.record_warnings(
+        TARGET_WRITE,
+        &powerio_core::render_diagnostics(result.diagnostics()),
+    );
+    let powerio_core::EmittedOutput::Memory { mut artifacts } = result.into_output() else {
+        return Err("a memory destination returned path output".to_owned());
+    };
+    let artifact = artifacts
+        .pop()
+        .filter(|_| artifacts.is_empty())
+        .ok_or_else(|| "geo layer emission returned several artifacts".to_owned())?;
+    let source = powerio_core::Source::from_memory("layer.geo.json", artifact.into_bytes())
+        .map_err(|err| err.to_string())?;
+    let options = powerio::ParseOptions::default()
+        .format("geo-json")
+        .map_err(|err| err.to_string())?;
+    let back = powerio::parse_with_options(source, &options).map_err(|err| err.to_string())?;
+    cell.record_warnings(
+        TARGET_READBACK,
+        &powerio_core::render_diagnostics(&back.diagnostics),
+    );
+    let powerio::PioValue::GeoLayer(read_back) = &back.value else {
+        return Err(format!(
+            "the geo layer document parsed as {}",
+            back.value.type_name()
+        ));
+    };
+    record_model_diffs(
+        "aux substation coordinates",
+        &serde_json::to_value(&layer).map_err(|err| err.to_string())?,
+        &serde_json::to_value(read_back).map_err(|err| err.to_string())?,
+        cell,
+    );
+    Ok(())
+}
+
 fn run_distribution_matrix() -> MatrixReport {
     let formats: Vec<_> = DISTRIBUTION_FORMATS.iter().map(|fmt| fmt.name).collect();
     let mut cells = Vec::new();
@@ -1060,9 +1637,11 @@ fn run_distribution_matrix() -> MatrixReport {
         cells.push(row);
     }
 
+    let groups = vec![("Into a distribution format", (0..formats.len()).collect())];
     MatrixReport {
         sources: formats.clone(),
         targets: formats,
+        groups,
         case_count: DISTRIBUTION_CASES.len(),
         cells,
         failures,
@@ -1335,41 +1914,44 @@ struct ParsedTransmission {
     warnings: Vec<String>,
 }
 
-fn parse_module_from(
+/// Parse one source under a declared format through the facade, which is the
+/// operation a caller has and the only one that reads a dataset directory.
+///
+/// A dataset directory states one network per scenario and a PyPSA folder one
+/// per snapshot; the matrix writes one snapshot, so it reads the first entry
+/// back.
+fn parse_transmission_source(
     source: powerio_core::Source,
-) -> Result<ParsedTransmission, powerio_core::Error> {
-    let module = powerio_tx::format::parse(source)?;
+    from: &str,
+) -> Result<ParsedTransmission, String> {
+    let format = powerio_core::FormatId::new(from.to_ascii_lowercase().replace('_', "-"))
+        .map_err(|err| err.to_string())?;
+    let options = powerio::ParseOptions::default().format_id(format);
+    let module = powerio::parse_with_options(source, &options).map_err(|err| err.to_string())?;
     let warnings = module
         .diagnostics
         .iter()
         .map(|d| format!("{}: {}", d.code(), d.message()))
         .collect();
-    Ok(ParsedTransmission {
-        warnings,
-        network: module.into_value(),
-    })
+    let network = balanced_network(&module.value)
+        .ok_or_else(|| format!("{from} parsed as {}", module.value.type_name()))?
+        .clone();
+    Ok(ParsedTransmission { network, warnings })
 }
 
-fn parse_transmission_file(
-    path: impl AsRef<std::path::Path>,
-    from: Option<&str>,
-) -> Result<ParsedTransmission, powerio_core::Error> {
-    let mut source = powerio_core::Source::open(path.as_ref())?;
-    if let Some(token) = from {
-        source = source.with_format(powerio_core::FormatId::new(
-            token.to_ascii_lowercase().replace('_', "-"),
-        )?);
+/// The balanced network a parsed module carries, whatever collection the format
+/// states it in.
+fn balanced_network(value: &powerio::PioValue) -> Option<&BalancedNetwork> {
+    match value {
+        powerio::PioValue::BalancedNetwork(network) => Some(network),
+        powerio::PioValue::ScenarioSet(scenarios) => scenarios.get_at(0).and_then(balanced_network),
+        powerio::PioValue::TimeSeries(series) => series.get(0).and_then(balanced_network),
+        powerio::PioValue::BalancedOperatingPoint(point) => Some(point.network()),
+        // A release of solved cases (DeepMind OPFData) parses as the solution
+        // it states; the network it solves is the snapshot a case format
+        // carries.
+        powerio::PioValue::AcOpfSolution(solution) => Some(solution.network()),
+        powerio::PioValue::AcPfSolution(solution) => Some(solution.network()),
+        _ => None,
     }
-    parse_module_from(source)
-}
-
-fn parse_transmission_str(
-    text: &str,
-    from: &str,
-) -> Result<ParsedTransmission, powerio_core::Error> {
-    let source = powerio_core::Source::from_memory("<memory>", text.as_bytes().to_vec())?
-        .with_format(powerio_core::FormatId::new(
-            from.to_ascii_lowercase().replace('_', "-"),
-        )?);
-    parse_module_from(source)
 }

--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -8,12 +8,23 @@
 //! Every format PowerIO 1.0 reads is a source row and every format it writes
 //! is a target column: the balanced case formats, the PowSybl and ENTSO-E
 //! exchange formats (XIIDM, JIIDM, CGMES, UCTE-DEF), the dataset directories
-//! (PyPSA CSV, GridFM Parquet), PowerIO's own network document, and the two
-//! read only sources (IEEE CDF, DeepMind OPFData). That is eighteen rows and
-//! sixteen columns, which no PR comment renders readably as one table, so the
-//! columns are grouped by what the formats are for and each group keeps every
-//! source row. The grouping changes the layout and not the cells: every source
-//! is still run into every target.
+//! (PyPSA CSV, GridFM Parquet), PowerIO's own network document, and the three
+//! read only sources (IEEE CDF, GO Challenge 3, DeepMind OPFData). That is
+//! nineteen rows and sixteen columns, which no PR comment renders readably as
+//! one table, so the columns are grouped by what the formats are for and each
+//! group keeps every source row. The grouping changes the layout and not the
+//! cells: every source is still run into every target.
+//!
+//! Two parse only inputs are named here rather than run. A revision 32 `.raw`
+//! row is the next one to land, and both vendored version 32 exports currently
+//! fail three checks rather than reporting a loss: the XIIDM and JIIDM cells
+//! fail to read back because the writer takes its detailed connectivity path
+//! for a network whose detailed record states no voltage level and emits no
+//! hierarchy at all; the MATPOWER, pandapower, GridFM, and UCTE cells change
+//! the element counts (a shunt, a generator, a branch). A `.pwb` row waits on
+//! the same vintage work: the export this repository vendors states no located
+//! bus type, so the case reaches a dataset target with no reference bus and
+//! cannot be written at all.
 //!
 //! A geographic layer is a `powerio.GeoLayer` rather than a network, and no
 //! grid exchange format states a standalone layer, so it has its own one cell
@@ -788,7 +799,7 @@ const fn read_only(
 /// Every 1.0 transmission format. The writable ones are both source rows and
 /// target columns, in this order; the read only ones are source rows only and
 /// come last, so a target column index indexes this array directly.
-const TRANSMISSION_FORMATS: [TransmissionFormat; 18] = [
+const TRANSMISSION_FORMATS: [TransmissionFormat; 19] = [
     transmission("MATPOWER .m", "matpower", Emission::Document, Family::Case),
     transmission(
         "PowerModels JSON",
@@ -850,6 +861,12 @@ const TRANSMISSION_FORMATS: [TransmissionFormat; 18] = [
         "ieee-cdf",
         Family::Case,
         "ieee-cdf/ieee14cdf.txt",
+    ),
+    read_only(
+        "GO Challenge 3 JSON",
+        "goc3-json",
+        Family::Case,
+        "goc3/goc3_small.json",
     ),
     read_only(
         "DeepMind OPFData JSON",
@@ -1021,33 +1038,74 @@ fn transmission_targets() -> impl Iterator<Item = (usize, TransmissionFormat)> {
 //   document states the whole typed model, so nothing is dropped. The
 //   pandapower row's single warning is its own parse declaring the absolute
 //   cost level a `pwl_cost` table leaves unstated.
-// - The `IEEE CDF` and `DeepMind OPFData JSON` rows parse one vendored case
-//   each, so their counts are per case rather than per six.
-const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 18] = [
-    [0, 1, 15, 15, 15, 7, 15, 23, 14, 76, 76, 301, 48, 15, 27, 0], // MATPOWER .m
-    [0, 0, 15, 15, 14, 6, 14, 22, 13, 75, 75, 300, 47, 14, 27, 0], // PowerModels JSON
-    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 256, 35, 9, 32, 0],        // PSS/E .raw 33
-    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 256, 35, 9, 32, 0],        // PSS/E RAWX 35
-    [0, 0, 0, 0, 0, 0, 2, 0, 0, 37, 37, 251, 33, 7, 32, 0],        // PowerWorld .aux
-    [0, 0, 9, 9, 9, 0, 8, 1, 7, 74, 74, 280, 42, 9, 27, 0],        // egret JSON
-    [1, 1, 8, 8, 8, 1, 2, 1, 8, 62, 62, 209, 59, 9, 28, 1],        // pandapower JSON
-    [0, 0, 9, 9, 9, 0, 7, 0, 7, 73, 73, 280, 42, 9, 27, 0],        // Surge JSON
-    [0, 0, 1, 1, 1, 0, 4, 3, 0, 44, 44, 255, 34, 8, 32, 0],        // PSLF .epc
-    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 354, 66, 15, 38, 6],     // XIIDM 1.17
-    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 354, 66, 15, 38, 6],     // JIIDM 1.17
+// - The `IEEE CDF`, `GO Challenge 3 JSON`, and `DeepMind OPFData JSON` rows
+//   parse one vendored case each, so their counts are per case rather than per
+//   six.
+//
+// The counts below are the same table after the per format warning review, and
+// every delta is attributed to one of these changes:
+//
+// - A CGMES document set whose FullModel states this writer's own modeling
+//   authority was produced by fresh emission, so its header identity, version,
+//   creation time, and dependency references, and the containers, limit types,
+//   islands, and subordinate mRIDs in its body, are values the writer
+//   synthesized and not data a source case stated. Reporting them as unmapped
+//   made every conversion through CGMES declare a loss of something never
+//   stated. That is the whole of the `→ CGMES 3.0` column's collapse (301 to
+//   64 on the MATPOWER row) and of the `CGMES 3.0` row's (244 to 7 on the
+//   MATPOWER cell). A third party set, whose authority differs, still reports
+//   every one of them.
+// - `rate_b` and `rate_c` are written as CGMES temporary limits admissible for
+//   twenty minutes and one minute, the durations the reference importer
+//   assigns those two ratings, instead of a TATL and a tripping current. A
+//   tripping current states a protection setting rather than an admissible
+//   loading, and the reader canonicalized it back to a TATL and said so once
+//   per limit: 74 per `→ CGMES 3.0` cell.
+// - The UCTE reader no longer keeps a second copy of a permanent current limit
+//   in `current_ratings`: `rate_a` in MVA and the same limit in ampere through
+//   the element's own voltage are one fact, and the writer divides by the
+//   voltage the reader multiplied by. That is −5 on eight cells of the
+//   `UCTE-DEF .uct` row and −71 on its CGMES cell, all of them a target
+//   reporting the drop of a restatement.
+// - A PowerWorld `.aux` Gen row states a generator's cost as a cubic
+//   input-output curve (`GenCostModel`, `GenFuelCost`, `GenFixedCost`,
+//   `GenIOB`, `GenIOC`, `GenIOD`), the vocabulary the vendored export states,
+//   so a polynomial cost now survives a conversion into aux at a unit fuel
+//   price. The `→ PowerWorld .aux` column pays +3 per cell for what the row
+//   still has no field for (a piecewise curve, a startup and shutdown cost,
+//   and the coefficient count a four slot curve returns padded), and the
+//   `PowerWorld .aux` source row pays honestly for the data it now carries:
+//   +6 wherever the target has no cost field, +23 on XIIDM and JIIDM, which
+//   report it per generator, and +1 on MATPOWER, where the dcline case's two
+//   piecewise rows do not survive the aux hop and `mpc.gencost` is
+//   all-or-nothing.
+// - `GO Challenge 3 JSON` is a new source row. A problem statement parses as
+//   the security constrained commitment it states, and the row runs the
+//   network that problem is stated on into every target.
+const TRANSMISSION_WARNING_BASELINE: [[usize; TRANSMISSION_TARGETS]; 19] = [
+    [0, 1, 15, 15, 18, 7, 15, 23, 14, 76, 76, 64, 48, 15, 27, 0], // MATPOWER .m
+    [0, 0, 15, 15, 17, 6, 14, 22, 13, 75, 75, 63, 47, 14, 27, 0], // PowerModels JSON
+    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 19, 35, 9, 32, 0],        // PSS/E .raw 33
+    [1, 1, 0, 0, 2, 1, 3, 1, 2, 38, 38, 19, 35, 9, 32, 0],        // PSS/E RAWX 35
+    [1, 0, 6, 6, 0, 0, 8, 0, 6, 60, 60, 37, 39, 13, 32, 0],       // PowerWorld .aux
+    [0, 0, 9, 9, 12, 0, 8, 1, 7, 74, 74, 43, 42, 9, 27, 0],       // egret JSON
+    [1, 1, 8, 8, 9, 1, 2, 1, 8, 62, 62, 43, 59, 9, 28, 1],        // pandapower JSON
+    [0, 0, 9, 9, 12, 0, 7, 0, 7, 73, 73, 43, 42, 9, 27, 0],       // Surge JSON
+    [0, 0, 1, 1, 1, 0, 4, 3, 0, 44, 44, 18, 34, 8, 32, 0],        // PSLF .epc
+    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // XIIDM 1.17
+    [7, 7, 39, 39, 8, 7, 9, 7, 8, 12, 12, 191, 66, 15, 38, 6],    // JIIDM 1.17
+    [7, 7, 74, 327, 7, 7, 8, 7, 7, 50, 50, 19, 58, 14, 39, 7],    // CGMES 3.0
     [
-        244, 244, 311, 564, 244, 244, 245, 244, 244, 287, 287, 419, 295, 251, 276, 244,
-    ], // CGMES 3.0
-    [
-        30, 19, 18, 18, 30, 24, 18, 19, 30, 49, 49, 256, 13, 24, 37, 7,
+        25, 19, 13, 13, 25, 19, 13, 19, 25, 49, 49, 26, 13, 19, 37, 7,
     ], // UCTE-DEF .uct
-    [0, 6, 14, 14, 14, 6, 9, 6, 12, 76, 76, 211, 44, 0, 27, 0],    // PyPSA CSV
+    [0, 6, 14, 14, 14, 6, 9, 6, 12, 76, 76, 45, 44, 0, 27, 0],    // PyPSA CSV
     [
-        28, 27, 35, 35, 35, 27, 30, 27, 33, 95, 95, 227, 67, 33, 54, 27,
+        28, 27, 35, 35, 35, 27, 30, 27, 33, 95, 95, 64, 67, 33, 54, 27,
     ], // GridFM Parquet
-    [0, 1, 15, 15, 15, 7, 15, 23, 14, 76, 76, 301, 48, 15, 27, 0], // model JSON
-    [7, 7, 6, 6, 7, 7, 8, 7, 7, 14, 14, 36, 14, 8, 12, 6],         // IEEE CDF
-    [3, 2, 5, 5, 5, 3, 4, 2, 4, 33, 33, 59, 32, 5, 8, 2],          // DeepMind OPFData JSON
+    [0, 1, 15, 15, 18, 7, 15, 23, 14, 76, 76, 64, 48, 15, 27, 0], // model JSON
+    [7, 7, 6, 6, 7, 7, 8, 7, 7, 14, 14, 10, 14, 8, 12, 6],        // IEEE CDF
+    [5, 4, 7, 7, 8, 4, 7, 4, 6, 9, 9, 9, 14, 8, 7, 1],            // GO Challenge 3 JSON
+    [3, 2, 5, 5, 5, 3, 4, 2, 4, 33, 33, 10, 32, 5, 8, 2],         // DeepMind OPFData JSON
 ];
 
 const TRANSMISSION_CASES: [(&str, &str); 6] = [
@@ -1587,10 +1645,10 @@ fn geo_layer_cell(cell: &mut Cell) -> Result<(), String> {
         TARGET_READBACK,
         &powerio_core::render_diagnostics(&back.diagnostics),
     );
-    let powerio::PioValue::GeoLayer(read_back) = &back.value else {
+    let powerio::PioValue::GeoLayer(read_back) = &back.value() else {
         return Err(format!(
             "the geo layer document parsed as {}",
-            back.value.type_name()
+            back.value().type_name()
         ));
     };
     record_model_diffs(
@@ -1933,8 +1991,8 @@ fn parse_transmission_source(
         .iter()
         .map(|d| format!("{}: {}", d.code(), d.message()))
         .collect();
-    let network = balanced_network(&module.value)
-        .ok_or_else(|| format!("{from} parsed as {}", module.value.type_name()))?
+    let network = balanced_network(module.value())
+        .ok_or_else(|| format!("{from} parsed as {}", module.value().type_name()))?
         .clone();
     Ok(ParsedTransmission { network, warnings })
 }
@@ -1952,6 +2010,10 @@ fn balanced_network(value: &powerio::PioValue) -> Option<&BalancedNetwork> {
         // carries.
         powerio::PioValue::AcOpfSolution(solution) => Some(solution.network()),
         powerio::PioValue::AcPfSolution(solution) => Some(solution.network()),
+        // A problem statement (GO Challenge 3) parses as the calculation it
+        // states; the network it commits units on is the snapshot a case
+        // format carries.
+        powerio::PioValue::AcScucInstance(instance) => Some(instance.network()),
         _ => None,
     }
 }

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -40,6 +40,10 @@ use crate::{Error, Result};
 const MAX_FILES: usize = 4_096;
 const MAX_BYTES: u64 = 64 << 20;
 const MAX_COMPRESSION_RATIO: u64 = 200;
+/// The modeling authority set fresh CGMES output states. A header carrying it
+/// was synthesized by this writer, so its identity, version, creation time,
+/// and profile dependencies state nothing a source document stated.
+const POWERIO_MODELING_AUTHORITY_SET: &str = "http://powerio.dev/cgmes";
 const CGMES_CLASS_PROPERTY: &str = "cgmes_class";
 const CGMES_SV_STATUS_PROPERTY: &str = "SvStatus.inService";
 const CGMES_GENERATING_UNIT_PROPERTY: &str = "RotatingMachine.GeneratingUnit";
@@ -1154,7 +1158,7 @@ mod tests {
         assert!(output.warnings.iter().any(|warning| {
             warning.info.code == crate::diagnostics::codes::EMIT_CGMES.record_dropped.code
                 && warning.contains("storage/not-emitted")
-                && warning.contains("no reactive limits association")
+                && warning.contains("no CGMES record states the storage")
         }));
 
         let parsed = read::read_cgmes_documents(output.files, Some("machine-min-max")).unwrap();
@@ -4931,7 +4935,7 @@ mod tests {
         assert!(equipment.contains("<cim:VoltageLevel.lowVoltageLimit>209.3"));
         assert!(equipment.contains("<cim:VoltageLevel.highVoltageLimit>250.7"));
         assert!(output.warnings.iter().any(|warning| {
-            warning.contains("2 area record(s) have no CGMES mapping yet and are dropped")
+            warning.contains("2 area record(s) dropped: a CGMES ControlArea states")
         }));
     }
 

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -476,18 +476,19 @@ mod tests {
     use super::*;
     use crate::TargetFormat;
     use crate::network::{
-        AcDcConverterControlMode, ActivePowerControl, Area, BoundaryLine, Branch, BranchSolution,
-        Bus, BusBreakerBus, BusId, BusType, BusbarSection, CalculatedBus, CaseMetadata,
-        ComponentMetadata, ConnectivityNode, CurveStyle, DcBusbar, DcConverterOperatingMode,
-        DcConverterUnit, DcGround, DcLine, DcNode, DcPolarity, DcSeriesDevice, DcSwitch,
-        DcSwitchKind, DcTerminal, DcTopologicalNode, DetailedConnectivity, EquipmentReactiveLimits,
-        ExternalIdentifier, Generator, GeneratorEnergySource, Hvdc, Impedance, Junction,
-        LineCommutatedConverter, LineCommutatedConverterOperatingMode,
-        LineCommutatedConverterReactiveModel, Load, LoadVoltageModel, LoadingLimits,
-        MinMaxReactiveLimits, OmittedField, OmittedFieldName, OperationalLimitGroup,
-        ReactiveCapabilityCurve, ReactiveCapabilityCurvePoint, ReactiveLimits, Shunt, ShuntBlock,
-        StaticVarCompensator, StaticVarCompensatorRegulationMode, Subnetwork, Substation, Switch,
-        SwitchKind, SwitchedShuntControl, SwitchedShuntMode, TapChanger, TapChangerKind,
+        AcDcConverterControlMode, ActivePowerControl, Area, BoundaryLine, Branch,
+        BranchCurrentRatings, BranchSolution, Bus, BusBreakerBus, BusId, BusType, BusbarSection,
+        CalculatedBus, CaseMetadata, ComponentMetadata, ConnectivityNode, CurveStyle, DcBusbar,
+        DcConverterOperatingMode, DcConverterUnit, DcGround, DcLine, DcNode, DcPolarity,
+        DcSeriesDevice, DcSwitch, DcSwitchKind, DcTerminal, DcTopologicalNode,
+        DetailedConnectivity, EquipmentReactiveLimits, ExternalIdentifier, Generator,
+        GeneratorEnergySource, Hvdc, Impedance, Junction, LineCommutatedConverter,
+        LineCommutatedConverterOperatingMode, LineCommutatedConverterReactiveModel, Load,
+        LoadVoltageModel, LoadingLimits, MinMaxReactiveLimits, OmittedField, OmittedFieldName,
+        OperationalLimitGroup, ReactiveCapabilityCurve, ReactiveCapabilityCurvePoint,
+        ReactiveLimits, Shunt, ShuntBlock, StaticVarCompensator,
+        StaticVarCompensatorRegulationMode, Subnetwork, Substation, Switch, SwitchKind,
+        SwitchedShuntControl, SwitchedShuntMode, TapChanger, TapChangerKind,
         TapChangerRegulationMode, TapChangerStep, TemporaryLimit, Terminal, TerminalReference,
         TieLine, TopologyEndpoint, TopologyKind, TopologySwitch, Transformer3W, VoltageLevel,
         VoltageSourceConverter, Winding,
@@ -516,6 +517,41 @@ mod tests {
             .push(Branch::new(BusId(1), BusId(2), 0.01, 0.1));
         network.assign_missing_component_ids();
         network
+    }
+
+    #[test]
+    fn derived_cgmes_limits_report_separate_current_ratings() {
+        let mut network = network();
+        network.branches_mut()[0].rate_a = 100.0;
+        network.branches_mut()[0].current_ratings =
+            Some(BranchCurrentRatings::new(500.0, 600.0, 700.0));
+
+        let output = write::write_cgmes(&network, CgmesVersion::V3_0).unwrap();
+        assert!(output.warnings.iter().any(|warning| {
+            warning.info.code == codes::EMIT_CGMES.field_dropped.code
+                && warning.contains("current rating record dropped")
+        }));
+    }
+
+    #[test]
+    fn a_v2415_permanent_limit_states_no_acceptable_duration() {
+        let mut network = network();
+        network.branches_mut()[0].rate_a = 100.0;
+
+        let output = write::write_cgmes(&network, CgmesVersion::V2_4_15).unwrap();
+        let xml = output
+            .files
+            .iter()
+            .map(|(_, text)| text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let permanent = xml
+            .split("<cim:OperationalLimitType ")
+            .nth(1)
+            .and_then(|text| text.split("</cim:OperationalLimitType>").next())
+            .expect("a positive rate_a emits one limit type");
+        assert!(permanent.contains("<cim:IdentifiedObject.name>patl</"));
+        assert!(!permanent.contains("acceptableDuration"), "{permanent}");
     }
 
     fn append_vs_converter_records(

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -2205,18 +2205,34 @@ mod tests {
         }
     }
 
+    /// A CGMES BaseVoltage states a positive nominal voltage and a per-unit
+    /// only case states none, so the substituted kilovolt is declared. It is
+    /// the value PowSybl's own MATPOWER importer uses for a bus row with
+    /// `BASE_KV = 0`, and it returns the same per-unit model because a reader
+    /// divides by the same nominal voltage the writer multiplied by.
     #[test]
-    fn emission_rejects_unknown_voltage_bases_instead_of_inventing_one_kv() {
-        let mut invalid_bus = network();
-        invalid_bus.buses_mut()[0].base_kv = 0.0;
-        let error = write::write_cgmes(&invalid_bus, CgmesVersion::V3_0).unwrap_err();
-        assert!(error.to_string().contains("bus 1"));
-        assert!(error.to_string().contains("base_kv 0"));
+    fn emission_substitutes_and_declares_an_unstated_voltage_base() {
+        let mut unstated_bus = network();
+        unstated_bus.buses_mut()[0].base_kv = 0.0;
+        let files = write::write_cgmes(&unstated_bus, CgmesVersion::V3_0).unwrap();
+        let messages = files
+            .warnings
+            .iter()
+            .map(|record| record.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
         assert!(
-            error
-                .to_string()
-                .contains("requires an exact positive voltage base")
+            messages.contains("1 bus(es) state no nominal voltage"),
+            "{messages}"
         );
+        assert!(messages.contains("bus 1"), "{messages}");
+        let eq = files
+            .files
+            .iter()
+            .find(|(name, _)| name.contains("_EQ"))
+            .map(|(_, text)| text.as_str())
+            .unwrap();
+        assert!(eq.contains("<cim:BaseVoltage.nominalVoltage>1</cim:BaseVoltage.nominalVoltage>"));
 
         let mut missing_topological_node_base = detailed_network();
         let detailed = Arc::make_mut(

--- a/powerio-tx/src/format/cgmes/read.rs
+++ b/powerio-tx/src/format/cgmes/read.rs
@@ -2202,6 +2202,70 @@ fn retain_regulating_control_properties(
     }
 }
 
+/// The substation a terminal's node sits in, through its connectivity node
+/// container.
+fn terminal_substation<'a>(store: &'a Store, node: &str) -> Option<&'a str> {
+    let container = topological_node_level(store, node).or_else(|| {
+        store
+            .refv(node, "ConnectivityNode.ConnectivityNodeContainer")
+            .map(|container| resolve_container(store, container))
+    })?;
+    store.refv(container, "VoltageLevel.Substation")
+}
+
+/// Substations a `PowerTransformer` joins, mapped to one substation each.
+///
+/// CGMES contains a PowerTransformer in one substation while its terminals may
+/// reach a node in another; IIDM and XIIDM state both ends of a transformer in
+/// one substation. PowSybl's own importer resolves this the same way: "CGMES
+/// substations that are connected by transformers will be mapped to a single
+/// IIDM substation" (`NodeContainerMapping`). The first substation of each
+/// group, in definition order, represents it.
+fn substations_joined_by_transformers(mapper: &Mapper<'_>) -> HashMap<String, String> {
+    let store = mapper.store;
+    let mut representative: HashMap<String, String> = HashMap::new();
+    let mut members: HashMap<String, Vec<String>> = HashMap::new();
+    for transformer in store.of_class("PowerTransformer") {
+        let mut joined = mapper
+            .wiring
+            .terminals(transformer)
+            .iter()
+            .filter_map(|terminal| mapper.wiring.node(terminal))
+            .filter_map(|node| terminal_substation(store, node))
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        joined.dedup();
+        if joined.len() < 2 {
+            continue;
+        }
+        let root = joined
+            .iter()
+            .find_map(|substation| representative.get(substation).cloned())
+            .unwrap_or_else(|| joined[0].clone());
+        let mut group = members.remove(&root).unwrap_or_else(|| vec![root.clone()]);
+        for substation in joined {
+            let previous = representative.insert(substation.clone(), root.clone());
+            if previous.as_deref() != Some(root.as_str()) {
+                if let Some(moved) = previous.and_then(|previous| members.remove(&previous)) {
+                    for member in moved {
+                        representative.insert(member.clone(), root.clone());
+                        group.push(member);
+                    }
+                }
+                group.push(substation);
+            }
+        }
+        group.sort_unstable();
+        group.dedup();
+        for member in &group {
+            representative.insert(member.clone(), root.clone());
+        }
+        members.insert(root, group);
+    }
+    representative.retain(|substation, root| substation != root);
+    representative
+}
+
 #[allow(clippy::too_many_lines)] // one ordered pass builds every linked topology table
 fn build_detailed_connectivity(
     mapper: &mut Mapper<'_>,
@@ -2209,8 +2273,25 @@ fn build_detailed_connectivity(
     equipment_reactive_limits: Vec<EquipmentReactiveLimits>,
 ) -> Result<DetailedConnectivity> {
     let store = mapper.store;
+    let merged_substations = substations_joined_by_transformers(mapper);
+    if !merged_substations.is_empty() {
+        let mut names = merged_substations
+            .iter()
+            .map(|(substation, root)| {
+                format!("`{}` into `{}`", store.name(substation), store.name(root))
+            })
+            .collect::<Vec<_>>();
+        names.sort_unstable();
+        mapper.warnings.push(format!(
+            "{} substation(s) are joined by a transformer and were mapped to one substation, as an IIDM transformer states both ends in one substation: {}",
+            merged_substations.len(),
+            names.join(", ")
+        ));
+    }
+    let store = mapper.store;
     let substations = store
         .of_class("Substation")
+        .filter(|id| !merged_substations.contains_key(*id))
         .map(|id| {
             Ok(Substation {
                 component: component_id("substation", id)?,
@@ -2252,7 +2333,14 @@ fn build_detailed_connectivity(
                 component: component_id("voltage_level", id)?,
                 substation: store
                     .refv(id, "VoltageLevel.Substation")
-                    .map(|substation| component_id("substation", substation))
+                    .map(|substation| {
+                        component_id(
+                            "substation",
+                            merged_substations
+                                .get(substation)
+                                .map_or(substation, String::as_str),
+                        )
+                    })
                     .transpose()?,
                 nominal_kv: base,
                 low_voltage_limit_kv: store.f(id, "VoltageLevel.lowVoltageLimit"),

--- a/powerio-tx/src/format/cgmes/read.rs
+++ b/powerio-tx/src/format/cgmes/read.rs
@@ -479,12 +479,10 @@ struct Store {
     /// the final diagnostic pass distinguish a mapped class from fields on
     /// that class which the mapping did not consume.
     read_props: RefCell<BTreeSet<(usize, usize)>>,
-    /// Whether every document that declared a modeling authority declared this
-    /// writer's own. Such a set was produced by fresh CGMES emission, so the
-    /// containers, limit types, islands, and subordinate mRIDs in it are values
-    /// the writer synthesized rather than anything a source case stated, and
-    /// reporting them as unmapped would make every conversion through CGMES
-    /// declare a loss of data that was never stated.
+    /// Whether a document declared this writer's modeling authority. The
+    /// declaration permits suppressing only the exact container, island, and
+    /// subordinate values fresh emission synthesizes; it does not make other
+    /// classes or properties safe to ignore.
     own_output: bool,
     /// Whether any document declared a modeling authority other than this
     /// writer's own, which makes the set a third party document set.
@@ -5595,27 +5593,73 @@ fn normalized_identity_value(raw: &str) -> &str {
 /// Warn for every unconsumed class and every unconsumed field on a consumed
 /// class. Property access is tracked by exact object and property position so
 /// repeated RDF properties cannot hide an unread value.
-/// Whether this document set was produced by fresh CGMES emission: every
-/// declared modeling authority is this writer's own.
+/// Whether every declared modeling authority is this writer's own.
 fn is_own_output(store: &Store) -> bool {
     store.own_output && !store.foreign_output
 }
 
+/// Unmapped container classes fresh emission creates to make a complete
+/// equipment hierarchy. No source-neutral record supplies their identity or
+/// fields.
+fn synthesized_unmapped_class(class: &str) -> bool {
+    matches!(class, "GeographicalRegion" | "SubGeographicalRegion")
+}
+
+/// Properties fresh emission derives solely to connect its generated CGMES
+/// hierarchy and state records.
+fn synthesized_unmapped_property(class: &str, property: &str) -> bool {
+    matches!(
+        (class, property),
+        ("GeneratingUnit", "Equipment.inService")
+            | ("OperationalLimitType", "OperationalLimitType.direction")
+            | (
+                "LinearShuntCompensator",
+                "ShuntCompensator.nomU" | "ShuntCompensator.normalSections"
+            )
+            | ("Substation", "Substation.Region")
+            | ("TopologicalIsland", "TopologicalIsland.TopologicalNodes")
+    )
+}
+
+/// Classes whose mRID identifies a record subordinate to source-neutral
+/// equipment. Fresh emission derives these identities from their owner.
+fn synthesized_subordinate_identity(class: &str) -> bool {
+    matches!(
+        class,
+        "TapChangerControl"
+            | "RatioTapChangerTable"
+            | "RatioTapChangerTablePoint"
+            | "PhaseTapChangerTable"
+            | "PhaseTapChangerTablePoint"
+            | "ReactiveCapabilityCurve"
+            | "VsCapabilityCurve"
+            | "CurveData"
+            | "OperationalLimitType"
+            | "CurrentLimit"
+            | "ActivePowerLimit"
+            | "ApparentPowerLimit"
+    )
+}
+
 fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
-    if is_own_output(store) {
-        return;
-    }
+    let own_output = is_own_output(store);
     let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
     let mut fields: BTreeMap<(&str, &str), (usize, Vec<&str>)> = BTreeMap::new();
     let read_props = store.read_props.borrow();
     for (object_at, object) in store.objects.iter().enumerate() {
         let class = object.class.as_str();
         if !class_is_consumed(class) {
+            if own_output && synthesized_unmapped_class(class) {
+                continue;
+            }
             *counts.entry(class).or_default() += 1;
             continue;
         }
         for (property_at, (property, value)) in object.props.iter().enumerate() {
             if read_props.contains(&(object_at, property_at)) {
+                continue;
+            }
+            if own_output && synthesized_unmapped_property(class, property) {
                 continue;
             }
             if property == "IdentifiedObject.mRID" {
@@ -5667,9 +5711,6 @@ fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
 }
 
 fn warn_regenerated_subordinate_identities(store: &Store, warnings: &mut CgmesDiagnostics) {
-    if is_own_output(store) {
-        return;
-    }
     for class in [
         "TapChangerControl",
         "RatioTapChangerTable",
@@ -5684,6 +5725,9 @@ fn warn_regenerated_subordinate_identities(store: &Store, warnings: &mut CgmesDi
         "ActivePowerLimit",
         "ApparentPowerLimit",
     ] {
+        if is_own_output(store) && synthesized_subordinate_identity(class) {
+            continue;
+        }
         let ids = store.of_class(class).collect::<Vec<_>>();
         if ids.is_empty() {
             continue;
@@ -6349,6 +6393,94 @@ mod tests {
             warning.contains("EquivalentInjection.p")
                 || (warning.contains("IdentifiedObject.mRID")
                     && warning.contains("EquivalentInjection"))
+        }));
+    }
+
+    #[test]
+    fn powerio_authority_suppresses_only_values_fresh_emission_synthesizes() {
+        let mut store = Store {
+            own_output: true,
+            ..Store::default()
+        };
+        store
+            .merge(CimDocument {
+                cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
+                header: None,
+                objects: vec![
+                    CimObject {
+                        class: "GeographicalRegion".into(),
+                        id: "generated-region".into(),
+                        definition: true,
+                        props: Vec::new(),
+                    },
+                    CimObject {
+                        class: "Substation".into(),
+                        id: "substation".into(),
+                        definition: true,
+                        props: vec![
+                            (
+                                "Substation.Region".into(),
+                                PropValue::Ref("generated-region".into()),
+                            ),
+                            (
+                                "Substation.vendorProperty".into(),
+                                PropValue::Text("retained".into()),
+                            ),
+                        ],
+                    },
+                    CimObject {
+                        class: "ACLineSegment".into(),
+                        id: "line".into(),
+                        definition: true,
+                        props: vec![(
+                            "ACLineSegment.shortCircuitEndTemperature".into(),
+                            PropValue::Text("80".into()),
+                        )],
+                    },
+                    CimObject {
+                        class: "LinearShuntCompensator".into(),
+                        id: "shunt".into(),
+                        definition: true,
+                        props: vec![
+                            (
+                                "ShuntCompensator.nomU".into(),
+                                PropValue::Text("230".into()),
+                            ),
+                            (
+                                "ShuntCompensator.normalSections".into(),
+                                PropValue::Text("1".into()),
+                            ),
+                        ],
+                    },
+                    CimObject {
+                        class: "VendorControl".into(),
+                        id: "control".into(),
+                        definition: true,
+                        props: Vec::new(),
+                    },
+                ],
+            })
+            .unwrap();
+
+        let mut warnings = CgmesDiagnostics::new(&codes::READ_CGMES_RECORD_UNMAPPED);
+        warn_unmapped(&store, &mut warnings);
+        assert!(warnings.iter().any(|warning| {
+            warning.info.code == codes::READ_CGMES_FIELD_UNMAPPED.code
+                && warning.contains("shortCircuitEndTemperature")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.info.code == codes::READ_CGMES_FIELD_UNMAPPED.code
+                && warning.contains("Substation.vendorProperty")
+        }));
+        assert!(warnings.iter().any(|warning| {
+            warning.info.code == codes::READ_CGMES_RECORD_UNMAPPED.code
+                && warning.contains("VendorControl")
+        }));
+        assert!(!warnings.iter().any(|warning| {
+            warning.contains("GeographicalRegion")
+                || warning.contains("Substation.Region")
+                || warning.contains("ShuntCompensator.nomU")
+                || warning.contains("ShuntCompensator.normalSections")
         }));
     }
 }

--- a/powerio-tx/src/format/cgmes/read.rs
+++ b/powerio-tx/src/format/cgmes/read.rs
@@ -319,6 +319,15 @@ fn warn_full_model_fields(
     let Some(header) = header else {
         return;
     };
+    // A header this writer synthesized restates nothing: the identity, the
+    // authority set, the creation time, the version, and the dependency
+    // references are all values fresh emission assigns, so reporting them as
+    // dropped would make every conversion into CGMES declare a loss the
+    // source never stated.
+    if header.modeling_authority_set.as_deref() == Some(super::POWERIO_MODELING_AUTHORITY_SET) {
+        warn_full_model_extra_properties(document_name, header, warnings);
+        return;
+    }
     if let Some(identity) = header.identity.as_deref() {
         warnings.push_as(
             &codes::READ_CGMES_FIELD_UNMAPPED,
@@ -372,6 +381,16 @@ fn warn_full_model_fields(
             ),
         );
     }
+    warn_full_model_extra_properties(document_name, header, warnings);
+}
+
+/// Report the FullModel properties beyond the mapped set, whoever wrote them:
+/// a property this reader does not map is stated by the document either way.
+fn warn_full_model_extra_properties(
+    document_name: &str,
+    header: &ModelHeader,
+    warnings: &mut CgmesDiagnostics,
+) {
     if !header.unmapped_properties.is_empty() {
         let mut grouped: BTreeMap<&str, usize> = BTreeMap::new();
         for (property, _) in &header.unmapped_properties {
@@ -403,7 +422,7 @@ fn warn_full_model_fields(
         warnings.push_as(
             &codes::READ_CGMES_FIELD_UNMAPPED,
             format!(
-                "FullModel in `{document_name}` has {} property value(s) encoded as nested RDF/XML: {fields}; PowerIO does not flatten or retain that nested structure",
+                "FullModel in `{document_name}` has {} property value(s) encoded as nested RDF/XML: {fields}; a header property reaches the electrical model as one text value and a nested structure has no such spelling",
                 header.nested_properties.len()
             ),
         );
@@ -452,6 +471,7 @@ struct Merged {
 }
 
 /// The merged object store plus the id and class indexes the mapping reads.
+#[derive(Default)]
 struct Store {
     objects: Vec<Merged>,
     by_id: HashMap<String, usize>,
@@ -459,6 +479,16 @@ struct Store {
     /// the final diagnostic pass distinguish a mapped class from fields on
     /// that class which the mapping did not consume.
     read_props: RefCell<BTreeSet<(usize, usize)>>,
+    /// Whether every document that declared a modeling authority declared this
+    /// writer's own. Such a set was produced by fresh CGMES emission, so the
+    /// containers, limit types, islands, and subordinate mRIDs in it are values
+    /// the writer synthesized rather than anything a source case stated, and
+    /// reporting them as unmapped would make every conversion through CGMES
+    /// declare a loss of data that was never stated.
+    own_output: bool,
+    /// Whether any document declared a modeling authority other than this
+    /// writer's own, which makes the set a third party document set.
+    foreign_output: bool,
 }
 
 /// CIM100 SSH serializes the inherited `Equipment.inService` property in an
@@ -475,6 +505,11 @@ impl Store {
             .header
             .as_ref()
             .and_then(|header| header.modeling_authority_set.clone());
+        match modeling_authority_set.as_deref() {
+            Some(super::POWERIO_MODELING_AUTHORITY_SET) => self.own_output = true,
+            Some(_) => self.foreign_output = true,
+            None => {}
+        }
         for CimObject {
             class,
             id,
@@ -895,11 +930,7 @@ pub(crate) fn read_cgmes_documents_into(
     name_hint: Option<&str>,
     warnings: &mut CgmesDiagnostics,
 ) -> Result<BalancedNetwork> {
-    let mut store = Store {
-        objects: Vec::new(),
-        by_id: HashMap::new(),
-        read_props: RefCell::new(BTreeSet::new()),
-    };
+    let mut store = Store::default();
     let mut versions: Vec<CgmesVersion> = Vec::new();
     let mut description: Option<String> = None;
     let mut scenario_time: Option<String> = None;
@@ -5428,9 +5459,13 @@ fn phase_shift_deg(mapper: &mut Mapper<'_>, ptc: &str, invert: bool) -> f64 {
     if invert { -degrees } else { degrees }
 }
 
-/// PATL → `rate_a`, TATL → `rate_b`, TC → `rate_c`, from the operational
-/// limit sets on the equipment's terminals (or the equipment itself).
-/// Current limits convert through √3·kV; apparent/active limits are MVA/MW.
+/// PATL → `rate_a`; a TATL admissible for longer than a minute → `rate_b` and
+/// one admissible for a minute or less → `rate_c`, the short term and
+/// emergency ratings the reference importer reads the same two durations as; a
+/// tripping current kind also lands on `rate_c`. Limits come from the
+/// operational limit sets on the equipment's terminals (or the equipment
+/// itself). Current limits convert through √3·kV; apparent/active limits are
+/// MVA/MW.
 fn apply_limits(
     mapper: &mut Mapper<'_>,
     equipment: &str,
@@ -5447,6 +5482,10 @@ fn apply_limits(
     terminals.push(equipment);
     apply_limits_to_targets(mapper.store, &terminals, branch, kv, version);
 }
+
+/// A temporary limit admissible for this many seconds or fewer is the
+/// emergency rating, as the reference importer classifies it.
+const EMERGENCY_LIMIT_SECONDS: f64 = 60.0;
 
 fn apply_limits_to_targets(
     store: &Store,
@@ -5495,7 +5534,16 @@ fn apply_limits_to_targets(
             };
             let slot = match kind {
                 Some("patl") => Some(&mut branch.rate_a),
-                Some("tatl") => Some(&mut branch.rate_b),
+                Some("tatl") => {
+                    if store
+                        .f(limit_type, "OperationalLimitType.acceptableDuration")
+                        .is_some_and(|seconds| seconds <= EMERGENCY_LIMIT_SECONDS)
+                    {
+                        Some(&mut branch.rate_c)
+                    } else {
+                        Some(&mut branch.rate_b)
+                    }
+                }
                 Some("tc" | "tct") => Some(&mut branch.rate_c),
                 _ => None,
             };
@@ -5547,7 +5595,16 @@ fn normalized_identity_value(raw: &str) -> &str {
 /// Warn for every unconsumed class and every unconsumed field on a consumed
 /// class. Property access is tracked by exact object and property position so
 /// repeated RDF properties cannot hide an unread value.
+/// Whether this document set was produced by fresh CGMES emission: every
+/// declared modeling authority is this writer's own.
+fn is_own_output(store: &Store) -> bool {
+    store.own_output && !store.foreign_output
+}
+
 fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
+    if is_own_output(store) {
+        return;
+    }
     let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
     let mut fields: BTreeMap<(&str, &str), (usize, Vec<&str>)> = BTreeMap::new();
     let read_props = store.read_props.borrow();
@@ -5569,7 +5626,7 @@ fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
                 warnings.push_as(
                     &codes::READ_CGMES_FIELD_UNMAPPED,
                     format!(
-                        "{} `{}` property `IdentifiedObject.mRID` is {}, but its RDF identity is `{}`; PowerIO uses the RDF identity and fresh CGMES output replaces this mRID",
+                        "{} `{}` property `IdentifiedObject.mRID` is {}, but its RDF identity is `{}`; a CIM object has one identity in the balanced calculation view, taken from the RDF identity, and fresh CGMES output replaces this mRID",
                         object.class,
                         object.id,
                         describe_property_value(value),
@@ -5589,7 +5646,7 @@ fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
     }
     for (class, count) in counts {
         warnings.push(format!(
-            "{count} {class} object(s) have no electrical or hierarchy mapping; only their identity metadata is retained"
+            "{count} {class} object(s) state no electrical value and no container the balanced calculation view holds; their identity metadata is retained and nothing else"
         ));
     }
     for ((class, property), (occurrences, ids)) in fields {
@@ -5602,7 +5659,7 @@ fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
         warnings.push_as(
             &codes::READ_CGMES_FIELD_UNMAPPED,
             format!(
-                "{} {class} object(s) provide {occurrences} `{property}` value(s) that PowerIO does not map (objects: [`{samples}`]{remainder}); fresh CGMES output omits this field",
+                "{} {class} object(s) state {occurrences} `{property}` value(s) that no field of the balanced calculation view holds (objects: [`{samples}`]{remainder}); fresh CGMES output omits this field",
                 ids.len(),
             ),
         );
@@ -5610,6 +5667,9 @@ fn warn_unmapped(store: &Store, warnings: &mut CgmesDiagnostics) {
 }
 
 fn warn_regenerated_subordinate_identities(store: &Store, warnings: &mut CgmesDiagnostics) {
+    if is_own_output(store) {
+        return;
+    }
     for class in [
         "TapChangerControl",
         "RatioTapChangerTable",
@@ -5640,7 +5700,7 @@ fn warn_regenerated_subordinate_identities(store: &Store, warnings: &mut CgmesDi
             ("identities", "are")
         };
         warnings.push(format!(
-            "{} {class} {identity} [`{sample}`]{remainder} {verb} not retained as PowerIO component IDs; the electrical values and relationships are retained, and fresh CGMES assigns deterministic subordinate mRIDs",
+            "{} {class} {identity} [`{sample}`]{remainder} {verb} the mRID of an object subordinate to an element, and the balanced calculation view identifies elements and not their subordinate objects; the electrical values and relationships are retained, and fresh CGMES assigns deterministic subordinate mRIDs",
             ids.len()
         ));
     }
@@ -5678,11 +5738,7 @@ mod tests {
 
     #[test]
     fn coalesces_equal_properties_and_rejects_conflicting_profile_values() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(document_with_property(true, PropValue::Text("10".into())))
             .unwrap();
@@ -5735,11 +5791,7 @@ mod tests {
             ("CurrentLimit", "CurrentLimit.value", "NaN"),
             ("TapChanger", "TapChanger.step", "-inf"),
         ] {
-            let mut store = Store {
-                objects: Vec::new(),
-                by_id: HashMap::new(),
-                read_props: RefCell::new(BTreeSet::new()),
-            };
+            let mut store = Store::default();
             let error = store
                 .merge(document_with_literal(class, property, value))
                 .unwrap_err();
@@ -5770,11 +5822,7 @@ mod tests {
             ),
             ("TapChanger", "TapChanger.ltcFlag", "on"),
         ] {
-            let mut store = Store {
-                objects: Vec::new(),
-                by_id: HashMap::new(),
-                read_props: RefCell::new(BTreeSet::new()),
-            };
+            let mut store = Store::default();
             let error = store
                 .merge(document_with_literal(class, property, value))
                 .unwrap_err();
@@ -5830,11 +5878,7 @@ mod tests {
                 "-1",
             ),
         ] {
-            let mut store = Store {
-                objects: Vec::new(),
-                by_id: HashMap::new(),
-                read_props: RefCell::new(BTreeSet::new()),
-            };
+            let mut store = Store::default();
             let message = store
                 .merge(document_with_literal(class, property, value))
                 .unwrap_err()
@@ -5869,11 +5913,7 @@ mod tests {
                 "OperationalLimitType.acceptableDuration",
             ),
         ] {
-            let mut store = Store {
-                objects: Vec::new(),
-                by_id: HashMap::new(),
-                read_props: RefCell::new(BTreeSet::new()),
-            };
+            let mut store = Store::default();
             store
                 .merge(document_with_literal(class, property, "2.5"))
                 .unwrap();
@@ -5961,11 +6001,7 @@ mod tests {
 
     #[test]
     fn noncanonical_limit_kinds_and_fractional_durations_are_explicit() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(CimDocument {
                 cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
@@ -6039,11 +6075,7 @@ mod tests {
     #[test]
     fn invalid_temporary_limit_durations_are_explicit() {
         for duration_value in ["-1", "18446744073709551616"] {
-            let mut store = Store {
-                objects: Vec::new(),
-                by_id: HashMap::new(),
-                read_props: RefCell::new(BTreeSet::new()),
-            };
+            let mut store = Store::default();
             store
                 .merge(CimDocument {
                     cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
@@ -6112,11 +6144,7 @@ mod tests {
 
     #[test]
     fn distinct_equal_base_voltage_identities_are_diagnosed() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(CimDocument {
                 cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
@@ -6146,11 +6174,7 @@ mod tests {
 
     #[test]
     fn unsupported_tap_control_mode_is_not_silently_defaulted() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(CimDocument {
                 cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
@@ -6188,11 +6212,7 @@ mod tests {
 
     #[test]
     fn rejects_resource_references_for_typed_literals() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         let mut document = document_with_literal("EnergyConsumer", "EnergyConsumer.p", "1");
         document.objects[0].props[0].1 = PropValue::Ref("not-a-number".into());
 
@@ -6203,11 +6223,7 @@ mod tests {
 
     #[test]
     fn unknown_limit_tap_changer_and_generating_unit_classes_are_diagnosed() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(CimDocument {
                 cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),
@@ -6238,18 +6254,14 @@ mod tests {
             assert!(warnings.iter().any(|warning| {
                 warning.info.code == codes::READ_CGMES_RECORD_UNMAPPED.code
                     && warning.contains(&format!("1 {class} object(s)"))
-                    && warning.contains("no electrical or hierarchy mapping")
+                    && warning.contains("state no electrical value and no container")
             }));
         }
     }
 
     #[test]
     fn mapped_classes_report_each_unread_field_without_false_mrid_matches() {
-        let mut store = Store {
-            objects: Vec::new(),
-            by_id: HashMap::new(),
-            read_props: RefCell::new(BTreeSet::new()),
-        };
+        let mut store = Store::default();
         store
             .merge(CimDocument {
                 cim_namespaces: BTreeSet::from(["http://iec.ch/TC57/CIM100#".into()]),

--- a/powerio-tx/src/format/cgmes/write.rs
+++ b/powerio-tx/src/format/cgmes/write.rs
@@ -3788,16 +3788,23 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             "network validation failed before CGMES emission: {error}"
         ))
     })?;
-    if let Some(bus) = net
-        .buses()
-        .iter()
-        .find(|bus| !bus.base_kv.is_finite() || bus.base_kv <= 0.0)
-    {
-        return Err(emission_error(format!(
-            "bus {} has nonpositive or nonfinite base_kv {}; CGMES emission requires an exact positive voltage base",
-            bus.id, bus.base_kv
-        )));
-    }
+    // A CGMES BaseVoltage states a positive nominal voltage, and a per-unit
+    // only case states none. The substitution keeps the per-unit model exact,
+    // and the diagnostic below names the buses it applied to.
+    let unstated_nominal_voltage = crate::format::unstated_nominal_voltage(net);
+    let unbounded_reactive_limits = crate::format::unbounded_reactive_limits(net);
+    let prepared =
+        (unstated_nominal_voltage.is_some() || unbounded_reactive_limits > 0).then(|| {
+            let mut prepared = net.clone();
+            for bus in prepared.buses_mut() {
+                if !crate::format::states_nominal_voltage(bus) {
+                    bus.base_kv = crate::format::SUBSTITUTE_NOMINAL_KV;
+                }
+            }
+            crate::format::substitute_unbounded_reactive_limits(&mut prepared);
+            prepared
+        });
+    let net = prepared.as_ref().unwrap_or(net);
     if let Some(level) = net.detailed_connectivity().as_deref().and_then(|detailed| {
         detailed
             .voltage_levels
@@ -3816,6 +3823,23 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
         p,
         warnings: CgmesDiagnostics::new(&codes::EMIT_CGMES.record_dropped),
     };
+    if unbounded_reactive_limits > 0 {
+        w.warnings.push_as(
+            &codes::EMIT_CGMES.value_substituted,
+            format!(
+                "{unbounded_reactive_limits} unbounded reactive limit(s) written as the largest finite double: a CGMES SynchronousMachine states minQ and maxQ as numbers and has no spelling for an absent bound, which is how PowSybl states one"
+            ),
+        );
+    }
+    if let Some((count, buses)) = &unstated_nominal_voltage {
+        w.warnings.push_as(
+            &codes::EMIT_CGMES.value_substituted,
+            format!(
+                "{count} bus(es) state no nominal voltage; a CGMES BaseVoltage requires one, so each was written at {} kV, on which the ohm, siemens, and kV values are computed: bus {buses}",
+                crate::format::SUBSTITUTE_NOMINAL_KV,
+            ),
+        );
+    }
     let detailed = net.detailed_connectivity().as_deref();
     let retained_metadata = retained_identified_metadata(detailed, &mut w.warnings);
     if let Some(detailed) = detailed {
@@ -4571,11 +4595,12 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
         eq.open("Terminal", &id, false);
         eq.reference("Terminal.ConductingEquipment", owner);
         eq.text("ACDCTerminal.sequenceNumber", seq);
-        if record.is_none_or(|record| {
+        let states_connectivity_node = record.is_none_or(|record| {
             detailed.is_none_or(|detailed| {
                 terminal_uses_connectivity_node(detailed, record, project_mixed_topology)
             })
-        }) {
+        });
+        if states_connectivity_node {
             eq.reference(
                 "Terminal.ConnectivityNode",
                 &connectivity_node_mrid(detailed, record, bus, project_mixed_topology),
@@ -4583,7 +4608,13 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
         }
         eq.close("Terminal");
         let terminal_connected = record.map_or(connected, |value| value.connected);
-        if terminal_connected {
+        // A terminal that states no connectivity node states its topological
+        // node even while disconnected. The TP profile groups the connected
+        // terminals, but an equipment whose terminals name no node at all
+        // states no location and no reader can place it; the switching state
+        // rides `ACDCTerminal.connected`, `Equipment.inService`, and
+        // `SvStatus.inService` instead.
+        if terminal_connected || !states_connectivity_node {
             tp.open("Terminal", &id, true);
             tp.reference(
                 "Terminal.TopologicalNode",
@@ -6758,6 +6789,15 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                 );
             }
         }
+        // A group id that names one group in the document identifies it, and
+        // a CGMES source's group ids are its own mRIDs. An id that repeats
+        // names none of them on its own: XIIDM states one selected group name
+        // per branch, so a network read from XIIDM has the same name on every
+        // one, and the derived mRID takes the equipment and terminal with it.
+        let mut group_id_uses = HashMap::<&str, usize>::new();
+        for group in &detailed.operational_limit_groups {
+            *group_id_uses.entry(group.id.as_str()).or_default() += 1;
+        }
         for group in &detailed.operational_limit_groups {
             let Some(owner) = equipment_mrid(net, Some(detailed), &group.equipment) else {
                 w.warnings.push(format!(
@@ -6773,11 +6813,12 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                 ));
                 continue;
             }
-            let set = mrid_or(
-                "source_limit_set",
-                &format!("{}:{}:{}", group.equipment, group.terminal, group.id),
-                Some(&group.id),
-            );
+            let identity = if group_id_uses.get(group.id.as_str()) == Some(&1) {
+                group.id.clone()
+            } else {
+                format!("{}:{}:{}", group.equipment, group.terminal, group.id)
+            };
+            let set = mrid_or("source_limit_set", &identity, Some(&identity));
             let mut emits = group.current_limits.is_some();
             if v3 {
                 emits |=

--- a/powerio-tx/src/format/cgmes/write.rs
+++ b/powerio-tx/src/format/cgmes/write.rs
@@ -50,6 +50,49 @@ pub struct CgmesFiles {
 /// provenance metadata, not data.
 const STAMP: &str = "2000-01-01T00:00:00Z";
 
+/// The `OperationalLimitType` one branch rating is written under.
+///
+/// `rate_a` is the permanent limit (PATL). `rate_b` and `rate_c` are temporary
+/// admissible loadings (TATL), told apart by the acceptable duration a CGMES
+/// TATL states: twenty minutes for the short term rating and one minute for
+/// the emergency rating, the durations the reference importer assigns to the
+/// same two ratings. A tripping current kind would state a protection setting
+/// rather than an admissible loading, so it is not used for a rating.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct RateLimitType {
+    /// Distinguishes the two TATL durations in a deterministic mRID and in the
+    /// generated set and limit names.
+    label: &'static str,
+    kind: &'static str,
+    /// Seconds a TATL is admissible for; unused when `infinite`.
+    duration_seconds: u64,
+    infinite: bool,
+}
+
+/// `rate_a` as a PATL.
+const RATE_A_LIMIT: RateLimitType = RateLimitType {
+    label: "patl",
+    kind: "patl",
+    duration_seconds: 0,
+    infinite: true,
+};
+
+/// `rate_b` as the twenty minute TATL.
+const RATE_B_LIMIT: RateLimitType = RateLimitType {
+    label: "tatl-1200",
+    kind: "tatl",
+    duration_seconds: 1200,
+    infinite: false,
+};
+
+/// `rate_c` as the one minute emergency TATL.
+const RATE_C_LIMIT: RateLimitType = RateLimitType {
+    label: "tatl-60",
+    kind: "tatl",
+    duration_seconds: 60,
+    infinite: false,
+};
+
 /// A UUID-shaped identifier derived from an object's role and name, so writes
 /// are reproducible; imported mRIDs (element `uid`s) take precedence at the
 /// call sites.
@@ -1485,7 +1528,8 @@ fn document(
     }
     let _ = writeln!(
         out,
-        "    <md:Model.modelingAuthoritySet>http://powerio.dev/cgmes</md:Model.modelingAuthoritySet>"
+        "    <md:Model.modelingAuthoritySet>{}</md:Model.modelingAuthoritySet>",
+        super::POWERIO_MODELING_AUTHORITY_SET
     );
     out.push_str("  </md:FullModel>\n");
     out.push_str(body);
@@ -4998,7 +5042,7 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             format!("{ext_ns}LimitTypeKind.{kind}")
         }
     };
-    let mut limit_types_used: Vec<&'static str> = Vec::new();
+    let mut limit_types_used: Vec<RateLimitType> = Vec::new();
     let mut limit_doc = Doc::new(Arc::clone(&retained_metadata));
 
     // --- loads ------------------------------------------------------------
@@ -6461,13 +6505,14 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             })
         });
         if !has_source_limits {
-            // PATL/TATL/TC current limits at terminal 1 through √3·kV.
-            let mut rate = |mva: f64, kind: &'static str| {
+            // PATL and TATL current limits at terminal 1 through √3·kV.
+            let mut rate = |mva: f64, limit_type: RateLimitType| {
                 if mva <= 0.0 {
                     return;
                 }
-                if !limit_types_used.contains(&kind) {
-                    limit_types_used.push(kind);
+                let kind = limit_type.label;
+                if !limit_types_used.contains(&limit_type) {
+                    limit_types_used.push(limit_type);
                 }
                 let set = det_mrid("limitset", &format!("{id}:{kind}"));
                 limit_body.named(
@@ -6497,18 +6542,21 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                 }
                 limit_body.close("CurrentLimit");
             };
-            rate(branch.rate_a, "patl");
-            rate(branch.rate_b, "tatl");
-            rate(branch.rate_c, "tc");
-            if !branch.rating_sets.is_empty() || branch.current_ratings.is_some() {
+            rate(branch.rate_a, RATE_A_LIMIT);
+            rate(branch.rate_b, RATE_B_LIMIT);
+            rate(branch.rate_c, RATE_C_LIMIT);
+            for rating_set in &branch.rating_sets {
                 w.warnings.push_as(
                     &codes::EMIT_CGMES.rating_set_dropped,
                     format!(
-                        "branch {} ({}-{}): extra rating sets / current ratings beyond \
-                     A/B/C have no CGMES slot",
+                        "branch {} ({}-{}) rating set `{}` = {} MVA dropped: a CGMES temporary \
+                         limit states the seconds it is admissible for and a named rating set \
+                         states no duration to place it under",
                         i + 1,
                         branch.from,
-                        branch.to
+                        branch.to,
+                        rating_set.name,
+                        rating_set.rate_mva
                     ),
                 );
             }
@@ -6715,16 +6763,17 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                 })
             });
             if !has_source_limits {
-                for (mva, kind) in [
-                    (winding.rate_a, "patl"),
-                    (winding.rate_b, "tatl"),
-                    (winding.rate_c, "tc"),
+                for (mva, limit_type) in [
+                    (winding.rate_a, RATE_A_LIMIT),
+                    (winding.rate_b, RATE_B_LIMIT),
+                    (winding.rate_c, RATE_C_LIMIT),
                 ] {
                     if mva <= 0.0 {
                         continue;
                     }
-                    if !limit_types_used.contains(&kind) {
-                        limit_types_used.push(kind);
+                    let kind = limit_type.label;
+                    if !limit_types_used.contains(&limit_type) {
+                        limit_types_used.push(limit_type);
                     }
                     let set = det_mrid("limitset", &format!("{id}:{end_number}:{kind}"));
                     limit_body.named(
@@ -6891,9 +6940,9 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
         }
     }
 
-    for kind in &limit_types_used {
-        let id = det_mrid("limittype", kind);
-        limit_doc.named("OperationalLimitType", &id, kind);
+    for limit_type in &limit_types_used {
+        let id = det_mrid("limittype", limit_type.label);
+        limit_doc.named("OperationalLimitType", &id, limit_type.label);
         limit_doc.enumeration(
             "OperationalLimitType.direction",
             w.p.cim_ns,
@@ -6903,16 +6952,28 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             limit_doc.ext_ref(
                 w.p.ext.0,
                 "OperationalLimitType.kind",
-                &limit_kind_uri(kind),
+                &limit_kind_uri(limit_type.kind),
             );
-            limit_doc.text("OperationalLimitType.isInfiniteDuration", *kind == "patl");
+            limit_doc.text(
+                "OperationalLimitType.isInfiniteDuration",
+                limit_type.infinite,
+            );
+            if !limit_type.infinite {
+                limit_doc.text(
+                    "OperationalLimitType.acceptableDuration",
+                    limit_type.duration_seconds,
+                );
+            }
         } else {
             limit_doc.ext_ref(
                 w.p.ext.0,
                 "OperationalLimitType.limitType",
-                &limit_kind_uri(kind),
+                &limit_kind_uri(limit_type.kind),
             );
-            limit_doc.text("OperationalLimitType.acceptableDuration", 900);
+            limit_doc.text(
+                "OperationalLimitType.acceptableDuration",
+                limit_type.duration_seconds,
+            );
         }
         limit_doc.close("OperationalLimitType");
     }
@@ -6996,7 +7057,7 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             };
             if !represented {
                 w.warnings.push_as(&codes::EMIT_CGMES.record_dropped, format!(
-                    "equipment reactive limits for `{}` were not emitted: the CGMES writer has no reactive limits association for component type `{}`",
+                    "equipment reactive limits for `{}` were not emitted: a CGMES ReactiveCapabilityCurve attaches to a synchronous machine or a power electronics connection, and no CGMES record states the {} they bound",
                     record.equipment,
                     record.equipment.component_type()
                 ));
@@ -7012,18 +7073,26 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
             "HVDC line `{id}` is a two terminal calculation record, not a physical CGMES DC network, and was not emitted. It has no DCConverterUnit operating mode and containment, DC node and terminal polarity identities, or ground or metallic return topology; its optional resistance, nominal voltage, converter technology, setpoints, and loss factors are insufficient to construct those standard records without inventing data. Use the source neutral detailed DC equipment records for CGMES emission"
         ));
     }
-    for (what, count) in [
-        ("storage unit", net.storage().len()),
-        ("area record", net.areas().len()),
+    for (what, count, reason) in [
+        (
+            "storage unit",
+            net.storage().len(),
+            "a CGMES BatteryUnit states an installed capacity and a charge state and no state              of charge bound, energy capacity, or charge and discharge efficiency",
+        ),
+        (
+            "area record",
+            net.areas().len(),
+            "a CGMES ControlArea states a net interchange and a tolerance, and CGMES states no              control area membership for a node and no area swing bus",
+        ),
         (
             "solver-parameter block",
             usize::from(net.solver().is_some()),
+            "CGMES describes equipment, topology, and state and has no class for the parameters              of a power flow calculation",
         ),
     ] {
         if count > 0 {
-            w.warnings.push(format!(
-                "{count} {what}(s) have no CGMES mapping yet and are dropped"
-            ));
+            w.warnings
+                .push(format!("{count} {what}(s) dropped: {reason}"));
         }
     }
 

--- a/powerio-tx/src/format/cgmes/write.rs
+++ b/powerio-tx/src/format/cgmes/write.rs
@@ -6560,6 +6560,17 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                     ),
                 );
             }
+            if branch.current_ratings.is_some() {
+                w.warnings.push_as(
+                    &codes::EMIT_CGMES.field_dropped,
+                    format!(
+                        "branch {} ({}-{}) current rating record dropped: CGMES CurrentLimit values were derived from the MVA ratings at the terminal voltage and cannot also state separate ampere ratings",
+                        i + 1,
+                        branch.from,
+                        branch.to
+                    ),
+                );
+            }
         }
     }
 
@@ -6970,10 +6981,12 @@ pub fn write_cgmes(net: &BalancedNetwork, version: CgmesVersion) -> Result<Cgmes
                 "OperationalLimitType.limitType",
                 &limit_kind_uri(limit_type.kind),
             );
-            limit_doc.text(
-                "OperationalLimitType.acceptableDuration",
-                limit_type.duration_seconds,
-            );
+            if !limit_type.infinite {
+                limit_doc.text(
+                    "OperationalLimitType.acceptableDuration",
+                    limit_type.duration_seconds,
+                );
+            }
         }
         limit_doc.close("OperationalLimitType");
     }

--- a/powerio-tx/src/format/egret.rs
+++ b/powerio-tx/src/format/egret.rs
@@ -97,7 +97,7 @@ pub fn write_egret_json(net: &BalancedNetwork) -> TextEmission {
 }
 
 fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
-    super::warn_dropped_areas(&F, "egret JSON", net, warnings);
+    super::warn_dropped_areas(&F, "egret JSON", true, net, warnings);
     if !net.transformers_3w().is_empty() {
         warnings.push(
             &F.record_dropped,

--- a/powerio-tx/src/format/egret.rs
+++ b/powerio-tx/src/format/egret.rs
@@ -57,7 +57,7 @@ pub fn write_egret_json(net: &BalancedNetwork) -> TextEmission {
     let with_caps = net.generators().iter().filter(|g| g.has_caps()).count();
     if with_caps > 0 {
         warnings.push(&F.field_dropped, format!(
-            "generator capability/ramp columns dropped for {with_caps} generator(s): the egret generator records written here carry none"
+            "generator capability/ramp columns dropped for {with_caps} generator(s): an egret generator dictionary states no reactive capability curve point and no MATPOWER ramp column"
         ));
     }
 
@@ -102,7 +102,7 @@ fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
         warnings.push(
             &F.record_dropped,
             format!(
-                "{} 3-winding transformer(s) dropped: the egret writer emits no 3-winding record",
+                "{} 3-winding transformer(s) dropped: an egret branch dictionary states two buses, so a three winding record needs the star bus and three branches a projection would synthesize",
                 net.transformers_3w().len()
             ),
         );
@@ -114,14 +114,14 @@ fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
     {
         warnings.push(
             &F.field_dropped,
-            "emergency voltage band(s) (EVHI/EVLO) dropped: this writer carries one voltage band",
+            "emergency voltage band(s) (EVHI/EVLO) dropped: an egret bus dictionary states one v_min/v_max pair",
         );
     }
     if !net.storage().is_empty() {
         warnings.push(
             &F.record_dropped,
             format!(
-                "{} storage unit(s) dropped: egret storage mapping not implemented",
+                "{} storage unit(s) dropped: an egret storage dictionary states an energy capacity and charge and discharge efficiencies, which the balanced storage record does not state",
                 net.storage().len()
             ),
         );
@@ -157,7 +157,7 @@ fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
         .count();
     if current_ratings > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{current_ratings} branch current rating record(s) dropped: egret branch records carry MVA ratings only"
+            "{current_ratings} branch current rating record(s) dropped: an egret branch dictionary states its rating in MVA"
         ));
     }
     warn_extra_branch_rating_sets(&F, "egret JSON", net, warnings);
@@ -168,7 +168,7 @@ fn warn_egret_writer_losses(net: &BalancedNetwork, warnings: &mut Diagnostics) {
         .count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{branch_solutions} branch solution value set(s) dropped: egret branch result fields are not written"
+            "{branch_solutions} branch solution value set(s) dropped: an egret branch dictionary states case data, and its flow fields belong to a solution the ModelData holds separately"
         ));
     }
 }

--- a/powerio-tx/src/format/matpower/writer.rs
+++ b/powerio-tx/src/format/matpower/writer.rs
@@ -147,6 +147,29 @@ fn canonical_warnings(net: &BalancedNetwork) -> Diagnostics {
              with no status"
         ));
     }
+    let mut shunts_per_bus = BTreeMap::<BusId, usize>::new();
+    let switched_shunts = net
+        .shunts()
+        .iter()
+        .filter(|shunt| shunt.in_service)
+        .inspect(|shunt| *shunts_per_bus.entry(shunt.bus).or_default() += 1)
+        .filter(|shunt| shunt.control.is_some() || shunt.section_count.is_some())
+        .count();
+    let collapsed_buses = shunts_per_bus.values().filter(|count| **count > 1).count();
+    if switched_shunts > 0 || collapsed_buses > 0 {
+        let message = match (switched_shunts, collapsed_buses) {
+            (switched, 0) => format!(
+                "{switched} switched shunt control record(s) dropped: a MATPOWER bus row carries only the current aggregate GS/BS values"
+            ),
+            (0, buses) => format!(
+                "shunt identity on {buses} bus(es) collapsed: a MATPOWER bus row carries only one aggregate GS/BS pair"
+            ),
+            (switched, buses) => format!(
+                "{switched} switched shunt control record(s) dropped and shunt identity on {buses} bus(es) collapsed: a MATPOWER bus row carries only one aggregate GS/BS pair"
+            ),
+        };
+        warnings.push(&F.value_collapsed, message);
+    }
     warn_extra_branch_rating_sets(&F, "MATPOWER .m", net, &mut warnings);
     let branch_solutions = net
         .branches()

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -1626,18 +1626,30 @@ pub(super) fn warn_dropped_extras(
 /// fixtures reach.
 const EXTRAS_KEYS_NAMED: usize = 6;
 
-/// Warn about the area attributes a target with no area table cannot state.
+/// Warn about the area data a target with no area table cannot state.
 ///
-/// Every one of these targets writes an area number on each bus row, so area
-/// membership itself survives and an area that states nothing else is carried
-/// whole. What such a format has no place for is the area's own attributes,
-/// and the line names the ones the network states.
+/// A target whose bus row carries the area number preserves membership and
+/// loses only attributes of the area record. A target with no bus area field
+/// loses the membership as well, so even an otherwise empty area is reported.
 pub(super) fn warn_dropped_areas(
     family: &'static EmitFamily,
     target: &str,
+    writes_bus_area: bool,
     net: &BalancedNetwork,
     warnings: &mut Diagnostics,
 ) {
+    if !writes_bus_area {
+        if !net.areas().is_empty() {
+            warnings.push(
+                &family.areas_dropped,
+                format!(
+                    "{} area record(s) dropped: {target} writes neither an area table nor a bus area number",
+                    net.areas().len()
+                ),
+            );
+        }
+        return;
+    }
     let mut fields: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
     for area in net.areas() {
         if area.slack_bus.is_some() {

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -803,6 +803,89 @@ pub(crate) fn id_from_f64(
     }
 }
 
+/// The nominal voltage a writer states for a bus whose source case declares
+/// none.
+///
+/// XIIDM and CGMES state impedances in ohms and voltages in kV, so every
+/// voltage level carries a positive nominal voltage; a case that works only in
+/// per unit (a MATPOWER bus row with `BASE_KV = 0`) states none. One
+/// substituted kilovolt keeps every derived ohm, siemens, and kV value finite
+/// and returns the same per-unit model, because a reader divides by the same
+/// nominal voltage the writer multiplied by.
+pub(crate) const SUBSTITUTE_NOMINAL_KV: f64 = 1.0;
+
+/// Whether a bus states a nominal voltage an absolute unit format can carry.
+pub(crate) fn states_nominal_voltage(bus: &crate::network::Bus) -> bool {
+    bus.base_kv.is_finite() && bus.base_kv > 0.0
+}
+
+/// The ids of the buses that state no nominal voltage, as the diagnostic
+/// spells them: at most five, then an ellipsis.
+pub(crate) fn unstated_nominal_voltage(network: &BalancedNetwork) -> Option<(usize, String)> {
+    let ids = network
+        .buses()
+        .iter()
+        .filter(|bus| !states_nominal_voltage(bus))
+        .map(|bus| bus.id.to_string())
+        .collect::<Vec<_>>();
+    if ids.is_empty() {
+        return None;
+    }
+    let shown = ids.iter().take(5).map(String::as_str).collect::<Vec<_>>();
+    let ellipsis = if ids.len() > shown.len() { ", ..." } else { "" };
+    Some((ids.len(), format!("{}{ellipsis}", shown.join(", "))))
+}
+
+/// How many reactive limits state no bound.
+///
+/// A format that states no reactive limits at all (a PyPSA generator CSV) is
+/// read as unbounded, and an absolute unit format states each limit as a
+/// number.
+pub(crate) fn unbounded_reactive_limits(network: &BalancedNetwork) -> usize {
+    let generators = network
+        .generators()
+        .iter()
+        .flat_map(|generator| [generator.qmin, generator.qmax]);
+    let storage = network
+        .storage()
+        .iter()
+        .flat_map(|storage| [storage.qmin, storage.qmax]);
+    let hvdc = network
+        .hvdc()
+        .iter()
+        .flat_map(|line| [line.qminf, line.qmaxf, line.qmint, line.qmaxt]);
+    generators
+        .chain(storage)
+        .chain(hvdc)
+        .filter(|value| value.is_infinite())
+        .count()
+}
+
+/// Replace an unbounded reactive limit with the largest finite double, which
+/// is how PowSybl states an unbounded limit
+/// (`MinMaxReactiveLimitsImpl(-Double.MAX_VALUE, Double.MAX_VALUE)`).
+pub(crate) fn substitute_unbounded_reactive_limits(network: &mut BalancedNetwork) {
+    fn bound(value: &mut f64) {
+        if value.is_infinite() {
+            *value = value.signum() * f64::MAX;
+        }
+    }
+    for generator in network.generators_mut() {
+        bound(&mut generator.qmin);
+        bound(&mut generator.qmax);
+    }
+    for storage in network.storage_mut() {
+        bound(&mut storage.qmin);
+        bound(&mut storage.qmax);
+    }
+    for line in network.hvdc_mut() {
+        bound(&mut line.qminf);
+        bound(&mut line.qmaxf);
+        bound(&mut line.qmint);
+        bound(&mut line.qmaxt);
+    }
+}
+
 /// Reject a case with neither an AC calculation view nor physical DC equipment.
 /// XIIDM 1.17 permits a network containing only DC nodes and equipment, while
 /// the other balanced formats still need at least one bus.

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -1566,8 +1566,8 @@ pub(super) fn branch_rating_set_drop_warning(
 /// replay. `consumed` is the writer's own rule: the keys it reads back into a
 /// record. Everything else was retained by a reader because the source stated
 /// more than a rewrite would synthesize, so dropping it without saying so is
-/// an undeclared loss (#330). One line, a count and the reason, matching the
-/// granularity of the other writer warnings.
+/// an undeclared loss (#330). The line names every key it drops, because a key
+/// is the field the target has no record for and a bare count states no loss.
 pub(super) fn warn_dropped_extras(
     family: &'static EmitFamily,
     target: &str,
@@ -1575,47 +1575,113 @@ pub(super) fn warn_dropped_extras(
     consumed: impl Fn(&str) -> bool,
     warnings: &mut Diagnostics,
 ) {
-    let carries = |extras: &crate::network::Extras| extras.keys().any(|k| !consumed(k));
-    let dropped = net.buses().iter().filter(|e| carries(&e.extras)).count()
-        + net.branches().iter().filter(|e| carries(&e.extras)).count()
-        + net.loads().iter().filter(|e| carries(&e.extras)).count()
-        + net.shunts().iter().filter(|e| carries(&e.extras)).count()
-        + net.switches().iter().filter(|e| carries(&e.extras)).count()
-        + net.storage().iter().filter(|e| carries(&e.extras)).count()
-        + net.hvdc().iter().filter(|e| carries(&e.extras)).count()
-        + net
-            .transformers_3w()
-            .iter()
-            .filter(|e| carries(&e.extras))
-            .count();
+    let mut dropped = 0usize;
+    let mut keys: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for extras in net
+        .buses()
+        .iter()
+        .map(|e| &e.extras)
+        .chain(net.branches().iter().map(|e| &e.extras))
+        .chain(net.loads().iter().map(|e| &e.extras))
+        .chain(net.shunts().iter().map(|e| &e.extras))
+        .chain(net.switches().iter().map(|e| &e.extras))
+        .chain(net.storage().iter().map(|e| &e.extras))
+        .chain(net.hvdc().iter().map(|e| &e.extras))
+        .chain(net.transformers_3w().iter().map(|e| &e.extras))
+    {
+        let mut carries = false;
+        for key in extras.keys().filter(|key| !consumed(key)) {
+            carries = true;
+            keys.insert(key.clone());
+        }
+        if carries {
+            dropped += 1;
+        }
+    }
     if dropped > 0 {
+        let named = keys
+            .iter()
+            .take(EXTRAS_KEYS_NAMED)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join("`, `");
+        let remainder = keys.len().saturating_sub(EXTRAS_KEYS_NAMED);
+        let remainder = if remainder > 0 {
+            format!(" and {remainder} more")
+        } else {
+            String::new()
+        };
         warnings.push(
             &family.extras_dropped,
             format!(
-                "{dropped} element(s) carry source-format passthrough fields (extras) the {target} \
-                 writer does not replay; dropped"
+                "{dropped} element(s) state field(s) `{named}`{remainder} that no {target} record \
+                 holds; dropped"
             ),
         );
     }
 }
 
-/// Warn when a writer drops the area table. Its own line rather than the
-/// extras count: `areas` is a typed field, not a passthrough (#330).
+/// How many extras keys one dropped-extras line names before it counts the
+/// rest. Six keeps the line readable while naming every key the vendored
+/// fixtures reach.
+const EXTRAS_KEYS_NAMED: usize = 6;
+
+/// Warn about the area attributes a target with no area table cannot state.
+///
+/// Every one of these targets writes an area number on each bus row, so area
+/// membership itself survives and an area that states nothing else is carried
+/// whole. What such a format has no place for is the area's own attributes,
+/// and the line names the ones the network states.
 pub(super) fn warn_dropped_areas(
     family: &'static EmitFamily,
     target: &str,
     net: &BalancedNetwork,
     warnings: &mut Diagnostics,
 ) {
-    if !net.areas().is_empty() {
-        warnings.push(
-            &family.areas_dropped,
-            format!(
-                "{} area record(s) dropped: the {target} writer emits no area table",
-                net.areas().len()
-            ),
-        );
+    let mut fields: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for area in net.areas() {
+        if area.slack_bus.is_some() {
+            fields.insert("swing bus");
+        }
+        if area.net_interchange != 0.0 {
+            fields.insert("scheduled net interchange");
+        }
+        if area.tolerance != 0.0 {
+            fields.insert("interchange tolerance");
+        }
+        if area.name.is_some() {
+            fields.insert("name");
+        }
+        if area.uid.is_some() {
+            fields.insert("source identity");
+        }
+        if area.area_type.is_some() {
+            fields.insert("classification");
+        }
     }
+    if fields.is_empty() {
+        return;
+    }
+    warnings.push(
+        &family.areas_dropped,
+        format!(
+            "{} of {} area record(s) state {}: a {target} bus row carries the area number and \
+             {target} has no record for an area's own attributes",
+            net.areas()
+                .iter()
+                .filter(|area| {
+                    area.slack_bus.is_some()
+                        || area.net_interchange != 0.0
+                        || area.tolerance != 0.0
+                        || area.name.is_some()
+                        || area.uid.is_some()
+                        || area.area_type.is_some()
+                })
+                .count(),
+            net.areas().len(),
+            fields.into_iter().collect::<Vec<_>>().join(", ")
+        ),
+    );
 }
 
 pub(super) fn warn_extra_branch_rating_sets(

--- a/powerio-tx/src/format/pandapower.rs
+++ b/powerio-tx/src/format/pandapower.rs
@@ -1011,7 +1011,7 @@ fn warn_pandapower_branch_losses(net: &BalancedNetwork, warnings: &mut Diagnosti
         ));
     }
     warn_extra_branch_rating_sets(&F, "pandapower JSON", net, warnings);
-    super::warn_dropped_areas(&F, "pandapower JSON", net, warnings);
+    super::warn_dropped_areas(&F, "pandapower JSON", false, net, warnings);
     let branch_solutions = net
         .branches()
         .iter()
@@ -1673,11 +1673,13 @@ fn ext_grid_frame(net: &BalancedNetwork, warnings: &mut Diagnostics) -> Value {
     let mut data = Vec::new();
     // A Ref bus with no generator gets an ext_grid row so pandapower sees a
     // slack; reading the file back materializes the row as a Ref generator.
+    let mut synthesized = 0usize;
     for b in net.buses() {
         if b.kind != BusType::Ref || net.generators().iter().any(|g| g.bus == b.id) {
             continue;
         }
         index.push(Value::from(data.len() as u64));
+        synthesized += 1;
         data.push(vec![
             b.name.clone().map_or(Value::Null, Value::String),
             pp_bus(b.id),
@@ -1687,6 +1689,14 @@ fn ext_grid_frame(net: &BalancedNetwork, warnings: &mut Diagnostics) -> Value {
             Value::Bool(true),
             Value::Bool(true),
         ]);
+    }
+    if synthesized > 0 {
+        warnings.push(
+            &F.value_defaulted,
+            format!(
+                "{synthesized} reference bus(es) have no generator; emitted zero-output ext_grid rows because pandapower requires a slack element, and those rows read back as generators"
+            ),
+        );
     }
     frame("ext_grid", &columns, index, data, warnings)
 }
@@ -3691,6 +3701,7 @@ mod tests {
     #[test]
     fn writer_zip_load_columns_round_trip() {
         let mut net = test_net(vec![test_bus(1, BusType::Ref)]);
+        net.generators_mut().push(test_gen(1, None));
         net.loads_mut().push(Load {
             bus: BusId(1),
             p: 10.0,
@@ -3834,6 +3845,10 @@ mod tests {
                 json!(true),
             ]
         );
+        assert!(conv.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code() == F.value_defaulted.code
+                && diagnostic.message().contains("read back as generators")
+        }));
     }
 
     #[test]

--- a/powerio-tx/src/format/powermodels.rs
+++ b/powerio-tx/src/format/powermodels.rs
@@ -107,7 +107,7 @@ pub fn write_powermodels_json(net: &BalancedNetwork) -> TextEmission {
             net.transformers_3w().len()
         ));
     }
-    super::warn_dropped_areas(&F, "PowerModels JSON", net, &mut warnings);
+    super::warn_dropped_areas(&F, "PowerModels JSON", true, net, &mut warnings);
     let voltage_loads = net
         .loads()
         .iter()

--- a/powerio-tx/src/format/powerworld/map.rs
+++ b/powerio-tx/src/format/powerworld/map.rs
@@ -14,8 +14,8 @@ use crate::diagnostics::codes::EMIT_POWERWORLD as F;
 use crate::diagnostics::{Diagnostics, codes};
 use crate::format::{TextEmission, sanitize_quoted, warn_extra_branch_rating_sets};
 use crate::network::{
-    BalancedNetwork, BalancedNetworkTables, Branch, Bus, BusId, BusType, Extras, Generator,
-    GeneratorEnergySource, Load, LoadVoltageModel, Shunt, SourceFormat,
+    BalancedNetwork, BalancedNetworkTables, Branch, Bus, BusId, BusType, Extras, GenCost,
+    Generator, GeneratorEnergySource, Load, LoadVoltageModel, Shunt, SourceFormat,
 };
 use crate::{Error, Result};
 
@@ -30,6 +30,17 @@ const NAME_FORBIDDEN: &[char] = &['"'];
 /// PowerWorld reader produces the same extras.
 pub(super) const LINE_CIRCUIT: &str = "LineCircuit";
 pub(super) const BRANCH_DEVICE_TYPE: &str = "BranchDeviceType";
+/// The `Gen` fields a vendored PowerWorld export states a generator's fuel
+/// input-output curve and fuel price in.
+const GEN_COST_MODEL: &str = "GenCostModel";
+const GEN_FUEL_COST: &str = "GenFuelCost";
+const GEN_FIXED_COST: &str = "GenFixedCost";
+const GEN_IO_B: &str = "GenIOB";
+const GEN_IO_C: &str = "GenIOC";
+const GEN_IO_D: &str = "GenIOD";
+/// Coefficients a cubic input-output curve holds: the constant plus three
+/// powers of MW.
+const GEN_IO_COEFFICIENTS: usize = 4;
 
 // ---- Reader -----------------------------------------------------------------
 
@@ -609,7 +620,7 @@ fn read_gen(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Generator> {
         vg: f_alias(r, &["GenVoltSet", "VoltSet"], 1.0)?,
         mbase: f_alias(r, &["GenMVABase", "MVABase"], 100.0)?,
         in_service: on_alias(r, &["GenStatus", "Status"])?,
-        cost: None,
+        cost: read_gen_cost(r)?,
         caps: Default::default(),
         voltage_regulation_on: true,
         regulating_terminal: None,
@@ -617,6 +628,31 @@ fn read_gen(r: &Row, bus_labels: &HashMap<&str, BusId>) -> Result<Generator> {
         active_power_control: None,
         uid: None,
     })
+}
+
+/// The generator input-output curve as a polynomial cost in currency per hour.
+///
+/// A PowerWorld `Gen` row states the curve as a cubic in MBtu/hr
+/// (`GenFixedCost` plus `GenIOB`, `GenIOC`, and `GenIOD` on the first three
+/// powers of MW) together with the fuel cost per MBtu, so the product is the
+/// cost curve. The four slots are read as four coefficients, highest order
+/// first, which is the polynomial shape the row states.
+fn read_gen_cost(r: &Row) -> Result<Option<GenCost>> {
+    let Some(model) = first(r, &[GEN_COST_MODEL]) else {
+        return Ok(None);
+    };
+    if !model.trim_matches('"').trim().eq_ignore_ascii_case("cubic") {
+        return Ok(None);
+    }
+    let fuel = f_or(r, GEN_FUEL_COST, 1.0)?;
+    let coefficients = [GEN_IO_D, GEN_IO_C, GEN_IO_B, GEN_FIXED_COST]
+        .iter()
+        .map(|key| f_or(r, key, 0.0).map(|value| value * fuel))
+        .collect::<Result<Vec<f64>>>()?;
+    if coefficients.iter().all(|value| *value == 0.0) {
+        return Ok(None);
+    }
+    Ok(Some(GenCost::new(2, 0.0, 0.0, coefficients)))
 }
 
 fn read_branch(
@@ -752,6 +788,12 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
     // writes `""` for the odd bus without a point; the reader leaves those
     // unpromoted.
     let write_locations = net.buses().iter().any(|b| b.location.is_some());
+    // The input-output curve columns appear only when a generator states a
+    // polynomial cost; a case with no cost data writes the plain Gen row.
+    let write_gen_cost = net
+        .generators()
+        .iter()
+        .any(|g| g.cost.as_ref().is_some_and(|cost| cost.model == 2));
     block(
         &mut s,
         "Bus",
@@ -832,10 +874,14 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
     block(
         &mut s,
         "Gen",
-        "[BusNum, GenID, GenMW, GenMVR, GenMWMax, GenMWMin, GenMVRMax, GenMVRMin, GenVoltSet, GenMVABase, GenStatus]",
+        if write_gen_cost {
+            "[BusNum, GenID, GenMW, GenMVR, GenMWMax, GenMWMin, GenMVRMax, GenMVRMin, GenVoltSet, GenMVABase, GenStatus, GenCostModel, GenFuelCost, GenFixedCost, GenIOB, GenIOC, GenIOD]"
+        } else {
+            "[BusNum, GenID, GenMW, GenMVR, GenMWMax, GenMWMin, GenMVRMax, GenMVRMin, GenVoltSet, GenMVABase, GenStatus]"
+        },
         |rows| {
             for (i, g) in net.generators().iter().enumerate() {
-                rows.push(format!(
+                let mut row = format!(
                     "{} \"{}\" {} {} {} {} {} {} {} {} \"{}\"",
                     g.bus,
                     i + 1,
@@ -848,7 +894,31 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
                     n(g.vg),
                     n(g.mbase),
                     status(g.in_service)
-                ));
+                );
+                if write_gen_cost {
+                    // Highest order last in the row: the constant rides
+                    // GenFixedCost and the three powers of MW ride
+                    // GenIOB/GenIOC/GenIOD, at a unit fuel price so the
+                    // input-output curve is the cost curve itself.
+                    let mut coefficients = [0.0f64; GEN_IO_COEFFICIENTS];
+                    if let Some(cost) = g.cost.as_ref().filter(|cost| cost.model == 2) {
+                        for (slot, value) in coefficients
+                            .iter_mut()
+                            .zip(cost.coeffs.iter().rev().take(GEN_IO_COEFFICIENTS))
+                        {
+                            *slot = *value;
+                        }
+                    }
+                    let _ = write!(
+                        row,
+                        " \"Cubic\" 1 {} {} {} {}",
+                        n(coefficients[0]),
+                        n(coefficients[1]),
+                        n(coefficients[2]),
+                        n(coefficients[3])
+                    );
+                }
+                rows.push(row);
             }
         },
     );
@@ -896,24 +966,76 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         },
     );
 
-    if net.generators().iter().any(|g| g.cost.is_some()) {
-        warnings.push(
-            &F.field_dropped,
-            "generator cost curves dropped: not written to PowerWorld .aux",
-        );
+    // A polynomial cost rides the input-output curve columns. What the row has
+    // no field for is stated per field.
+    let piecewise_costs = net
+        .generators()
+        .iter()
+        .filter(|g| g.cost.as_ref().is_some_and(|cost| cost.model != 2))
+        .count();
+    if piecewise_costs > 0 {
+        warnings.push(&F.field_dropped, format!(
+            "{piecewise_costs} piecewise generator cost curve(s) dropped: a PowerWorld .aux Gen row states its cost as a cubic input-output curve and has no breakpoint field"
+        ));
+    }
+    let long_costs = net
+        .generators()
+        .iter()
+        .filter(|g| {
+            g.cost
+                .as_ref()
+                .is_some_and(|cost| cost.model == 2 && cost.coeffs.len() > GEN_IO_COEFFICIENTS)
+        })
+        .count();
+    if long_costs > 0 {
+        warnings.push(&F.value_truncated, format!(
+            "{long_costs} generator cost curve(s) truncated to a cubic: a PowerWorld .aux Gen row states GenFixedCost, GenIOB, GenIOC, and GenIOD and no higher power of MW"
+        ));
+    }
+    let commitment_costs = net
+        .generators()
+        .iter()
+        .filter(|g| {
+            g.cost
+                .as_ref()
+                .is_some_and(|cost| cost.startup != 0.0 || cost.shutdown != 0.0)
+        })
+        .count();
+    if commitment_costs > 0 {
+        warnings.push(&F.field_dropped, format!(
+            "{commitment_costs} generator startup and shutdown cost(s) dropped: a PowerWorld .aux Gen row states a running cost curve and no commitment cost"
+        ));
+    }
+    // A cost curve with fewer than four coefficients reads back padded with
+    // leading zeros, which states the same cost at every MW but not the same
+    // coefficient count.
+    let padded_costs = net
+        .generators()
+        .iter()
+        .filter(|g| {
+            g.cost
+                .as_ref()
+                .is_some_and(|cost| cost.model == 2 && cost.coeffs.len() < GEN_IO_COEFFICIENTS)
+        })
+        .count();
+    if padded_costs > 0 {
+        warnings.push(&F.value_defaulted, format!(
+            "{padded_costs} generator cost curve(s) read back as four coefficients: a PowerWorld .aux Gen row states GenFixedCost, GenIOB, GenIOC, and GenIOD and no coefficient count, so a shorter curve returns padded with leading zeros"
+        ));
     }
     if !net.hvdc().is_empty() {
         warnings.push(
             &F.record_dropped,
             format!(
-                "{} dcline(s) dropped: PowerWorld HVDC not modeled",
+                "{} dcline(s) dropped: a PowerWorld DC line is a separate object family, and no vendored \
+                 .aux export states its field names, so writing one would invent a vocabulary",
                 net.hvdc().len()
             ),
         );
     }
     if !net.transformers_3w().is_empty() {
         warnings.push(&F.record_dropped, format!(
-            "{} 3-winding transformer(s) dropped: the PowerWorld .aux writer emits no 3-winding record",
+            "{} 3-winding transformer(s) dropped: a PowerWorld .aux Branch row states two terminals, so a three winding record needs the star bus and three branches a projection would synthesize",
             net.transformers_3w().len()
         ));
     }
@@ -924,14 +1046,16 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
     {
         warnings.push(
             &F.field_dropped,
-            "emergency voltage band(s) (EVHI/EVLO) dropped: this writer carries one voltage band",
+            "emergency voltage band(s) (EVHI/EVLO) dropped: a PowerWorld .aux Bus row states one BusVMax/BusVMin pair",
         );
     }
     if !net.storage().is_empty() {
         warnings.push(
             &F.record_dropped,
             format!(
-                "{} storage unit(s) dropped: PowerWorld storage not modeled",
+                "{} storage unit(s) dropped: a PowerWorld energy storage object is a separate object family, \
+                 and no vendored .aux export states its field names, so writing one would invent \
+                 a vocabulary",
                 net.storage().len()
             ),
         );
@@ -947,7 +1071,7 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         .count();
     if voltage_loads > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{voltage_loads} voltage dependent load model(s) dropped: PowerWorld Load records carry static MW/MVR only"
+            "{voltage_loads} voltage dependent load model(s) dropped: a PowerWorld .aux Load row states constant MW/MVR, constant current, and constant impedance components and no exponential model or model nominal voltage"
         ));
     }
     let terminal_charging = net
@@ -957,7 +1081,7 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         .count();
     if terminal_charging > 0 {
         warnings.push(&F.value_collapsed, format!(
-            "{terminal_charging} branch terminal admittance record(s) collapsed to total susceptance: PowerWorld aux branch rows written here cannot carry conductance or asymmetric terminal charging"
+            "{terminal_charging} branch terminal admittance record(s) collapsed to total susceptance: a PowerWorld .aux Branch row states one LineC and no terminal conductance"
         ));
     }
     let current_ratings = net
@@ -967,7 +1091,7 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         .count();
     if current_ratings > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{current_ratings} branch current rating record(s) dropped: PowerWorld aux branch rows written here carry MVA ratings only"
+            "{current_ratings} branch current rating record(s) dropped: a PowerWorld .aux Branch row states its ratings in MVA through LineAMVA, LineBMVA, and LineCMVA"
         ));
     }
     warn_extra_branch_rating_sets(&F, "PowerWorld .aux", net, &mut warnings);
@@ -990,19 +1114,19 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         .count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{branch_solutions} branch solution value set(s) dropped: PowerWorld aux result fields are not written"
+            "{branch_solutions} branch solution value set(s) dropped: a PowerWorld .aux flow field is a case result, and no vendored .aux export states its field names, so writing one would invent a vocabulary"
         ));
     }
     if net.branches().iter().any(Branch::has_angle_limits) {
         warnings.push(
             &F.field_dropped,
-            "branch angle limits (angmin/angmax) dropped: not written to PowerWorld .aux",
+            "branch angle limits (angmin/angmax) dropped: a PowerWorld .aux Branch row states no angle difference limit",
         );
     }
     if net.generators().iter().any(Generator::has_caps) {
         warnings.push(
             &F.field_dropped,
-            "generator ramp/capability columns dropped: not written to PowerWorld .aux",
+            "generator ramp/capability columns dropped: a PowerWorld .aux Gen row states no reactive capability curve point, and its ramp rate fields are named by no vendored export",
         );
     }
     if nonfinite {

--- a/powerio-tx/src/format/powerworld/map.rs
+++ b/powerio-tx/src/format/powerworld/map.rs
@@ -1106,7 +1106,7 @@ pub(crate) fn write_powerworld(net: &BalancedNetwork) -> TextEmission {
         |key| matches!(key, "LoadID" | "ShuntID" | "BranchDeviceType") || key == LINE_CIRCUIT,
         &mut warnings,
     );
-    super::super::warn_dropped_areas(&F, "PowerWorld .aux", net, &mut warnings);
+    super::super::warn_dropped_areas(&F, "PowerWorld .aux", true, net, &mut warnings);
     let branch_solutions = net
         .branches()
         .iter()

--- a/powerio-tx/src/format/pslf.rs
+++ b/powerio-tx/src/format/pslf.rs
@@ -1688,7 +1688,7 @@ pub fn write_pslf(net: &BalancedNetwork) -> TextEmission {
     let with_caps = net.generators().iter().filter(|g| g.has_caps()).count();
     if with_caps > 0 {
         warnings.push(&F.field_dropped, format!(
-            "generator capability/ramp columns dropped for {with_caps} generator(s): the PSLF .epc generator records written here carry no MATPOWER capability columns"
+            "generator capability/ramp columns dropped for {with_caps} generator(s): a PSLF .epc generator record states no reactive capability curve point and no ramp column"
         ));
     }
     if net.hvdc().iter().any(|d| d.cost.is_some()) {
@@ -1731,7 +1731,7 @@ pub fn write_pslf(net: &BalancedNetwork) -> TextEmission {
         .count();
     if current_ratings > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{current_ratings} branch current rating record(s) dropped: PSLF branch records written here carry MVA ratings only"
+            "{current_ratings} branch current rating record(s) dropped: a PSLF .epc branch record states its ratings in MVA through rate1, rate2, and rate3"
         ));
     }
     warn_extra_branch_rating_sets(&F, "PSLF .epc", net, &mut warnings);
@@ -1771,7 +1771,7 @@ pub fn write_pslf(net: &BalancedNetwork) -> TextEmission {
         .count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{branch_solutions} branch solution value set(s) dropped: PSLF solved flow fields are not written"
+            "{branch_solutions} branch solution value set(s) dropped: a PSLF .epc branch record states impedance, taps, and ratings and no solved flow"
         ));
     }
     // The generator record this writer emits regulates the unit's own terminal, so

--- a/powerio-tx/src/format/pslf.rs
+++ b/powerio-tx/src/format/pslf.rs
@@ -1763,7 +1763,7 @@ pub fn write_pslf(net: &BalancedNetwork) -> TextEmission {
         },
         &mut warnings,
     );
-    super::warn_dropped_areas(&F, "PSLF .epc", net, &mut warnings);
+    super::warn_dropped_areas(&F, "PSLF .epc", true, net, &mut warnings);
     let branch_solutions = net
         .branches()
         .iter()

--- a/powerio-tx/src/format/psse.rs
+++ b/powerio-tx/src/format/psse.rs
@@ -1094,8 +1094,24 @@ fn write_psse_rev_inner(
         let rdc = dc_f64(&dc.extras, "psse_dc_rdc").unwrap_or(0.0);
         let vschd = dc_f64(&dc.extras, "psse_dc_vschd").unwrap_or(0.0);
         let l1_tail = dc_tail(&dc.extras, "psse_dc_control_tail", DEFAULT_CONTROL_TAIL);
-        let rect_tail = dc_tail(&dc.extras, "psse_dc_rectifier_tail", DEFAULT_CONVERTER_TAIL);
-        let inv_tail = dc_tail(&dc.extras, "psse_dc_inverter_tail", DEFAULT_CONVERTER_TAIL);
+        let (rect_tail, dropped_rectifier_bridges) =
+            dc_converter_tail(&dc.extras, "psse_dc_rectifier_tail", rev);
+        let (inv_tail, dropped_inverter_bridges) =
+            dc_converter_tail(&dc.extras, "psse_dc_inverter_tail", rev);
+        for (end, bridges) in [
+            ("rectifier", dropped_rectifier_bridges),
+            ("inverter", dropped_inverter_bridges),
+        ] {
+            if let Some(bridges) = bridges {
+                warnings.push(
+                    &codes::EMIT_PSSE.field_dropped,
+                    format!(
+                        "DC line `{}` {end} states {bridges} bridge(s) in series; a PSS/E revision 33 two-terminal DC record has no NDR/NDI column",
+                        dc.uid.as_deref().unwrap_or("<unnamed>")
+                    ),
+                );
+            }
+        }
         // SETVL in the stored mode's own unit, the exact inverse of the
         // reader's derivation: MDC 2 schedules a current, so the rectifier
         // power converts back to amps through the scheduled voltage. Every
@@ -1666,6 +1682,62 @@ fn emit_controlled_bus(
 /// replay their own tail; these defaults serve a cross-format source.
 const DEFAULT_CONVERTER_TAIL: &str =
     "1, 15.0, 5.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.5, 0.51, 0.00625, 0, 0, 0, '1', 0.0";
+
+/// Fields a two-terminal DC converter line states after the bus number in
+/// revision 33: NBR through XCAPR.
+const CONVERTER_TAIL_FIELDS_33: usize = 16;
+
+/// Where `NDR`/`NDI`, the number of bridges in series, sits in that tail from
+/// revision 34 on: after ICR and before IFR.
+const CONVERTER_TAIL_BRIDGE_INDEX: usize = 13;
+
+/// The converter tail of a two-terminal DC record at `rev`.
+///
+/// The rectifier and inverter lines state `NDR`/`NDI` from revision 34 on and
+/// have no such column in revision 33, so a tail retained from one revision
+/// carries one field more or fewer than the record being written and the
+/// column belongs at its own position, not at the end. Returns the tail and
+/// the bridge count a revision 33 record has no column for.
+fn dc_converter_tail(extras: &Extras, key: &str, rev: u32) -> (String, Option<String>) {
+    let states_bridges = rev >= 34;
+    let stated = extras
+        .get(key)
+        .and_then(Value::as_array)
+        .filter(|fields| !fields.is_empty());
+    let Some(stated) = stated else {
+        let mut fields = DEFAULT_CONVERTER_TAIL
+            .split(", ")
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        if states_bridges {
+            fields.insert(CONVERTER_TAIL_BRIDGE_INDEX, "0".to_owned());
+        }
+        return (fields.join(", "), None);
+    };
+    let mut fields = stated
+        .iter()
+        .filter_map(Value::as_str)
+        // These come from a source file's `extras` and are replayed into a
+        // record, so they go through the quoting seam like every other
+        // interpolated string: a terminator here would forge a whole DC
+        // record or a section end.
+        .map(|field| sanitize_quoted(field, NAME_FORBIDDEN, ' ').into_owned())
+        .collect::<Vec<_>>();
+    let mut dropped_bridges = None;
+    match (fields.len() > CONVERTER_TAIL_FIELDS_33, states_bridges) {
+        (true, false) => {
+            let bridges = fields.remove(CONVERTER_TAIL_BRIDGE_INDEX);
+            if bridges.trim() != "0" {
+                dropped_bridges = Some(bridges);
+            }
+        }
+        (false, true) if fields.len() == CONVERTER_TAIL_FIELDS_33 => {
+            fields.insert(CONVERTER_TAIL_BRIDGE_INDEX, "0".to_owned());
+        }
+        _ => {}
+    }
+    (fields.join(", "), dropped_bridges)
+}
 
 /// Control-line tail (everything after VSCHD) for a synthesized two-terminal DC
 /// record: compounding voltage, margin, metering code, and minimum firing data.
@@ -4423,8 +4495,23 @@ fn read_dc_line(
 /// retention; any textual difference — a real value, extra columns, even a
 /// different numeric spelling — keeps the tail, conservatively.
 fn tail_is_default(f: &[Cow<'_, str>], start: usize, default: &str) -> bool {
-    let defaults = default.split(", ").map(|t| t.trim_matches('\''));
-    f.iter().skip(start).map(Cow::as_ref).eq(defaults)
+    let defaults = default
+        .split(", ")
+        .map(|t| t.trim_matches('\''))
+        .collect::<Vec<_>>();
+    let mut tail = f.iter().skip(start).map(Cow::as_ref).collect::<Vec<_>>();
+    // Revision 34 and later state one column more in a two-terminal DC
+    // converter tail, the bridge count between ICR and IFR. A record whose
+    // bridge count is zero and whose other fields are the default states the
+    // same converter as the shorter revision 33 default, and retaining it as
+    // an extra would make every later hop report the loss of nothing.
+    if tail.len() == defaults.len() + 1
+        && default == DEFAULT_CONVERTER_TAIL
+        && tail[CONVERTER_TAIL_BRIDGE_INDEX] == "0"
+    {
+        tail.remove(CONVERTER_TAIL_BRIDGE_INDEX);
+    }
+    tail == defaults
 }
 
 /// The fields of `f` from index `start` as a JSON string array (for extras).

--- a/powerio-tx/src/format/pypsa.rs
+++ b/powerio-tx/src/format/pypsa.rs
@@ -655,7 +655,7 @@ pub(crate) fn pypsa_csv_artifacts(
         );
     }
     if net.generators().iter().any(Generator::has_caps) {
-        warnings.push(&F.field_dropped, "generator capability/ramp columns dropped: PyPSA generator CSV has no MATPOWER capability columns");
+        warnings.push(&F.field_dropped, "generator capability/ramp columns dropped: a PyPSA generators.csv row states p_nom and no reactive capability curve point");
     }
     let voltage_loads = net
         .loads()
@@ -710,7 +710,7 @@ pub(crate) fn pypsa_csv_artifacts(
         .count();
     if current_ratings > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{current_ratings} branch current rating record(s) dropped: PyPSA static branch tables carry s_nom, not source current ratings"
+            "{current_ratings} branch current rating record(s) dropped: a PyPSA lines.csv row states s_nom in MVA and no current rating"
         ));
     }
     warn_extra_branch_rating_sets(&F, "PyPSA CSV", net, &mut warnings);
@@ -722,7 +722,7 @@ pub(crate) fn pypsa_csv_artifacts(
         .count();
     if branch_solutions > 0 {
         warnings.push(&F.field_dropped, format!(
-            "{branch_solutions} branch solution value set(s) dropped: PyPSA result time series are not written"
+            "{branch_solutions} branch solution value set(s) dropped: a PyPSA component CSV states case data, and a flow belongs to a result time series over snapshots this profile does not state"
         ));
     }
     let terminal_charging = net

--- a/powerio-tx/src/format/pypsa.rs
+++ b/powerio-tx/src/format/pypsa.rs
@@ -714,7 +714,7 @@ pub(crate) fn pypsa_csv_artifacts(
         ));
     }
     warn_extra_branch_rating_sets(&F, "PyPSA CSV", net, &mut warnings);
-    super::warn_dropped_areas(&F, "PyPSA CSV", net, &mut warnings);
+    super::warn_dropped_areas(&F, "PyPSA CSV", false, net, &mut warnings);
     let branch_solutions = net
         .branches()
         .iter()

--- a/powerio-tx/src/format/surge.rs
+++ b/powerio-tx/src/format/surge.rs
@@ -92,7 +92,7 @@ pub fn write_surge_json(net: &BalancedNetwork) -> TextEmission {
     root.insert("network".into(), Value::Object(network));
 
     warn_extra_branch_rating_sets(&F, FMT, net, &mut warnings);
-    super::warn_dropped_areas(&F, FMT, net, &mut warnings);
+    super::warn_dropped_areas(&F, FMT, true, net, &mut warnings);
     finish(&F, root, warnings)
 }
 

--- a/powerio-tx/src/format/ucte/mod.rs
+++ b/powerio-tx/src/format/ucte/mod.rs
@@ -39,9 +39,8 @@ use super::{TextEmission, warn_extra_branch_rating_sets};
 use crate::diagnostics::codes::EMIT_UCTE as F;
 use crate::diagnostics::{DiagnosticInfo, Diagnostics, codes};
 use crate::network::{
-    Area, BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, Bus, BusId, BusType,
-    Extras, Generator, GeneratorEnergySource, Load, SourceFormat, Switch, TransformerControl,
-    TransformerControlMode,
+    Area, BalancedNetwork, Branch, BranchCharging, Bus, BusId, BusType, Extras, Generator,
+    GeneratorEnergySource, Load, SourceFormat, Switch, TransformerControl, TransformerControlMode,
 };
 use crate::{Error, Result};
 

--- a/powerio-tx/src/format/ucte/read.rs
+++ b/powerio-tx/src/format/ucte/read.rs
@@ -2,10 +2,10 @@
 
 use super::{
     AngleRegulation, Area, BASE_FREQUENCY, BASE_MVA, BTreeSet, BalancedNetwork, Branch,
-    BranchCharging, BranchCurrentRatings, Bus, BusId, BusType, CONTROL_AREA, CROSS_BORDER_AREA,
-    DEFAULT_POWER_LIMIT, DiagnosticInfo, Diagnostics, ElementId, Error, Extras, FMT, Generator,
-    GeneratorEnergySource, HashMap, Load, MIN_REACTANCE_OHM, NodeCode, ORDER_CODES, PLANT_TYPES,
-    PhaseRegulation, REVISION, REVISIONS, Result, SQRT_3, SourceFormat, Switch, TransformerControl,
+    BranchCharging, Bus, BusId, BusType, CONTROL_AREA, CROSS_BORDER_AREA, DEFAULT_POWER_LIMIT,
+    DiagnosticInfo, Diagnostics, ElementId, Error, Extras, FMT, Generator, GeneratorEnergySource,
+    HashMap, Load, MIN_REACTANCE_OHM, NodeCode, ORDER_CODES, PLANT_TYPES, PhaseRegulation,
+    REVISION, REVISIONS, Result, SQRT_3, SourceFormat, Switch, TransformerControl,
     TransformerControlMode, Value, codes, country_iso, json,
 };
 
@@ -874,7 +874,11 @@ fn rated_voltage(
 }
 
 /// The permanent current limit in ampere becomes `rate_a` in MVA at the
-/// element's voltage level and stays exact in `current_ratings`.
+/// element's voltage level. A rating in MVA and the same rating in ampere
+/// through the element's own voltage are one fact, and the writer divides by
+/// the voltage the reader multiplied by, so a second copy in
+/// `current_ratings` would only make every other target report dropping a
+/// restatement.
 fn apply_current_limit(
     reader: &mut Reader<'_>,
     record: &Record<'_>,
@@ -887,7 +891,6 @@ fn apply_current_limit(
         Some(limit) if limit > 0 => {
             let amps = limit as f64;
             branch.rate_a = SQRT_3 * kv * amps / 1000.0;
-            branch.current_ratings = Some(BranchCurrentRatings::new(amps, 0.0, 0.0));
         }
         Some(limit) => reader.warn(
             &codes::READ_UCTE_VALUE_SUBSTITUTED,

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -62,6 +62,13 @@ const EQUIPMENT_NAMESPACE_PREFIX: &str = "http://www.powsybl.org/schema/iidm/equ
 /// IIDM 1.0 predates the PowSybl domain and declares the iTesla namespace.
 const ITESLA_NAMESPACE_PREFIX: &str = "http://www.itesla_project.eu/schema/iidm/";
 const EXTENSION_NAMESPACE_PREFIX: &str = "http://www.powsybl.org/schema/iidm/ext/";
+/// The SlackTerminal extension namespace family. Every published version
+/// (1.0 through 1.5) states one terminal reference, so the version selects only
+/// the schema PowSybl validates against and not the data read here.
+const SLACK_TERMINAL_NAMESPACE_PREFIX: &str =
+    "http://www.powsybl.org/schema/iidm/ext/slack_terminal/";
+/// The version PowSybl writes for IIDM 1.8 and later.
+const SLACK_TERMINAL_NAMESPACE: &str = "http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_5";
 const ACTIVE_POWER_CONTROL_NAMESPACE_V1_0: &str =
     "http://www.itesla_project.eu/schema/iidm/ext/active_power_control/1_0";
 const ACTIVE_POWER_CONTROL_NAMESPACE_V1_1: &str =
@@ -244,6 +251,26 @@ impl ActivePowerControlVersion {
     }
 }
 
+/// Whether an element inside an `<extension>` is one the mapping reads. Every
+/// other extension child is counted as unmapped and skipped.
+fn is_mapped_extension_child(tag: &str, namespace: Option<&str>) -> bool {
+    match tag {
+        "activePowerControl" => ActivePowerControlVersion::from_namespace(namespace).is_some(),
+        "slackTerminal" => is_slack_terminal_namespace(namespace),
+        _ => false,
+    }
+}
+
+/// Whether a namespace URI names a version of the SlackTerminal extension.
+fn is_slack_terminal_namespace(namespace: Option<&str>) -> bool {
+    namespace
+        .and_then(|uri| uri.strip_prefix(SLACK_TERMINAL_NAMESPACE_PREFIX))
+        .and_then(|suffix| suffix.split_once('_'))
+        .is_some_and(|(major, minor)| {
+            major == "1" && !minor.is_empty() && minor.bytes().all(|byte| byte.is_ascii_digit())
+        })
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct XiidmNamespace {
     version: XiidmVersion,
@@ -373,6 +400,14 @@ enum RawEndpoint {
 struct RawTerminalReference {
     id: String,
     terminal: u8,
+}
+
+/// One SlackTerminal extension: the voltage level it is attached to and the
+/// terminal it names as that voltage level's power flow reference.
+#[derive(Clone, Debug)]
+struct RawSlackTerminal {
+    voltage_level: String,
+    reference: RawTerminalReference,
 }
 
 #[derive(Clone, Debug)]
@@ -772,7 +807,7 @@ struct ParsedXiidm {
     dc_switches: Vec<DcSwitch>,
     voltage_source_converters: Vec<RawVoltageSourceConverter>,
     line_commutated_converters: Vec<RawLineCommutatedConverter>,
-    slack_terminal: Option<String>,
+    slack_terminals: Vec<RawSlackTerminal>,
 }
 
 pub(crate) fn parse_xiidm_source(
@@ -1358,11 +1393,10 @@ impl ParsedXiidm {
                     }
                     return Ok(());
                 }
-                let active_power_control = tag == "activePowerControl"
-                    && ActivePowerControlVersion::from_namespace(namespace).is_some();
+                let mapped_extension_child = is_mapped_extension_child(tag, namespace);
                 if self.current_extension_target.is_some()
                     && tag != "extension"
-                    && !active_power_control
+                    && !mapped_extension_child
                 {
                     if namespace.is_none_or(is_xiidm_namespace_uri) {
                         return Err(format_error(format!(
@@ -1414,8 +1448,7 @@ impl ParsedXiidm {
         }
         if self.root_seen {
             let recognized_extension = self.current_extension_target.is_some()
-                && tag == "activePowerControl"
-                && ActivePowerControlVersion::from_namespace(namespace).is_some();
+                && is_mapped_extension_child(tag, namespace);
             if !recognized_extension
                 && !self
                     .namespace
@@ -2169,7 +2202,16 @@ impl ParsedXiidm {
                 });
             }
             "property" => self.read_property(&attrs, diagnostics)?,
-            "slackTerminal" => self.slack_terminal = Some(required_text(&attrs, "id")?.to_owned()),
+            "slackTerminal" => {
+                let voltage_level = self
+                    .current_extension_target
+                    .clone()
+                    .ok_or_else(|| format_error("slackTerminal appears outside an extension"))?;
+                self.slack_terminals.push(RawSlackTerminal {
+                    voltage_level,
+                    reference: parse_terminal_reference(&attrs)?,
+                });
+            }
             "terminalRef" if self.current_tap.is_some() => {
                 let reference = parse_terminal_reference(&attrs)?;
                 let equipment = self.current_equipment()?;
@@ -3944,13 +3986,35 @@ fn build_network(parsed: &ParsedXiidm, diagnostics: &mut Diagnostics) -> Result<
         }
     }
 
-    if let Some(slack) = parsed.slack_terminal.as_deref() {
-        if let Some(bus) = generator_bus_by_id.get(slack).copied() {
-            set_bus_kind(&mut buses, bus, BusType::Ref);
-        } else {
+    // A SlackTerminal extension names the power flow reference of one voltage
+    // level, so a network with several synchronous components declares one per
+    // component. The balanced calculation view states a single reference bus:
+    // the first resolvable terminal becomes it and the rest are reported.
+    let mut reference_bus = None;
+    for slack in &parsed.slack_terminals {
+        let resolved =
+            resolve_regulating_bus(parsed, &slack.reference, &bus_builder, &voltage_levels)?;
+        let Some(bus) = resolved else {
             diagnostics.push(
                 &codes::READ_XIIDM_FIELD_UNMAPPED,
-                format!("slack terminal `{slack}` does not identify a mapped generator"),
+                format!(
+                    "slackTerminal on voltage level `{}` names terminal `{}`, which is not a mapped equipment terminal",
+                    slack.voltage_level, slack.reference.id
+                ),
+            );
+            continue;
+        };
+        if reference_bus.is_none() {
+            reference_bus = Some(bus);
+            set_bus_kind(&mut buses, bus, BusType::Ref);
+        } else if reference_bus != Some(bus) {
+            diagnostics.push(
+                &codes::READ_XIIDM_VALUE_DEFAULTED,
+                format!(
+                    "slackTerminal on voltage level `{}` names a second reference bus {bus}; the balanced calculation view states one reference bus and keeps bus {}",
+                    slack.voltage_level,
+                    reference_bus.expect("checked present")
+                ),
             );
         }
     }
@@ -6790,6 +6854,123 @@ fn format_error(message: impl Into<String>) -> Error {
     }
 }
 
+/// The nominal voltage XIIDM states for a bus whose source case declares none.
+///
+/// XIIDM states impedances in ohms and voltages in kV, so every voltage level
+/// carries a positive nominal voltage; a case that works only in per unit (a
+/// MATPOWER bus row with `BASE_KV = 0`) states none. One substituted kilovolt
+/// keeps every derived ohm, siemens, and kV value finite, and preserves the
+/// per-unit model exactly, because a reader divides by the same nominal voltage
+/// the writer multiplied by.
+const SUBSTITUTE_NOMINAL_KV: f64 = 1.0;
+
+/// Whether a bus states a nominal voltage XIIDM can carry.
+fn states_nominal_voltage(bus: &Bus) -> bool {
+    bus.base_kv.is_finite() && bus.base_kv > 0.0
+}
+
+/// Whether a DC line states the converter model XIIDM requires.
+fn states_converter_model(line: &Hvdc) -> bool {
+    line.resistance_ohm.is_some()
+        && line.nominal_voltage_kv.is_some()
+        && line.converters_mode.is_some()
+        && line.converter1.is_some()
+        && line.converter2.is_some()
+}
+
+/// Build the DC circuit XIIDM states for a DC line that states a loss model
+/// instead.
+///
+/// A MATPOWER `mpc.dcline` row states the delivered power as
+/// `pt = pf - loss0 - loss1 * pf`; IIDM states a DC line resistance, a DC
+/// nominal voltage, and one converter station per end, and derives the
+/// delivered power from them. The two agree at the stated setpoint: `loss1` is
+/// a fraction of the sending end power, which is what a converter station's
+/// `lossFactor` states as a percentage, and `loss0` is the `r * I²` loss at the
+/// setpoint current, so a resistance of `loss0 / I²` reproduces it. That fixes
+/// the resistance from the DC voltage, which the source never states, so the
+/// terminal's own nominal voltage is used.
+///
+/// Returns one message per line whose loss model does not survive.
+fn substitute_converter_model(network: &mut BalancedNetwork) -> Vec<String> {
+    let nominal_voltage = network
+        .buses()
+        .iter()
+        .map(|bus| (bus.id, bus.base_kv))
+        .collect::<HashMap<_, _>>();
+    let mut messages = Vec::new();
+    for line in network.hvdc_mut() {
+        if states_converter_model(line) {
+            continue;
+        }
+        let id = line.uid.clone().unwrap_or_else(|| "hvdc".to_owned());
+        let nominal_v = line.nominal_voltage_kv.unwrap_or_else(|| {
+            nominal_voltage
+                .get(&line.from)
+                .copied()
+                .filter(|value| value.is_finite() && *value > 0.0)
+                .unwrap_or(SUBSTITUTE_NOMINAL_KV)
+        });
+        let current_ka = line.pf / nominal_v;
+        if line.resistance_ohm.is_none() {
+            line.resistance_ohm = Some(if current_ka == 0.0 {
+                if line.loss0 != 0.0 {
+                    messages.push(format!(
+                        "DC line `{id}` states a constant loss of {} MW at a zero power setpoint; an XIIDM DC line states loss as resistance times current squared, which is zero at zero current",
+                        line.loss0
+                    ));
+                }
+                0.0
+            } else {
+                line.loss0 / (current_ka * current_ka)
+            });
+        }
+        let mut loss_factor_percent = line.loss1 * 100.0;
+        if !(0.0..=100.0).contains(&loss_factor_percent) {
+            messages.push(format!(
+                "DC line `{id}` states a proportional loss of {}; an XIIDM converter station `lossFactor` is a percentage between 0 and 100, so it was written as {}",
+                line.loss1,
+                loss_factor_percent.clamp(0.0, 100.0)
+            ));
+            loss_factor_percent = loss_factor_percent.clamp(0.0, 100.0);
+        }
+        if !line.pt_matches_loss_model(1e-9) {
+            messages.push(format!(
+                "DC line `{id}` states a delivered power of {} MW that its own loss model does not produce; an XIIDM DC line has no field for the receiving end, which PowSybl derives from the converter loss factors and the line resistance",
+                line.pt
+            ));
+        }
+        line.nominal_voltage_kv = Some(nominal_v);
+        line.converters_mode = Some(if line.pf < 0.0 {
+            HvdcConvertersMode::Side1InverterSide2Rectifier
+        } else {
+            HvdcConvertersMode::Side1RectifierSide2Inverter
+        });
+        let station =
+            |side: u8, loss_factor_percent: f64, setpoint_kv: f64| -> Result<HvdcConverter> {
+                Ok(HvdcConverter {
+                    component: component_id("hvdc_converter", &format!("{id}-{side}"))?,
+                    kind: HvdcConverterKind::Vsc,
+                    loss_factor_percent,
+                    voltage_regulator_on: Some(true),
+                    voltage_setpoint_kv: Some(setpoint_kv),
+                    reactive_power_setpoint_mvar: None,
+                    power_factor: None,
+                    regulating_terminal: None,
+                })
+            };
+        let from_kv = nominal_voltage.get(&line.from).copied().unwrap_or(1.0);
+        let to_kv = nominal_voltage.get(&line.to).copied().unwrap_or(1.0);
+        if line.converter1.is_none() {
+            line.converter1 = station(1, loss_factor_percent, line.vf * from_kv).ok();
+        }
+        if line.converter2.is_none() {
+            line.converter2 = station(2, 0.0, line.vt * to_kv).ok();
+        }
+    }
+    messages
+}
+
 fn has_missing_component_ids(network: &BalancedNetwork) -> bool {
     network.buses().iter().any(|value| value.uid.is_none())
         || network.loads().iter().any(|value| value.uid.is_none())
@@ -7526,18 +7707,58 @@ impl<'a> XiidmWriteIndex<'a> {
 }
 
 pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
-    let prepared_network = has_missing_component_ids(network).then(|| {
+    let unstated_nominal_voltage = network
+        .buses()
+        .iter()
+        .filter(|bus| !states_nominal_voltage(bus))
+        .map(|bus| bus.id.to_string())
+        .collect::<Vec<_>>();
+    let mut prepared_network = None;
+    let mut converter_model_losses = Vec::new();
+    if has_missing_component_ids(network)
+        || !unstated_nominal_voltage.is_empty()
+        || !network.hvdc().iter().all(states_converter_model)
+    {
         let mut prepared = network.clone();
         prepared.assign_missing_component_ids();
-        prepared
-    });
+        for bus in prepared.buses_mut() {
+            if !states_nominal_voltage(bus) {
+                bus.base_kv = SUBSTITUTE_NOMINAL_KV;
+            }
+        }
+        converter_model_losses = substitute_converter_model(&mut prepared);
+        prepared_network = Some(prepared);
+    }
     let network = prepared_network.as_ref().unwrap_or(network);
     network.validate().map_err(|error| Error::Emit {
         format: FORMAT,
         message: format!("network validation failed before XIIDM emission: {error}"),
     })?;
-    validate_xiidm_hvdc_emission(network)?;
     let mut diagnostics = Diagnostics::new();
+    if !unstated_nominal_voltage.is_empty() {
+        let shown = unstated_nominal_voltage
+            .iter()
+            .take(5)
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let ellipsis = if unstated_nominal_voltage.len() > 5 {
+            ", ..."
+        } else {
+            ""
+        };
+        diagnostics.push(
+            &codes::EMIT_XIIDM.value_substituted,
+            format!(
+                "{} bus(es) state no nominal voltage; an XIIDM voltage level requires one, so each was written at {SUBSTITUTE_NOMINAL_KV} kV, on which the ohm, siemens, and kV values are computed: bus {shown}{ellipsis}",
+                unstated_nominal_voltage.len(),
+            ),
+        );
+    }
+    for message in converter_model_losses {
+        diagnostics.push(&codes::EMIT_XIIDM.field_dropped, message);
+    }
+    validate_xiidm_hvdc_emission(network)?;
     let metadata = network.case_metadata();
     let case_date = metadata.case_date.as_deref().unwrap_or_else(|| {
         diagnostics.push(
@@ -7615,9 +7836,14 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
     let active_power_control_namespace = active_power_control_namespace.then_some(format!(
         " xmlns:apc=\"{ACTIVE_POWER_CONTROL_NAMESPACE_V1_2}\""
     ));
+    let slack_terminal = slack_terminal_equipment(network);
+    let slack_terminal_namespace = slack_terminal
+        .is_some()
+        .then_some(format!(" xmlns:slt=\"{SLACK_TERMINAL_NAMESPACE}\""));
     let mut output = format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<iidm:network xmlns:iidm=\"{namespace}\"{} id=\"{}\" caseDate=\"{}\" forecastDistance=\"{forecast_distance}\" sourceFormat=\"{}\" minimumValidationLevel=\"{}\">\n",
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<iidm:network xmlns:iidm=\"{namespace}\"{}{} id=\"{}\" caseDate=\"{}\" forecastDistance=\"{forecast_distance}\" sourceFormat=\"{}\" minimumValidationLevel=\"{}\">\n",
         active_power_control_namespace.as_deref().unwrap_or(""),
+        slack_terminal_namespace.as_deref().unwrap_or(""),
         xml(network.name()),
         xml(case_date),
         xml(source_model_format),
@@ -7671,6 +7897,13 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
             &mut diagnostics,
         );
         write_active_power_control_extensions(network, &root_components, 2, &mut output)?;
+        write_slack_terminal_extension(
+            slack_terminal.as_ref(),
+            &index,
+            &root_components,
+            2,
+            &mut output,
+        );
         output.push_str("</iidm:network>\n");
         return Ok(TextEmission::new(output, diagnostics));
     }
@@ -7692,6 +7925,7 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
         &mut diagnostics,
     );
     write_active_power_control_extensions(network, &|_| true, 2, &mut output)?;
+    write_slack_terminal_extension(slack_terminal.as_ref(), &index, &|_| true, 2, &mut output);
     output.push_str("</iidm:network>\n");
     Ok(TextEmission::new(output, diagnostics))
 }
@@ -8719,6 +8953,13 @@ fn write_subnetwork(
         4,
         output,
     )?;
+    write_slack_terminal_extension(
+        slack_terminal_equipment(network).as_ref(),
+        index,
+        &|component| members.contains(component),
+        4,
+        output,
+    );
     output.push_str("  </iidm:network>\n");
     Ok(())
 }
@@ -8776,6 +9017,79 @@ fn write_active_power_control_extensions(
         }
     }
     Ok(())
+}
+
+/// The equipment whose terminal XIIDM states as the network's power flow
+/// reference.
+///
+/// IIDM has no bus type, so `BusType::Ref` rides PowSybl's SlackTerminal
+/// extension, which names one terminal per voltage level. PowSybl's load flow
+/// resolves that terminal's bus, so any connectable at the reference bus states
+/// the same fact; an in-service injection is preferred, and generators come
+/// first because a reference bus regulates through one.
+fn slack_terminal_equipment(network: &BalancedNetwork) -> Option<ComponentId> {
+    let reference = network
+        .buses()
+        .iter()
+        .find(|bus| bus.kind == BusType::Ref)?
+        .id;
+    let generators = network.generators().iter().map(|value| {
+        (
+            "generator",
+            value.uid.as_deref(),
+            value.bus,
+            value.in_service,
+        )
+    });
+    let storage = network
+        .storage()
+        .iter()
+        .map(|value| ("storage", value.uid.as_deref(), value.bus, value.in_service));
+    let loads = network
+        .loads()
+        .iter()
+        .map(|value| ("load", value.uid.as_deref(), value.bus, value.in_service));
+    let shunts = network
+        .shunts()
+        .iter()
+        .map(|value| ("shunt", value.uid.as_deref(), value.bus, value.in_service));
+    let mut out_of_service = None;
+    for (kind, uid, bus, in_service) in generators.chain(storage).chain(loads).chain(shunts) {
+        let Some(uid) = uid.filter(|_| bus == reference) else {
+            continue;
+        };
+        let component = component_id(kind, uid).ok()?;
+        if in_service {
+            return Some(component);
+        }
+        out_of_service = out_of_service.or(Some(component));
+    }
+    out_of_service
+}
+
+/// Write the SlackTerminal extension for the network's reference bus. Nothing
+/// is written when the reference bus hosts no emitted connectable, because the
+/// extension states a terminal.
+fn write_slack_terminal_extension(
+    slack_terminal: Option<&ComponentId>,
+    index: &XiidmWriteIndex<'_>,
+    included: &dyn Fn(&ComponentId) -> bool,
+    indent: usize,
+    output: &mut String,
+) {
+    let Some(component) = slack_terminal.filter(|component| included(component)) else {
+        return;
+    };
+    let Some(terminal) = index.terminal(component, 1) else {
+        return;
+    };
+    let parent_indent = " ".repeat(indent);
+    let child_indent = " ".repeat(indent + 2);
+    output.push_str(&format!(
+        "{parent_indent}<iidm:extension id=\"{}\">\n{child_indent}<slt:slackTerminal id=\"{}\"/>\n{parent_indent}</iidm:extension>\n",
+        xml(terminal.voltage_level.local_id()),
+        xml(component.local_id()),
+    ));
 }
 
 fn validate_active_power_control_for_emission(
@@ -11538,14 +11852,26 @@ fn write_hvdc_converter_stations(
             } else {
                 injection_solution_attributes(index, &component, p, q)
             };
+            // A station that stated a reactive capability curve keeps it: the
+            // curve is the reactive envelope over active power, and one
+            // minQ/maxQ pair states a wider envelope at every operating point
+            // but the one the pair came from. A station with no curve states
+            // the terminal's own min and max.
+            let mut reactive_limits = String::new();
+            match index.reactive_limits.get(&component).copied() {
+                Some(record) => write_reactive_limits(&record.limits, &mut reactive_limits),
+                None => reactive_limits.push_str(&format!(
+                    "        <iidm:minMaxReactiveLimits minQ=\"{}\" maxQ=\"{}\"/>\n",
+                    number(qmin),
+                    number(qmax),
+                )),
+            }
             output.push_str(&format!(
-                    "      <iidm:vscConverterStation id=\"{}\"{} lossFactor=\"{}\" voltageRegulatorOn=\"{}\"{voltage_setpoint}{reactive_power_setpoint}{terminal}{solution}>\n        <iidm:minMaxReactiveLimits minQ=\"{}\" maxQ=\"{}\"/>\n{}      </iidm:vscConverterStation>\n",
+                    "      <iidm:vscConverterStation id=\"{}\"{} lossFactor=\"{}\" voltageRegulatorOn=\"{}\"{voltage_setpoint}{reactive_power_setpoint}{terminal}{solution}>\n{reactive_limits}{}      </iidm:vscConverterStation>\n",
                     xml(&id),
                     identifiable_attributes(metadata),
                     number(loss_factor),
                     voltage_regulator_on,
-                    number(qmin),
-                    number(qmax),
                     converter
                         .regulating_terminal
                         .as_ref()
@@ -11601,10 +11927,13 @@ fn write_hvdc_lines(
             write_identifiable_children(metadata, output);
             output.push_str("  </iidm:hvdcLine>\n");
         }
-        if line.pmin < 0.0 {
+        if line.pmin != 0.0 {
             diagnostics.push(
                 &codes::EMIT_XIIDM.field_dropped,
-                format!("HVDC line `{id}` reverse power bound has no XIIDM hvdcLine attribute"),
+                format!(
+                    "HVDC line `{id}` states an active power floor of {} MW; an XIIDM hvdcLine states `maxP` alone, so the floor reads back as 0",
+                    line.pmin
+                ),
             );
         }
         if line.cost.is_some() {
@@ -13711,6 +14040,244 @@ mod tests {
         );
     }
 
+    // Reduced from PowSybl's MPL-2.0 `V1_17/slackTerminalRef.xml` shape: the
+    // extension is attached to a voltage level and names one terminal.
+    const POWSYBL_SLACK_TERMINAL: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" xmlns:slt="http://www.powsybl.org/schema/iidm/ext/slack_terminal/1_5" id="slack" caseDate="2026-01-01T00:00:00Z" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+  <iidm:substation id="S">
+    <iidm:voltageLevel id="VL1" nominalV="230" topologyKind="BUS_BREAKER">
+      <iidm:busBreakerTopology><iidm:bus id="B1"/></iidm:busBreakerTopology>
+      <iidm:generator id="G1" energySource="OTHER" minP="0" maxP="200" voltageRegulatorOn="true" targetP="100" targetV="230" bus="B1" connectableBus="B1">
+        <iidm:minMaxReactiveLimits minQ="-50" maxQ="50"/>
+      </iidm:generator>
+    </iidm:voltageLevel>
+    <iidm:voltageLevel id="VL2" nominalV="230" topologyKind="BUS_BREAKER">
+      <iidm:busBreakerTopology><iidm:bus id="B2"/></iidm:busBreakerTopology>
+      <iidm:generator id="G2" energySource="OTHER" minP="0" maxP="200" voltageRegulatorOn="true" targetP="80" targetV="230" bus="B2" connectableBus="B2">
+        <iidm:minMaxReactiveLimits minQ="-50" maxQ="50"/>
+      </iidm:generator>
+      <iidm:load id="L2" loadType="UNDEFINED" p0="170" q0="30" bus="B2" connectableBus="B2"/>
+    </iidm:voltageLevel>
+  </iidm:substation>
+  <iidm:line id="LINE" r="2" x="20" g1="0" b1="0" g2="0" b2="0" bus1="B1" connectableBus1="B1" voltageLevelId1="VL1" bus2="B2" connectableBus2="B2" voltageLevelId2="VL2"/>
+  <iidm:extension id="VL2"><slt:slackTerminal id="G2"/></iidm:extension>
+</iidm:network>"#;
+
+    /// The SlackTerminal extension is the only place IIDM states a reference
+    /// bus, so reading it decides `BusType::Ref` instead of the first
+    /// generator default.
+    #[test]
+    fn slack_terminal_extension_selects_the_reference_bus() {
+        let mut diagnostics = Diagnostics::new();
+        let network = parse_xiidm_source(POWSYBL_SLACK_TERMINAL, &mut diagnostics).unwrap();
+        let reference = network
+            .buses()
+            .iter()
+            .find(|bus| bus.kind == BusType::Ref)
+            .unwrap();
+        assert_eq!(reference.uid.as_deref(), Some("B2"));
+        assert_eq!(
+            network
+                .buses()
+                .iter()
+                .filter(|bus| bus.kind == BusType::Ref)
+                .count(),
+            1
+        );
+        assert!(
+            !diagnostics
+                .records()
+                .iter()
+                .any(|record| record.message().contains("no mapped slack terminal")),
+            "a declared slack terminal is not a defaulted reference"
+        );
+    }
+
+    /// The reference bus survives a fresh emission: the writer states it as the
+    /// same extension, on the voltage level holding a connectable at that bus.
+    #[test]
+    fn the_reference_bus_survives_fresh_emission_as_a_slack_terminal() {
+        let network = parse_xiidm_source(POWSYBL_SLACK_TERMINAL, &mut Diagnostics::new()).unwrap();
+        let emission = write_xiidm(&network).unwrap();
+        assert!(
+            emission
+                .text
+                .contains(&format!("xmlns:slt=\"{SLACK_TERMINAL_NAMESPACE}\""))
+        );
+        assert!(
+            emission
+                .text
+                .contains("<iidm:extension id=\"VL2\">\n    <slt:slackTerminal id=\"G2\"/>")
+        );
+
+        let mut diagnostics = Diagnostics::new();
+        let back = parse_xiidm_source(&emission.text, &mut diagnostics).unwrap();
+        let reference = back
+            .buses()
+            .iter()
+            .find(|bus| bus.kind == BusType::Ref)
+            .unwrap();
+        assert_eq!(reference.uid.as_deref(), Some("B2"));
+    }
+
+    /// A slack terminal naming an equipment the document does not declare is a
+    /// read error, as it is in PowSybl (`TerminalRefSerDe.resolve` throws on an
+    /// identifiable that is not in the network).
+    #[test]
+    fn a_slack_terminal_naming_unknown_equipment_is_a_read_error() {
+        let source = POWSYBL_SLACK_TERMINAL.replace(
+            "<slt:slackTerminal id=\"G2\"/>",
+            "<slt:slackTerminal id=\"MISSING\"/>",
+        );
+        let error = parse_xiidm_source(&source, &mut Diagnostics::new()).unwrap_err();
+        assert!(error.to_string().contains("MISSING"), "{error}");
+    }
+
+    /// A VSC converter station's reactive capability curve is the reactive
+    /// envelope over active power; one minQ/maxQ pair states a different
+    /// envelope, so the curve is written as a curve.
+    #[test]
+    fn a_converter_station_reactive_capability_curve_survives_fresh_emission() {
+        let source = EQUIPMENT_COVERAGE.replace(
+            "<iidm:minMaxReactiveLimits minQ=\"-20\" maxQ=\"20\"/></iidm:vscConverterStation>",
+            "<iidm:reactiveCapabilityCurve><iidm:point p=\"0\" minQ=\"-20\" maxQ=\"20\"/><iidm:point p=\"100\" minQ=\"-5\" maxQ=\"5\"/></iidm:reactiveCapabilityCurve></iidm:vscConverterStation>",
+        );
+        let network = parse_xiidm_source(&source, &mut Diagnostics::new()).unwrap();
+        let emission = write_xiidm(&network).unwrap();
+        let station = emission
+            .text
+            .split("<iidm:vscConverterStation id=\"C1\"")
+            .nth(1)
+            .unwrap()
+            .split("</iidm:vscConverterStation>")
+            .next()
+            .unwrap();
+        assert!(
+            station.contains("<iidm:reactiveCapabilityCurve>"),
+            "{station}"
+        );
+        assert!(
+            station.contains("p=\"100\" minQ=\"-5\" maxQ=\"5\""),
+            "{station}"
+        );
+        assert!(!station.contains("minMaxReactiveLimits"), "{station}");
+    }
+
+    /// A per-unit only case states no bus nominal voltage, and XIIDM states
+    /// ohms and kV. One substituted kilovolt keeps every derived value finite
+    /// and returns the same per-unit model.
+    #[test]
+    fn buses_with_no_nominal_voltage_are_written_at_one_kilovolt() {
+        let mut network = BalancedNetwork::in_memory(
+            "per unit only",
+            DEFAULT_BASE_MVA,
+            vec![
+                Bus::new(BusId::new(1), BusType::Ref, 0.0),
+                Bus::new(BusId::new(2), BusType::Pq, 0.0),
+            ],
+            vec![Branch::new(BusId::new(1), BusId::new(2), 0.01, 0.1)],
+        );
+        network
+            .shunts_mut()
+            .push(Shunt::new(BusId::new(2), 0.0, 0.19));
+        network.generators_mut().push(Generator::new(BusId::new(1)));
+
+        let emission = write_xiidm(&network).unwrap();
+        assert!(
+            emission.text.contains("nominalV=\"1\""),
+            "{}",
+            emission.text
+        );
+        assert!(!emission.text.contains("NaN"), "{}", emission.text);
+        assert!(!emission.text.contains("inf"), "{}", emission.text);
+        assert!(emission.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code() == codes::EMIT_XIIDM.value_substituted.code
+                && diagnostic.message().contains("state no nominal voltage")
+        }));
+
+        let back = parse_xiidm_source(&emission.text, &mut Diagnostics::new()).unwrap();
+        assert_eq!(back.branches()[0].r, 0.01);
+        assert_eq!(back.branches()[0].x, 0.1);
+        assert_eq!(back.shunts()[0].b, 0.19);
+    }
+
+    /// A MATPOWER shaped DC line states a loss model, not a DC circuit. The
+    /// resistance and converter loss factors XIIDM states are derived from it,
+    /// so the delivered power at the stated setpoint survives.
+    #[test]
+    fn a_dc_line_loss_model_becomes_an_xiidm_converter_model() {
+        let mut network = BalancedNetwork::in_memory(
+            "dc loss model",
+            DEFAULT_BASE_MVA,
+            vec![
+                Bus::new(BusId::new(1), BusType::Ref, 345.0),
+                Bus::new(BusId::new(2), BusType::Pq, 345.0),
+            ],
+            vec![Branch::new(BusId::new(1), BusId::new(2), 0.01, 0.1)],
+        );
+        network.generators_mut().push(Generator::new(BusId::new(1)));
+        let mut line = Hvdc::new(BusId::new(1), BusId::new(2));
+        line.uid = Some("dc".to_owned());
+        line.pf = 10.0;
+        line.loss0 = 1.0;
+        line.loss1 = 0.01;
+        line.pt = Hvdc::calc_delivered_power(line.pf, line.loss0, line.loss1);
+        line.pmax = 10.0;
+        line.vf = 1.01;
+        line.vt = 1.0;
+        network.hvdc_mut().push(line);
+
+        let emission = write_xiidm(&network).unwrap();
+        assert!(
+            emission.text.contains("<iidm:hvdcLine id=\"dc\""),
+            "{}",
+            emission.text
+        );
+        assert!(
+            emission.text.contains("lossFactor=\"1\""),
+            "{}",
+            emission.text
+        );
+
+        let back = parse_xiidm_source(&emission.text, &mut Diagnostics::new()).unwrap();
+        let line = &back.hvdc()[0];
+        assert!((line.loss0 - 1.0).abs() < 1e-9, "{}", line.loss0);
+        assert!((line.loss1 - 0.01).abs() < 1e-9, "{}", line.loss1);
+        assert!((line.pt - 8.9).abs() < 1e-9, "{}", line.pt);
+        assert!((line.vf - 1.01).abs() < 1e-9, "{}", line.vf);
+    }
+
+    /// A DC line whose stated received power its own loss model does not
+    /// produce reports the field XIIDM has no place for.
+    #[test]
+    fn a_dc_line_received_power_off_its_loss_model_is_reported() {
+        let mut network = BalancedNetwork::in_memory(
+            "dc received power",
+            DEFAULT_BASE_MVA,
+            vec![
+                Bus::new(BusId::new(1), BusType::Ref, 345.0),
+                Bus::new(BusId::new(2), BusType::Pq, 345.0),
+            ],
+            vec![Branch::new(BusId::new(1), BusId::new(2), 0.01, 0.1)],
+        );
+        network.generators_mut().push(Generator::new(BusId::new(1)));
+        let mut line = Hvdc::new(BusId::new(1), BusId::new(2));
+        line.uid = Some("dc".to_owned());
+        line.pf = 2.0;
+        line.pt = 1.96;
+        line.pmax = 10.0;
+        network.hvdc_mut().push(line);
+
+        let emission = write_xiidm(&network).unwrap();
+        assert!(emission.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code() == codes::EMIT_XIIDM.field_dropped.code
+                && diagnostic.message().contains("delivered power")
+                && diagnostic
+                    .message()
+                    .contains("no field for the receiving end")
+        }));
+    }
+
     #[test]
     fn fresh_emission_rejects_constant_y_reactive_limits_on_all_xiidm_equipment() {
         let mut network = parse_xiidm_source(EQUIPMENT_COVERAGE, &mut Diagnostics::new()).unwrap();
@@ -14171,29 +14738,39 @@ mod tests {
         assert_eq!(reparsed_derived.hvdc().len(), 1);
     }
 
+    /// The DC circuit fields a source may not state are derived from the DC
+    /// line's own loss model rather than refused, and the derivation keeps the
+    /// power the line delivers.
+    #[test]
+    fn xiidm_hvdc_emission_derives_the_dc_circuit_fields_a_source_omits() {
+        let network = parse_xiidm_source(EQUIPMENT_COVERAGE, &mut Diagnostics::new()).unwrap();
+        let stated = &network.hvdc()[0];
+        let (loss0, loss1, delivered) = (stated.loss0, stated.loss1, stated.pt);
+
+        let mut without_dc_circuit = network.clone();
+        let line = &mut without_dc_circuit.hvdc_mut()[0];
+        line.nominal_voltage_kv = None;
+        line.resistance_ohm = None;
+        line.converters_mode = None;
+        line.converter1 = None;
+        line.converter2 = None;
+        let emission = write_xiidm(&without_dc_circuit).unwrap();
+        assert!(emission.text.contains("<iidm:hvdcLine id=\"DC\""));
+
+        let back = parse_xiidm_source(&emission.text, &mut Diagnostics::new()).unwrap();
+        let line = &back.hvdc()[0];
+        assert!((line.loss0 - loss0).abs() < 1e-9, "{} {loss0}", line.loss0);
+        assert!((line.loss1 - loss1).abs() < 1e-9, "{} {loss1}", line.loss1);
+        assert!(
+            (line.pt - delivered).abs() < 1e-9,
+            "{} {delivered}",
+            line.pt
+        );
+    }
+
     #[test]
     fn xiidm_hvdc_emission_refuses_missing_required_values() {
         let network = parse_xiidm_source(EQUIPMENT_COVERAGE, &mut Diagnostics::new()).unwrap();
-
-        let mut missing_nominal_voltage = network.clone();
-        missing_nominal_voltage.hvdc_mut()[0].nominal_voltage_kv = None;
-        let error = write_xiidm(&missing_nominal_voltage).unwrap_err();
-        assert!(error.to_string().contains("nominalV"));
-
-        let mut missing_resistance = network.clone();
-        missing_resistance.hvdc_mut()[0].resistance_ohm = None;
-        let error = write_xiidm(&missing_resistance).unwrap_err();
-        assert!(error.to_string().contains("`r`"));
-
-        let mut missing_mode = network.clone();
-        missing_mode.hvdc_mut()[0].converters_mode = None;
-        let error = write_xiidm(&missing_mode).unwrap_err();
-        assert!(error.to_string().contains("convertersMode"));
-
-        let mut missing_converter = network.clone();
-        missing_converter.hvdc_mut()[0].converter1 = None;
-        let error = write_xiidm(&missing_converter).unwrap_err();
-        assert!(error.to_string().contains("converterStation1"));
 
         let mut missing_regulation_flag = network.clone();
         missing_regulation_flag.hvdc_mut()[0]

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -251,6 +251,32 @@ impl ActivePowerControlVersion {
     }
 }
 
+/// The extension namespaces the mapping reads, with the extension name and
+/// version that name each one.
+///
+/// XIIDM states an extension's version in its namespace URI; JIIDM states it
+/// in the root `extensionVersions` array instead, and PowSybl refuses an
+/// extension element whose version that array does not name. The two spellings
+/// meet here, so a namespace is added in one place.
+const MAPPED_EXTENSION_NAMESPACES: [(&str, &str, &str); 4] = [
+    (
+        "activePowerControl",
+        "1.0",
+        ACTIVE_POWER_CONTROL_NAMESPACE_V1_0,
+    ),
+    (
+        "activePowerControl",
+        "1.1",
+        ACTIVE_POWER_CONTROL_NAMESPACE_V1_1,
+    ),
+    (
+        "activePowerControl",
+        "1.2",
+        ACTIVE_POWER_CONTROL_NAMESPACE_V1_2,
+    ),
+    ("slackTerminal", "1.5", SLACK_TERMINAL_NAMESPACE),
+];
+
 /// Whether an element inside an `<extension>` is one the mapping reads. Every
 /// other extension child is counted as unmapped and skipped.
 fn is_mapped_extension_child(tag: &str, namespace: Option<&str>) -> bool {
@@ -1184,17 +1210,22 @@ impl JsonWalker<'_> {
     /// control namespace when the document names a version the reader maps,
     /// otherwise a PowSybl extension namespace the mapping does not read.
     fn extension_namespace(&self, name: &str) -> String {
-        let version = self
-            .extension_versions
-            .get(name)
-            .map_or("1.2", String::as_str);
-        if name == "activePowerControl" {
-            match version {
-                "1.0" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_0.to_owned(),
-                "1.1" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_1.to_owned(),
-                "1.2" => return ACTIVE_POWER_CONTROL_NAMESPACE_V1_2.to_owned(),
-                _ => {}
-            }
+        let stated = self.extension_versions.get(name).map(String::as_str);
+        let version = stated.unwrap_or("1.2");
+        if let Some((_, _, namespace)) = MAPPED_EXTENSION_NAMESPACES
+            .iter()
+            .find(|(extension, mapped, _)| *extension == name && *mapped == version)
+        {
+            return (*namespace).to_owned();
+        }
+        // A document that states no version for an extension the mapping reads
+        // still names its own namespace, which is the version PowerIO writes.
+        if stated.is_none()
+            && let Some((_, _, namespace)) = MAPPED_EXTENSION_NAMESPACES
+                .iter()
+                .find(|(extension, _, _)| *extension == name)
+        {
+            return (*namespace).to_owned();
         }
         format!(
             "{EXTENSION_NAMESPACE_PREFIX}{name}/{}",
@@ -1254,6 +1285,11 @@ impl JsonWalker<'_> {
         }
         let in_extension = tag == "extension";
         for (key, value) in fields {
+            // The root's own version fields are read before the walk, not as
+            // elements of the network.
+            if root && (key == "version" || key == "extensionVersions") {
+                continue;
+            }
             let child_namespace = if in_extension {
                 Some(self.extension_namespace(key))
             } else {
@@ -4004,18 +4040,19 @@ fn build_network(parsed: &ParsedXiidm, diagnostics: &mut Diagnostics) -> Result<
             );
             continue;
         };
-        if reference_bus.is_none() {
-            reference_bus = Some(bus);
-            set_bus_kind(&mut buses, bus, BusType::Ref);
-        } else if reference_bus != Some(bus) {
-            diagnostics.push(
+        match reference_bus {
+            None => {
+                reference_bus = Some(bus);
+                set_bus_kind(&mut buses, bus, BusType::Ref);
+            }
+            Some(reference) if reference != bus => diagnostics.push(
                 &codes::READ_XIIDM_VALUE_DEFAULTED,
                 format!(
-                    "slackTerminal on voltage level `{}` names a second reference bus {bus}; the balanced calculation view states one reference bus and keeps bus {}",
+                    "slackTerminal on voltage level `{}` names a second reference bus {bus}; the balanced calculation view states one reference bus and keeps bus {reference}",
                     slack.voltage_level,
-                    reference_bus.expect("checked present")
                 ),
-            );
+            ),
+            Some(_) => {}
         }
     }
     for generator in &generators {
@@ -6854,21 +6891,6 @@ fn format_error(message: impl Into<String>) -> Error {
     }
 }
 
-/// The nominal voltage XIIDM states for a bus whose source case declares none.
-///
-/// XIIDM states impedances in ohms and voltages in kV, so every voltage level
-/// carries a positive nominal voltage; a case that works only in per unit (a
-/// MATPOWER bus row with `BASE_KV = 0`) states none. One substituted kilovolt
-/// keeps every derived ohm, siemens, and kV value finite, and preserves the
-/// per-unit model exactly, because a reader divides by the same nominal voltage
-/// the writer multiplied by.
-const SUBSTITUTE_NOMINAL_KV: f64 = 1.0;
-
-/// Whether a bus states a nominal voltage XIIDM can carry.
-fn states_nominal_voltage(bus: &Bus) -> bool {
-    bus.base_kv.is_finite() && bus.base_kv > 0.0
-}
-
 /// Whether a DC line states the converter model XIIDM requires.
 fn states_converter_model(line: &Hvdc) -> bool {
     line.resistance_ohm.is_some()
@@ -6898,6 +6920,9 @@ fn substitute_converter_model(network: &mut BalancedNetwork) -> Vec<String> {
         .iter()
         .map(|bus| (bus.id, bus.base_kv))
         .collect::<HashMap<_, _>>();
+    // A station identity shares the network's identity space, which XIIDM
+    // indexes as one namespace.
+    let mut used = network.component_ids_in_use();
     let mut messages = Vec::new();
     for line in network.hvdc_mut() {
         if states_converter_model(line) {
@@ -6909,7 +6934,7 @@ fn substitute_converter_model(network: &mut BalancedNetwork) -> Vec<String> {
                 .get(&line.from)
                 .copied()
                 .filter(|value| value.is_finite() && *value > 0.0)
-                .unwrap_or(SUBSTITUTE_NOMINAL_KV)
+                .unwrap_or(super::SUBSTITUTE_NOMINAL_KV)
         });
         let current_ka = line.pf / nominal_v;
         if line.resistance_ohm.is_none() {
@@ -6946,10 +6971,19 @@ fn substitute_converter_model(network: &mut BalancedNetwork) -> Vec<String> {
         } else {
             HvdcConvertersMode::Side1RectifierSide2Inverter
         });
+        let mut station_identity = |side: u8| -> String {
+            let mut candidate = format!("{id}-converter{side}");
+            let mut bump = 2;
+            while !used.insert(candidate.clone()) {
+                candidate = format!("{id}-converter{side}-{bump}");
+                bump += 1;
+            }
+            candidate
+        };
         let station =
-            |side: u8, loss_factor_percent: f64, setpoint_kv: f64| -> Result<HvdcConverter> {
+            |identity: &str, loss_factor_percent: f64, setpoint_kv: f64| -> Result<HvdcConverter> {
                 Ok(HvdcConverter {
-                    component: component_id("hvdc_converter", &format!("{id}-{side}"))?,
+                    component: component_id("hvdc_converter", identity)?,
                     kind: HvdcConverterKind::Vsc,
                     loss_factor_percent,
                     voltage_regulator_on: Some(true),
@@ -6962,10 +6996,12 @@ fn substitute_converter_model(network: &mut BalancedNetwork) -> Vec<String> {
         let from_kv = nominal_voltage.get(&line.from).copied().unwrap_or(1.0);
         let to_kv = nominal_voltage.get(&line.to).copied().unwrap_or(1.0);
         if line.converter1.is_none() {
-            line.converter1 = station(1, loss_factor_percent, line.vf * from_kv).ok();
+            let identity = station_identity(1);
+            line.converter1 = station(&identity, loss_factor_percent, line.vf * from_kv).ok();
         }
         if line.converter2.is_none() {
-            line.converter2 = station(2, 0.0, line.vt * to_kv).ok();
+            let identity = station_identity(2);
+            line.converter2 = station(&identity, 0.0, line.vt * to_kv).ok();
         }
     }
     messages
@@ -7707,25 +7743,23 @@ impl<'a> XiidmWriteIndex<'a> {
 }
 
 pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
-    let unstated_nominal_voltage = network
-        .buses()
-        .iter()
-        .filter(|bus| !states_nominal_voltage(bus))
-        .map(|bus| bus.id.to_string())
-        .collect::<Vec<_>>();
+    let unstated_nominal_voltage = super::unstated_nominal_voltage(network);
+    let unbounded_reactive_limits = super::unbounded_reactive_limits(network);
     let mut prepared_network = None;
     let mut converter_model_losses = Vec::new();
     if has_missing_component_ids(network)
-        || !unstated_nominal_voltage.is_empty()
+        || unstated_nominal_voltage.is_some()
+        || unbounded_reactive_limits > 0
         || !network.hvdc().iter().all(states_converter_model)
     {
         let mut prepared = network.clone();
         prepared.assign_missing_component_ids();
         for bus in prepared.buses_mut() {
-            if !states_nominal_voltage(bus) {
-                bus.base_kv = SUBSTITUTE_NOMINAL_KV;
+            if !super::states_nominal_voltage(bus) {
+                bus.base_kv = super::SUBSTITUTE_NOMINAL_KV;
             }
         }
+        super::substitute_unbounded_reactive_limits(&mut prepared);
         converter_model_losses = substitute_converter_model(&mut prepared);
         prepared_network = Some(prepared);
     }
@@ -7735,23 +7769,20 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
         message: format!("network validation failed before XIIDM emission: {error}"),
     })?;
     let mut diagnostics = Diagnostics::new();
-    if !unstated_nominal_voltage.is_empty() {
-        let shown = unstated_nominal_voltage
-            .iter()
-            .take(5)
-            .map(String::as_str)
-            .collect::<Vec<_>>()
-            .join(", ");
-        let ellipsis = if unstated_nominal_voltage.len() > 5 {
-            ", ..."
-        } else {
-            ""
-        };
+    if unbounded_reactive_limits > 0 {
         diagnostics.push(
             &codes::EMIT_XIIDM.value_substituted,
             format!(
-                "{} bus(es) state no nominal voltage; an XIIDM voltage level requires one, so each was written at {SUBSTITUTE_NOMINAL_KV} kV, on which the ohm, siemens, and kV values are computed: bus {shown}{ellipsis}",
-                unstated_nominal_voltage.len(),
+                "{unbounded_reactive_limits} unbounded reactive limit(s) written as the largest finite double: an XIIDM `minMaxReactiveLimits` states minQ and maxQ as numbers and has no spelling for an absent bound, which is how PowSybl states one"
+            ),
+        );
+    }
+    if let Some((count, buses)) = &unstated_nominal_voltage {
+        diagnostics.push(
+            &codes::EMIT_XIIDM.value_substituted,
+            format!(
+                "{count} bus(es) state no nominal voltage; an XIIDM voltage level requires one, so each was written at {} kV, on which the ohm, siemens, and kV values are computed: bus {buses}",
+                super::SUBSTITUTE_NOMINAL_KV,
             ),
         );
     }
@@ -8069,17 +8100,14 @@ fn close_element(
         let extension_versions = open
             .namespaces
             .iter()
-            .filter_map(|namespace| {
-                let version = match namespace.as_str() {
-                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_0 => "1.0",
-                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_1 => "1.1",
-                    ACTIVE_POWER_CONTROL_NAMESPACE_V1_2 => "1.2",
-                    _ => return None,
-                };
+            .filter_map(|declared| {
+                let (name, version, _) = MAPPED_EXTENSION_NAMESPACES
+                    .iter()
+                    .find(|(_, _, namespace)| *namespace == declared.as_str())?;
                 Some(JsonOut::Object(vec![
                     (
                         "extensionName".to_owned(),
-                        JsonOut::Scalar(json_string("activePowerControl")),
+                        JsonOut::Scalar(json_string(name)),
                     ),
                     ("version".to_owned(), JsonOut::Scalar(json_string(version))),
                 ]))
@@ -9376,20 +9404,60 @@ fn diagnose_xiidm_dc_terminal(
 }
 
 #[allow(clippy::too_many_lines)]
+/// The components a repeated loss applies to, as a diagnostic spells them: at
+/// most five, then an ellipsis. One finding per lost field reads; one finding
+/// per element buries the field under the inventory.
+fn diagnosed_components(components: &[String]) -> String {
+    let shown = components
+        .iter()
+        .take(EXACT_ASSIGNMENT_DIAGNOSTIC_LIMIT)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    if components.len() > EXACT_ASSIGNMENT_DIAGNOSTIC_LIMIT {
+        format!("{shown}, ...")
+    } else {
+        shown
+    }
+}
+
 fn diagnose_xiidm_projection(
     detailed: &DetailedConnectivity,
     diagnostics: &mut Diagnostics,
 ) -> Result<()> {
+    // A node breaker voltage level states connectivity through switch
+    // positions: a disconnected terminal is one whose switches to the busbar
+    // are open. A level with no switch has no position to open, so a terminal
+    // recorded as disconnected there is emitted at its node like any other.
+    let node_breaker_levels_with_switches = detailed
+        .switches
+        .iter()
+        .map(|switch| &switch.voltage_level)
+        .collect::<HashSet<_>>();
+    let unstated_disconnections = detailed
+        .terminals
+        .iter()
+        .filter(|terminal| {
+            terminal.node.is_some()
+                && !terminal.connected
+                && !node_breaker_levels_with_switches.contains(&terminal.voltage_level)
+        })
+        .count();
+    if unstated_disconnections > 0 {
+        diagnostics.push(
+            &codes::EMIT_XIIDM.field_dropped,
+            format!(
+                "{unstated_disconnections} disconnected terminal(s) sit in a node breaker voltage level with no switch; XIIDM states a node breaker disconnection as an open switch position, so they were emitted connected"
+            ),
+        );
+    }
     let metadata_by_component = detailed
         .component_metadata
         .iter()
         .map(|metadata| (&metadata.component, metadata))
         .collect::<HashMap<_, _>>();
-    for terminal in &detailed.terminals {
-        let Some(component) = terminal.component.as_ref() else {
-            continue;
-        };
-        let has_metadata = metadata_by_component
+    let states_metadata = |component: &ComponentId| {
+        metadata_by_component
             .get(component)
             .is_some_and(|metadata| {
                 metadata.name.is_some()
@@ -9398,53 +9466,59 @@ fn diagnose_xiidm_projection(
                     || !metadata.external_identifiers.is_empty()
                     || !metadata.properties.is_empty()
                     || metadata.fictitious
-            });
+            })
+    };
+    let mut terminal_identities = Vec::new();
+    let mut terminals_with_metadata = 0;
+    for terminal in &detailed.terminals {
+        let Some(component) = terminal.component.as_ref() else {
+            continue;
+        };
+        if states_metadata(component) {
+            terminals_with_metadata += 1;
+        }
+        terminal_identities.push(format!(
+            "`{component}` on `{}` terminal {}",
+            terminal.equipment, terminal.terminal
+        ));
+    }
+    if !terminal_identities.is_empty() {
         diagnostics.push(
             &codes::EMIT_XIIDM.field_dropped,
             format!(
-                "`{}` terminal {} identity `{component}`{} has no XIIDM 1.17 representation",
-                terminal.equipment,
-                terminal.terminal,
-                if has_metadata {
-                    " and its attached metadata"
-                } else {
-                    ""
-                },
+                "{} terminal identit(ies) have no XIIDM 1.17 representation, {terminals_with_metadata} of them with attached metadata: {}",
+                terminal_identities.len(),
+                diagnosed_components(&terminal_identities),
             ),
         );
     }
+    let mut node_identities = Vec::new();
+    let mut allocated_node_numbers = 0;
+    let mut nodes_with_metadata = 0;
     for node in &detailed.connectivity_nodes {
         let xiidm_identity = node
             .node_number
             .and_then(|number| node_component_id(node.voltage_level.local_id(), number).ok());
-        let metadata = metadata_by_component.get(&node.component);
-        let has_unrepresentable_metadata = metadata.is_some_and(|metadata| {
-            metadata.name.is_some()
-                || metadata.equipment_container.is_some()
-                || !metadata.aliases.is_empty()
-                || !metadata.external_identifiers.is_empty()
-                || !metadata.properties.is_empty()
-                || metadata.fictitious
-        });
+        let has_unrepresentable_metadata = states_metadata(&node.component);
         if xiidm_identity.as_ref() != Some(&node.component) || has_unrepresentable_metadata {
-            diagnostics.push(
-                &codes::EMIT_XIIDM.field_dropped,
-                format!(
-                    "connectivity node `{}`{} is emitted only as an XIIDM local node number; its source identity{} cannot be retained",
-                    node.component,
-                    if node.node_number.is_none() {
-                        " has no source node number and receives an allocated number"
-                    } else {
-                        ""
-                    },
-                    if has_unrepresentable_metadata {
-                        " and attached metadata"
-                    } else {
-                        ""
-                    },
-                ),
-            );
+            if node.node_number.is_none() {
+                allocated_node_numbers += 1;
+            }
+            if has_unrepresentable_metadata {
+                nodes_with_metadata += 1;
+            }
+            node_identities.push(format!("`{}`", node.component));
         }
+    }
+    if !node_identities.is_empty() {
+        diagnostics.push(
+            &codes::EMIT_XIIDM.field_dropped,
+            format!(
+                "{} connectivity node identit(ies) are emitted as XIIDM local node numbers alone, {allocated_node_numbers} of them under an allocated number and {nodes_with_metadata} with attached metadata: {}",
+                node_identities.len(),
+                diagnosed_components(&node_identities),
+            ),
+        );
     }
     for tap in &detailed.tap_changers {
         let mut fields = Vec::new();
@@ -9462,25 +9536,41 @@ fn diagnose_xiidm_projection(
         }
         diagnose_xiidm_dropped_fields(&tap.transformer, &fields, diagnostics);
     }
-    for metadata in &detailed.component_metadata {
-        if !metadata.external_identifiers.is_empty() {
-            diagnostics.push(
-                &codes::EMIT_XIIDM.value_collapsed,
-                format!(
-                    "`{}` external identifiers are emitted as XIIDM aliases; XIIDM does not preserve the distinction between an alias and an external identifier",
-                    metadata.component
-                ),
-            );
-        }
-        if let Some(container) = &metadata.equipment_container {
-            diagnostics.push(
-                &codes::EMIT_XIIDM.field_dropped,
-                format!(
-                    "`{}` explicit equipment container `{container}` is expressed through XIIDM nesting where possible; the source metadata relationship is not retained",
-                    metadata.component
-                ),
-            );
-        }
+    let with_external_identifiers = detailed
+        .component_metadata
+        .iter()
+        .filter(|metadata| !metadata.external_identifiers.is_empty())
+        .map(|metadata| format!("`{}`", metadata.component))
+        .collect::<Vec<_>>();
+    if !with_external_identifiers.is_empty() {
+        diagnostics.push(
+            &codes::EMIT_XIIDM.value_collapsed,
+            format!(
+                "{} component(s) state external identifiers, emitted as XIIDM aliases: XIIDM has no attribute that tells an alias from an external identifier: {}",
+                with_external_identifiers.len(),
+                diagnosed_components(&with_external_identifiers),
+            ),
+        );
+    }
+    let with_containers = detailed
+        .component_metadata
+        .iter()
+        .filter_map(|metadata| {
+            metadata
+                .equipment_container
+                .as_ref()
+                .map(|container| format!("`{}` in `{container}`", metadata.component))
+        })
+        .collect::<Vec<_>>();
+    if !with_containers.is_empty() {
+        diagnostics.push(
+            &codes::EMIT_XIIDM.field_dropped,
+            format!(
+                "{} component(s) state an explicit equipment container, expressed through XIIDM nesting where the hierarchy allows it: XIIDM has no container attribute to state the relationship itself: {}",
+                with_containers.len(),
+                diagnosed_components(&with_containers),
+            ),
+        );
     }
     for (kind, components) in [
         (
@@ -11853,10 +11943,10 @@ fn write_hvdc_converter_stations(
                 injection_solution_attributes(index, &component, p, q)
             };
             // A station that stated a reactive capability curve keeps it: the
-            // curve is the reactive envelope over active power, and one
-            // minQ/maxQ pair states a wider envelope at every operating point
-            // but the one the pair came from. A station with no curve states
-            // the terminal's own min and max.
+            // curve states a reactive minimum and maximum per active power
+            // point, and one minQ/maxQ pair states a wider reactive range at
+            // every operating point but the one the pair came from. A station
+            // with no curve states the terminal's own min and max.
             let mut reactive_limits = String::new();
             match index.reactive_limits.get(&component).copied() {
                 Some(record) => write_reactive_limits(&record.limits, &mut reactive_limits),
@@ -12857,14 +12947,19 @@ mod tests {
         let mut diagnostics = Diagnostics::new();
         diagnose_xiidm_projection(&connectivity, &mut diagnostics).unwrap();
         let messages = diagnostics.lines().join("\n");
-        assert!(messages.contains("terminal 1 identity `terminal/terminal-mrid`"));
-        assert!(messages.contains("connectivity node `connectivity_node/node-mrid`"));
+        assert!(messages.contains("`terminal/terminal-mrid` on `load/L` terminal 1"));
+        assert!(messages.contains("terminal identit(ies) have no XIIDM 1.17 representation"));
+        assert!(messages.contains("`connectivity_node/node-mrid`"));
+        assert!(
+            messages
+                .contains("connectivity node identit(ies) are emitted as XIIDM local node numbers")
+        );
         assert!(messages.contains("tap changer identity"));
         assert!(messages.contains("neutral tap position distinct from low tap position"));
         assert!(messages.contains("normal tap position distinct from assigned tap position"));
         assert!(messages.contains("voltage step increment"));
-        assert!(messages.contains("external identifiers are emitted as XIIDM aliases"));
-        assert!(messages.contains("explicit equipment container `voltage_level/VL`"));
+        assert!(messages.contains("state external identifiers, emitted as XIIDM aliases"));
+        assert!(messages.contains("`load/L` in `voltage_level/VL`"));
 
         let mut native = DetailedConnectivity::default();
         native.connectivity_nodes.push(ConnectivityNode {
@@ -14133,9 +14228,9 @@ mod tests {
         assert!(error.to_string().contains("MISSING"), "{error}");
     }
 
-    /// A VSC converter station's reactive capability curve is the reactive
-    /// envelope over active power; one minQ/maxQ pair states a different
-    /// envelope, so the curve is written as a curve.
+    /// A VSC converter station's reactive capability curve states a reactive
+    /// minimum and maximum per active power point; one minQ/maxQ pair states a
+    /// different reactive range, so the curve is written as a curve.
     #[test]
     fn a_converter_station_reactive_capability_curve_survives_fresh_emission() {
         let source = EQUIPMENT_COVERAGE.replace(

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -14290,10 +14290,20 @@ mod tests {
                 && diagnostic.message().contains("state no nominal voltage")
         }));
 
+        // The reader divides by the same substituted nominal voltage the
+        // writer multiplied by, so the per unit values return unchanged up to
+        // the last bit of the two conversions.
         let back = parse_xiidm_source(&emission.text, &mut Diagnostics::new()).unwrap();
-        assert_eq!(back.branches()[0].r, 0.01);
-        assert_eq!(back.branches()[0].x, 0.1);
-        assert_eq!(back.shunts()[0].b, 0.19);
+        for (returned, stated) in [
+            (back.branches()[0].r, 0.01),
+            (back.branches()[0].x, 0.1),
+            (back.shunts()[0].b, 0.19),
+        ] {
+            assert!(
+                (returned - stated).abs() <= 1e-12 * stated.abs(),
+                "{returned} is not {stated}"
+            );
+        }
     }
 
     /// A MATPOWER shaped DC line states a loss model, not a DC circuit. The

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -1212,6 +1212,13 @@ impl JsonWalker<'_> {
     fn extension_namespace(&self, name: &str) -> String {
         let stated = self.extension_versions.get(name).map(String::as_str);
         let version = stated.unwrap_or("1.2");
+        if name == "slackTerminal"
+            && let Some(minor) = version.strip_prefix("1.")
+            && !minor.is_empty()
+            && minor.bytes().all(|byte| byte.is_ascii_digit())
+        {
+            return format!("{SLACK_TERMINAL_NAMESPACE_PREFIX}1_{minor}");
+        }
         if let Some((_, _, namespace)) = MAPPED_EXTENSION_NAMESPACES
             .iter()
             .find(|(extension, mapped, _)| *extension == name && *mapped == version)
@@ -7880,7 +7887,11 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
         xml(source_model_format),
         xml(validation),
     );
-    if let Some(detailed) = network.detailed_connectivity() {
+    if let Some(detailed) = network
+        .detailed_connectivity()
+        .as_deref()
+        .filter(|detailed| network.buses().is_empty() || !detailed.voltage_levels.is_empty())
+    {
         diagnose_xiidm_projection(detailed, &mut diagnostics)?;
         validate_xiidm_tap_changers(detailed)?;
         validate_xiidm_reactive_limits(detailed)?;
@@ -7940,9 +7951,15 @@ pub(crate) fn write_xiidm(network: &BalancedNetwork) -> Result<TextEmission> {
     }
     diagnostics.push(
         &codes::EMIT_XIIDM.value_defaulted,
-        "the network has no substation or voltage level hierarchy; XIIDM hierarchy was derived from buses",
+        "the network has no complete substation or voltage level hierarchy; XIIDM hierarchy was derived from buses",
     );
-    let detailed = derive_detailed_connectivity(network, &mut diagnostics)?;
+    let mut detailed = derive_detailed_connectivity(network, &mut diagnostics)?;
+    if let Some(supplied) = network.detailed_connectivity() {
+        detailed.omitted_fields.clone_from(&supplied.omitted_fields);
+        detailed
+            .component_metadata
+            .clone_from(&supplied.component_metadata);
+    }
     validate_xiidm_tap_changers(&detailed)?;
     validate_xiidm_reactive_limits(&detailed)?;
     validate_xiidm_dc_emission(&detailed)?;
@@ -14213,6 +14230,22 @@ mod tests {
             .find(|bus| bus.kind == BusType::Ref)
             .unwrap();
         assert_eq!(reference.uid.as_deref(), Some("B2"));
+
+        let jiidm = write_jiidm(&network).unwrap();
+        let older = jiidm
+            .text
+            .replacen("\"version\" : \"1.5\"", "\"version\" : \"1.3\"", 1);
+        assert_ne!(
+            older, jiidm.text,
+            "the fixture must state SlackTerminal 1.3"
+        );
+        let back = parse_jiidm_source(&older, &mut Diagnostics::new()).unwrap();
+        let reference = back
+            .buses()
+            .iter()
+            .find(|bus| bus.kind == BusType::Ref)
+            .unwrap();
+        assert_eq!(reference.uid.as_deref(), Some("B2"));
     }
 
     /// A slack terminal naming an equipment the document does not declare is a
@@ -14693,6 +14726,55 @@ mod tests {
         assert_eq!(detailed.switches.len(), 1);
         assert_eq!(detailed.switches[0].kind, SwitchKind::Breaker);
         assert!(detailed.switches[0].open);
+    }
+
+    #[test]
+    fn metadata_only_detailed_connectivity_derives_a_writable_hierarchy() {
+        let mut network = parse_xiidm_source(BUS_BREAKER, &mut Diagnostics::new()).unwrap();
+        let metadata = network
+            .detailed_connectivity()
+            .as_ref()
+            .unwrap()
+            .component_metadata
+            .clone();
+        *network.detailed_connectivity_mut() = Some(Arc::new(DetailedConnectivity {
+            component_metadata: metadata,
+            ..DetailedConnectivity::default()
+        }));
+
+        let emission = write_xiidm(&network).unwrap();
+        assert!(emission.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code() == codes::EMIT_XIIDM.value_defaulted.code
+                && diagnostic.message().contains("hierarchy was derived")
+        }));
+        let reparsed = parse_xiidm_source(&emission.text, &mut Diagnostics::new()).unwrap();
+        assert!(
+            !reparsed
+                .detailed_connectivity()
+                .as_ref()
+                .unwrap()
+                .voltage_levels
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn dc_only_detailed_connectivity_needs_no_ac_voltage_level() {
+        let source = r#"<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_17" id="dc-only" caseDate="2026-01-01T00:00:00Z" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+  <iidm:dcNode id="N1" nominalV="500"/>
+  <iidm:dcNode id="N2" nominalV="500"/>
+  <iidm:dcSwitch id="S" dcNode1="N1" dcNode2="N2" kind="BREAKER" open="false" r="0"/>
+</iidm:network>"#;
+        let network = parse_xiidm_source(source, &mut Diagnostics::new()).unwrap();
+
+        let emission = write_xiidm(&network).unwrap();
+        assert!(emission.text.contains("<iidm:dcNode"));
+        assert!(emission.text.contains("<iidm:dcSwitch"));
+        assert!(!emission.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code() == codes::EMIT_XIIDM.value_defaulted.code
+                && diagnostic.message().contains("hierarchy was derived")
+        }));
     }
 
     #[test]

--- a/powerio-tx/src/network.rs
+++ b/powerio-tx/src/network.rs
@@ -1904,9 +1904,17 @@ impl BalancedNetwork {
     /// them. A suffix distinguishes several records attached to the same bus
     /// or terminal pair.
     ///
+    /// The identities are unique across the whole network, not only within one
+    /// table: a load and a generator at bus 3 are two records, and formats that
+    /// index every element by one identifier (XIIDM, CGMES) reject the same
+    /// identifier twice. The first record to claim a stem keeps it and the next
+    /// takes a numeric suffix.
+    ///
     /// Callers that assemble a network by pushing records can call this once
     /// after construction. PowerIO parsers call it before returning a module.
     pub fn assign_missing_component_ids(&mut self) {
+        let mut used = self.component_ids_in_use();
+        let mut next_suffix = HashMap::new();
         macro_rules! assign {
             ($table:ident, $table_mut:ident, $set_uid:expr, $stem:expr) => {
                 if self.$table().iter().any(|value| value.uid.is_none()) {
@@ -1915,6 +1923,8 @@ impl BalancedNetwork {
                         |value| value.uid.as_deref(),
                         $set_uid,
                         $stem,
+                        &mut used,
+                        &mut next_suffix,
                     );
                 }
             };
@@ -1984,6 +1994,33 @@ impl BalancedNetwork {
             }
         );
     }
+
+    /// Every identity the network's records already carry.
+    fn component_ids_in_use(&self) -> HashSet<String> {
+        let mut used = HashSet::new();
+        macro_rules! collect {
+            ($($table:ident),+) => {
+                $(used.extend(
+                    self.$table()
+                        .iter()
+                        .filter_map(|value| value.uid.as_deref().map(str::to_owned)),
+                );)+
+            };
+        }
+        collect!(
+            buses,
+            loads,
+            shunts,
+            static_var_compensators,
+            branches,
+            switches,
+            generators,
+            storage,
+            hvdc,
+            transformers_3w
+        );
+        used
+    }
 }
 
 fn assign_missing_ids<T>(
@@ -1991,13 +2028,9 @@ fn assign_missing_ids<T>(
     uid: impl for<'a> Fn(&'a T) -> Option<&'a str>,
     mut set_uid: impl FnMut(&mut T, String),
     stem: impl Fn(&T) -> String,
+    used: &mut HashSet<String>,
+    next_suffix: &mut HashMap<String, usize>,
 ) {
-    let mut used: HashSet<String> = values
-        .iter()
-        .filter_map(|value| uid(value).map(str::to_owned))
-        .collect();
-    let mut next_suffix = HashMap::<String, usize>::new();
-
     for value in values {
         if uid(value).is_some() {
             continue;
@@ -5604,6 +5637,45 @@ mod tests {
         let restored = BalancedNetwork::from_json(&network.to_json().unwrap()).unwrap();
         assert_eq!(restored.loads()[0].uid, network.loads()[0].uid);
         assert_eq!(restored.branches()[0].uid, network.branches()[0].uid);
+    }
+
+    /// XIIDM and CGMES index every element by one identifier, so a load and a
+    /// generator at the same bus cannot both be `bus-20`.
+    #[test]
+    fn generated_identities_are_unique_across_tables() {
+        let mut network = BalancedNetwork::in_memory(
+            "cross table ids",
+            100.0,
+            vec![
+                Bus::new(BusId(10), BusType::Ref, 230.0),
+                Bus::new(BusId(20), BusType::Pq, 230.0),
+            ],
+            vec![Branch::new(BusId(10), BusId(20), 0.0, 0.1)],
+        );
+        network.loads_mut().push(Load::new(BusId(20), 10.0, 1.0));
+        network.shunts_mut().push(Shunt::new(BusId(20), 0.0, 0.5));
+        network.generators_mut().push(Generator::new(BusId(20)));
+        network.assign_missing_component_ids();
+
+        let mut identities = vec![
+            network.loads()[0].uid.clone().unwrap(),
+            network.shunts()[0].uid.clone().unwrap(),
+            network.generators()[0].uid.clone().unwrap(),
+        ];
+        identities.sort();
+        assert_eq!(identities, ["bus-20", "bus-20-2", "bus-20-3"]);
+
+        // Assigning again leaves every identity alone, so an identity stays
+        // stable across a reload.
+        let before = identities.clone();
+        network.assign_missing_component_ids();
+        let mut after = vec![
+            network.loads()[0].uid.clone().unwrap(),
+            network.shunts()[0].uid.clone().unwrap(),
+            network.generators()[0].uid.clone().unwrap(),
+        ];
+        after.sort();
+        assert_eq!(after, before);
     }
 
     #[test]

--- a/powerio-tx/src/network.rs
+++ b/powerio-tx/src/network.rs
@@ -1996,7 +1996,7 @@ impl BalancedNetwork {
     }
 
     /// Every identity the network's records already carry.
-    fn component_ids_in_use(&self) -> HashSet<String> {
+    pub(crate) fn component_ids_in_use(&self) -> HashSet<String> {
         let mut used = HashSet::new();
         macro_rules! collect {
             ($($table:ident),+) => {

--- a/powerio-tx/tests/convert.rs
+++ b/powerio-tx/tests/convert.rs
@@ -9,9 +9,9 @@ use helpers::*;
 use std::path::{Path, PathBuf};
 
 use powerio_tx::{
-    BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet, BranchSolution,
-    Bus, BusId, BusType, EmitOptions, Load, LoadVoltageModel, MissingGenCostPolicy, SourceFormat,
-    TargetFormat, parse_gen_cost_csv,
+    Area, BalancedNetwork, Branch, BranchCharging, BranchCurrentRatings, BranchRatingSet,
+    BranchSolution, Bus, BusId, BusType, EmitOptions, Load, LoadVoltageModel, MissingGenCostPolicy,
+    SourceFormat, TargetFormat, parse_gen_cost_csv,
 };
 use serde_json::Value;
 
@@ -310,6 +310,25 @@ fn extra_branch_rating_sets_survive_model_json() {
     assert_eq!(back.branches()[0].rating_sets.len(), 1);
     assert_eq!(back.branches()[0].rating_sets[0].name, "RATE4");
     assert!((back.branches()[0].rating_sets[0].rate_mva - 125.0).abs() < 1e-12);
+}
+
+#[test]
+fn writers_without_a_bus_area_field_report_membership_loss() {
+    let mut net = rich_audit_network();
+    net.areas_mut().push(Area::new(7));
+
+    let pandapower = emit_pandapower_json(&net);
+    assert!(has_warning(
+        &pandapower.render_diagnostics(),
+        "writes neither an area table nor a bus area number"
+    ));
+
+    let out = tmp_dir("area-membership-pypsa");
+    let pypsa = emit_pypsa_csv_folder(&net, &out).unwrap();
+    assert!(has_warning(
+        &pypsa.render_diagnostics(),
+        "writes neither an area table nor a bus area number"
+    ));
 }
 
 #[test]

--- a/powerio-tx/tests/ucte.rs
+++ b/powerio-tx/tests/ucte.rs
@@ -156,8 +156,11 @@ fn the_synthetic_case_parses_to_the_expected_counts_and_values() {
     assert!(approx(line.r, 2.5 / zbase));
     assert!(approx(line.x, 25.0 / zbase));
     assert!(approx(line.b, 300.0e-6 * zbase));
+    // The permanent current limit is one fact stated once, as `rate_a` in MVA
+    // at the element's voltage level; the writer divides by the same voltage
+    // to recover the ampere the record states.
     assert!(approx(line.rate_a, 3f64.sqrt() * 380.0 * 1200.0 / 1000.0));
-    assert_eq!(line.current_ratings.unwrap().c_rating_a, 1200.0);
+    assert!(line.current_ratings.is_none());
     assert_eq!(line.name.as_deref(), Some("GEN-LOAD 1"));
     assert_eq!(line.tap, 0.0);
     assert!(line.in_service);

--- a/powerio/tests/iidm_versions.rs
+++ b/powerio/tests/iidm_versions.rs
@@ -320,6 +320,30 @@ fn fresh_jiidm_follows_the_powsybl_field_order() {
         key_orders(&reference, "", &mut reference_orders);
         let mut fresh_orders = Vec::new();
         key_orders(&fresh, "", &mut fresh_orders);
+        // IIDM has no bus type, so PowerIO states the reference bus as the
+        // SlackTerminal extension PowSybl defines for it. A PowSybl fixture
+        // that declares no reference bus therefore has no `extensions` paths
+        // where the fresh output has them; every path the fixture does state
+        // is compared in order.
+        let reference_paths = reference_orders
+            .iter()
+            .map(|(path, _)| path.clone())
+            .collect::<std::collections::HashSet<_>>();
+        let extra = fresh_orders
+            .iter()
+            .filter(|(path, _)| !reference_paths.contains(path))
+            .map(|(path, _)| path.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            extra,
+            [
+                "/extensionVersions[]",
+                "/extensions[]",
+                "/extensions[]/slackTerminal"
+            ],
+            "{name}"
+        );
+        fresh_orders.retain(|(path, _)| reference_paths.contains(path));
         assert_eq!(fresh_orders.len(), reference_orders.len(), "{name}");
         for ((fresh_path, fresh_keys), (reference_path, reference_keys)) in
             fresh_orders.iter().zip(&reference_orders)


### PR DESCRIPTION
## Summary

- Add a GO Challenge 3 JSON source row to the conversion matrix.
- Recognize a CGMES set declaring this writer's own modeling authority as fresh emission, so its header, regions, containment, limit types and islands are not reported as lost.
- Map CGMES `rate_b`/`rate_c` to temporary loadings at twenty minutes and one minute.
- Write a PowerWorld aux generator cost through the input-output vocabulary at a unit fuel price.
- State a UCTE permanent current limit once, as `rate_a`.
- Warnings name the key, object, field or class they refer to.

## Testing

- workspace tests, clippy 1.98.0 `-D warnings`, fmt, terminology, value types, ABI 7, header regen, doc symbols, mdbook
- PowSybl 7.3.0 gate: 57,644 assertions

Closes #465
