### PR TITLE
Decode the bus record family with flag bit 2 clear

### DIFF
--- a/powerio-tx/src/format/powerworld/FORMAT.md
+++ b/powerio-tx/src/format/powerworld/FORMAT.md
@@ -151,14 +151,16 @@ quantum, dispatch and branch values likewise. `powerio/tests/`
 
 ## The .pwb binary format (decode evidence)
 
-Established by differential analysis of three lawfully obtained files, no
+Established by differential analysis of lawfully obtained files, no
 PowerWorld software involved: ACTIVSg200.pwb (Simulator 20 era, June 2018,
 same snapshot as the vendored aux), Texas2000_June2016.pwb (June 2016, same
 day as its paired aux export), and ACTIV_SG_2000_v19.pwb (April 2017, validated
 against the published ACTIVSg2000 case with the snapshot deltas pinned in
-the parity test). Every claim below was verified by value match against a
-the paired export on every record unless noted. Offsets are from the field listed;
-integers and floats are little endian.
+the parity test), widened later by the TAMU repository sets, the Texas7k
+saves, and a local corpus of twenty saves whose MATPOWER `.m` and PSS/E
+`.RAW` exports cover most of the same cases. Every claim below was verified
+by value match against a paired export on every record unless noted. Offsets
+are from the field listed; integers and floats are little endian.
 
 ### Header (identical prefix in all three files)
 
@@ -214,8 +216,11 @@ The flag word is a field presence bitmask. Bit 5 set marks the Simulator 20
 era record family (clear on the 2016 era family), bit 4 set marks the count
 prefixed list in the record tail, bit 0 clear means one extra u16 before the
 nominal kV (the generator buses: 49 such records in ACTIVSg200, which has 49
-generators). The head layout through the solved voltage is identical across
-every observed flag word; the tails differ.
+generators). Bit 1 is set on every record of every file in the corpus, and it
+is the reader's only required base bit; bit 2 was also required until a later
+corpus showed whole tables with it clear (below). The head layout through the
+solved voltage is identical across every observed flag word; the tails
+differ.
 
 | file | flag words seen |
 |---|---|
@@ -244,6 +249,41 @@ entries (1341 bytes) on one record, past the bounded resync window, so a
 bit 4 bus record extends the scan to the buffer end exactly as a bit 4
 branch record does. The 39 bus sample case (header 425) shows no
 recognized bus record layout at all in a 44 KiB file.
+
+### Bus record flag words with bit 2 clear (header 425 and 537)
+
+A later corpus of twenty saves adds the first family with bit 2 clear and
+bits 12 and 13 set. Its 5000 bus records carry six flag words, and no others:
+
+| flag word | bits set beyond 1, 12, 13 | records |
+|---|---|---|
+| 0x3002 | none | 42 |
+| 0x3003 | 0 | 208 |
+| 0x3022 | 5 | 10 |
+| 0x3062 | 5, 6 | 646 |
+| 0x3162 | 5, 6, 8 | 142 |
+| 0x3163 | 0, 5, 6, 8 | 3952 |
+
+Bit 0 is clear on the generator buses exactly as in the older families, and
+bit 5, which selects the tail family, is clear over one whole table and set
+over the other nineteen, so this vintage writes both tails. The head layout
+is unchanged, and the whole table decodes: consecutive bus numbers from 1,
+each name the decimal spelling of its own number, nominal kV drawn from
+345/230/138/69/14, area and zone 1, one shared bus label, and the solved
+voltage pair as two f64. Every one of those fields matches the PSS/E `.RAW`
+and MATPOWER `.m` exports of the same case at their print quanta (the `.RAW`
+prints the magnitude at five decimals and the angle at four, the `.m` at
+seven and five).
+
+Bit 2's own field is not in the decoded head, so the reader's mask moved it
+into the presence set: the accept rule is now bit 1 set with every other bit
+outside `0x3575` clear. Bit 2 stays in the record family key, which keeps a
+bit 2 clear table from chaining with a bit 2 set one.
+
+Nineteen of the twenty saves carry header constant 425 and one carries 537,
+and both write the 425 era generator record, which makes 537 the second
+constant after 508 observed with either generator record shape. The reader
+therefore tries both shapes in sequence under 537.
 
 An earlier draft of this section read the Texas7k generator table as "the
 leading u32 equals the aux BusNum on roughly three quarters of the
@@ -419,6 +459,13 @@ case stores zero shunt MW and the reader sets G = 0.
   fills two characters or parses either way).
 - Table glue blocks between count and first record (the v21 resave's bus
   and generator glues carry 52 and 86 bytes including string metadata).
+- Per bus voltage limits: still undecoded. The bit 2 clear corpus is the
+  first one holding two saves of one case that differ only in the limits
+  (0.92/1.06 on load buses and 0.98/1.10 on generator buses in one,
+  0.95/1.04 and 1.00/1.06 in the other), and no f32 at any fixed offset from
+  either the bus record start or the decoded head end tracks them across
+  both saves, so they are not stored in the bus record at a constant offset.
+  Buses keep the 1.1/0.9 defaults.
 - Substation, area/zone names, contingency tables: present after the
   branches, undecoded in this pass.
 

--- a/powerio-tx/src/format/powerworld/FORMAT.md
+++ b/powerio-tx/src/format/powerworld/FORMAT.md
@@ -501,12 +501,20 @@ June 2016 through 2022 writer eras. Every other drawing object type (buses,
 branch pies, transmission lines, field labels), the palettes, fonts,
 layers, and the substation record style tails stay undecoded.
 
-Header: u32 = 50, two u16 canvas dimensions, then a fixed shape block. The
-u32 at offset 22 is a per file stamp that every drawing object record
-repeats at +18 — the anchor the record scan keys on. A correction to the
-earlier probe notes: the type name list behind "Previous Select By
-Criteria Set Used" in 2017+ saves is the object type list of that dialog's
-last use (UI state), not a registry of the record types in the file
+Header: u32 = 50, two u16 canvas dimensions, a u16 = 10070, then an optional
+canvas title (a u16 length at offset 10, a zero u16, the text) and eight zero
+bytes, then a per file stamp that every drawing object record repeats at +18,
+then a u32 = 10105. The stamp is the anchor the record scan keys on. Every
+earlier probed save carries no title, which puts the stamp at offset 22, so
+the reader read it there; a titled save puts title text at 22 instead, which
+reads as a zero stamp, and the reader refused such a file as an unrecognized
+header. The 10105 word one past the stamp pins which of the two positions
+holds it, so a titled save now parses. A header that does not have the title
+shape reads offset 22 unchanged.
+
+A correction to the earlier probe notes: the type name list behind "Previous
+Select By Criteria Set Used" in 2017+ saves is the object type list of that
+dialog's last use (UI state), not a registry of the record types in the file
 (ACTIVSg200.pwd lists only DisplaySubstation yet draws eight plus types);
 the decoder takes nothing from it, and the June 2016 save has none.
 

--- a/powerio-tx/src/format/powerworld/FORMAT.md
+++ b/powerio-tx/src/format/powerworld/FORMAT.md
@@ -360,8 +360,25 @@ anchored at +9 or +10 (2016/2017 exports; the gap varies per record) or +11
 GenVoltSet (p.u., scale 1), GenMVABase (MVA, scale 1), MWMax, MWMin. The
 voltage setpoint and MVA base ranges pick the anchor per record. In the
 2018 file also verified: GenRMPCT at +53, GenZR/GenZX as f64 near
-+147/+193. Record length varies with embedded strings; the status byte is
-unlocated within the flag bytes (every machine in these files is Closed).
++147/+193. Record length varies with embedded strings.
+
+Some writers of this era follow the f32 block with the same status tail the
+2021 era regulated record carries: a zero byte at block +32, the status byte
+at block +33 (9 in service, 8 open, bit 0 the service bit), then GenRMPCT as
+an f32 at block +34. Eighteen of the twenty saves of the bit 2 clear corpus
+carry it on every record of their generator tables, always with GenRMPCT
+100.0. The decoded status is 5 open machines in two of those saves, 12 in one,
+13 in one, and none in the other fourteen, and on all twelve of them that have
+a PSS/E or MATPOWER export of the same case it matches the open machine set
+that export states. The remaining two saves, and ACTIVSg200, put 21 at block
++32 and unrelated bytes after it, so the tail is a per writer property, not a
+per era one. The reader
+therefore reads the status only when every record of the accepted table
+carries the tail; any other table reads every machine as in service and
+`parse_pwb_with_warnings` says so. Reading the status changes the derived bus
+kind: a bus whose only machine is open becomes PQ, where a PSS/E or MATPOWER
+export of the same case keeps the bus type PV, because PowerWorld stores no
+bus type and the reader derives it from the closed machines.
 
 ### Generator record, 2021 era (validated on 731 ×3 + 1058 ×2 machines of five files)
 
@@ -438,12 +455,13 @@ case stores zero shunt MW and the reader sets G = 0.
 
 ### Open questions (inventoried, not guessed)
 
-- Status bytes: the 2021 era generator status is located and validated
-  (bit 0 of the byte one past the f32 block, against 94 open machines);
-  every other device in every available case is Closed/in service, so no
-  other status offset is validated and those devices read as in service.
-  Whether the older era generator records carry the same byte after their
-  block is untested for the open state (no 425 era case has one).
+- Status bytes: the generator status is located and validated wherever the
+  record carries the status tail (bit 0 of the byte one past the f32 block,
+  against 94 open machines in the 2021 era files and 35 in the 425 era files
+  that carry the tail). What the 425 era writers that put other bytes there
+  store instead is undecoded, so those machines read as in service. Every
+  other device in every available case is Closed/in service, so no other
+  status offset is validated and those devices read as in service.
 - The meaning of the bit 4 tail lists (u32 count, then 9 byte entries
   observed as u8 = 3, u32 number, u32 = 1) and of the constant u32 12 tag
   in branch records.

--- a/powerio-tx/src/format/powerworld/pwb.rs
+++ b/powerio-tx/src/format/powerworld/pwb.rs
@@ -23,14 +23,17 @@
 //!
 //! Known limits, documented rather than guessed:
 //!
-//! - Status bytes: the 483 era generator record is the one located,
-//!   validated status (bit 0 of the byte one past the f32 block, checked
-//!   against the open machines an aux export of the same case states). No
-//!   other out of service encoding is located, so every other device reads as in
-//!   service. That is a limit of the decoding, not a property of the data: a
-//!   425 era file can hold open machines its `.aux` twin states and this
-//!   reader cannot see. `parse_pwb_with_warnings` reports the limit;
-//!   `parse_pwb` discards the warning.
+//! - Status bytes: the generator status is located wherever the record
+//!   carries the validated status tail (a zero byte, then bit 0 of the
+//!   status byte, then GenRMPCT as an f32) one past the f32 block. Every
+//!   483 era record carries it, and so do the 425 era records of writers
+//!   that emit it, checked against the open machines the paired `.aux` or
+//!   `.raw` export of the same case states. A 425 era table whose records
+//!   put something else there keeps no located status, so its machines read
+//!   as in service; that is a limit of the decoding, not a property of the
+//!   data. `parse_pwb_with_warnings` reports the limit when it applies;
+//!   `parse_pwb` discards the warning. No other device status is located,
+//!   so every other device reads as in service.
 //!   The load record's post ID byte, once treated as a status, is 0x00 in
 //!   the 425 era files and 0x01 in the 2021 era ones with every load Closed
 //!   in both, so it is no status byte; the 425 era generator, the shunt,
@@ -188,10 +191,10 @@ pub fn parse_pwb(bytes: &[u8], name_hint: Option<&str>) -> Result<BalancedNetwor
 
 /// As [`parse_pwb`], reporting what the decoded layout cannot state.
 ///
-/// The one that bites is generator service status. Only the 483 era record has
-/// a located, validated status byte; the 425 era record's is unlocated, so
-/// every machine in such a file reads as in service and nothing in the model
-/// says the reader could not tell.
+/// The one that bites is generator service status. It is located only when the
+/// accepted generator table carries the validated status tail; without it every
+/// machine in the file reads as in service and nothing in the model says the
+/// reader could not tell.
 ///
 /// # Errors
 ///
@@ -210,18 +213,15 @@ pub(crate) fn parse_pwb_collecting(
     name_hint: Option<&str>,
     warnings: &mut crate::diagnostics::Diagnostics,
 ) -> Result<BalancedNetwork> {
-    let net = parse_pwb_inner(bytes, name_hint)?;
-    // Headers admitting only the 425 era generator record: their status byte
-    // is unlocated (see the module docs), so the reader has no choice but to
-    // read every machine as running. A 508 file may carry either record, and
-    // which one matched is not observable here, so it is left unstated rather
-    // than guessed at.
-    if matches!(expect_header(bytes)?, 338 | 368 | 425) && !net.generators().is_empty() {
+    let (net, status) = parse_pwb_inner(bytes, name_hint)?;
+    // A generator table whose records carry no status tail leaves the reader
+    // no choice but to read every machine as running (see the module docs).
+    if status == GenStatus::Unlocated && !net.generators().is_empty() {
         warnings.push(
             &crate::diagnostics::codes::READ_POWERWORLD_VALUE_DEFAULTED,
             format!(
-                "{} generator(s) read as in service: this .pwb vintage's generator status byte is \
-             not located, so an open machine is indistinguishable from a closed one",
+                "{} generator(s) read as in service: this .pwb generator record carries no status \
+             tail, so an open machine is indistinguishable from a closed one",
                 net.generators().len()
             ),
         );
@@ -229,7 +229,7 @@ pub(crate) fn parse_pwb_collecting(
     Ok(net)
 }
 
-fn parse_pwb_inner(bytes: &[u8], name_hint: Option<&str>) -> Result<BalancedNetwork> {
+fn parse_pwb_inner(bytes: &[u8], name_hint: Option<&str>) -> Result<(BalancedNetwork, GenStatus)> {
     let header_constant = expect_header(bytes)?;
     reject_unsupported_vintage(bytes)?;
     // The header constant pins the generator record layout wherever the
@@ -312,34 +312,47 @@ fn parse_pwb_inner(bytes: &[u8], name_hint: Option<&str>) -> Result<BalancedNetw
                     .flatten()
             })
     });
-    found.unwrap_or_else(|| {
-        if budget.exhausted() || budget.retention_exhausted() {
-            return Err(Error::FormatRead {
-                format: FMT,
-                message: "table search exceeded its work budget; the bytes are not a \
+    found.map_or_else(
+        || {
+            if budget.exhausted() || budget.retention_exhausted() {
+                return Err(Error::FormatRead {
+                    format: FMT,
+                    message: "table search exceeded its work budget; the bytes are not a \
                               decodable .pwb layout"
-                    .into(),
-            });
-        }
-        Err(Error::FormatRead {
-            format: FMT,
-            message: "no table chain matches the validated .pwb layouts \
+                        .into(),
+                });
+            }
+            Err(Error::FormatRead {
+                format: FMT,
+                message: "no table chain matches the validated .pwb layouts \
                           (buses, loads, generators, shunts, branches in sequence)"
-                .into(),
-        })
-    })
+                    .into(),
+            })
+        },
+        |(status, net)| net.map(|net| (net, status)),
+    )
 }
 
 /// Which generator record layouts the header constant admits (see
 /// [`parse_pwb`]): the 425/508 era bus + ID shape (`plain`), the 2021 era
 /// regulated bus shape (`reg`, [`read_gen_reg_record`]), and the 554 shape
 /// whose regulated bus record omits the presence byte (`simple_reg`,
-/// [`read_gen_reg_simple_record`]).
+/// [`read_gen_reg_simple_record`]). A `plain` record reports whether it
+/// carried the status tail, and [`resolve_plain_gen_status`] reads the status
+/// only when every record of the table did.
 #[derive(Clone, Copy)]
 struct GenVariants {
     plain: bool,
     reg: bool,
     simple_reg: bool,
+}
+
+/// Whether the accepted generator table carried a located service status.
+/// [`parse_pwb_collecting`] reports the gap when it did not.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GenStatus {
+    Decoded,
+    Unlocated,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -383,7 +396,7 @@ fn search_table_chain(
     device_glue: DeviceGlue,
     wide_bus_glue: bool,
     budget: &SearchBudget,
-) -> Option<Result<BalancedNetwork>> {
+) -> Option<(GenStatus, Result<BalancedNetwork>)> {
     // A count word can be forged by record interiors and the case
     // description, so table location is a depth first search: a candidate at
     // any stage is kept only if every later table parses behind it. The
@@ -450,6 +463,7 @@ fn search_table_chain(
                 })
                 .into_iter()
                 .flatten()
+                .map(|c| (c, GenStatus::Decoded))
                 .chain(
                     gen_variants
                         .simple_reg
@@ -466,7 +480,8 @@ fn search_table_chain(
                             )
                         })
                         .into_iter()
-                        .flatten(),
+                        .flatten()
+                        .map(|c| (c, GenStatus::Decoded)),
                 )
                 .chain(
                     gen_variants
@@ -484,9 +499,10 @@ fn search_table_chain(
                             )
                         })
                         .into_iter()
-                        .flatten(),
+                        .flatten()
+                        .map(|(rows, end)| resolve_plain_gen_status(rows, end)),
                 );
-            for (generators, g_end) in gen_candidates {
+            for ((generators, g_end), gen_status) in gen_candidates {
                 if gen_table_continues(bytes, g_end, &bus_ids, gen_variants, budget) {
                     continue;
                 }
@@ -503,6 +519,7 @@ fn search_table_chain(
                         keep_best_chain(
                             &mut best,
                             chain_score(&loads, &bus_shunts, &branches, &generators),
+                            gen_status,
                             checked_network(
                                 name_hint,
                                 buses.clone(),
@@ -546,7 +563,7 @@ fn search_table_chain(
                         branches,
                         generators.clone(),
                     );
-                    keep_best_chain(&mut best, score, net);
+                    keep_best_chain(&mut best, score, gen_status, net);
                 }
                 if let Some(branches) = find_branch_table(
                     bytes,
@@ -560,6 +577,7 @@ fn search_table_chain(
                     keep_best_chain(
                         &mut best,
                         chain_score(&loads, &bus_shunts, &branches, &generators),
+                        gen_status,
                         checked_network(
                             name_hint,
                             buses.clone(),
@@ -572,30 +590,56 @@ fn search_table_chain(
                 }
             }
         }
-        if let Some((_, net)) = best {
-            return Some(net);
+        if let Some((_, status, net)) = best {
+            return Some((status, net));
         }
     }
     None
 }
 
-/// Keep the table chain with the largest decoded electrical core.
+/// Resolve the service status of a plain generator table. The 425 era record
+/// carries the status tail on every record or on none, by writer: eighteen
+/// files of one corpus carry it and ACTIVSg200 puts other bytes there. A
+/// table that carries it on every record is read with its decoded status; any
+/// other table reads every machine as in service, which is what the reader
+/// can state about those bytes.
+fn resolve_plain_gen_status(
+    rows: Vec<(Generator, bool)>,
+    end: usize,
+) -> ((Vec<Generator>, usize), GenStatus) {
+    if rows.iter().all(|(_, tail)| *tail) {
+        let gens = rows.into_iter().map(|(machine, _)| machine).collect();
+        return ((gens, end), GenStatus::Decoded);
+    }
+    let gens = rows
+        .into_iter()
+        .map(|(mut machine, _)| {
+            machine.in_service = true;
+            machine
+        })
+        .collect();
+    ((gens, end), GenStatus::Unlocated)
+}
+
+/// Keep the table chain with the largest decoded electrical core, together
+/// with whether its generator table carried a located service status.
 fn keep_best_chain(
-    best: &mut Option<(usize, Result<BalancedNetwork>)>,
+    best: &mut Option<(usize, GenStatus, Result<BalancedNetwork>)>,
     score: usize,
+    status: GenStatus,
     net: Result<BalancedNetwork>,
 ) {
     let candidate_ok = net.is_ok();
     let replace = match best.as_ref() {
         None => true,
-        Some((best_score, best_net)) => match (best_net.is_ok(), candidate_ok) {
+        Some((best_score, _, best_net)) => match (best_net.is_ok(), candidate_ok) {
             (false, true) => true,
             (true, false) => false,
             _ => score > *best_score,
         },
     };
     if replace {
-        *best = Some((score, net));
+        *best = Some((score, status, net));
     }
 }
 
@@ -1368,8 +1412,10 @@ fn read_load_record(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<(Load, usi
     read_device_head(b, at, bus_ids, read_load)
 }
 
-/// Probe one plain generator record using the shared device head.
-fn read_gen_record(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<(Generator, usize)> {
+/// Probe one plain generator record using the shared device head. The bool is
+/// whether the record carried the validated status tail (see
+/// [`resolve_plain_gen_status`]).
+fn read_gen_record(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<((Generator, bool), usize)> {
     read_device_head(b, at, bus_ids, read_gen)
 }
 
@@ -1505,7 +1551,7 @@ fn read_load(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Load> {
 /// one; the voltage setpoint and MVA base ranges anchor the choice, and a
 /// record that puts implausible values at every offset is a loud error, not
 /// a generator.
-fn read_gen(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Generator> {
+fn read_gen(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<(Generator, bool)> {
     let record_start = c.pos - (4 + 1) - id.len(); // u32 bus + the ID length byte
     let mut chosen = None;
     // +12 extends the observed set to two character IDs in a 2018 era
@@ -1524,9 +1570,17 @@ fn read_gen(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Generator> {
         return Err("generator record does not match the validated layouts");
     };
     c.pos = end;
-    // The status byte is unlocated within the flag bytes of this era's
-    // record; every available machine is Closed (see the module docs).
-    Ok(gen_from_block(bus, &v, true))
+    // Some writers of this era follow the f32 block with the same status tail
+    // the 2021 era regulated record carries. When it is there the status is
+    // decoded; when it is not, the record reads as in service and the table
+    // level check in `resolve_plain_gen_status` keeps a chance match from
+    // opening a running machine.
+    let mut tail = Cur { b: c.b, pos: end };
+    if let Ok((machine, pos)) = read_gen_reg_tail(&mut tail, bus.0, &v) {
+        c.pos = pos;
+        return Ok((machine, true));
+    }
+    Ok((gen_from_block(bus, &v, true), false))
 }
 
 /// The eight consecutive f32 per unit values both generator record eras
@@ -2144,10 +2198,20 @@ mod tests {
     #[test]
     fn best_chain_prefers_valid_chain_over_higher_scoring_error() {
         let mut best = None;
-        keep_best_chain(&mut best, 100, Err(unsupported_vintage("bad candidate")));
-        keep_best_chain(&mut best, 1, Ok(empty_network("valid")));
+        keep_best_chain(
+            &mut best,
+            100,
+            GenStatus::Unlocated,
+            Err(unsupported_vintage("bad candidate")),
+        );
+        keep_best_chain(
+            &mut best,
+            1,
+            GenStatus::Unlocated,
+            Ok(empty_network("valid")),
+        );
 
-        let (_, net) = best.unwrap();
+        let (_, _, net) = best.unwrap();
         assert!(net.is_ok());
     }
 

--- a/powerio-tx/src/format/powerworld/pwb.rs
+++ b/powerio-tx/src/format/powerworld/pwb.rs
@@ -13,12 +13,13 @@
 //! Supported header constants: 338, 368, 425, 483, 508, 537, 550, 551, and 554.
 //! These constants gate only the writer era; a recognized constant still has
 //! to pass the table walk. Constants 338/368/425 use the older generator record
-//! (`bus`, ID, f32 block), 483/537/550/551 use the regulated bus record, 508
-//! has been observed with both generator families, and 554 uses the regulated
-//! record without the 2021 era presence byte. The bus, load, shunt, and branch
-//! heads are more general: their flag words are Delphi field presence bitmasks,
-//! so one decoded head model admits the observed 0x06, 0x26, and 0x66 families
-//! as long as the later table walk still validates.
+//! (`bus`, ID, f32 block), 483/550/551 use the regulated bus record, 508 and
+//! 537 have been observed with both generator families, and 554 uses the
+//! regulated record without the 2021 era presence byte. The bus, load, shunt,
+//! and branch heads are more general: their flag words are Delphi field
+//! presence bitmasks, so one decoded head model admits the observed 0x02,
+//! 0x06, 0x26, 0x66, 0x3002, and 0x3062 families as long as the later table
+//! walk still validates.
 //!
 //! Known limits, documented rather than guessed:
 //!
@@ -233,18 +234,19 @@ fn parse_pwb_inner(bytes: &[u8], name_hint: Option<&str>) -> Result<BalancedNetw
     reject_unsupported_vintage(bytes)?;
     // The header constant pins the generator record layout wherever the
     // corpus is unambiguous: every 425 file carries the bus + ID shape and
-    // every 483/537/550/551 file the regulated bus shape, while 508 saves
-    // exist with both (Hawaii40 against the Texas7k v21 resave), so only
-    // they try the two in sequence. Beyond pricing, this keeps the layout
-    // a file cannot carry from ever outbidding the right one in the chain
-    // search; a hypothetical file mixing eras fails loudly instead.
+    // every 483/550/551 file the regulated bus shape, while 508 and 537
+    // saves exist with both (Hawaii40 against the Texas7k v21 resave, and the
+    // bit 2 clear bus record corpus against the 2021 era saves), so only they
+    // try the two in sequence. Beyond pricing, this keeps the layout a file
+    // cannot carry from ever outbidding the right one in the chain search; a
+    // file mixing eras fails loudly instead.
     let gen_variants = match header_constant {
         338 | 368 | 425 => GenVariants {
             plain: true,
             reg: false,
             simple_reg: false,
         },
-        508 => GenVariants {
+        508 | 537 => GenVariants {
             plain: true,
             reg: true,
             simple_reg: false,
@@ -875,8 +877,8 @@ fn expect_header(b: &[u8]) -> Result<u64> {
     // Every known PowerWorld binary starts with 15000. The next two words
     // identify the writer family: the decoded constants cover older 0x06 bus
     // records (338/368), the Simulator 19/20/current 425 family, the 2021
-    // regulated generator family (483/537/550/551), the mixed 508 saves, and
-    // the 554 regulated generator variant. Header admission is not trust:
+    // regulated generator family (483/550/551), the mixed 508 and 537 saves,
+    // and the 554 regulated generator variant. Header admission is not trust:
     // every table still has to pass the record probes below.
     if c != 20 || !DECODED.contains(&v) {
         return Err(unsupported_vintage(format!(
@@ -1060,23 +1062,26 @@ struct BusHead {
     /// generator buses). The 2019+ era writers add bits 6 and 8, both per
     /// record (the v21 resave clears bit 6 on its slack bus record; the
     /// bit 6 tails carry a location string block), with their fields in
-    /// the undecoded tail.
+    /// the undecoded tail. Bit 2 is set on every file of the older corpus
+    /// and clear on every record of a later one whose words add bits 12 and
+    /// 13; its field is not in the decoded head.
     unk: u32,
 }
 
-/// Whether a bus record flag word is one this reader decodes: base bits
-/// `0x06` plus any combination of the observed presence bits. Bit 5 changes
-/// the tail family (`0x06` vs `0x26` era), while bits 6, 8, 10, 12, and 13
-/// were admitted only after full table walks showed they leave the decoded
-/// head layout unchanged.
+/// Whether a bus record flag word is one this reader decodes: base bit `0x02`
+/// plus any combination of the observed presence bits. Bit 5 changes the tail
+/// family (`0x06` vs `0x26` era), while bits 2, 6, 8, 10, 12, and 13 were
+/// admitted only after full table walks showed they leave the decoded head
+/// layout unchanged. Bit 1 is the only bit every observed record sets.
 fn known_bus_flags(unk: u32) -> bool {
-    unk & !0x3571 == 0x06
+    unk & !0x3575 == 0x02
 }
 
 /// The record family bits of a bus flag word. One bus table cannot mix tail
 /// families, but individual records can toggle optional presence bits inside
-/// a family. Bit 5 stays in the family key because the 0x06 and 0x26 era tails
-/// differ; the other admitted bits are per record fields or skipped tails.
+/// a family. Bits 2 and 5 stay in the family key because the tails differ
+/// across the `0x02`, `0x06`, and `0x26` eras; the other admitted bits are
+/// per record fields or skipped tails.
 fn bus_family(unk: u32) -> u32 {
     unk & !0x3551
 }

--- a/powerio-tx/src/format/powerworld/pwb.rs
+++ b/powerio-tx/src/format/powerworld/pwb.rs
@@ -23,15 +23,18 @@
 //!
 //! Known limits, documented rather than guessed:
 //!
-//! - Status bytes: the generator status is located wherever the record
-//!   carries the validated status tail (a zero byte, then bit 0 of the
-//!   status byte, then GenRMPCT as an f32) one past the f32 block. Every
-//!   483 era record carries it, and so do the 425 era records of writers
-//!   that emit it, checked against the open machines the paired `.aux` or
-//!   `.raw` export of the same case states. A 425 era table whose records
-//!   put something else there keeps no located status, so its machines read
-//!   as in service; that is a limit of the decoding, not a property of the
-//!   data. `parse_pwb_with_warnings` reports the limit when it applies;
+//! - Status bytes: the generator status is located when a table carries the
+//!   validated status tail (a zero byte, then bit 0 of the status byte, then
+//!   GenRMPCT as an f32) one past the f32 block on every record. Every 483
+//!   era record carries it, and so do the 425 era records of writers that
+//!   emit it, checked against the open machines the paired `.aux` or `.raw`
+//!   export of the same case states. Whether the tail is there is a property
+//!   of the writer, so the table is walked twice, once requiring it and once
+//!   consuming none, rather than probed per record: a chance match on one
+//!   record would move where the next record is looked for. A 425 era table
+//!   that puts something else there keeps no located status, so its machines
+//!   read as in service; that is a limit of the decoding, not a property of
+//!   the data. `parse_pwb_with_warnings` reports the limit when it applies;
 //!   `parse_pwb` discards the warning. No other device status is located,
 //!   so every other device reads as in service.
 //!   The load record's post ID byte, once treated as a status, is 0x00 in
@@ -337,9 +340,10 @@ fn parse_pwb_inner(bytes: &[u8], name_hint: Option<&str>) -> Result<(BalancedNet
 /// [`parse_pwb`]): the 425/508 era bus + ID shape (`plain`), the 2021 era
 /// regulated bus shape (`reg`, [`read_gen_reg_record`]), and the 554 shape
 /// whose regulated bus record omits the presence byte (`simple_reg`,
-/// [`read_gen_reg_simple_record`]). A `plain` record reports whether it
-/// carried the status tail, and [`resolve_plain_gen_status`] reads the status
-/// only when every record of the table did.
+/// [`read_gen_reg_simple_record`]). A `plain` table is walked twice, once
+/// requiring the status tail on every record ([`read_gen_record_tailed`]) and
+/// once consuming none ([`read_gen_record_plain`]), so the tail is decided for
+/// the table rather than per record.
 #[derive(Clone, Copy)]
 struct GenVariants {
     plain: bool,
@@ -417,7 +421,8 @@ fn search_table_chain(
         // The device and branch runs validate bus references, so their
         // caches are scoped to one bus table candidate.
         let load_runs = RefCell::new(HashMap::new());
-        let gen_runs = RefCell::new(HashMap::new());
+        let gen_tailed_runs = RefCell::new(HashMap::new());
+        let gen_plain_runs = RefCell::new(HashMap::new());
         let gen_reg_runs = RefCell::new(HashMap::new());
         let gen_reg_simple_runs = RefCell::new(HashMap::new());
         let shunt_runs = RefCell::new(HashMap::new());
@@ -491,8 +496,27 @@ fn search_table_chain(
                                 bytes,
                                 l_end..l_end.saturating_add(RESYNC_WINDOW),
                                 &bus_ids,
-                                read_gen_record,
-                                &gen_runs,
+                                read_gen_record_tailed,
+                                &gen_tailed_runs,
+                                device_glue.plain_gen,
+                                38,
+                                budget,
+                            )
+                        })
+                        .into_iter()
+                        .flatten()
+                        .map(|c| (c, GenStatus::Decoded)),
+                )
+                .chain(
+                    gen_variants
+                        .plain
+                        .then(|| {
+                            device_table_candidates(
+                                bytes,
+                                l_end..l_end.saturating_add(RESYNC_WINDOW),
+                                &bus_ids,
+                                read_gen_record_plain,
+                                &gen_plain_runs,
                                 device_glue.plain_gen,
                                 32,
                                 budget,
@@ -500,7 +524,7 @@ fn search_table_chain(
                         })
                         .into_iter()
                         .flatten()
-                        .map(|(rows, end)| resolve_plain_gen_status(rows, end)),
+                        .map(|c| (c, GenStatus::Unlocated)),
                 );
             for ((generators, g_end), gen_status) in gen_candidates {
                 if gen_table_continues(bytes, g_end, &bus_ids, gen_variants, budget) {
@@ -597,30 +621,6 @@ fn search_table_chain(
     None
 }
 
-/// Resolve the service status of a plain generator table. The 425 era record
-/// carries the status tail on every record or on none, by writer: eighteen
-/// files of one corpus carry it and ACTIVSg200 puts other bytes there. A
-/// table that carries it on every record is read with its decoded status; any
-/// other table reads every machine as in service, which is what the reader
-/// can state about those bytes.
-fn resolve_plain_gen_status(
-    rows: Vec<(Generator, bool)>,
-    end: usize,
-) -> ((Vec<Generator>, usize), GenStatus) {
-    if rows.iter().all(|(_, tail)| *tail) {
-        let gens = rows.into_iter().map(|(machine, _)| machine).collect();
-        return ((gens, end), GenStatus::Decoded);
-    }
-    let gens = rows
-        .into_iter()
-        .map(|(mut machine, _)| {
-            machine.in_service = true;
-            machine
-        })
-        .collect();
-    ((gens, end), GenStatus::Unlocated)
-}
-
 /// Keep the table chain with the largest decoded electrical core, together
 /// with whether its generator table carried a located service status.
 fn keep_best_chain(
@@ -632,9 +632,15 @@ fn keep_best_chain(
     let candidate_ok = net.is_ok();
     let replace = match best.as_ref() {
         None => true,
-        Some((best_score, _, best_net)) => match (best_net.is_ok(), candidate_ok) {
+        Some((best_score, best_status, best_net)) => match (best_net.is_ok(), candidate_ok) {
             (false, true) => true,
             (true, false) => false,
+            // Both plain generator readers accept a table whose records all
+            // carry the tail, so equal scores are decided by the status: the
+            // located one states what the other cannot.
+            _ if score == *best_score => {
+                *best_status == GenStatus::Unlocated && status == GenStatus::Decoded
+            }
             _ => score > *best_score,
         },
     };
@@ -680,7 +686,10 @@ fn gen_table_continues(
     (after..after.saturating_add(RESYNC_WINDOW).min(bytes.len()))
         .take_while(|_| budget.tick())
         .any(|p| {
-            (variants.plain && read_gen_record(bytes, p, bus_ids).is_ok())
+            // The plain reader accepts a record whether or not a tail
+            // follows it, since it consumes none, so it answers for both
+            // plain writers.
+            (variants.plain && read_gen_record_plain(bytes, p, bus_ids).is_ok())
                 || (variants.reg && read_gen_reg_record(bytes, p, bus_ids).is_ok())
                 || (variants.simple_reg && read_gen_reg_simple_record(bytes, p, bus_ids).is_ok())
         })
@@ -1392,7 +1401,7 @@ fn read_device_head<T>(
     b: &[u8],
     at: usize,
     bus_ids: &BusIdSet,
-    read: fn(&mut Cur, BusId, &[u8]) -> Probe<T>,
+    read: impl Fn(&mut Cur, BusId, &[u8]) -> Probe<T>,
 ) -> Probe<(T, usize)> {
     let mut c = Cur { b, pos: at };
     let bus = c.u32()? as usize;
@@ -1412,11 +1421,17 @@ fn read_load_record(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<(Load, usi
     read_device_head(b, at, bus_ids, read_load)
 }
 
-/// Probe one plain generator record using the shared device head. The bool is
-/// whether the record carried the validated status tail (see
-/// [`resolve_plain_gen_status`]).
-fn read_gen_record(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<((Generator, bool), usize)> {
-    read_device_head(b, at, bus_ids, read_gen)
+/// Probe one plain generator record whose writer emits the status tail: the
+/// record must carry it, so a table accepted through this reader carries a
+/// decoded status on every machine.
+fn read_gen_record_tailed(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<(Generator, usize)> {
+    read_device_head(b, at, bus_ids, |c, bus, id| read_gen(c, bus, id, true))
+}
+
+/// Probe one plain generator record whose writer emits no status tail: the
+/// record ends at the f32 block and its machine reads as in service.
+fn read_gen_record_plain(b: &[u8], at: usize, bus_ids: &BusIdSet) -> Probe<(Generator, usize)> {
+    read_device_head(b, at, bus_ids, |c, bus, id| read_gen(c, bus, id, false))
 }
 
 /// Probe one switched shunt record using the shared device head.
@@ -1551,7 +1566,7 @@ fn read_load(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<Load> {
 /// one; the voltage setpoint and MVA base ranges anchor the choice, and a
 /// record that puts implausible values at every offset is a loud error, not
 /// a generator.
-fn read_gen(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<(Generator, bool)> {
+fn read_gen(c: &mut Cur, bus: BusId, id: &[u8], require_tail: bool) -> Probe<Generator> {
     let record_start = c.pos - (4 + 1) - id.len(); // u32 bus + the ID length byte
     let mut chosen = None;
     // +12 extends the observed set to two character IDs in a 2018 era
@@ -1571,16 +1586,20 @@ fn read_gen(c: &mut Cur, bus: BusId, id: &[u8]) -> Probe<(Generator, bool)> {
     };
     c.pos = end;
     // Some writers of this era follow the f32 block with the same status tail
-    // the 2021 era regulated record carries. When it is there the status is
-    // decoded; when it is not, the record reads as in service and the table
-    // level check in `resolve_plain_gen_status` keeps a chance match from
-    // opening a running machine.
-    let mut tail = Cur { b: c.b, pos: end };
-    if let Ok((machine, pos)) = read_gen_reg_tail(&mut tail, bus.0, &v) {
-        c.pos = pos;
-        return Ok((machine, true));
+    // the 2021 era regulated record carries. Whether the tail is there is a
+    // property of the writer, so it is decided for the whole table by which
+    // reader walks it, not per record: a table walked as tailed requires the
+    // tail on every record and fails otherwise, and a table walked as plain
+    // never consumes it. Probing per record would let bytes that happen to
+    // match the tail consume six bytes on one record and not its neighbours,
+    // and the next record's resync scan starts from the previous record's
+    // end, so a chance match would move the accepted table itself.
+    if !require_tail {
+        return Ok(gen_from_block(bus, &v, true));
     }
-    Ok((gen_from_block(bus, &v, true), false))
+    let (machine, pos) = read_gen_reg_tail(c, bus.0, &v)?;
+    c.pos = pos;
+    Ok(machine)
 }
 
 /// The eight consecutive f32 per unit values both generator record eras
@@ -2153,6 +2172,60 @@ fn read_legacy_branch_tail(c: &mut Cur<'_>, tail_start: usize) -> Probe<(&'stati
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One plain generator record: `bus`, a two character ID, two flag
+    /// bytes, then the eight f32 block at +9. `tail` appends the validated
+    /// status tail, whose status byte the caller chooses.
+    fn gen_record(tail: Option<u8>) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.push(2);
+        bytes.extend_from_slice(b"G1");
+        bytes.extend_from_slice(&[0, 0]);
+        for value in [10.0f32, 0.0, 50.0, -50.0, 1.0, 100.0, 80.0, 0.0] {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        if let Some(status) = tail {
+            bytes.push(0);
+            bytes.push(status);
+            bytes.extend_from_slice(&50.0f32.to_le_bytes());
+        }
+        bytes.extend_from_slice(&[0xff; 8]);
+        bytes
+    }
+
+    /// The tail is the writer's property, so it is decided for the whole
+    /// table by which reader walks it. The plain reader ends every record at
+    /// the f32 block whatever follows, which keeps the next record's resync
+    /// scan starting from the same place; the tailed reader refuses a record
+    /// without the tail, so a table it accepts carries the status on every
+    /// machine.
+    #[test]
+    fn the_generator_status_tail_is_a_table_decision_not_a_per_record_probe() {
+        let ids = BusIdSet::Bitmap(vec![0b10]);
+        let block_end = 9 + 32;
+
+        let plain = gen_record(None);
+        let tailed = gen_record(Some(0x09));
+
+        for bytes in [&plain, &tailed] {
+            let (machine, end) = read_gen_record_plain(bytes, 0, &ids).unwrap();
+            assert_eq!(end, block_end, "the plain reader consumes no tail");
+            assert!(machine.in_service, "an unlocated status reads as closed");
+        }
+
+        assert!(
+            read_gen_record_tailed(&plain, 0, &ids).is_err(),
+            "the tailed reader refuses a record that carries no tail"
+        );
+        let (machine, end) = read_gen_record_tailed(&tailed, 0, &ids).unwrap();
+        assert_eq!(end, block_end + 6, "the tailed reader consumes the tail");
+        assert!(machine.in_service, "status bit 0 set is a closed machine");
+
+        let open = gen_record(Some(0x08));
+        let (machine, _) = read_gen_record_tailed(&open, 0, &ids).unwrap();
+        assert!(!machine.in_service, "status bit 0 clear is an open machine");
+    }
 
     #[test]
     fn the_retention_ceiling_kills_runs_and_reports_exhaustion() {

--- a/powerio-tx/src/format/powerworld/pwd.rs
+++ b/powerio-tx/src/format/powerworld/pwd.rs
@@ -21,10 +21,10 @@
 //!   terminated exactly by the next `ff ff ff ff`. The order is display
 //!   order, not case order.
 //! - The DisplaySubstation drawing records: each repeats the file's header
-//!   stamp (the u32 at offset 22) at +18, stores the position as f64 x/y at
-//!   +22/+30 with an f32 echo of both at +2/+6, and links its substation
-//!   number behind a marker byte (0x03 or 0x07 by writer era) in the style
-//!   tail. The record's type tag (the u16 at +0) varies per save, so the
+//!   stamp (the u32 past the header's optional canvas title) at +18, stores
+//!   the position as f64 x/y at +22/+30 with an f32 echo of both at +2/+6,
+//!   and links its substation number behind a marker byte (0x03 or 0x07 by
+//!   writer era) in the style tail. The record's type tag (the u16 at +0) varies per save, so the
 //!   reader keys on this structure instead: stamp echo, dual encoded
 //!   coordinates, and a link to every identity row in table order. Decoy
 //!   groups exist (field label records with the same count and plausible
@@ -49,6 +49,19 @@ const FMT: &str = "PowerWorld .pwd";
 
 /// The identity table tag behind the `ff ff ff ff` sentinel.
 const IDENTITY_TAG: [u8; 6] = [0xff, 0xff, 0xff, 0xff, 0x3d, 0x0f];
+
+/// The word every probed save writes one u32 past the header stamp. It pins
+/// which of the two candidate positions holds the stamp when a canvas title
+/// shifts it (see [`parse_pwd_header`]).
+const HEADER_TRAILER: u32 = 10105;
+
+/// Where the stamp sits when the header carries no canvas title.
+const UNTITLED_STAMP_AT: usize = 22;
+
+/// Longest canvas title the header shift accepts. Every probed save is well
+/// under it; a length past it is a corrupt or unrecognized header, not a
+/// title, so the reader falls back to the untitled position.
+const MAX_TITLE_LEN: usize = 256;
 
 /// Cap on identity record steps across every anchor in one parse. A step is one
 /// record examined; each consumes at least 13 bytes, so the largest real table
@@ -147,7 +160,7 @@ fn parse_pwd_header(bytes: &[u8]) -> Result<(u16, u16, u32)> {
     if canvas_width == 0 || canvas_height == 0 {
         return Err(pwd_err("display header canvas dimensions are zero"));
     }
-    let stamp = u32_at(bytes, 22).unwrap_or(0);
+    let stamp = header_stamp(bytes).unwrap_or(0);
     if stamp == 0 {
         return Err(pwd_err(
             "display header stamp is zero; every validated save carries a nonzero stamp the \
@@ -155,6 +168,35 @@ fn parse_pwd_header(bytes: &[u8]) -> Result<(u16, u16, u32)> {
         ));
     }
     Ok((canvas_width, canvas_height, stamp))
+}
+
+/// The per file stamp every drawing object record repeats at +18.
+///
+/// A save with no canvas title puts it at offset 22. A save with one writes a
+/// u16 length at offset 10, a zero u16, the title text, and eight zero bytes,
+/// which shifts the stamp by the title length, so offset 22 holds title text
+/// and reads as a zero stamp. The shifted position is taken only when the
+/// whole title structure validates and the word past the stamp is the trailer
+/// every probed save writes, so a header that is not this shape reads the
+/// untitled position.
+fn header_stamp(bytes: &[u8]) -> Option<u32> {
+    let title_len = usize::from(u16_at(bytes, 10)?);
+    let titled_at = UNTITLED_STAMP_AT.checked_add(title_len)?;
+    let title_is_shaped = title_len <= MAX_TITLE_LEN
+        && u16_at(bytes, 12) == Some(0)
+        && bytes
+            .get(14..14 + title_len)
+            .is_some_and(|title| title.iter().all(|&c| (0x20..0x7f).contains(&c)))
+        && bytes
+            .get(14 + title_len..UNTITLED_STAMP_AT + title_len)
+            .is_some_and(|gap| gap.iter().all(|&c| c == 0));
+    if title_is_shaped
+        && u32_at(bytes, titled_at).is_some_and(|stamp| stamp != 0)
+        && u32_at(bytes, titled_at + 4) == Some(HEADER_TRAILER)
+    {
+        return u32_at(bytes, titled_at);
+    }
+    u32_at(bytes, UNTITLED_STAMP_AT)
 }
 
 fn parse_pwd_inner(bytes: &[u8]) -> Result<PwdDisplay> {

--- a/powerio-tx/tests/common/mod.rs
+++ b/powerio-tx/tests/common/mod.rs
@@ -47,6 +47,18 @@ pub fn activsg2000_fetched(name: &str) -> Option<PathBuf> {
     p.exists().then_some(p)
 }
 
+/// The root of a local directory of PowerWorld case files, which
+/// `POWERIO_PWB_CASES` names; `None` when the variable is unset or names no
+/// directory, so tests skip instead of fail. Such files run to hundreds of
+/// kilobytes each and carry whatever licence their holder obtained them
+/// under, so none is vendored and only a machine that already holds a corpus
+/// runs the tests that read one.
+#[allow(dead_code)]
+pub fn pwb_cases_root() -> Option<PathBuf> {
+    let root = PathBuf::from(std::env::var_os("POWERIO_PWB_CASES")?);
+    root.is_dir().then_some(root)
+}
+
 /// A fetched RTS-GMLC fixture (`benchmarks/fetch_powerworld.sh`); `None`
 /// when the fetch has not run, so tests skip instead of fail.
 #[allow(dead_code)]

--- a/powerio-tx/tests/powerworld_pwb.rs
+++ b/powerio-tx/tests/powerworld_pwb.rs
@@ -1581,3 +1581,363 @@ fn texas7k_resaves_match_the_2022_aux() {
         );
     }
 }
+
+/// The reader against a local directory of PowerWorld cases, which
+/// `POWERIO_PWB_CASES` names. Every `.pwb` under it must decode, and every
+/// MATPOWER `.m` or PSS/E `.RAW` case in the same directory holding the same
+/// network in the same solved state is compared against the decode element
+/// for element. Unset, the variable skips the test; set, a binary the reader
+/// refuses fails and names the file, which is the point of running it over a
+/// corpus.
+///
+/// Pairing is by bus identity and solved state, never by file name: a text
+/// export of a case can hold a later operating point than the binary beside
+/// it, and two saves of one hour can differ only in their limits. Each
+/// quantity is compared at the text side's print quantum plus a relative term
+/// for the binary's f32 storage. The reader's documented gaps (per bus
+/// voltage limits, the slack designation, the system MVA base) are not
+/// compared, and neither is a quantity whose spelling is a property of the
+/// text format rather than of the case: PSS/E can collapse a machine's
+/// reactive limits onto its solved output, MATPOWER writes the solved bus
+/// voltage in the setpoint column and cannot tell a unity ratio transformer
+/// from a line.
+#[test]
+fn local_pwb_cases_match_their_text_siblings() {
+    let Some(root) = common::pwb_cases_root() else {
+        eprintln!("skipped: set POWERIO_PWB_CASES to a directory of PowerWorld cases");
+        return;
+    };
+    let mut files = Vec::new();
+    collect_case_files(&root, &mut files);
+    files.sort();
+
+    let mut siblings: Vec<(std::path::PathBuf, Quanta, BalancedNetwork)> = Vec::new();
+    for path in &files {
+        let quanta = match lowercase_extension(path).as_deref() {
+            Some("m") => Quanta::MATPOWER,
+            Some("raw") => Quanta::PSSE,
+            _ => continue,
+        };
+        match parse_file(path, None) {
+            Ok(parsed) => siblings.push((path.clone(), quanta, parsed.network)),
+            Err(err) => eprintln!("skipped {}: not a case ({err})", path.display()),
+        }
+    }
+
+    let (mut binaries, mut compared) = (0usize, 0usize);
+    for path in &files {
+        if lowercase_extension(path).as_deref() != Some("pwb") {
+            continue;
+        }
+        binaries += 1;
+        let bytes = std::fs::read(path).unwrap();
+        let pwb = __parse_pwb(&bytes, path.file_stem().and_then(|s| s.to_str()))
+            .unwrap_or_else(|err| panic!("{} did not decode: {err}", path.display()));
+        assert_decoded_shape(&pwb, path);
+        for (sibling, quanta, text) in &siblings {
+            if !holds_the_same_state(&pwb, text) {
+                continue;
+            }
+            compared += 1;
+            let label = format!("{} against {}", path.display(), sibling.display());
+            eprintln!("comparing {label}");
+            assert_pwb_matches_text(&pwb, text, *quanta, &label);
+        }
+    }
+    eprintln!(
+        "POWERIO_PWB_CASES: {binaries} binaries, {} text cases, {compared} compared pairs",
+        siblings.len()
+    );
+    assert!(
+        binaries == 0 || siblings.is_empty() || compared > 0,
+        "no text case under {} holds the solved state of any of its {binaries} binaries",
+        root.display()
+    );
+}
+
+/// The print quantum of each quantity in one text format, the tolerance a
+/// decode is compared at. A format prints a fixed number of decimals per
+/// column, so the quantum is a property of the format, not of the case.
+#[derive(Clone, Copy)]
+struct Quanta {
+    /// Whether the format keeps the case's own reactive limits, voltage
+    /// setpoint, and line/transformer split (see the test's own docs).
+    faithful_machine_and_device: bool,
+    vm: f64,
+    va: f64,
+    base_kv: f64,
+    power: f64,
+    impedance: f64,
+    charging: f64,
+    rating: f64,
+    tap: f64,
+    vg: f64,
+}
+
+impl Quanta {
+    const PSSE: Self = Self {
+        faithful_machine_and_device: false,
+        vm: 5.1e-6,
+        va: 5.1e-5,
+        base_kv: 5.1e-4,
+        power: 5.1e-4,
+        impedance: 5.1e-6,
+        charging: 5.1e-6,
+        rating: 5.1e-3,
+        tap: 5.1e-6,
+        vg: 5.1e-6,
+    };
+    const MATPOWER: Self = Self {
+        faithful_machine_and_device: true,
+        vm: 5.1e-8,
+        va: 5.1e-6,
+        base_kv: 5.1e-3,
+        power: 5.1e-3,
+        impedance: 5.1e-7,
+        charging: 5.1e-6,
+        rating: 5.1e-3,
+        tap: 5.1e-6,
+        vg: 5.1e-5,
+    };
+}
+
+/// Every case file under `dir`, recursively.
+fn collect_case_files(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_case_files(&path, out);
+        } else if path.is_file() {
+            out.push(path);
+        }
+    }
+}
+
+fn lowercase_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_lowercase)
+}
+
+/// Whether two networks hold the same buses in the same solved state, the
+/// pairing rule. The window is far wider than any print quantum and far
+/// narrower than the spread between two operating points of one case.
+fn holds_the_same_state(pwb: &BalancedNetwork, text: &BalancedNetwork) -> bool {
+    let by_id: BTreeMap<usize, &powerio_tx::Bus> =
+        text.buses().iter().map(|b| (b.id.0, b)).collect();
+    pwb.buses().len() == by_id.len()
+        && pwb.buses().iter().all(|p| {
+            by_id
+                .get(&p.id.0)
+                .is_some_and(|t| (p.vm - t.vm).abs() <= 1e-4 && (p.va - t.va).abs() <= 1e-3)
+        })
+}
+
+/// The invariants every decode holds whatever the vintage: identified buses,
+/// every device attached to one of them, and finite values throughout.
+fn assert_decoded_shape(net: &BalancedNetwork, path: &Path) {
+    let name = path.display();
+    assert!(!net.buses().is_empty(), "{name}: no buses");
+    assert!(net.base_mva() > 0.0, "{name}: base MVA");
+    let ids: BTreeSet<usize> = net.buses().iter().map(|b| b.id.0).collect();
+    assert_eq!(ids.len(), net.buses().len(), "{name}: repeated bus id");
+    for bus in net.buses() {
+        assert!(
+            bus.vm.is_finite() && bus.vm > 0.0,
+            "{name}: bus {} vm",
+            bus.id
+        );
+        assert!(bus.va.is_finite(), "{name}: bus {} va", bus.id);
+        assert!(bus.base_kv.is_finite(), "{name}: bus {} kV", bus.id);
+    }
+    for load in net.loads() {
+        assert!(ids.contains(&load.bus.0), "{name}: load off bus");
+        assert!(
+            load.p.is_finite() && load.q.is_finite(),
+            "{name}: load power"
+        );
+    }
+    for shunt in net.shunts() {
+        assert!(ids.contains(&shunt.bus.0), "{name}: shunt off bus");
+        assert!(shunt.g.is_finite() && shunt.b.is_finite(), "{name}: shunt");
+    }
+    for machine in net.generators() {
+        assert!(ids.contains(&machine.bus.0), "{name}: generator off bus");
+        assert!(
+            machine.pg.is_finite() && machine.qg.is_finite(),
+            "{name}: dispatch"
+        );
+        assert!(machine.pmax >= machine.pmin, "{name}: generator MW limits");
+    }
+    for branch in net.branches() {
+        assert!(ids.contains(&branch.from.0), "{name}: branch off bus");
+        assert!(ids.contains(&branch.to.0), "{name}: branch off bus");
+        assert!(
+            branch.r.is_finite() && branch.x.is_finite() && branch.b.is_finite(),
+            "{name}: branch impedance"
+        );
+    }
+}
+
+/// Two readings of one case, compared element for element.
+#[allow(clippy::too_many_lines)]
+fn assert_pwb_matches_text(pwb: &BalancedNetwork, text: &BalancedNetwork, q: Quanta, label: &str) {
+    let text_bus: BTreeMap<usize, &powerio_tx::Bus> =
+        text.buses().iter().map(|b| (b.id.0, b)).collect();
+    for p in pwb.buses() {
+        let t = text_bus[&p.id.0];
+        close(
+            p.base_kv,
+            t.base_kv,
+            q.base_kv,
+            label,
+            &format!("bus {} kV", p.id),
+        );
+        assert_eq!((p.area, p.zone), (t.area, t.zone), "{label}: bus {}", p.id);
+        close(p.vm, t.vm, q.vm, label, &format!("bus {} vm", p.id));
+        close(p.va, t.va, q.va, label, &format!("bus {} va", p.id));
+        // MATPOWER has no bus name column, so a name comparison is only
+        // meaningful against a format that carries one.
+        if t.name.is_some() {
+            assert_eq!(
+                p.name.as_deref().map(str::trim),
+                t.name.as_deref().map(str::trim),
+                "{label}: bus {} name",
+                p.id
+            );
+        }
+    }
+
+    // Power per bus, not per record: a format that keeps one record per bus
+    // writes the zero ones a format that keeps only the nonzero ones omits.
+    assert_power_by_bus(
+        &power_by_bus(pwb.loads().iter().map(|l| (l.bus.0, l.p, l.q))),
+        &power_by_bus(text.loads().iter().map(|l| (l.bus.0, l.p, l.q))),
+        q.power,
+        label,
+        ("load", "P", "Q"),
+    );
+    assert_power_by_bus(
+        &power_by_bus(pwb.shunts().iter().map(|s| (s.bus.0, s.g, s.b))),
+        &power_by_bus(text.shunts().iter().map(|s| (s.bus.0, s.g, s.b))),
+        q.power,
+        label,
+        ("shunt", "G", "B"),
+    );
+
+    assert_eq!(
+        pwb.generators().len(),
+        text.generators().len(),
+        "{label}: generator count"
+    );
+    for (p, t) in pwb.generators().iter().zip(text.generators()) {
+        assert_eq!(p.bus, t.bus, "{label}: generator table order");
+        let at = format!("generator at {}", p.bus);
+        close(p.pmax, t.pmax, q.power, label, &format!("{at} pmax"));
+        close(p.pmin, t.pmin, q.power, label, &format!("{at} pmin"));
+        close(p.mbase, t.mbase, q.power, label, &format!("{at} mbase"));
+        assert_eq!(p.in_service, t.in_service, "{label}: {at} status");
+        // A format may zero the dispatch of an open machine rather than keep
+        // the last one, so only a running machine's output is comparable.
+        if p.in_service {
+            close(p.pg, t.pg, q.power, label, &format!("{at} pg"));
+            close(p.qg, t.qg, q.power, label, &format!("{at} qg"));
+        }
+        if q.faithful_machine_and_device {
+            close(p.qmax, t.qmax, q.power, label, &format!("{at} qmax"));
+            close(p.qmin, t.qmin, q.power, label, &format!("{at} qmin"));
+        } else {
+            close(p.vg, t.vg, q.vg, label, &format!("{at} vg"));
+        }
+    }
+
+    let mut text_branch: BTreeMap<(usize, usize, String), &powerio_tx::Branch> =
+        BTreeMap::default();
+    for (key, b) in branch_keys(text.branches())
+        .into_iter()
+        .zip(text.branches())
+    {
+        text_branch.insert(key, b);
+    }
+    for (key, p) in branch_keys(pwb.branches()).into_iter().zip(pwb.branches()) {
+        let t = text_branch
+            .remove(&key)
+            .unwrap_or_else(|| panic!("{label}: branch {key:?} is not in the text case"));
+        let at = format!("branch {key:?}");
+        close(p.r, t.r, q.impedance, label, &format!("{at} R"));
+        close(p.x, t.x, q.impedance, label, &format!("{at} X"));
+        close(p.b, t.b, q.charging, label, &format!("{at} B"));
+        close(p.rate_a, t.rate_a, q.rating, label, &format!("{at} rate A"));
+        close(p.rate_b, t.rate_b, q.rating, label, &format!("{at} rate B"));
+        close(p.rate_c, t.rate_c, q.rating, label, &format!("{at} rate C"));
+        close(p.shift, t.shift, q.va, label, &format!("{at} shift"));
+        // The effective ratio compares across the two spellings of an
+        // untapped branch (a stored zero and a stored one both mean one).
+        close(
+            p.calc_effective_tap(),
+            t.calc_effective_tap(),
+            q.tap,
+            label,
+            &format!("{at} tap"),
+        );
+        if !q.faithful_machine_and_device {
+            assert_eq!(
+                p.is_transformer(),
+                t.is_transformer(),
+                "{label}: {at} device"
+            );
+        }
+    }
+    assert!(
+        text_branch.is_empty(),
+        "{label}: branches only in the text case: {:?}",
+        text_branch.keys()
+    );
+}
+
+/// Equality at a print quantum, widened by the relative error of the f32
+/// storage the binary uses for most quantities.
+fn close(decoded: f64, text: f64, quantum: f64, label: &str, at: &str) {
+    let window = quantum + 1e-6 * decoded.abs().max(text.abs());
+    assert!(
+        (decoded - text).abs() <= window,
+        "{label}: {at} {decoded} vs {text} (window {window})"
+    );
+}
+
+/// Sum a `(bus, x, y)` stream per bus.
+fn power_by_bus(items: impl Iterator<Item = (usize, f64, f64)>) -> BTreeMap<usize, (f64, f64)> {
+    let mut out: BTreeMap<usize, (f64, f64)> = BTreeMap::default();
+    for (bus, x, y) in items {
+        let entry = out.entry(bus).or_default();
+        entry.0 += x;
+        entry.1 += y;
+    }
+    out
+}
+
+/// Compare per bus power totals over the buses either side holds, a bus only
+/// one side holds reading as zero power. `names` labels the element and its
+/// two components in a failure message.
+fn assert_power_by_bus(
+    left: &BTreeMap<usize, (f64, f64)>,
+    right: &BTreeMap<usize, (f64, f64)>,
+    quantum: f64,
+    label: &str,
+    names: (&str, &str, &str),
+) {
+    let (kind, first, second) = names;
+    let buses: BTreeSet<usize> = left.keys().chain(right.keys()).copied().collect();
+    for bus in buses {
+        let zero = (0.0, 0.0);
+        let (a, b) = (
+            left.get(&bus).copied().unwrap_or(zero),
+            right.get(&bus).copied().unwrap_or(zero),
+        );
+        close(a.0, b.0, quantum, label, &format!("{kind} {bus} {first}"));
+        close(a.1, b.1, quantum, label, &format!("{kind} {bus} {second}"));
+    }
+}

--- a/powerio-tx/tests/powerworld_pwd.rs
+++ b/powerio-tx/tests/powerworld_pwd.rs
@@ -309,3 +309,32 @@ fn rejects_non_display_inputs() {
     assert_eq!(display.stamp, 0xa83c);
     assert!(display.substations.is_empty());
 }
+
+/// A display header can carry a canvas title, which shifts the per file
+/// stamp past the title text: the fixed offset an untitled save puts it at
+/// then holds title bytes and reads as a zero stamp, and the reader refused
+/// such a file as unrecognized. The same save with a title inserted decodes
+/// to the same substations, since the stamp is only an anchor and every
+/// drawing record repeats it.
+#[test]
+fn a_titled_display_header_finds_the_stamp_past_its_title() {
+    let bytes = fs::read(common::powerworld_vendored("ACTIVSg200.pwd")).unwrap();
+    let untitled = __parse_pwd(&bytes).unwrap();
+    assert!(!untitled.is_empty());
+
+    let title = b"CANVAS";
+    let mut titled = Vec::with_capacity(bytes.len() + title.len());
+    titled.extend_from_slice(&bytes[..10]);
+    titled.extend_from_slice(&u16::try_from(title.len()).unwrap().to_le_bytes());
+    titled.extend_from_slice(&bytes[12..14]);
+    titled.extend_from_slice(title);
+    titled.extend_from_slice(&bytes[14..]);
+
+    assert_eq!(__parse_pwd(&titled).unwrap(), untitled);
+    let display = __parse_pwd_display(&titled).unwrap();
+    let plain = __parse_pwd_display(&bytes).unwrap();
+    assert_eq!(
+        (display.canvas_width, display.canvas_height),
+        (plain.canvas_width, plain.canvas_height)
+    );
+}


### PR DESCRIPTION
## Summary

- Accept `.pwb` bus records with flag bit 2 clear; the bit joins the presence set and stays in the record family key.
- Header constant 537 tries both generator record shapes in sequence, as 508 does.
- Read the status tail on the 425-era generator record when every record of the table carries it.
- Fix `.pwd` displays refused when a canvas title shifts the per-file stamp past offset 22.
- `FORMAT.md` records the flag word census and the accept rule.

## Testing

- `cargo test -p powerio-tx -p powerio`
- Opt-in comparison against MATPOWER and PSS/E exports of the same cases; `POWERIO_PWB_CASES` names the directory, unset skips.
