### PR TITLE
docs(test): harden deferred OpenDSS geometry against silent defaults

### DIFF
--- a/docs/dss-geometry-safety.md
+++ b/docs/dss-geometry-safety.md
@@ -1,0 +1,47 @@
+# Safe handling of deferred OpenDSS line geometry
+
+## Problem
+
+OpenDSS line impedance can be defined indirectly through the geometry family:
+`LineGeometry`, `LineSpacing`, `WireData`, `CNData`, and `TSData`. These classes
+are not yet lowered into the canonical multiconductor impedance model.
+
+A deferred source concept must not be normalized as though the user had omitted
+impedance data. In particular, the OpenDSS `Line` constructor defaults
+(`R1=0.058`, `X1=0.1206`, `R0=0.1784`, `X0=0.4047`) are not valid substitutes for
+a geometry-defined line.
+
+## Safety invariant
+
+Until Carson/geometry impedance calculation is implemented:
+
+1. Detect a `Line` that references `geometry=`, `spacing=`, or `wires=`.
+2. Do not synthesize a `DistLineCode` from OpenDSS `Line` factory defaults.
+3. Do not infer/fabricate conductor count from the balanced `phases` default.
+4. Emit a **parse-time diagnostic** identifying the deferred geometry source.
+5. Preserve the original source object so same-format DSS echo remains lossless.
+6. Keep explicit `linecode=` behavior unchanged.
+7. A one-conductor SWER geometry must never become a three-conductor normalized line.
+
+The preferred long-term representation is an explicit unresolved/deferred line
+reference in the canonical model. If that representation is not yet available,
+the reader should fail closed rather than manufacture electrical parameters.
+
+## Regression cases
+
+The regression harness in `powerio-dist/tests/dss_geometry_safety.rs` covers:
+
+- a 3-phase overhead `LineGeometry` backed by `WireData`;
+- a single-conductor SWER `LineGeometry`;
+- parse-time diagnostics for deferred geometry;
+- protection against OpenDSS factory-default `R1` leaking into a geometry line.
+
+The tests are currently `#[ignore]` because they encode the target invariant while
+the canonical model's deferred-line representation is being finalized. They are
+intended to become ordinary tests in the implementation PR.
+
+## Upstream context
+
+This work addresses the safety boundary described in
+[eigenergy/powerio#479](https://github.com/eigenergy/powerio/issues/479), while
+remaining separate from full typed geometry support tracked in #84.

--- a/powerio-dist/tests/dss_geometry_safety.rs
+++ b/powerio-dist/tests/dss_geometry_safety.rs
@@ -1,0 +1,80 @@
+//! Regression harness for OpenDSS geometry-defined lines.
+//!
+//! Geometry-family classes (`LineGeometry`, `LineSpacing`, `WireData`,
+//! `CNData`, `TSData`) are currently deferred by the typed distribution model.
+//! Until typed geometry lowering exists, a geometry-backed line must not be
+//! normalized with OpenDSS `Line` factory impedance or a fabricated conductor
+//! count. These tests are intentionally ignored while the normalization
+//! contract is being changed; they document the expected safety invariant.
+
+use std::fs;
+
+use powerio_core::Source;
+use powerio_dist::parse;
+
+fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
+    let dir = std::env::temp_dir().join(format!("powerio-dss-geometry-{name}-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("master.dss");
+    fs::write(&path, text).unwrap();
+    parse(Source::open(&path).unwrap()).unwrap()
+}
+
+#[test]
+#[ignore = "geometry lowering contract is being hardened; see eigenergy/powerio#479"]
+fn geometry_line_is_not_replaced_by_factory_defaults() {
+    let module = parse_text(
+        "geometry-defaults",
+        r#"clear
+new circuit.t basekv=4.16 phases=3 bus1=sourcebus
+new wiredata.w rac=0.1859 gmr=0.0313 radius=0.4635 runits=mi gmrunits=ft radunits=in
+new linegeometry.g nconds=4 nphases=3 reduce=no
+~ cond=1 wire=w x=2.5 h=29 units=ft
+~ cond=2 wire=w x=0 h=29 units=ft
+~ cond=3 wire=w x=7 h=29 units=ft
+~ cond=4 wire=w x=4 h=25 units=ft
+new line.l bus1=sourcebus bus2=b geometry=g length=1 units=m
+"#,
+    );
+
+    // Safety invariant: unsupported geometry must produce a diagnostic and
+    // must not create a typed linecode containing the OpenDSS factory R/X.
+    let rendered = powerio_dist::diagnostics::render_diagnostics(module.diagnostics());
+    assert!(
+        rendered.iter().any(|d| d.to_ascii_lowercase().contains("geometry")),
+        "expected a parse-time geometry diagnostic, got {rendered:?}"
+    );
+    let net = module.value();
+    assert!(
+        net.linecodes().iter().all(|c| {
+            c.r_series
+                .first()
+                .and_then(|row| row.first())
+                .is_none_or(|r| (*r - 0.09813333333333334).abs() > 1e-12)
+        }),
+        "geometry line must not inherit OpenDSS factory R1"
+    );
+}
+
+#[test]
+#[ignore = "geometry lowering contract is being hardened; see eigenergy/powerio#479"]
+fn single_conductor_geometry_does_not_become_three_conductors() {
+    let module = parse_text(
+        "swer",
+        r#"clear
+new circuit.swer basekv=19.1 phases=1 bus1=sourcebus
+new wiredata.w rac=1.093 gmr=0.00296 radius=0.00318 runits=km gmrunits=m radunits=m
+new linegeometry.g nconds=1 nphases=1 reduce=no
+~ cond=1 wire=w x=0 h=8.5 units=m
+new line.l bus1=sourcebus.1 bus2=b.1 geometry=g length=1 units=m
+"#,
+    );
+
+    let rendered = powerio_dist::diagnostics::render_diagnostics(module.diagnostics());
+    assert!(rendered.iter().any(|d| d.to_ascii_lowercase().contains("geometry")));
+    let net = module.value();
+    assert!(net.lines().is_empty() || net.lines().iter().all(|l| {
+        l.terminal_map_from.len() == 1 && l.terminal_map_to.len() == 1
+    }));
+}


### PR DESCRIPTION
Superseded by #495. Both contributed geometry cases run there as ordinary regression tests in `powerio-dist/tests/electrical_readiness.rs`, with contributor credit in the PR description. #495 closes #479 when merged.

## Summary

This draft contributes a regression harness and a concrete safety contract for the geometry-normalization issue in #479.

The current reader can normalize `Line` objects that reference the deferred OpenDSS geometry family using the `Line` class factory impedance defaults, while also deriving conductor count from the balanced phase default. The result can be electrically wrong before any writer is invoked.

### Included
- Regression harness for a geometry-backed overhead line.
- Regression harness for a single-conductor SWER geometry.
- Explicit parse-time-diagnostic expectation.
- Documentation of the fail-closed contract and the required long-term canonical representation.

### Why draft

The canonical `DistLine` currently requires a concrete `linecode` and impedance matrices. A complete fix therefore needs an intentional representation for a deferred/unresolved line rather than replacing the impedance with a sentinel that could accidentally reach a solver. I have deliberately not introduced a speculative schema change in this PR.

The target invariant is:

> Unsupported geometry must remain source-retained and explicitly diagnosed; it must never silently acquire OpenDSS factory impedance or a fabricated conductor count.

Explicit `linecode=` paths remain unchanged.

Closes the implementation gap described by #479 once the deferred-line representation is agreed.