### PR TITLE
Give PowerIO IR one version rule for the 0.11 line

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -189,11 +189,11 @@ jobs:
         <a href="$target">$1</a>
         HTML
         }
-        redirect_schema_page "pio-module/0.1"
-        redirect_schema_page "pio-module/0.2"
-        redirect_schema_page "pio-module/0.9"
-        redirect_schema_page "pio-module/0.10.0"
-        redirect_schema_page "pio-module/0.11.0"
+        # Every schema in the archive is served, so a release adds its
+        # directory and nothing here.
+        for schema in docs/schema/pio-module/*/schema.json; do
+          redirect_schema_page "$(dirname "${schema#docs/schema/}")"
+        done
     - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
       with:
         path: target/doc

--- a/.github/workflows/julia-binding.yml
+++ b/.github/workflows/julia-binding.yml
@@ -22,10 +22,10 @@ name: Julia binding
 on:
   push:
     branches: [ "main" ]
-    paths: [ "powerio/**", "powerio-capi/**", "powerio-matrix/**", "powerio-dist/**", "powerio-prob/**", ".github/workflows/julia-binding.yml" ]
+    paths: [ "powerio/**", "powerio-core/**", "powerio-tx/**", "powerio-capi/**", "powerio-matrix/**", "powerio-dist/**", "powerio-prob/**", ".github/workflows/julia-binding.yml" ]
   # No branch filter: stacked PRs must run this too (see rust.yml).
   pull_request:
-    paths: [ "powerio/**", "powerio-capi/**", "powerio-matrix/**", "powerio-dist/**", "powerio-prob/**", ".github/workflows/julia-binding.yml" ]
+    paths: [ "powerio/**", "powerio-core/**", "powerio-tx/**", "powerio-capi/**", "powerio-matrix/**", "powerio-dist/**", "powerio-prob/**", ".github/workflows/julia-binding.yml" ]
 
 # One run per workflow per branch. A force push to a stacked pull request
 # otherwise leaves the superseded run going: it finishes, it fails or it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,7 +178,7 @@ powerio-tx/                   # balanced network model, parsers, and emitters
 ├── src/lib.rs               # public re-exports
 ├── src/network.rs           # BalancedNetwork, Bus, Load, Shunt, Branch, Generator,
 │                            #   GenCost, Storage, Hvdc, BusType, SourceFormat;
-│                            #   to_json / from_json (the structured transport)
+│                            #   the serde form PowerIO IR nests as value.data
 ├── src/indexed.rs           # IndexCore, IndexedNetwork (dense indexed analysis
 │                            #   data), ConnectivityReport; petgraph data:
 │                            #   to_petgraph, is_radial, connectivity_report
@@ -311,9 +311,11 @@ fuzz/                        # libFuzzer targets (detached workspace; see fuzz/R
   durable source map, diagnostic, and history records. Retained source is run
   time data and is not serialized. `TimeSeries<T>` and `ScenarioSet<T>` belong
   in the typed value rather than common module fields and compose as
-  `ScenarioSet<TimeSeries<T>>`. PowerIO 0.11 reads and writes only
-  `powerio.module` version `0.11.0`. Collection indexing must not serialize or
-  clone the network.
+  `ScenarioSet<TimeSeries<T>>`. PowerIO writes `powerio.module` documents at
+  its own version and reads the compatible release line no newer than itself;
+  `powerio::IR_SCHEMA_VERSION` states the rule, so a 0.11.x change to the
+  document must be additive with a default. Collection indexing must not
+  serialize or clone the network.
 - **Bus IDs.** MATPOWER 1 based; `IndexedNetwork::bus_index(id)` is the only mapping into dense `[0, n)`. Don't clamp out of range; return `Error::UnknownBus`.
 - **`BR_B` is already per unit.** Never divide by `base_mva` again.
 - **`tap == 0` ⇒ `tap = 1`.** Use `Branch::effective_tap()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ public dependency boundaries.
 
 PowerIO IR has one document shape per release: `"schema": "powerio.module"`
 and `"version"` equal to the `powerio` crate version, beginning with
-`"0.11.0"`. A build reads every document a compatible release no newer than
-itself wrote, so 0.11.x documents stay readable across the line, and it refuses
-a newer document or a 0.10 document with the version named. Readers and upgrade
-code for earlier document generations are removed.
+`"0.11.0"`. A build reads every document a SemVer compatible release no newer
+than itself wrote, so a 0.11.x build reads the documents of every 0.11.x
+release up to its own, and it refuses a newer document or a 0.10 document with
+the version named. Readers and upgrade code for earlier document generations
+are removed.
+`powerio::IR_SCHEMA_NAME` re-exports `powerio_core::IR_SCHEMA_NAME`, so the
+document discriminator has one definition, and `powerio::IR_SCHEMA_ID` names
+the `$id` of the JSON Schema this build writes against.
 C ABI 7 is the only C ABI and contains no aliases for earlier ABI generations.
 
 `BalancedNetwork` and `MulticonductorNetwork` are the two electrical network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ work; an unavoidable breaking public API change moves to 0.12. PowerIO 1.0
 follows a downstream stabilization cycle and an explicit decision about those
 public dependency boundaries.
 
-PowerIO IR has one current document shape: `"schema": "powerio.module"` and
-`"version": "0.11.0"`. Beginning with this release, its version equals the
-`powerio` crate version. Readers and upgrade code for earlier documents are
-removed.
+PowerIO IR has one document shape per release: `"schema": "powerio.module"`
+and `"version"` equal to the `powerio` crate version, beginning with
+`"0.11.0"`. A build reads every document a compatible release no newer than
+itself wrote, so 0.11.x documents stay readable across the line, and it refuses
+a newer document or a 0.10 document with the version named. Readers and upgrade
+code for earlier document generations are removed.
 C ABI 7 is the only C ABI and contains no aliases for earlier ABI generations.
 
 `BalancedNetwork` and `MulticonductorNetwork` are the two electrical network

--- a/docs/release-notes/0.11.0-draft.md
+++ b/docs/release-notes/0.11.0-draft.md
@@ -107,7 +107,8 @@ The serializer and deserializer use PowerIO IR version `0.11.0`:
 `"schema": "powerio.module"` and `"version": "0.11.0"`. Beginning with this
 release, the IR version equals the `powerio` crate version, and every 0.11.x
 build reads the documents of the 0.11.x releases no newer than itself, the way
-an LLVM release reads the bitcode of the releases before it. A document from a
+an LLVM release reads the bitcode inside its compatibility window. A document
+from a
 newer patch, or from 0.10, is refused with its version named. Runtime retained
 source bytes are not serialized.
 

--- a/docs/release-notes/0.11.0-draft.md
+++ b/docs/release-notes/0.11.0-draft.md
@@ -105,7 +105,10 @@ multipliers replace the ambiguous beta price and signed branch dual fields.
 
 The serializer and deserializer use PowerIO IR version `0.11.0`:
 `"schema": "powerio.module"` and `"version": "0.11.0"`. Beginning with this
-release, the IR version equals the `powerio` crate version. Runtime retained
+release, the IR version equals the `powerio` crate version, and every 0.11.x
+build reads the documents of the 0.11.x releases no newer than itself, the way
+an LLVM release reads the bitcode of the releases before it. A document from a
+newer patch, or from 0.10, is refused with its version named. Runtime retained
 source bytes are not serialized.
 
 `docs/schema/README.md` records one PowerIO IR history. It archives the `0.1`,

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -19,9 +19,13 @@ replaced `NetworkPackage` with the serialization of `PioModule<PioValue>`.
 That is when the document discriminator changed to `powerio.module`.
 
 The v0.10.0 document used the integer version `1`. That choice suggested a
-stable first major schema while the IR was still changing, so v0.11.0 replaces
-it with the simpler rule that the PowerIO IR version is the `powerio` crate
-version. ABI 7 remains independent.
+stable first major schema while the IR was still changing, and it said nothing
+about which builds could read a document. From v0.11.0 the PowerIO IR version
+is the `powerio` release that wrote the document, which makes the reader's
+window a statement about releases rather than about an opaque counter: see
+[Compatibility policy](#compatibility-policy). ABI 7 remains independent, and
+the "Reader status" column above names the shape a build writes, not the whole
+set it reads.
 
 The four historical files are exact copies of the schemas checked into their
 releases. Their original `$id` values and field names are evidence of what
@@ -45,22 +49,34 @@ Generate the current schema with:
 cargo run -p powerio --example generate_schemas --features schema -- docs/schema
 ```
 
-CI regenerates the current file and fails on a difference. A release preserves
-its schema here; changing a historical file would erase evidence rather than
+CI regenerates the current file and fails on a difference. A release adds its
+generated directory and its row in the table above; `powerio/tests/frozen_schemas.rs`
+holds the directory, the table, and this build's version to one another, and
+the documentation site serves every directory listed. A release preserves its
+schema here; changing a historical file would erase evidence rather than
 upgrade a document.
 
 ## Compatibility policy
 
-The schema archive documents history. Compatibility exists only when the
-deserializer and its tests explicitly implement it. PowerIO v0.11.0 accepts
-the v0.11.0 document and rejects every other schema name or version.
+The schema archive documents history. Compatibility exists only where the
+deserializer and its tests implement it, and the deserializer implements one
+rule, stated once on `powerio::IR_SCHEMA_VERSION`: a build reads every
+document a SemVer compatible build no newer than itself wrote. On the `0.y`
+line that is the same minor version with a patch no later than the reader's,
+so PowerIO 0.11.3 reads the documents of 0.11.0 through 0.11.3 and refuses
+0.10.0, 0.12.0, and 0.11.4, naming the version it found and whether a newer
+PowerIO or a regenerated document is the remedy. The compatible line is
+therefore additive: a 0.11.x release may add a field with a default and may
+not remove or redefine one, which is what lets the newer reader read the older
+document without an upgrade pass.
 
 This follows the useful distinction in LLVM and MLIR between a current
-in-memory representation and supported serialized input. LLVM records released
-bitcode compatibility fixtures and upgrades supported old input; MLIR's stable
-bytecode lets a dialect record a version and provide an explicit upgrade hook.
-PowerIO does not claim either guarantee merely because an old JSON Schema is
-archived.
+in-memory representation and supported serialized input. LLVM reads the
+bitcode of the releases inside its compatibility window and upgrades it on
+load; MLIR's stable bytecode lets a dialect record a version and provide an
+explicit upgrade hook. PowerIO's window is the compatible release line, and it
+claims nothing for an earlier line merely because that line's JSON Schema is
+archived here.
 
 - [LLVM IR backwards compatibility](https://llvm.org/docs/DeveloperPolicy.html#ir-backwards-compatibility)
 - [MLIR bytecode versioning](https://mlir.llvm.org/docs/BytecodeFormat/#versioning)

--- a/docs/src/api-0.11.md
+++ b/docs/src/api-0.11.md
@@ -89,9 +89,10 @@ changes and whether energized connectivity changed.
 
 ## PowerIO IR and C ABI
 
-PowerIO IR version `0.11.0` has one shape:
-`"schema": "powerio.module"`, `"version": "0.11.0"`. It has no reader for
-earlier document versions or source alias.
+PowerIO IR has one shape per release: `"schema": "powerio.module"` and
+`"version"` naming the release that wrote it. A build reads the compatible
+0.11.x documents no newer than itself and has no reader for 0.10 documents and
+no source alias.
 
 C ABI 7 is the only exported ABI. It has no ABI 4, 5, or 6 symbol aliases. All
 values use opaque reference counted handles, explicit buffer lengths, one

--- a/docs/src/capi.md
+++ b/docs/src/capi.md
@@ -90,9 +90,11 @@ pio_destination_release(destination);
 ```
 
 `pio_module_serialize` writes PowerIO IR. `pio_module_deserialize` reads it.
-The IR header is `"schema": "powerio.module"` and
-`"version": "0.11.0"`; ABI 7 does not expose readers for earlier document
-versions or module JSON aliases.
+The IR header is `"schema": "powerio.module"` and `"version"` naming the
+library release that wrote it; `pio_schema_report` reports both.
+`pio_module_deserialize` reads the compatible 0.11.x documents no newer than
+the library and refuses any other with its version named. ABI 7 exposes no
+reader for 0.10 documents and no module JSON aliases.
 
 ## Collections, updates, and calculations
 

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -30,7 +30,7 @@ PowerIO's design borrows from LLVM and MLIR where their problems genuinely overl
 
 **Registries checked mechanically where tables drift.** Structural type names, format tokens, diagnostic codes, and drawn architecture edges are each held to one source by a CI gate, which is the maintainable slice of MLIR's declarative dialect definitions.
 
-**Serialization specified apart from memory.** `.pio.json` version `0.11.0` has an explicit schema and validation rules; the Rust structs never derive the public document layout. PowerIO v0.11.0 reads and writes only that shape, and [PowerIO IR reference](ir-reference.md) defines every structural type of that shape field by field, the way the MLIR language reference defines its types; a test holds the page to the generated schema.
+**Serialization specified apart from memory.** Each `.pio.json` version has an explicit schema and validation rules; the Rust structs never derive the public document layout. A build reads the documents of its compatible release line no newer than itself, the way an LLVM release reads the bitcode of the releases before it, and [PowerIO IR reference](ir-reference.md) defines every structural type field by field, the way the MLIR language reference defines its types; a test holds the page to the generated schema.
 
 **Scrutiny proportional to permanence.** A new core concept (a value family or common module record) needs a registered structural type name, an exact IR representation, and binding coverage. A new format adapter needs none of that.
 

--- a/docs/src/compiler-ir.md
+++ b/docs/src/compiler-ir.md
@@ -30,7 +30,7 @@ PowerIO's design borrows from LLVM and MLIR where their problems genuinely overl
 
 **Registries checked mechanically where tables drift.** Structural type names, format tokens, diagnostic codes, and drawn architecture edges are each held to one source by a CI gate, which is the maintainable slice of MLIR's declarative dialect definitions.
 
-**Serialization specified apart from memory.** Each `.pio.json` version has an explicit schema and validation rules; the Rust structs never derive the public document layout. A build reads the documents of its compatible release line no newer than itself, the way an LLVM release reads the bitcode of the releases before it, and [PowerIO IR reference](ir-reference.md) defines every structural type field by field, the way the MLIR language reference defines its types; a test holds the page to the generated schema.
+**Serialization specified apart from memory.** Each `.pio.json` version has an explicit schema and validation rules; the Rust structs never derive the public document layout. A build reads the documents of its compatible release line no newer than itself, the way an LLVM release reads the bitcode inside its compatibility window, and [PowerIO IR reference](ir-reference.md) defines every structural type field by field, the way the MLIR language reference defines its types; a test holds the page to the generated schema.
 
 **Scrutiny proportional to permanence.** A new core concept (a value family or common module record) needs a registered structural type name, an exact IR representation, and binding coverage. A new format adapter needs none of that.
 

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -155,5 +155,6 @@ support. It describes formats; value types are named by `PioValue` and its
 language counterparts.
 
 PowerIO IR is separate: `serialize` and `deserialize` preserve PowerIO types
-and module records. It has one 1.0 document shape and is absent from grid
-exchange format discovery.
+and module records. It has one document shape per release, which a build reads
+back across its own compatible line, and is absent from grid exchange format
+discovery.

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -1,9 +1,9 @@
 # Developer Guides
 
-Material for contributors: the 0.11 candidate API, crate graph, checked architecture
+Material for contributors: the 0.11 API, crate graph, checked architecture
 map, compiler infrastructure lessons, matrix internals, evaluation corpus,
 performance work, and release checks. The changelog records older releases;
-the guide documents only the 1.0 implementation. The dated design record
-behind the candidate 1.0 API (terminology, rationale, ontology, and architecture) lives
-outside the guide at
+the guide documents only the current implementation. The dated design record
+behind the candidate 1.0 API (terminology, rationale, ontology, and
+architecture) lives outside the guide at
 [`docs/design/`](https://github.com/eigenergy/powerio/tree/main/docs/design).

--- a/docs/src/distribution.md
+++ b/docs/src/distribution.md
@@ -24,9 +24,12 @@ result.diagnostics
 
 There is no implicit conversion between the multiconductor and balanced models. The balanced positive sequence equivalent is an explicit transformation that states its assumptions (voltage bases per zone, phase aggregation, switch merging) and refuses what it cannot state:
 
-```julia
-report = to_balanced_report(feeder)         # ready plus assumptions, losses, and diagnostics
-balanced = to_balanced(feeder)              # PioModule{BalancedNetwork}
+```rust
+let report = to_balanced_report(feeder)?;   // ready plus assumptions, losses, and diagnostics
+let balanced = to_balanced(feeder)?;        // PioModule<BalancedNetwork>
 ```
+
+This transformation is Rust and Python only in 0.11: it has no C ABI entry
+point, so PowerIO.jl does not bind it.
 
 Multiconductor admittance matrices build directly from the multiconductor network, without this transformation, through `powerio_matrix::calc_multiconductor_admittance_matrix`. This entry point is Rust only in 0.11: there is no C ABI entry point yet, so no Python or Julia binding exists either.

--- a/docs/src/migration-0.11.md
+++ b/docs/src/migration-0.11.md
@@ -110,9 +110,10 @@ formats.
 
 Use `serialize` and `deserialize` for PowerIO IR. `.pio.json` is not a grid
 exchange format and is absent from format discovery. Both operations use the
-PowerIO IR v0.11.0 document shape: `"schema": "powerio.module"` and
-`"version": "0.11.0"`. Earlier documents must be regenerated from their
-original power system data.
+PowerIO IR document shape: `"schema": "powerio.module"` and `"version"` naming
+the release that wrote it. Every 0.11.x build reads the documents of the
+0.11.x releases no newer than itself; 0.10 documents must be regenerated from
+their original power system data.
 
 The following 0.10 names are removed:
 

--- a/docs/src/pio-json-schema.md
+++ b/docs/src/pio-json-schema.md
@@ -17,8 +17,9 @@ version. The current document shape begins:
 }
 ```
 
-Use `serialize` to produce it and `deserialize` to read it. PowerIO v0.11.0
-reads the v0.11.0 document shape.
+Use `serialize` to produce it and `deserialize` to read it. A build reads the
+documents of its own compatible release line, as [Schema changes](#schema-changes)
+states.
 
 The generated JSON Schema is checked in at
 `docs/schema/pio-module/0.11.0/schema.json` and served from
@@ -126,6 +127,11 @@ than allocation failures or truncated results.
 ## Schema changes
 
 The version belongs to the PowerIO IR document, not the Rust memory layout, a
-grid exchange format, or the C ABI. PowerIO v0.11.0 writes and reads document
-version `0.11.0`. Historical schemas document what earlier releases produced;
-they do not add implicit compatibility to the deserializer.
+grid exchange format, or the C ABI. Since 0.11.0 it is the `powerio` release
+that wrote the document, and a build reads every document a SemVer compatible
+build no newer than itself wrote: PowerIO 0.11.3 reads the documents of 0.11.0
+through 0.11.3 and refuses 0.10.0, 0.12.0, and 0.11.4, naming the version it
+found and whether a newer PowerIO or a regenerated document is the remedy. A
+0.11.x release may therefore add a field with a default and may not remove or
+redefine one. Historical schemas document what earlier lines produced; they do
+not add compatibility to the deserializer.

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -114,10 +114,11 @@ powerio.serialize(module, "case.pio.json")
 same_module = powerio.deserialize(ir.artifacts[0].data)
 ```
 
-The IR header is `"schema": "powerio.module"` and
-`"version": "0.11.0"`. PowerIO v0.11.0 does not accept earlier document
-versions. PowerIO IR is not a grid exchange format and is absent from format
-discovery.
+The IR header is `"schema": "powerio.module"` and `"version"` equal to
+`powerio.__version__`; `powerio.versions()["module_schema"]` reports both.
+`deserialize` reads the compatible 0.11.x documents no newer than the installed
+build and refuses a newer or a 0.10 document with its version named. PowerIO IR
+is not a grid exchange format and is absent from format discovery.
 
 ## Collections
 

--- a/docs/src/scope-0.11.md
+++ b/docs/src/scope-0.11.md
@@ -14,7 +14,9 @@ documentation state the shipped API.
 - Structured diagnostics with stable codes and native record access in every language. A diagnostic carries source spans end to end, and the MATPOWER and PSS/E readers attach the byte range of the record a finding is about; the other readers attach none yet (see Known limits).
 - Balanced matrices (Y bus, FDPF B' and B'', LACPF, incidence, DC operators, AC power flow Jacobians, PTDF and LODF), all carrying element mappings; direct multiconductor admittance assembles in Rust only this release (see Known limits).
 - One stored `.pio.json` document with `"schema": "powerio.module"` and
-  `"version": "0.11.0"`. Earlier PowerIO IR documents are not accepted.
+  `"version"` naming the release that wrote it. A build reads the documents of
+  every compatible 0.11.x release no newer than itself; 0.10 documents are not
+  accepted.
 - C ABI 7, the Python package, PowerIO.jl, the `powerio` command line tool,
   and the MCP server over one set of names and types.
 
@@ -43,7 +45,7 @@ and PowerIO.jl. The independently checked boundaries are:
 |---|---|---|---|
 | PowerIO release | 0.11.0 | manifests, `powerio.versions()`, `build_info` | every release |
 | C ABI | 7 | `pio_abi_version` handshake at load | an existing C signature or documented behavior changes |
-| PowerIO IR | 0.11.0 | the stored document header | every release, matching the `powerio` crate version |
+| PowerIO IR | 0.11.0 | the stored document header | every release, matching the `powerio` crate version; a build reads its compatible line up to its own version |
 | matrix Arrow tables | append only, no separate number | the Arrow catalog report, stamped with the PowerIO release version | an existing table's identity or column order would change (a removed table's id is burned, never reused) |
 | MCP electrical data | PowerIO IR 0.11.0 | PowerIO deserialization | with the PowerIO IR schema |
 

--- a/docs/src/scope-0.11.md
+++ b/docs/src/scope-0.11.md
@@ -43,7 +43,7 @@ and PowerIO.jl. The independently checked boundaries are:
 
 | Boundary | Value at 0.11 | Checked where | Moves when |
 |---|---|---|---|
-| PowerIO release | 0.11.0 | manifests, `powerio.versions()`, `build_info` | every release |
+| PowerIO release | 0.11.0 | manifests, `powerio.versions()`, `pio_version` | every release |
 | C ABI | 7 | `pio_abi_version` handshake at load | an existing C signature or documented behavior changes |
 | PowerIO IR | 0.11.0 | the stored document header | every release, matching the `powerio` crate version; a build reads its compatible line up to its own version |
 | matrix Arrow tables | append only, no separate number | the Arrow catalog report, stamped with the PowerIO release version | an existing table's identity or column order would change (a removed table's id is burned, never reused) |

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -2290,6 +2290,11 @@ PioModule *pio_parse(const PioSource *source,
 
 /**
  * Deserialize one PowerIO IR source.
+ *
+ * A document names the PowerIO release that wrote it, which
+ * `pio_schema_report` reports for this library. This library reads the
+ * documents of its own compatible release line no newer than itself and
+ * refuses any other through `error`, naming the version it found.
  */
 PioModule *pio_module_deserialize(const PioSource *source, PioError **error);
 

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -3532,6 +3532,11 @@ pub unsafe extern "C" fn pio_parse(
 }
 
 /// Deserialize one PowerIO IR source.
+///
+/// A document names the PowerIO release that wrote it, which
+/// `pio_schema_report` reports for this library. This library reads the
+/// documents of its own compatible release line no newer than itself and
+/// refuses any other through `error`, naming the version it found.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_module_deserialize(
     source: *const PioSource,

--- a/powerio-core/src/lib.rs
+++ b/powerio-core/src/lib.rs
@@ -26,7 +26,7 @@ pub use diagnostic::{
     render_diagnostics,
 };
 pub use error::Error;
-pub use module::{PioModule, StagedEdit};
+pub use module::{IR_SCHEMA_NAME, PioModule, StagedEdit};
 pub use output::{
     ArtifactPath, Destination, EmitResult, EmittedOutput, Fidelity, IntoDestination,
     MemoryArtifact, OutputLayout,

--- a/powerio-core/src/module.rs
+++ b/powerio-core/src/module.rs
@@ -9,6 +9,11 @@ use crate::{
     SourceId, SourceMapEntry, SourceRelation, SourceSpan,
 };
 
+/// The `schema` discriminator every PowerIO IR document carries. The
+/// serializer writes it and the JSON classifier recognizes a document by it,
+/// so both read this one constant.
+pub const IR_SCHEMA_NAME: &str = "powerio.module";
+
 #[derive(Clone, Debug)]
 struct ModuleRecords {
     producer: Producer,

--- a/powerio-tx/src/format/cgmes/mod.rs
+++ b/powerio-tx/src/format/cgmes/mod.rs
@@ -1622,8 +1622,7 @@ mod tests {
         detailed.terminals.push(terminal);
         network.validate().unwrap();
 
-        let network: BalancedNetwork =
-            serde_json::from_str(&serde_json::to_string(&network).unwrap()).unwrap();
+        let network = crate::network::serde_round_trip(&network);
         for version in [CgmesVersion::V2_4_15, CgmesVersion::V3_0] {
             let output = write::write_cgmes(&network, version).unwrap();
             let equipment = output

--- a/powerio-tx/src/format/matpower/tests.rs
+++ b/powerio-tx/src/format/matpower/tests.rs
@@ -418,8 +418,7 @@ fn piecewise_gencost_constructor_counts_breakpoints() {
     assert_eq!(cost.ncost, 2);
     assert_eq!(cost.coeffs, vec![0.0, 0.0, 1.0, 1.0]);
 
-    let restored: BalancedNetwork =
-        serde_json::from_str(&serde_json::to_string(&net).unwrap()).unwrap();
+    let restored = crate::network::serde_round_trip(&net);
     let restored_cost = restored.generators()[0].cost.as_ref().unwrap();
     assert_eq!(restored_cost.ncost, 2);
     assert_eq!(restored_cost.coeffs, vec![0.0, 0.0, 1.0, 1.0]);

--- a/powerio-tx/src/format/mod.rs
+++ b/powerio-tx/src/format/mod.rs
@@ -1630,56 +1630,48 @@ pub(super) fn warn_dropped_areas(
         }
         return;
     }
-    let mut fields: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    let mut fields = std::collections::BTreeSet::new();
+    let mut stated = 0usize;
     for area in net.areas() {
-        if area.slack_bus.is_some() {
-            fields.insert("swing bus");
+        let mut states_any = false;
+        for field in stated_area_fields(area) {
+            fields.insert(field);
+            states_any = true;
         }
-        if area.net_interchange != 0.0 {
-            fields.insert("scheduled net interchange");
-        }
-        if area.tolerance != 0.0 {
-            fields.insert("interchange tolerance");
-        }
-        if area.name.is_some() {
-            fields.insert("name");
-        }
-        if area.uid.is_some() {
-            fields.insert("source identity");
-        }
-        if area.area_type.is_some() {
-            fields.insert("classification");
-        }
+        stated += usize::from(states_any);
     }
     if fields.is_empty() {
         return;
     }
     let total = net.areas().len();
-    let stated = net
-        .areas()
-        .iter()
-        .filter(|area| {
-            area.slack_bus.is_some()
-                || area.net_interchange != 0.0
-                || area.tolerance != 0.0
-                || area.name.is_some()
-                || area.uid.is_some()
-                || area.area_type.is_some()
-        })
-        .count();
-    let (subject, verb) = if total == 1 {
-        ("the area record".to_owned(), "states")
+    let subject = if total == 1 {
+        "the area record states".to_owned()
     } else {
-        (format!("{stated} of {total} area records"), "state")
+        format!("{stated} of {total} area records state")
     };
     warnings.push(
         &family.areas_dropped,
         format!(
-            "{subject} {verb} {}: {target} bus rows carry the area number, but {target} has no \
-             record for the area's attributes",
+            "{subject} {}: {target} bus rows carry the area number, but {target} has no record \
+             for the area's attributes",
             fields.into_iter().collect::<Vec<_>>().join(", ")
         ),
     );
+}
+
+/// The attributes an area record states beyond its number, by the names the
+/// dropped area warning reports them under.
+fn stated_area_fields(area: &crate::Area) -> impl Iterator<Item = &'static str> {
+    [
+        (area.slack_bus.is_some(), "swing bus"),
+        (area.net_interchange != 0.0, "scheduled net interchange"),
+        (area.tolerance != 0.0, "interchange tolerance"),
+        (area.name.is_some(), "name"),
+        (area.uid.is_some(), "source identity"),
+        (area.area_type.is_some(), "classification"),
+    ]
+    .into_iter()
+    .filter_map(|(stated, field)| stated.then_some(field))
 }
 
 pub(super) fn warn_extra_branch_rating_sets(

--- a/powerio-tx/src/format/routing.rs
+++ b/powerio-tx/src/format/routing.rs
@@ -200,8 +200,10 @@ pub enum JsonClass {
 /// its optional `:<format>` tail, the Python `classify_json_text` status, and
 /// the Julia family symbol.
 ///
-/// Consumers can read this list rather than hard-code the classifier's output
-/// vocabulary.
+/// A consumer may cache this set. A spelling never changes, a new family is
+/// appended within a release line, and a family leaves only in a breaking
+/// release that records the removal in the changelog and the migration guide,
+/// as 0.11 recorded `model-json`.
 pub const JSON_CLASSES: [&str; 5] = [
     "transmission",
     "distribution",
@@ -248,7 +250,7 @@ pub fn classify_json_text(text: &str) -> JsonClass {
         return JsonClass::Case(Detection::Unknown);
     };
     // PowerIO IR names itself in its header.
-    if header.schema.as_deref() == Some("powerio.module") {
+    if header.schema.as_deref() == Some(powerio_core::IR_SCHEMA_NAME) {
         return JsonClass::Module;
     }
     header.classify()
@@ -535,6 +537,18 @@ mod tests {
             classify_json_text(r#"{"schema":"powerio.module","version":"0.11.0"}"#),
             JsonClass::Module
         );
+        // Routing is the schema name's job alone. Every PowerIO IR generation
+        // reaches the deserializer, which owns the version rule and can then
+        // name the version it refuses.
+        for version in [r#""0.10.0""#, r#""99.0.0""#, "1", "null"] {
+            assert_eq!(
+                classify_json_text(&format!(
+                    r#"{{"schema":"powerio.module","version":{version}}}"#
+                )),
+                JsonClass::Module,
+                "version {version}"
+            );
+        }
         assert_eq!(
             classify_json_text(r#"{"buses":[],"linecodes":[]}"#),
             JsonClass::Case(Detection::Unknown)

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -13305,8 +13305,7 @@ mod tests {
                 })
         );
 
-        let restored: BalancedNetwork =
-            serde_json::from_str(&serde_json::to_string(&network).unwrap()).unwrap();
+        let restored = crate::network::serde_round_trip(&network);
         let emission = write_xiidm(&restored).unwrap();
         let generator = emission
             .text
@@ -13415,8 +13414,7 @@ mod tests {
                 .omitted_fields,
             detailed.omitted_fields
         );
-        let restored: BalancedNetwork =
-            serde_json::from_str(&serde_json::to_string(&network).unwrap()).unwrap();
+        let restored = crate::network::serde_round_trip(&network);
         assert_eq!(
             restored
                 .detailed_connectivity()
@@ -15069,8 +15067,7 @@ mod tests {
         assert_eq!(metadata.aliases[0].value, "n-1");
         assert_eq!(metadata.properties["owner"], "RTE");
 
-        let serialized = serde_json::to_string(&network).unwrap();
-        let restored: BalancedNetwork = serde_json::from_str(&serialized).unwrap();
+        let restored = crate::network::serde_round_trip(&network);
         assert!(restored.buses().is_empty());
         assert_eq!(
             restored.detailed_connectivity().as_ref().unwrap().dc_nodes,

--- a/powerio-tx/src/network.rs
+++ b/powerio-tx/src/network.rs
@@ -4994,13 +4994,17 @@ impl BalancedNetwork {
     }
 }
 
+/// A network as it comes back from its own serde representation, the form
+/// PowerIO IR nests as `value.data`. Shared by the unit tests of every module
+/// that checks a field survives that trip.
+#[cfg(test)]
+pub(crate) fn serde_round_trip(network: &BalancedNetwork) -> BalancedNetwork {
+    serde_json::from_str(&serde_json::to_string(network).unwrap()).unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn serde_round_trip(network: &BalancedNetwork) -> BalancedNetwork {
-        serde_json::from_str(&serde_json::to_string(network).unwrap()).unwrap()
-    }
 
     fn close(actual: f64, expected: f64) {
         assert!((actual - expected).abs() < 1e-12, "{actual} != {expected}");
@@ -6155,7 +6159,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)]
-    fn nonfinite_values_round_trip_through_model_json() {
+    fn nonfinite_values_round_trip_through_serde() {
         let bus = |id, vm| Bus {
             id: BusId(id),
             kind: BusType::Pq,

--- a/powerio-tx/tests/base_frequency.rs
+++ b/powerio-tx/tests/base_frequency.rs
@@ -120,20 +120,11 @@ fn serde_round_trips_and_defaults() {
         1,'B1          ', 230.0,3,1,1,1,1.0,0.0,1.1,0.9,1.1,0.9\n\
         0 / END OF BUS DATA, BEGIN LOAD DATA\nQ\n";
     let net = parse_psse(raw).unwrap();
-    let json = serde_json::to_string(&net).unwrap();
-    assert_eq!(
-        serde_json::from_str::<BalancedNetwork>(&json)
-            .unwrap()
-            .base_frequency(),
-        50.0
-    );
+    assert_eq!(serde_round_trip(&net).base_frequency(), 50.0);
 
     // A JSON document with no base_frequency key falls back to the default.
-    let without: serde_json::Value = {
-        let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        v.as_object_mut().unwrap().remove("base_frequency");
-        v
-    };
+    let mut without = serde_json::to_value(&net).unwrap();
+    without.as_object_mut().unwrap().remove("base_frequency");
     let restored: BalancedNetwork = serde_json::from_value(without).unwrap();
     assert_eq!(restored.base_frequency(), DEFAULT_BASE_FREQUENCY);
 }

--- a/powerio-tx/tests/convert.rs
+++ b/powerio-tx/tests/convert.rs
@@ -305,8 +305,7 @@ fn rich_writer_warnings_cover_simple_formats() {
 fn extra_branch_rating_sets_survive_serde_round_trip() {
     let net = rich_audit_network();
 
-    let text = serde_json::to_string(&net).unwrap();
-    let back: BalancedNetwork = serde_json::from_str(&text).unwrap();
+    let back = serde_round_trip(&net);
 
     assert_eq!(back.branches()[0].rating_sets.len(), 1);
     assert_eq!(back.branches()[0].rating_sets[0].name, "RATE4");
@@ -2504,9 +2503,8 @@ fn generator_cost_csv_patches_validate_index_and_bus() {
 
 #[test]
 fn a_bare_network_object_is_not_a_case_format() {
-    let net = parse_matpower_file(data("case14.m")).unwrap();
-    let text = serde_json::to_string(&net).unwrap();
-    let source = powerio_core::Source::from_memory("network.json", text.into_bytes()).unwrap();
+    let text = r#"{"name":"network","base_mva":100.0,"buses":[],"branches":[]}"#;
+    let source = powerio_core::Source::from_memory("network.json", text.as_bytes()).unwrap();
     let error = powerio_tx::parse(source).expect_err("an unmarked object must not parse");
     assert!(error.to_string().contains("cannot infer JSON format"));
 }

--- a/powerio-tx/tests/geo_formats.rs
+++ b/powerio-tx/tests/geo_formats.rs
@@ -189,8 +189,7 @@ fn locations_and_routes_survive_serde_round_trip() {
             kind: None,
         },
     ]);
-    let text = serde_json::to_string(&net).unwrap();
-    let back: powerio_tx::BalancedNetwork = serde_json::from_str(&text).unwrap();
+    let back = serde_round_trip(&net);
     assert_eq!(back.buses()[0].location, net.buses()[0].location);
     assert_eq!(back.branches()[0].route, net.branches()[0].route);
     assert_eq!(back.geo(), net.geo());

--- a/powerio-tx/tests/helpers/mod.rs
+++ b/powerio-tx/tests/helpers/mod.rs
@@ -47,6 +47,12 @@ fn text_from_result(result: powerio_core::EmitResult) -> TextEmission {
     }
 }
 
+/// A network as it comes back from its own serde representation, the form
+/// PowerIO IR nests as `value.data`.
+pub fn serde_round_trip(network: &BalancedNetwork) -> BalancedNetwork {
+    serde_json::from_str(&serde_json::to_string(network).unwrap()).unwrap()
+}
+
 pub fn emit_module(
     module: &powerio_core::PioModule<BalancedNetwork>,
     target: powerio_tx::TargetFormat,

--- a/powerio-tx/tests/network_serde.rs
+++ b/powerio-tx/tests/network_serde.rs
@@ -1,29 +1,21 @@
-//! Serde checks for `BalancedNetwork` as embedded in a PowerIO IR value.
-//!
-//! PowerIO IR is the public document. These tests pin the nested network data
-//! that its facade-owned DTO currently serializes.
+//! `BalancedNetwork` through its own serde representation, the form PowerIO IR
+//! nests as `value.data`: additive fields keep their defaults, control and
+//! geographic records survive the trip, and component identities survive it
+//! once assigned.
+
+mod helpers;
+use helpers::serde_round_trip;
 
 use powerio_tx::{
     BalancedNetwork, Branch, Bus, BusId, BusType, CoordinateSpace, CoordsKind, GenCaps, Generator,
     GeoMeta, Location, SourceFormat, TerminalReference,
 };
 
-fn serialize_network(network: &BalancedNetwork) -> String {
-    let mut network = network.clone();
-    network.assign_missing_component_ids();
-    serde_json::to_string(&network).unwrap()
-}
-
-fn deserialize_network(text: &str) -> BalancedNetwork {
-    serde_json::from_str(text).unwrap()
-}
-
 #[test]
 fn nested_network_ignores_unknown_fields_and_defaults_omitted_caps() {
-    // Build a minimal valid network, mutate its serialized fields, and confirm
-    // the nested IR value keeps its additive defaults.
-    let net = small_net();
-    let mut v: serde_json::Value = serde_json::from_str(&serialize_network(&net)).unwrap();
+    // Serialize a minimal valid network, edit the document the way another
+    // writer might have, and confirm the additive defaults hold.
+    let mut v = serde_json::to_value(small_net()).unwrap();
 
     // (a) an unknown future top-level field is ignored (deny_unknown_fields off).
     v["future_field_v5"] = serde_json::json!("ignored");
@@ -33,8 +25,7 @@ fn nested_network_ignores_unknown_fields_and_defaults_omitted_caps() {
     generator.remove("voltage_regulation_on");
     generator.remove("regulating_terminal");
 
-    let text = serde_json::to_string(&v).unwrap();
-    let parsed = deserialize_network(&text);
+    let parsed: BalancedNetwork = serde_json::from_value(v).unwrap();
     assert_eq!(parsed.generators().len(), 1);
     assert!(
         !parsed.generators()[0].has_caps(),
@@ -59,7 +50,7 @@ fn generator_voltage_control_survives_serde_round_trip() {
     net.generators_mut()[0].regulated_bus = Some(BusId(2));
     net.generators_mut()[0].regulating_terminal = Some(reference.clone());
 
-    let parsed = deserialize_network(&serialize_network(&net));
+    let parsed = serde_round_trip(&net);
     let generator = &parsed.generators()[0];
     assert!(!generator.voltage_regulation_on);
     assert_eq!(generator.regulated_bus, Some(BusId(2)));
@@ -90,18 +81,21 @@ fn small_net() -> BalancedNetwork {
 }
 
 #[test]
-fn component_ids_survive_serde_roundtrip_and_are_assigned_when_absent() {
+fn component_ids_survive_serde_round_trip_once_assigned() {
+    // The PowerIO IR serializer assigns the missing component identities
+    // before it nests a network; serde carries whatever is set.
     let mut net = small_net();
     net.generators_mut()[0].uid = Some("gen-a".to_owned());
+    net.assign_missing_component_ids();
 
-    let v: serde_json::Value = serde_json::from_str(&serialize_network(&net)).unwrap();
+    let v = serde_json::to_value(&net).unwrap();
     assert_eq!(v["generators"][0]["uid"], serde_json::json!("gen-a"));
     let bus_uid = v["buses"][0]["uid"]
         .as_str()
-        .expect("version 1 serialization assigns a stable component ID");
+        .expect("an assigned bus identity is written");
     assert!(!bus_uid.is_empty());
 
-    let parsed = deserialize_network(&serde_json::to_string(&v).unwrap());
+    let parsed = serde_round_trip(&net);
     assert_eq!(parsed.generators()[0].uid.as_deref(), Some("gen-a"));
     assert_eq!(parsed.buses()[0].uid.as_deref(), Some(bus_uid));
 }
@@ -109,11 +103,11 @@ fn component_ids_survive_serde_roundtrip_and_are_assigned_when_absent() {
 #[test]
 fn geo_fields_roundtrip_and_are_omitted_when_absent() {
     let net = small_net();
-    let text = serialize_network(&net);
+    let text = serde_json::to_string(&net).unwrap();
     assert!(!text.contains(r#""geo""#));
     assert!(!text.contains(r#""location""#));
-    let parsed = deserialize_network(&text);
-    assert_eq!(serialize_network(&parsed), text);
+    let parsed = serde_round_trip(&net);
+    assert_eq!(serde_json::to_string(&parsed).unwrap(), text);
 
     let v: serde_json::Value = serde_json::from_str(&text).unwrap();
     assert!(v.get("geo").is_none());
@@ -130,7 +124,7 @@ fn geo_fields_roundtrip_and_are_omitted_when_absent() {
         kind: None,
     });
 
-    let v: serde_json::Value = serde_json::from_str(&serialize_network(&with_geo)).unwrap();
+    let v = serde_json::to_value(&with_geo).unwrap();
     assert_eq!(
         v["geo"],
         serde_json::json!({"space": "geographic", "kind": "source"})
@@ -138,7 +132,7 @@ fn geo_fields_roundtrip_and_are_omitted_when_absent() {
     assert_eq!(v["buses"][0]["location"]["x"], serde_json::json!(-80.0));
     assert_eq!(v["buses"][0]["location"]["y"], serde_json::json!(35.0));
 
-    let parsed = deserialize_network(&serde_json::to_string(&v).unwrap());
+    let parsed = serde_round_trip(&with_geo);
     assert_eq!(parsed.geo(), with_geo.geo());
     assert_eq!(parsed.buses()[0].location, with_geo.buses()[0].location);
 }

--- a/powerio/examples/generate_schemas.rs
+++ b/powerio/examples/generate_schemas.rs
@@ -23,29 +23,21 @@ mod generate {
             .nth(1)
             .map_or_else(|| PathBuf::from("docs/schema"), PathBuf::from);
 
-        // Since 0.11.0, the IR schema version is the `powerio` crate version.
-        let relative_path = format!("pio-module/{}", powerio::IR_SCHEMA_VERSION);
-        let id = format!(
-            "https://powerio.dev/schema/pio-module/{}/schema.json",
-            powerio::IR_SCHEMA_VERSION
-        );
+        // The schema lives at the version this build writes, and its `$id` is
+        // the address that directory is served from.
         write_schema(
             serde_json::to_value(powerio::generate_ir_schema())?,
-            &out,
-            &relative_path,
-            &id,
-            &[],
-        )?;
-
-        Ok(())
+            &out.join("pio-module")
+                .join(powerio::IR_SCHEMA_VERSION)
+                .join("schema.json"),
+            powerio::IR_SCHEMA_ID,
+        )
     }
 
     fn write_schema(
         mut schema: serde_json::Value,
-        out: &Path,
-        rel: &str,
+        path: &Path,
         id: &str,
-        also_required: &[&str],
     ) -> Result<(), Box<dyn std::error::Error>> {
         spell_nonfinite_floats(&mut schema)?;
         let root = schema
@@ -53,30 +45,6 @@ mod generate {
             .ok_or("schemars returned a non-object schema root")?;
         root.insert("$id".to_owned(), json!(id));
 
-        let properties = root
-            .get("properties")
-            .and_then(serde_json::Value::as_object)
-            .ok_or("schemars returned a root with no properties")?;
-        // A name that no longer exists would silently demand a field the
-        // document cannot carry, so it is an error rather than a no-op.
-        if let Some(missing) = also_required
-            .iter()
-            .find(|name| !properties.contains_key(**name))
-        {
-            return Err(format!("`{missing}` is required but is not a property of {rel}").into());
-        }
-        let required = root
-            .entry("required")
-            .or_insert_with(|| json!([]))
-            .as_array_mut()
-            .ok_or("schemars returned a non-array `required`")?;
-        for name in also_required {
-            if !required.iter().any(|value| value == name) {
-                required.push(json!(name));
-            }
-        }
-
-        let path = out.join(rel).join("schema.json");
         fs::create_dir_all(path.parent().ok_or("schema path has no parent")?)?;
         let mut text = serde_json::to_string_pretty(&schema)?;
         text.push('\n');

--- a/powerio/src/ir.rs
+++ b/powerio/src/ir.rs
@@ -6,6 +6,57 @@ use powerio_core::{
 
 use crate::PioValue;
 
+/// Whether this build deserializes a PowerIO IR document stating `version`.
+///
+/// This is the one statement of the compatibility window that
+/// [`IR_SCHEMA_VERSION`](crate::IR_SCHEMA_VERSION) documents: a document is
+/// readable when a SemVer compatible build no newer than this one wrote it.
+pub(crate) fn ir_version_is_readable(version: &str) -> bool {
+    readable_by(version, crate::IR_SCHEMA_VERSION)
+}
+
+/// Whether a document stating `version` comes from a newer build on this
+/// build's own compatible line, so that a newer PowerIO reads it and this one
+/// does not.
+pub(crate) fn ir_version_is_newer_compatible(version: &str) -> bool {
+    version != crate::IR_SCHEMA_VERSION && readable_by(crate::IR_SCHEMA_VERSION, version)
+}
+
+/// A document written by `document` is readable by a build at `reader` when
+/// the two versions are SemVer compatible and the reader is not the older.
+fn readable_by(document: &str, reader: &str) -> bool {
+    let (Some((major, minor, patch)), Some((reader_major, reader_minor, reader_patch))) =
+        (parse_version(document), parse_version(reader))
+    else {
+        return false;
+    };
+    if major != reader_major {
+        return false;
+    }
+    if major == 0 {
+        minor == reader_minor && patch <= reader_patch
+    } else {
+        (minor, patch) <= (reader_minor, reader_patch)
+    }
+}
+
+/// `MAJOR.MINOR.PATCH` as numbers. A prerelease, a build tag, or any other
+/// spelling is not a released PowerIO version and reads as none.
+fn parse_version(text: &str) -> Option<(u64, u64, u64)> {
+    fn number(part: &str) -> Option<u64> {
+        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| part.parse().ok())
+            .flatten()
+    }
+    let mut parts = text.split('.');
+    let version = (
+        number(parts.next()?)?,
+        number(parts.next()?)?,
+        number(parts.next()?)?,
+    );
+    parts.next().is_none().then_some(version)
+}
+
 /// Serialize a diagnostics list as the JSON array of PowerIO IR diagnostic
 /// records: the encoding a module's `diagnostics` field carries, with an
 /// identity minted for every record that has none.
@@ -76,4 +127,50 @@ pub fn deserialize(input: impl powerio_core::IntoSource) -> Result<PioModule<Pio
     crate::stored::read_module(text)
         .map(|module| module.with_source(source.clone()))
         .map_err(|error| error.with_source(source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ir_version_is_newer_compatible, ir_version_is_readable, readable_by};
+
+    #[test]
+    fn this_build_reads_its_own_documents_and_no_newer_ones() {
+        assert!(ir_version_is_readable(crate::IR_SCHEMA_VERSION));
+        assert!(!ir_version_is_newer_compatible(crate::IR_SCHEMA_VERSION));
+    }
+
+    #[test]
+    fn a_reader_accepts_compatible_documents_no_newer_than_itself() {
+        // The same 0.y line, no later than the reader.
+        assert!(readable_by("0.11.0", "0.11.0"));
+        assert!(readable_by("0.11.0", "0.11.3"));
+        assert!(!readable_by("0.11.4", "0.11.3"));
+        // Another 0.y line is another document shape in either direction.
+        assert!(!readable_by("0.10.0", "0.11.0"));
+        assert!(!readable_by("0.12.0", "0.11.0"));
+        // From 1.0 the minor version is compatible as well, still no newer.
+        assert!(readable_by("1.0.0", "1.2.1"));
+        assert!(readable_by("1.2.0", "1.2.1"));
+        assert!(!readable_by("1.2.2", "1.2.1"));
+        assert!(!readable_by("1.3.0", "1.2.1"));
+        assert!(!readable_by("0.11.0", "1.0.0"));
+        assert!(!readable_by("2.0.0", "1.0.0"));
+    }
+
+    #[test]
+    fn only_a_released_version_spelling_is_readable() {
+        for spelling in [
+            "1",
+            "0.11",
+            "0.11.0.1",
+            "0.11.0-rc1",
+            "0.11.0+build",
+            "v0.11.0",
+            "",
+            " 0.11.0",
+            "0.11.+1",
+        ] {
+            assert!(!readable_by(spelling, "0.11.0"), "{spelling:?}");
+        }
+    }
 }

--- a/powerio/src/ir.rs
+++ b/powerio/src/ir.rs
@@ -15,11 +15,18 @@ pub(crate) fn ir_version_is_readable(version: &str) -> bool {
     readable_by(version, crate::IR_SCHEMA_VERSION)
 }
 
-/// Whether a document stating `version` comes from a newer build on this
-/// build's own compatible line, so that a newer PowerIO reads it and this one
-/// does not.
-pub(crate) fn ir_version_is_newer_compatible(version: &str) -> bool {
-    version != crate::IR_SCHEMA_VERSION && readable_by(crate::IR_SCHEMA_VERSION, version)
+/// Whether a document stating `version` was written by a PowerIO release
+/// later than this build, so that upgrading is what makes it readable. An
+/// unreadable document that is not newer came from an earlier line and has to
+/// be regenerated instead.
+pub(crate) fn ir_version_is_newer(version: &str) -> bool {
+    match (
+        parse_version(version),
+        parse_version(crate::IR_SCHEMA_VERSION),
+    ) {
+        (Some(document), Some(this)) => document > this,
+        _ => false,
+    }
 }
 
 /// A document written by `document` is readable by a build at `reader` when
@@ -131,12 +138,39 @@ pub fn deserialize(input: impl powerio_core::IntoSource) -> Result<PioModule<Pio
 
 #[cfg(test)]
 mod tests {
-    use super::{ir_version_is_newer_compatible, ir_version_is_readable, readable_by};
+    use super::{ir_version_is_newer, ir_version_is_readable, readable_by};
 
     #[test]
-    fn this_build_reads_its_own_documents_and_no_newer_ones() {
+    fn this_build_reads_its_own_documents_and_is_not_newer_than_itself() {
         assert!(ir_version_is_readable(crate::IR_SCHEMA_VERSION));
-        assert!(!ir_version_is_newer_compatible(crate::IR_SCHEMA_VERSION));
+        assert!(!ir_version_is_newer(crate::IR_SCHEMA_VERSION));
+    }
+
+    /// A refusal advises an upgrade for every later release and a regenerated
+    /// document for every earlier one, on this build's line or another.
+    #[test]
+    fn a_later_release_is_newer_whatever_line_it_is_on() {
+        let (major, minor, patch) = super::parse_version(crate::IR_SCHEMA_VERSION).unwrap();
+        for (m, n, p) in [
+            (major, minor, patch + 1),
+            (major, minor + 1, 0),
+            (major + 1, 0, 0),
+        ] {
+            let later = format!("{m}.{n}.{p}");
+            assert!(ir_version_is_newer(&later), "{later}");
+        }
+        for earlier in [
+            patch.checked_sub(1).map(|p| format!("{major}.{minor}.{p}")),
+            minor.checked_sub(1).map(|n| format!("{major}.{n}.999")),
+            major.checked_sub(1).map(|m| format!("{m}.999.999")),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            assert!(!ir_version_is_newer(&earlier), "{earlier}");
+        }
+        // An unparsable version is neither, so it takes the regenerate advice.
+        assert!(!ir_version_is_newer("1"));
     }
 
     #[test]

--- a/powerio/src/ir.rs
+++ b/powerio/src/ir.rs
@@ -16,9 +16,9 @@ pub(crate) fn ir_version_is_readable(version: &str) -> bool {
 }
 
 /// Whether a document stating `version` was written by a PowerIO release
-/// later than this build, so that upgrading is what makes it readable. An
-/// unreadable document that is not newer came from an earlier line and has to
-/// be regenerated instead.
+/// later than this build, so that upgrading is what makes it readable. Every
+/// other unreadable document — an earlier line, or a spelling no release
+/// wrote — has to be regenerated instead.
 pub(crate) fn ir_version_is_newer(version: &str) -> bool {
     match (
         parse_version(version),
@@ -30,28 +30,34 @@ pub(crate) fn ir_version_is_newer(version: &str) -> bool {
 }
 
 /// A document written by `document` is readable by a build at `reader` when
-/// the two versions are SemVer compatible and the reader is not the older.
+/// both sit on one compatible line and the reader is not the older.
 fn readable_by(document: &str, reader: &str) -> bool {
-    let (Some((major, minor, patch)), Some((reader_major, reader_minor, reader_patch))) =
-        (parse_version(document), parse_version(reader))
-    else {
+    let (Some(document), Some(reader)) = (parse_version(document), parse_version(reader)) else {
         return false;
     };
-    if major != reader_major {
-        return false;
-    }
-    if major == 0 {
-        minor == reader_minor && patch <= reader_patch
-    } else {
-        (minor, patch) <= (reader_minor, reader_patch)
+    compatible_line(document) == compatible_line(reader) && document <= reader
+}
+
+/// The releases a version promises compatibility with, as Cargo resolves it:
+/// the major line from 1.0 on, the `0.y` line below that, and at `0.0.z`
+/// nothing but itself, where every patch may break the one before.
+fn compatible_line((major, minor, patch): (u64, u64, u64)) -> (u64, u64, u64) {
+    match (major, minor) {
+        (0, 0) => (0, 0, patch),
+        (0, minor) => (0, minor, 0),
+        (major, _) => (major, 0, 0),
     }
 }
 
-/// `MAJOR.MINOR.PATCH` as numbers. A prerelease, a build tag, or any other
-/// spelling is not a released PowerIO version and reads as none.
+/// `MAJOR.MINOR.PATCH` as numbers. A prerelease, a build tag, a leading zero,
+/// or any other spelling is not a released PowerIO version and reads as none.
 fn parse_version(text: &str) -> Option<(u64, u64, u64)> {
     fn number(part: &str) -> Option<u64> {
-        (!part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+        // A leading zero is not SemVer, and the published schema pins `version`
+        // to one spelling, so accepting `0.11.00` would read as current a
+        // document that validating against the schema rejects.
+        let digits = !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit());
+        (digits && (part == "0" || !part.starts_with('0')))
             .then(|| part.parse().ok())
             .flatten()
     }
@@ -189,6 +195,10 @@ mod tests {
         assert!(!readable_by("1.3.0", "1.2.1"));
         assert!(!readable_by("0.11.0", "1.0.0"));
         assert!(!readable_by("2.0.0", "1.0.0"));
+        // Below 0.1 every patch is its own line, as Cargo resolves `^0.0.z`.
+        assert!(readable_by("0.0.2", "0.0.2"));
+        assert!(!readable_by("0.0.1", "0.0.2"));
+        assert!(!readable_by("0.0.2", "0.0.1"));
     }
 
     #[test]
@@ -203,6 +213,11 @@ mod tests {
             "",
             " 0.11.0",
             "0.11.+1",
+            // A leading zero is not SemVer, and the schema's `version` const
+            // names one spelling, so the reader may not accept a second.
+            "0.11.00",
+            "00.11.0",
+            "0.011.0",
         ] {
             assert!(!readable_by(spelling, "0.11.0"), "{spelling:?}");
         }

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -80,8 +80,8 @@ pub use powerio_core::IR_SCHEMA_NAME;
 ///
 /// Beginning with PowerIO 0.11.0, the IR version is the `powerio` crate
 /// version, and [`deserialize`] reads every document a SemVer compatible
-/// build no newer than this one wrote: the same major version, and on the
-/// `0.y` line the same minor version, with a patch no later than this build's.
+/// build no newer than this one wrote: the same major version from 1.0 on,
+/// and on the `0.y` line that is the same minor version as well.
 /// PowerIO 0.11.3 reads the documents of 0.11.0 through 0.11.3 and refuses
 /// 0.10.0, 0.12.0, and 0.11.4, naming the version it found. The compatible
 /// line therefore stays additive, and an older build never misreads a newer

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -73,14 +73,28 @@
 /// The facade version recorded on producers and stored modules.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// The discriminator written in every current PowerIO IR document.
-pub const IR_SCHEMA_NAME: &str = "powerio.module";
+/// The `schema` discriminator of every PowerIO IR document.
+pub use powerio_core::IR_SCHEMA_NAME;
 
-/// The current PowerIO IR schema version.
+/// The PowerIO IR version this build writes.
 ///
-/// Beginning with PowerIO 0.11.0, the schema version is the `powerio` crate
-/// version. The C ABI is versioned independently.
+/// Beginning with PowerIO 0.11.0, the IR version is the `powerio` crate
+/// version, and [`deserialize`] reads every document a SemVer compatible
+/// build no newer than this one wrote: the same major version, and on the
+/// `0.y` line the same minor version, with a patch no later than this build's.
+/// PowerIO 0.11.3 reads the documents of 0.11.0 through 0.11.3 and refuses
+/// 0.10.0, 0.12.0, and 0.11.4, naming the version it found. The compatible
+/// line therefore stays additive, and an older build never misreads a newer
+/// document. The C ABI is versioned independently.
 pub const IR_SCHEMA_VERSION: &str = VERSION;
+
+/// The `$id` of the JSON Schema for the documents this build writes, which is
+/// also the address the schema is served from.
+pub const IR_SCHEMA_ID: &str = concat!(
+    "https://powerio.dev/schema/pio-module/",
+    env!("CARGO_PKG_VERSION"),
+    "/schema.json"
+);
 
 use powerio_tx::format;
 pub use powerio_tx::{
@@ -797,13 +811,6 @@ fn json_family(
     let Ok(text) = std::str::from_utf8(buffer.content_bytes()) else {
         return Ok(RoutedFamily::Balanced(None));
     };
-    if serde_json::from_str::<serde_json::Value>(text).is_ok_and(|value| {
-        value
-            .as_object()
-            .is_some_and(|root| root.contains_key("time_series_output"))
-    }) {
-        return Ok(RoutedFamily::Goc3);
-    }
     let class = format::routing::classify_json_text(text);
     match class {
         JsonClass::Case(Detection::Known(SourceFormat::Transmission(

--- a/powerio/src/stored/convert.rs
+++ b/powerio/src/stored/convert.rs
@@ -58,42 +58,69 @@ pub fn emit_module(module: &PioModule<PioValue>) -> Result<String> {
     serde_json::to_string_pretty(&stored).map_err(|error| invalid(error.to_string()))
 }
 
-/// Decode one current PowerIO IR document. Other schemas and versions are refused.
+/// Decode one PowerIO IR document. A document a compatible build no newer
+/// than this one wrote decodes directly (see [`crate::IR_SCHEMA_VERSION`]);
+/// any other schema name or version is refused with what was found named.
 ///
 /// # Errors
 /// An unsupported schema or version, or an invalid document.
 pub fn read_module(text: &str) -> Result<PioModule<PioValue>> {
     let text = text.strip_prefix('\u{feff}').unwrap_or(text);
+    // One scan decodes the current shape. Only a document that is not one is
+    // scanned again, for its header alone, so the refusal can say whether it
+    // is another PowerIO IR generation, a current document that is invalid,
+    // or not PowerIO IR at all.
+    let decode_error = match serde_json::from_str::<StoredModule>(text) {
+        Ok(stored) if is_readable(&stored.schema, &stored.version) => {
+            dto::validate(&stored).map_err(invalid)?;
+            return decode_stored(stored);
+        }
+        Ok(stored) => return Err(unsupported(&stored.schema, &stored.version)),
+        Err(error) => error,
+    };
     let header: dto::StoredHeader =
         serde_json::from_str(text).map_err(|error| invalid(error.to_string()))?;
-    match (header.schema.as_deref(), header.version.as_ref()) {
-        (Some(crate::IR_SCHEMA_NAME), Some(serde_json::Value::String(version)))
-            if version == crate::IR_SCHEMA_VERSION =>
+    match (header.schema.as_deref(), header.version) {
+        (Some(schema), Some(dto::StoredVersion::Text(version)))
+            if is_readable(schema, &version) =>
         {
-            let stored: StoredModule =
-                serde_json::from_str(text).map_err(|error| invalid(error.to_string()))?;
-            dto::validate(&stored).map_err(invalid)?;
-            decode_stored(stored)
+            Err(invalid(decode_error.to_string()))
         }
-        (Some(schema), version) => Err(powerio_core::Error::new(
-            &codes::READ_MODULE_UNSUPPORTED,
-            format!(
-                "unsupported stored module `{schema}` version {}",
-                version.map_or_else(
-                    || "<none>".to_string(),
-                    |value| {
-                        value
-                            .as_str()
-                            .map_or_else(|| value.to_string(), str::to_owned)
-                    },
-                )
-            ),
+        (Some(schema), version) => Err(unsupported(
+            schema,
+            &version.map_or_else(|| "<none>".to_owned(), |version| version.to_string()),
         )),
         (None, _) => Err(powerio_core::Error::new(
             &codes::READ_MODULE_UNSUPPORTED,
             "the document is not PowerIO IR",
         )),
     }
+}
+
+fn is_readable(schema: &str, version: &str) -> bool {
+    schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_readable(version)
+}
+
+/// The refusal for a header naming a schema or version this build does not
+/// read. It states what was found and what to do about it: a document a newer
+/// compatible PowerIO wrote needs that newer reader; anything else is
+/// regenerated from its source data.
+fn unsupported(schema: &str, version: &str) -> powerio_core::Error {
+    let this = crate::IR_SCHEMA_VERSION;
+    let guidance =
+        if schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_newer_compatible(version) {
+            format!("a newer PowerIO than this build ({this}) wrote it; upgrade PowerIO to read it")
+        } else {
+            format!(
+                "this build ({this}) reads `{}` documents from its own compatible release line; \
+                 regenerate this one from its source data",
+                crate::IR_SCHEMA_NAME
+            )
+        };
+    powerio_core::Error::new(
+        &codes::READ_MODULE_UNSUPPORTED,
+        format!("unsupported stored module `{schema}` version {version}: {guidance}"),
+    )
 }
 
 // ---- value encoding ---------------------------------------------------------

--- a/powerio/src/stored/convert.rs
+++ b/powerio/src/stored/convert.rs
@@ -101,10 +101,10 @@ fn is_readable(schema: &str, version: &str) -> bool {
     schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_readable(version)
 }
 
-/// The refusal for a header naming a schema or version this build does not
-/// read. It states what was found and what to do about it: a document a newer
-/// compatible PowerIO wrote needs that newer reader; anything else is
-/// regenerated from its source data.
+/// The refusal for a schema or version this build does not read. It states
+/// what was found and what to do about it: a document a later PowerIO release
+/// wrote needs that newer reader; anything else is regenerated from its
+/// source data.
 fn unsupported(schema: &str, version: &str) -> powerio_core::Error {
     let this = crate::IR_SCHEMA_VERSION;
     let guidance = if schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_newer(version) {

--- a/powerio/src/stored/convert.rs
+++ b/powerio/src/stored/convert.rs
@@ -107,16 +107,15 @@ fn is_readable(schema: &str, version: &str) -> bool {
 /// regenerated from its source data.
 fn unsupported(schema: &str, version: &str) -> powerio_core::Error {
     let this = crate::IR_SCHEMA_VERSION;
-    let guidance =
-        if schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_newer_compatible(version) {
-            format!("a newer PowerIO than this build ({this}) wrote it; upgrade PowerIO to read it")
-        } else {
-            format!(
-                "this build ({this}) reads `{}` documents from its own compatible release line; \
-                 regenerate this one from its source data",
-                crate::IR_SCHEMA_NAME
-            )
-        };
+    let guidance = if schema == crate::IR_SCHEMA_NAME && crate::ir::ir_version_is_newer(version) {
+        format!("a PowerIO later than this build ({this}) wrote it; upgrade PowerIO to read it")
+    } else {
+        format!(
+            "this build ({this}) reads `{}` documents from its own compatible release line; \
+             regenerate this one from its source data",
+            crate::IR_SCHEMA_NAME
+        )
+    };
     powerio_core::Error::new(
         &codes::READ_MODULE_UNSUPPORTED,
         format!("unsupported stored module `{schema}` version {version}: {guidance}"),

--- a/powerio/src/stored/dto.rs
+++ b/powerio/src/stored/dto.rs
@@ -1350,12 +1350,33 @@ impl<'de> Deserialize<'de> for StoredModule {
     }
 }
 
+/// The `version` a document states, kept as written so a refusal can name it:
+/// the string this reader compares, or whatever an earlier generation wrote
+/// there (the v0.10.0 document carried the integer `1`).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum StoredVersion {
+    Text(String),
+    Other(serde_json::Value),
+}
+
+impl fmt::Display for StoredVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Text(text) => f.write_str(text),
+            Self::Other(value) => value.fmt(f),
+        }
+    }
+}
+
+/// The two header fields the reader dispatches on, read from a document that
+/// did not decode as the current shape.
 #[derive(Debug, Deserialize)]
 pub(super) struct StoredHeader {
     #[serde(default)]
     pub(super) schema: Option<String>,
     #[serde(default)]
-    pub(super) version: Option<serde_json::Value>,
+    pub(super) version: Option<StoredVersion>,
 }
 
 /// Structural validation of one decoded document: identities, digests,

--- a/powerio/tests/frozen_schemas.rs
+++ b/powerio/tests/frozen_schemas.rs
@@ -1,26 +1,79 @@
 //! The committed current PowerIO IR schema matches the implementation, and
-//! the historical schema archive remains intact.
+//! the schema archive matches the history `docs/schema/README.md` documents.
 
-mod helpers;
-use helpers::serialize_module_text;
+use std::path::Path;
 
-fn current_ir_version() -> String {
-    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../tests/data/case9.m");
-    let module = powerio::parse_with_options(
-        powerio::Source::open(path).unwrap(),
-        &powerio::ParseOptions::default().format("matpower").unwrap(),
-    )
-    .unwrap();
-    let text = serialize_module_text(&module).unwrap();
-    let document: serde_json::Value = serde_json::from_str(&text).unwrap();
-    document["version"].as_str().unwrap().to_owned()
+const SCHEMA_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../docs/schema");
+
+/// The `$id` each archived release wrote into its schema: evidence of what
+/// those releases produced, so it is pinned here rather than derived.
+const HISTORICAL_IDS: [(&str, &str); 4] = [
+    ("0.1", "https://powerio.dev/schema/pio-package/0.1"),
+    ("0.2", "https://powerio.dev/schema/pio-package/0.2"),
+    (
+        "0.9",
+        "https://powerio.dev/schema/pio-package/0.9/schema.json",
+    ),
+    (
+        "0.10.0",
+        "https://powerio.dev/schema/pio-module/1/schema.json",
+    ),
+];
+
+/// One row of the README's history table.
+struct ArchivedSchema {
+    path: String,
+    current: bool,
 }
 
-/// The directory is one PowerIO IR history, not separate package and module
-/// schema families.
+/// The archive `docs/schema/README.md` documents, read from its history
+/// table: one row per release, naming the archived file and whether this is
+/// the document the current reader writes.
+fn documented_archive() -> Vec<ArchivedSchema> {
+    let readme = read_schema_file("README.md");
+    let rows: Vec<ArchivedSchema> = readme
+        .lines()
+        .filter(|line| line.starts_with("| v"))
+        .map(|line| {
+            let cells: Vec<&str> = line.split('|').map(str::trim).collect();
+            assert_eq!(cells.len(), 6, "a history table row has four cells: {line}");
+            ArchivedSchema {
+                path: cells[3].trim_matches('`').to_owned(),
+                current: cells[4] == "current",
+            }
+        })
+        .collect();
+    assert!(
+        !rows.is_empty(),
+        "docs/schema/README.md has a history table with one row per release"
+    );
+    rows
+}
+
+fn current_schema_path() -> String {
+    format!("pio-module/{}/schema.json", powerio::IR_SCHEMA_VERSION)
+}
+
+fn read_schema_file(relative: &str) -> String {
+    let path = Path::new(SCHEMA_ROOT).join(relative);
+    std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "{} is not checked in: {error}. The current schema is generated with \
+             `cargo run -p powerio --example generate_schemas --features schema -- docs/schema`",
+            path.display()
+        )
+    })
+}
+
+fn declares_id(text: &str, id: &str) -> bool {
+    text.contains(&format!("\"$id\": \"{id}\""))
+}
+
+/// The directory is one PowerIO IR history: exactly the files the README's
+/// table documents, plus the README itself.
 #[test]
-fn the_schema_directory_contains_the_documented_powerio_ir_history() {
-    fn collect_files(root: &std::path::Path, path: &std::path::Path, out: &mut Vec<String>) {
+fn the_schema_directory_is_the_documented_powerio_ir_history() {
+    fn collect_files(root: &Path, path: &Path, out: &mut Vec<String>) {
         for entry in std::fs::read_dir(path).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
@@ -37,63 +90,70 @@ fn the_schema_directory_contains_the_documented_powerio_ir_history() {
         }
     }
 
-    let root = std::path::Path::new("../docs/schema");
+    let root = Path::new(SCHEMA_ROOT);
     let mut files = Vec::new();
     collect_files(root, root, &mut files);
     files.sort();
+
+    let mut documented: Vec<String> = documented_archive()
+        .into_iter()
+        .map(|row| row.path)
+        .collect();
+    documented.push("README.md".to_owned());
+    documented.sort();
     assert_eq!(
-        files,
-        [
-            "README.md",
-            "pio-module/0.1/schema.json",
-            "pio-module/0.10.0/schema.json",
-            "pio-module/0.11.0/schema.json",
-            "pio-module/0.2/schema.json",
-            "pio-module/0.9/schema.json",
-        ]
+        files, documented,
+        "docs/schema holds exactly what its README documents"
     );
 }
 
-/// Historical files preserve the identifiers that appeared in the checked-in
-/// schemas for those releases, even though the archive now presents them as
-/// one PowerIO IR lineage.
+/// The README's one current row is this build's schema, and every other row
+/// is a historical release whose `$id` is pinned above, in release order.
+#[test]
+fn the_documented_history_ends_at_this_build() {
+    let rows = documented_archive();
+    let current: Vec<&str> = rows
+        .iter()
+        .filter(|row| row.current)
+        .map(|row| row.path.as_str())
+        .collect();
+    assert_eq!(current, [current_schema_path().as_str()]);
+
+    let historical: Vec<&str> = rows
+        .iter()
+        .filter(|row| !row.current)
+        .map(|row| row.path.as_str())
+        .collect();
+    let pinned: Vec<String> = HISTORICAL_IDS
+        .iter()
+        .map(|(version, _)| format!("pio-module/{version}/schema.json"))
+        .collect();
+    assert_eq!(historical, pinned);
+}
+
+/// Historical files preserve the identifiers their releases wrote, even though
+/// the archive presents them as one PowerIO IR lineage.
 #[test]
 fn historical_schemas_preserve_their_original_identifiers() {
-    for (version, expected_id) in [
-        ("0.1", "https://powerio.dev/schema/pio-package/0.1"),
-        ("0.2", "https://powerio.dev/schema/pio-package/0.2"),
-        (
-            "0.9",
-            "https://powerio.dev/schema/pio-package/0.9/schema.json",
-        ),
-        (
-            "0.10.0",
-            "https://powerio.dev/schema/pio-module/1/schema.json",
-        ),
-    ] {
-        let path = format!("../docs/schema/pio-module/{version}/schema.json");
-        let text = std::fs::read_to_string(path).unwrap();
-        let schema: serde_json::Value = serde_json::from_str(&text).unwrap();
-        assert_eq!(schema["$id"], expected_id, "historical schema {version}");
+    for (version, id) in HISTORICAL_IDS {
+        let text = read_schema_file(&format!("pio-module/{version}/schema.json"));
+        assert!(
+            declares_id(&text, id),
+            "historical schema {version} does not declare `$id` {id}"
+        );
     }
 }
 
-/// The document for this build's PowerIO IR version is committed.
+/// The document for this build's PowerIO IR version is committed and names
+/// the address this build serves it from.
 #[test]
 fn the_current_module_document_is_committed() {
-    let version = current_ir_version();
-    let path = format!("../docs/schema/pio-module/{version}/schema.json");
-    let text = std::fs::read_to_string(&path).unwrap_or_else(|e| {
-        panic!(
-            "{path} is the schema document this build serves. Generate it with \
-             `cargo run -p powerio --example generate_schemas --features schema -- \
-             docs/schema` and commit it: {e}"
-        )
-    });
-    let id = format!("https://powerio.dev/schema/pio-module/{version}/schema.json");
+    let text = read_schema_file(&current_schema_path());
     assert!(
-        text.contains(&id),
-        "{path} does not declare `$id` {id}; regenerate it"
+        declares_id(&text, powerio::IR_SCHEMA_ID),
+        "{} does not declare `$id` {}; regenerate it",
+        current_schema_path(),
+        powerio::IR_SCHEMA_ID
     );
 }
 
@@ -131,11 +191,7 @@ fn every_module_document_property_is_typed() {
         }
     }
 
-    let path = format!(
-        "../docs/schema/pio-module/{}/schema.json",
-        current_ir_version()
-    );
-    let text = std::fs::read_to_string(path).unwrap();
+    let text = read_schema_file(&current_schema_path());
     let schema: serde_json::Value = serde_json::from_str(&text).unwrap();
     let mut bad = Vec::new();
     walk(&schema, "$", &mut bad);

--- a/powerio/tests/ir_reference.rs
+++ b/powerio/tests/ir_reference.rs
@@ -11,7 +11,16 @@
 use std::collections::BTreeSet;
 
 const PAGE: &str = include_str!("../../docs/src/ir-reference.md");
-const SCHEMA: &str = include_str!("../../docs/schema/pio-module/0.11.0/schema.json");
+const SCHEMA_PATH: &str = concat!(
+    "docs/schema/pio-module/",
+    env!("CARGO_PKG_VERSION"),
+    "/schema.json"
+);
+const SCHEMA: &str = include_str!(concat!(
+    "../../docs/schema/pio-module/",
+    env!("CARGO_PKG_VERSION"),
+    "/schema.json"
+));
 
 /// A line beginning with this text names the definitions of the next table.
 const MARKER: &str = "Schema definition";
@@ -164,7 +173,7 @@ fn every_documented_field_exists_and_every_schema_field_is_documented() {
 
     assert!(
         problems.is_empty(),
-        "docs/src/ir-reference.md disagrees with docs/schema/pio-module/0.11.0/schema.json:\n{}",
+        "docs/src/ir-reference.md disagrees with {SCHEMA_PATH}:\n{}",
         problems.join("\n")
     );
 }

--- a/powerio/tests/stored_module.rs
+++ b/powerio/tests/stored_module.rs
@@ -430,14 +430,19 @@ fn only_compatible_powerio_ir_versions_are_accepted() {
     assert!(error.contains(&format!("version {newer}")), "{error}");
     assert!(error.contains("upgrade PowerIO"), "{error}");
 
-    // Another line, earlier or later, is another document shape.
-    for version in ["0.10.0", "99.0.0"] {
-        let error = deserialize_module_text(&header(version.into()))
-            .unwrap_err()
-            .to_string();
-        assert!(error.contains(&format!("version {version}")), "{error}");
-        assert!(error.contains("regenerate this one"), "{error}");
-    }
+    // A later release on any line takes the same upgrade advice.
+    let error = deserialize_module_text(&header("99.0.0".into()))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("version 99.0.0"), "{error}");
+    assert!(error.contains("upgrade PowerIO"), "{error}");
+
+    // An earlier line is a document shape no upgrade brings back.
+    let error = deserialize_module_text(&header("0.10.0".into()))
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("version 0.10.0"), "{error}");
+    assert!(error.contains("regenerate this one"), "{error}");
 
     // The v0.10.0 document's integer version is named as written.
     let error = deserialize_module_text(&header(1.into()))

--- a/powerio/tests/stored_module.rs
+++ b/powerio/tests/stored_module.rs
@@ -403,10 +403,10 @@ fn unknown_semantic_fields_are_refused() {
 }
 
 /// The refusal names the version found and says what to do: a document from
-/// a newer build on this build's own line needs that newer PowerIO; a
-/// document from another line, or one that is not PowerIO IR, is regenerated.
+/// any later PowerIO release needs that newer build; a document from an
+/// earlier line, or one that is not PowerIO IR, is regenerated.
 #[test]
-fn only_compatible_powerio_ir_versions_are_accepted() {
+fn an_unreadable_powerio_ir_version_is_refused_with_the_remedy() {
     let header = |version: serde_json::Value| {
         serde_json::json!({ "schema": powerio::IR_SCHEMA_NAME, "version": version }).to_string()
     };
@@ -457,6 +457,7 @@ fn only_compatible_powerio_ir_versions_are_accepted() {
     .to_string();
     let error = deserialize_module_text(&text).unwrap_err().to_string();
     assert!(error.contains("someone.else"), "{error}");
+    assert!(error.contains("regenerate this one"), "{error}");
 }
 
 // ---- the remaining promoted kinds round trip ---------------------------------

--- a/powerio/tests/stored_module.rs
+++ b/powerio/tests/stored_module.rs
@@ -402,19 +402,45 @@ fn unknown_semantic_fields_are_refused() {
     assert!(error.contains("surprise"), "{error}");
 }
 
+/// The refusal names the version found and says what to do: a document from
+/// a newer build on this build's own line needs that newer PowerIO; a
+/// document from another line, or one that is not PowerIO IR, is regenerated.
 #[test]
-fn only_the_current_powerio_ir_version_is_accepted() {
-    for version in ["0.10.0", "0.11.1", "1.0.0"] {
-        let text = serde_json::json!({
-            "schema": powerio::IR_SCHEMA_NAME,
-            "version": version,
-        })
+fn only_compatible_powerio_ir_versions_are_accepted() {
+    let header = |version: serde_json::Value| {
+        serde_json::json!({ "schema": powerio::IR_SCHEMA_NAME, "version": version }).to_string()
+    };
+
+    // The next patch on this build's line, whatever this build's version is.
+    let newer = {
+        let mut parts: Vec<u64> = powerio::IR_SCHEMA_VERSION
+            .split('.')
+            .map(|part| part.parse().unwrap())
+            .collect();
+        *parts.last_mut().unwrap() += 1;
+        parts
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(".")
+    };
+    let error = deserialize_module_text(&header(newer.clone().into()))
+        .unwrap_err()
         .to_string();
-        let error = deserialize_module_text(&text).unwrap_err().to_string();
+    assert!(error.contains(&format!("version {newer}")), "{error}");
+    assert!(error.contains("upgrade PowerIO"), "{error}");
+
+    // Another line, earlier or later, is another document shape.
+    for version in ["0.10.0", "99.0.0"] {
+        let error = deserialize_module_text(&header(version.into()))
+            .unwrap_err()
+            .to_string();
         assert!(error.contains(&format!("version {version}")), "{error}");
+        assert!(error.contains("regenerate this one"), "{error}");
     }
 
-    let error = deserialize_module_text(r#"{"schema": "powerio.module", "version": 1}"#)
+    // The v0.10.0 document's integer version is named as written.
+    let error = deserialize_module_text(&header(1.into()))
         .unwrap_err()
         .to_string();
     assert!(error.contains("version 1"), "{error}");

--- a/python/tests/test_mcp.py
+++ b/python/tests/test_mcp.py
@@ -223,8 +223,10 @@ def test_display_decodes_powerworld_pwd():
 def test_about_reports_exact_tool_list():
     about = server._about_tool()
     assert about["powerio_version"] == powerio.__version__
+    # `about` passes the library's own version report through unchanged;
+    # `scripts/wheel-smoke.py` owns pinning that report to the release version.
+    assert about["module_schema"] == powerio.versions()["module_schema"]
     assert about["module_schema"]["name"] == "powerio.module"
-    assert about["module_schema"]["version"] == powerio.__version__
     assert "parse" in about["tools"]
     assert "export_state" not in about["tools"]
 

--- a/python/tests/test_powerio.py
+++ b/python/tests/test_powerio.py
@@ -533,7 +533,7 @@ def test_balanced_network_module_builds_typed_calculation_instances():
         assert isinstance(module.value, value_type)
         document = json.loads(powerio.serialize(module).text)
         assert document["schema"] == "powerio.module"
-        assert document["version"] == powerio.__version__
+        assert document["version"] == powerio.versions()["module_schema"]["version"]
         assert document["value"]["type"] == structural_type
         assert document["history"][-1]["kind"] == "transform"
 
@@ -799,7 +799,7 @@ def test_parse_goc3_problem_and_solution_with_one_parse(tmp_path):
     assert solution._inner._type_name == "powerio.AcScucSolution"
     document = json.loads(powerio.serialize(solution).text)
     assert document["schema"] == "powerio.module"
-    assert document["version"] == powerio.__version__
+    assert document["version"] == powerio.versions()["module_schema"]["version"]
     assert document["value"]["type"] == "powerio.AcScucSolution"
 
     emitted = json.loads(powerio.emit(solution, "goc3-json").text)
@@ -1085,9 +1085,12 @@ def test_pio_module_emit_uses_dynamic_writer(tmp_path):
     assert json.loads(solved_text)["value"]["type"] == "powerio.AcOpfSolution"
 
 
-def test_deserialize_rejects_a_different_powerio_ir_version():
+def test_deserialize_rejects_a_newer_powerio_ir_version():
+    # The next patch on this build's own line: a document a newer PowerIO
+    # wrote, which this build refuses rather than misreads.
     document = json.loads(powerio.serialize(powerio.parse(DATA / "case9.m")).text)
-    document["version"] = "0.11.1"
+    major, minor, patch = document["version"].split(".")
+    document["version"] = f"{major}.{minor}.{int(patch) + 1}"
 
     with pytest.raises(powerio.PowerIOError) as failure:
         powerio.deserialize(io.StringIO(json.dumps(document)))

--- a/scripts/check-doc-symbols.py
+++ b/scripts/check-doc-symbols.py
@@ -4,7 +4,7 @@ exist on the surfaces that ship. A rendered page with a dead symbol fails.
 
 Checked shapes:
 - C symbols (`pio_*`) in active pages exist in the installed header; the
-  1.0 beta migration inventory may name removed ones.
+  0.10-to-0.11 migration inventory may name removed ones.
 - CLI invocations in shell fences use real subcommands.
 - Julia identifiers in julia fences that PowerIO.jl exports; needs POWERIO_JL
   naming a checkout, else skipped.

--- a/scripts/check-release-versions.sh
+++ b/scripts/check-release-versions.sh
@@ -3,8 +3,9 @@
 # one story before anything publishes.
 #
 # - PIO_ABI_VERSION in the Rust source and the checked-in C header agree.
-# - The PowerIO IR schema name and version agree with the current schema file.
-#   Since 0.11.0, the schema version is the `powerio` crate version.
+# - The generated PowerIO IR schema states the workspace version: since
+#   0.11.0 the IR version is the `powerio` crate version, so the schema file,
+#   its `$id`, and its header constants all name that version.
 # - Every publishable crate carries the one workspace version.
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -17,21 +18,38 @@ if [ "$rust_abi" != "$header_abi" ]; then
 fi
 
 workspace_version=$(grep -oE '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-schema_name=$(grep -oE 'pub const IR_SCHEMA_NAME: &str = "[^"]+"' powerio/src/lib.rs | grep -oE '"[^"]+"$' | tr -d '"')
-if [ "$schema_name" != "powerio.module" ]; then
-    echo "unexpected PowerIO IR schema name: $schema_name" >&2
-    exit 1
-fi
-grep -q 'pub const IR_SCHEMA_VERSION: &str = VERSION;' powerio/src/lib.rs \
-    || { echo "IR_SCHEMA_VERSION must track the powerio crate version" >&2; exit 1; }
+# The generated schema is what a consumer validates a document against, so it
+# is the artifact that states the IR identity: CI regenerates it from the Rust
+# constants, and this gate reads the identity back out of it.
 schema_path="docs/schema/pio-module/$workspace_version/schema.json"
 if [ ! -f "$schema_path" ]; then
     echo "$schema_path is not checked in" >&2
     exit 1
 fi
-grep -q "\"\$id\": \"https://powerio.dev/schema/pio-module/$workspace_version/schema.json\"" \
-    "$schema_path" \
-    || { echo "the current PowerIO IR schema \$id disagrees with $workspace_version" >&2; exit 1; }
+schema_name=$(python3 - "$schema_path" "$workspace_version" <<'PY'
+import json
+import sys
+
+path, version = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    schema = json.load(handle)
+header = schema["properties"]
+expected_id = f"https://powerio.dev/schema/pio-module/{version}/schema.json"
+problems = []
+if schema.get("$id") != expected_id:
+    problems.append(f"$id is {schema.get('$id')!r}, not {expected_id}")
+if header["version"].get("const") != version:
+    problems.append(f"the version constant is {header['version'].get('const')!r}, not {version!r}")
+if problems:
+    print(f"{path}: " + "; ".join(problems), file=sys.stderr)
+    sys.exit(1)
+print(header["schema"]["const"])
+PY
+) || { echo "the current PowerIO IR schema disagrees with workspace version $workspace_version" >&2; exit 1; }
+if [ "$schema_name" != "powerio.module" ]; then
+    echo "unexpected PowerIO IR schema name: $schema_name" >&2
+    exit 1
+fi
 
 for manifest in powerio/Cargo.toml powerio-core/Cargo.toml powerio-tx/Cargo.toml \
                 powerio-dist/Cargo.toml powerio-matrix/Cargo.toml powerio-prob/Cargo.toml \

--- a/scripts/check-value-types.sh
+++ b/scripts/check-value-types.sh
@@ -43,9 +43,11 @@ print("\n".join(sorted(names)))
 PY
 )
 
-schema=$(python3 - <<'PY'
+workspace_version=$(grep -oE '^version = "[0-9]+\.[0-9]+\.[0-9]+"' Cargo.toml | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+schema=$(python3 - "docs/schema/pio-module/$workspace_version/schema.json" <<'PY'
 import json
-with open('docs/schema/pio-module/0.11.0/schema.json', encoding='utf-8') as handle:
+import sys
+with open(sys.argv[1], encoding='utf-8') as handle:
     document = json.load(handle)
 branches = document['$defs']['StoredValue']['oneOf']
 names = sorted(branch['properties']['type']['const'] for branch in branches)

--- a/scripts/terminology-gate.sh
+++ b/scripts/terminology-gate.sh
@@ -109,8 +109,8 @@ if hits=$(rg -n "$retired" "${surface_paths[@]}" 2>/dev/null); then
   exit 1
 fi
 
-# Retired diagnostic namespaces must not return. PowerIO IR has one current
-# reader and no exceptions for earlier documents.
+# Retired diagnostic namespaces must not return. PowerIO IR has one reader,
+# which reads only its own compatible release line.
 if hits=$(rg -n '\bLOWER\.[A-Z_]+' "${public_paths[@]}" 2>/dev/null); then
   echo "retired diagnostic namespace:"
   echo "$hits"


### PR DESCRIPTION
Folded into #482 — its four commits are now `agent/release-0.11` itself, so there is one release-prep branch rather than two. Closing to keep the stack single-file.

They fix the `PowerIO.jl against this C ABI` job that was #482's only red check, and correct the IR version rule so a 0.11.x build reads the whole 0.11.x line instead of demanding an exact version match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiVRGUNuLPF86V9joUBU2P