### PR TITLE
Update quick-xml to 0.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "encoding_rs",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ faer = { version = "0.24.4", default-features = false, features = ["std", "spars
 num-complex = "0.4"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
-quick-xml = { version = "0.38", features = ["encoding"] }
+quick-xml = { version = "0.41", features = ["encoding"] }
 zip = { version = "8.6", default-features = false, features = ["deflate"] }
 uuid = { version = "1", default-features = false, features = ["v5"] }
 schemars = { version = "1", features = ["derive"] }

--- a/powerio-tx/src/format/cgmes/write.rs
+++ b/powerio-tx/src/format/cgmes/write.rs
@@ -7206,7 +7206,7 @@ pub(super) fn validate_rdf_graph(files: &[(String, String)]) -> Result<()> {
                             ))
                         })?;
                         let (attribute_namespace, attribute_local_name) =
-                            reader.resolve_attribute(attribute.key);
+                            reader.resolver().resolve_attribute(attribute.key);
                         if !matches!(
                             attribute_namespace,
                             ResolveResult::Bound(ref value) if value.as_ref() == RDF_NS
@@ -7214,7 +7214,7 @@ pub(super) fn validate_rdf_graph(files: &[(String, String)]) -> Result<()> {
                             continue;
                         }
                         let value = attribute
-                            .decode_and_unescape_value(reader.decoder())
+                            .decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, reader.decoder())
                             .map_err(|error| {
                                 emission_error(format!(
                                     "generated CGMES file `{name}` has an invalid RDF attribute value: {error}"

--- a/powerio-tx/src/format/cgmes/xml.rs
+++ b/powerio-tx/src/format/cgmes/xml.rs
@@ -312,7 +312,7 @@ fn rdf_identity_attr<R>(
 ) -> Result<Option<String>> {
     for attr in start.attributes() {
         let attr = attr.map_err(xml_err)?;
-        let (namespace, local) = reader.resolve_attribute(attr.key);
+        let (namespace, local) = reader.resolver().resolve_attribute(attr.key);
         if is_rdf_attribute(&namespace, local.as_ref(), b"about")
             || is_rdf_attribute(&namespace, local.as_ref(), b"ID")
         {
@@ -331,7 +331,7 @@ fn read_object<R>(
     let mut definition = false;
     for attr in start.attributes() {
         let attr = attr.map_err(xml_err)?;
-        let (namespace, local) = reader.resolve_attribute(attr.key);
+        let (namespace, local) = reader.resolver().resolve_attribute(attr.key);
         if is_rdf_attribute(&namespace, local.as_ref(), b"ID") {
             definition = true;
             id = normalize_id(&String::from_utf8_lossy(&attr.value));
@@ -375,7 +375,7 @@ fn resource_attr<R>(
 ) -> Result<Option<String>> {
     for attr in start.attributes() {
         let attr = attr.map_err(xml_err)?;
-        let (namespace, local) = reader.resolve_attribute(attr.key);
+        let (namespace, local) = reader.resolver().resolve_attribute(attr.key);
         if is_rdf_attribute(&namespace, local.as_ref(), b"resource") {
             return Ok(Some(normalize_id(&String::from_utf8_lossy(&attr.value))));
         }

--- a/powerio-tx/src/format/xiidm.rs
+++ b/powerio-tx/src/format/xiidm.rs
@@ -6534,7 +6534,7 @@ fn attributes(element: &BytesStart<'_>, decoder: quick_xml::encoding::Decoder) -
             .map_err(|error| format_error(error.to_string()))?
             .to_owned();
         let value = attribute
-            .decode_and_unescape_value(decoder)
+            .decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, decoder)
             .map_err(|error| format_error(error.to_string()))?
             .into_owned();
         if values.insert(key.clone(), value).is_some() {
@@ -8230,7 +8230,7 @@ fn open_element(
         let key = std::str::from_utf8(attribute.key.as_ref())
             .map_err(|error| jiidm_emission_error(error.to_string()))?;
         let value = attribute
-            .decode_and_unescape_value(decoder)
+            .decoded_and_normalized_value(quick_xml::XmlVersion::Implicit1_0, decoder)
             .map_err(|error| jiidm_emission_error(error.to_string()))?
             .into_owned();
         if key == "xmlns" || key.starts_with("xmlns:") {


### PR DESCRIPTION
## Summary

- update the workspace `quick-xml` requirement from `0.38` to `0.41`
- refresh `Cargo.lock` to `quick-xml 0.41.0`
- migrate namespace resolution to the 0.41 resolver API
- migrate attribute decoding to the 0.41 normalized-value API
- retain the existing `encoding` feature

## Validation

All pull-request workflows pass on `0ef80882986d852dc8aa802746af873448145618`:

- Rust
- Validation
- Python
- Julia binding
- Docs
- Fuzz smoke
- Conversion Matrix
- PowSybl interoperability