### PR TITLE
FFI safety audit: mutation contract and boundary getter hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,13 @@ crates.
 
 ### Bindings
 
+- The C header states the mutation contract: `pio_apply_updates` and
+  `pio_apply_bus_load_active_power` invalidate plain view structs read from the
+  module handle and require exclusive access to it. Handle payloads are
+  checked `Send + Sync` at compile time, bus specification readers return a
+  range error instead of panicking, and the unit and field name getters in C
+  and Python return `unknown` for a variant the build does not name instead of
+  aborting.
 - C ABI 7 replaces ABI 6 with no aliases for earlier generations and no
   Arrow export. Sources, destinations, modules, typed values, collections,
   diagnostics, artifacts, matrices, and vectors use opaque reference counted

--- a/powerio-capi/cbindgen.toml
+++ b/powerio-capi/cbindgen.toml
@@ -21,7 +21,12 @@ header = """
  * Each opaque handle has retain and release functions. A child value,
  * network, collection entry, or artifact keeps its owner alive. Concurrent
  * immutable access is allowed; releasing one raw handle concurrently with a
- * call that uses that same raw handle is caller error.
+ * call that uses that same raw handle is caller error. pio_apply_updates and
+ * pio_apply_bus_load_active_power need exclusive access to their PioModule
+ * handle for the duration of the call, and they invalidate every plain
+ * Pio*View struct previously read from that handle; owner rooted handles
+ * stay valid. Every pointer a caller passes must be aligned for its type and
+ * must address at most PTRDIFF_MAX bytes.
  *
  * Every fallible operation reports through PioError **. A NULL error
  * parameter discards the error. Branch on pio_error_code, not on message

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -12,7 +12,12 @@
  * Each opaque handle has retain and release functions. A child value,
  * network, collection entry, or artifact keeps its owner alive. Concurrent
  * immutable access is allowed; releasing one raw handle concurrently with a
- * call that uses that same raw handle is caller error.
+ * call that uses that same raw handle is caller error. pio_apply_updates and
+ * pio_apply_bus_load_active_power need exclusive access to their PioModule
+ * handle for the duration of the call, and they invalidate every plain
+ * Pio*View struct previously read from that handle; owner rooted handles
+ * stay valid. Every pointer a caller passes must be aligned for its type and
+ * must address at most PTRDIFF_MAX bytes.
  *
  * Every fallible operation reports through PioError **. A NULL error
  * parameter discards the error. Branch on pio_error_code, not on message
@@ -4085,8 +4090,12 @@ void pio_calculation_update_release(PioCalculationUpdate *update);
 /**
  * Apply a complete typed update batch atomically.
  *
- * Existing borrowed views keep the pre-update module alive. The module handle
- * detaches by copy on write before a successful change.
+ * Owner rooted handles obtained before the call (values, networks, collection
+ * entries, artifacts) keep the pre-update module alive. Plain view structs read
+ * from this module handle (`PioStringView`, `PioModuleSourceView`, history and
+ * source map views) are invalidated by a successful call and must be read
+ * again. The caller must hold exclusive access to `module` for the duration of
+ * the call: no concurrent call of any kind on this handle, including retain.
  */
 PioUpdateReport *pio_apply_updates(PioModule *module,
                                    const PioCalculationUpdate *const *updates,
@@ -4095,6 +4104,9 @@ PioUpdateReport *pio_apply_updates(PioModule *module,
 
 /**
  * Replace aggregate active demand at one bus using the named allocation rule.
+ *
+ * The view invalidation and exclusivity contract of `pio_apply_updates`
+ * applies.
  */
 PioUpdateReport *pio_apply_bus_load_active_power(PioModule *module,
                                                  size_t bus_id,

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -2155,6 +2155,10 @@ pub struct PioScucContingencyComponentView {
 
 // ---- shared handle machinery ----------------------------------------------
 
+/// Every handle payload must be shareable across threads: the header lets
+/// callers move and retain handles from any thread.
+const fn assert_send_sync<T: Send + Sync>() {}
+
 #[repr(transparent)]
 struct HandleBox<T> {
     inner: Arc<T>,
@@ -2193,6 +2197,7 @@ macro_rules! opaque_handle {
         $(#[$doc])*
         #[repr(transparent)]
         pub struct $name(HandleBox<$inner>);
+        const _: () = assert_send_sync::<$inner>();
 
         #[allow(dead_code)]
         impl $name {
@@ -5777,7 +5782,18 @@ pub unsafe extern "C" fn pio_dc_pf_instance_bus_specification_at(
                     format!("DC bus specification index {index} is out of range"),
                 )
             })?;
-            let bus_id = instance.network().buses()[index].id.0;
+            let bus_id = instance
+                .network()
+                .buses()
+                .get(index)
+                .ok_or_else(|| {
+                    boundary_error(
+                        &codes::BIND_CAPI_INDEX_OUT_OF_RANGE,
+                        format!("bus specification index {index} has no bus"),
+                    )
+                })?
+                .id
+                .0;
             let (kind, net_active_power_mw, voltage_angle_degrees) = match *specification {
                 powerio_prob::DcBusSpecification::NetActivePower { p_mw } => {
                     ("net_active_power", p_mw, 0.0)
@@ -5845,7 +5861,18 @@ pub unsafe extern "C" fn pio_ac_pf_instance_bus_specification_at(
                     format!("AC bus specification index {index} is out of range"),
                 )
             })?;
-            let bus_id = instance.network().buses()[index].id.0;
+            let bus_id = instance
+                .network()
+                .buses()
+                .get(index)
+                .ok_or_else(|| {
+                    boundary_error(
+                        &codes::BIND_CAPI_INDEX_OUT_OF_RANGE,
+                        format!("bus specification index {index} has no bus"),
+                    )
+                })?
+                .id
+                .0;
             let (kind, p, q, vm, va) = match *specification {
                 powerio_prob::AcBusSpecification::Pq { p, q } => ("pq", p, q, 0.0, 0.0),
                 powerio_prob::AcBusSpecification::Pv { p, vm } => ("pv", p, 0.0, vm, 0.0),
@@ -14079,7 +14106,7 @@ pub unsafe extern "C" fn pio_active_power_unit(power: *const PioActivePower) -> 
         PioStringView::new(match power.unit() {
             ActivePowerUnit::Watts => "watts",
             ActivePowerUnit::Megawatts => "megawatts",
-            _ => unreachable!("unsupported active power unit from this PowerIO build"),
+            _ => "unknown",
         })
     })
 }
@@ -14117,7 +14144,7 @@ pub unsafe extern "C" fn pio_reactive_power_unit(power: *const PioReactivePower)
         PioStringView::new(match power.unit() {
             ReactivePowerUnit::Vars => "vars",
             ReactivePowerUnit::Megavars => "megavars",
-            _ => unreachable!("unsupported reactive power unit from this PowerIO build"),
+            _ => "unknown",
         })
     })
 }
@@ -14155,7 +14182,7 @@ pub unsafe extern "C" fn pio_apparent_power_unit(power: *const PioApparentPower)
         PioStringView::new(match power.unit() {
             ApparentPowerUnit::VoltAmperes => "volt_amperes",
             ApparentPowerUnit::MegavoltAmperes => "megavolt_amperes",
-            _ => unreachable!("unsupported apparent power unit from this PowerIO build"),
+            _ => "unknown",
         })
     })
 }
@@ -14755,8 +14782,12 @@ unsafe fn module_make_mut<'a>(
 
 /// Apply a complete typed update batch atomically.
 ///
-/// Existing borrowed views keep the pre-update module alive. The module handle
-/// detaches by copy on write before a successful change.
+/// Owner rooted handles obtained before the call (values, networks, collection
+/// entries, artifacts) keep the pre-update module alive. Plain view structs read
+/// from this module handle (`PioStringView`, `PioModuleSourceView`, history and
+/// source map views) are invalidated by a successful call and must be read
+/// again. The caller must hold exclusive access to `module` for the duration of
+/// the call: no concurrent call of any kind on this handle, including retain.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_apply_updates(
     module: *mut PioModule,
@@ -14796,6 +14827,9 @@ pub unsafe extern "C" fn pio_apply_updates(
 }
 
 /// Replace aggregate active demand at one bus using the named allocation rule.
+///
+/// The view invalidation and exclusivity contract of `pio_apply_updates`
+/// applies.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pio_apply_bus_load_active_power(
     module: *mut PioModule,
@@ -14884,7 +14918,7 @@ fn updated_field_name(field: UpdatedField) -> &'static str {
         UpdatedField::TransformerTapRatio => "transformer_tap_ratio",
         UpdatedField::TransformerPhaseShift => "transformer_phase_shift",
         UpdatedField::SwitchClosed => "switch_closed",
-        _ => unreachable!("unsupported updated field from this PowerIO build"),
+        _ => "unknown",
     }
 }
 

--- a/powerio-py/Cargo.toml
+++ b/powerio-py/Cargo.toml
@@ -19,9 +19,9 @@ crate-type = ["cdylib"]
 # Opt-in so `cargo test`/`cargo check -p powerio-py` don't link libpython.
 # maturin turns it on via pyproject `[tool.maturin] features`.
 extension-module = ["pyo3/extension-module"]
-# Compile in the gridfm-datakit Parquet writer (`Network.write_gridfm`,
-# `write_gridfm_batch`). The PyPI build enables this; custom local builds can
-# omit it when they need only parse/write/convert and sparse matrices.
+# Compile in the GridFM Parquet emitter behind `emit(module, "gridfm", ...)`.
+# The PyPI build enables this; custom local builds can omit it when they need
+# only parse, emit, and sparse matrices.
 gridfm = ["powerio-matrix/gridfm", "powerio/gridfm"]
 
 [dependencies]

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -1136,9 +1136,6 @@ impl PyBalancedNetwork {
         let report = inner.apply_geo_layer(&parsed.layer);
         let mut diagnostics = self.diagnostics().to_vec();
         diagnostics.extend(parsed.diagnostics);
-        // Locations never move buses, so the cached index stays valid.
-        let core = self.core.clone();
-        let _ = core;
         Ok((
             case_from_parts(inner, diagnostics),
             geo_report_dict(py, &report)?,
@@ -1896,7 +1893,15 @@ impl From<&powerio_prob::ScucReactiveCapability> for PyScucReactiveCapability {
                 slope_min: Some(*slope_min),
                 slope_max: Some(*slope_max),
             },
-            _ => unreachable!("unrecognized ScucReactiveCapability value"),
+            _ => Self {
+                kind: "unknown",
+                reactive_power_at_zero_active_power: std::option::Option::None,
+                reactive_power_at_zero_active_power_min: std::option::Option::None,
+                reactive_power_at_zero_active_power_max: std::option::Option::None,
+                slope: std::option::Option::None,
+                slope_min: std::option::Option::None,
+                slope_max: std::option::Option::None,
+            },
         }
     }
 }
@@ -1994,7 +1999,7 @@ impl PyScucDevice {
         match self.inner.kind {
             powerio_prob::ScucDeviceKind::Producer => "producer",
             powerio_prob::ScucDeviceKind::Consumer => "consumer",
-            _ => unreachable!("unrecognized ScucDeviceKind value"),
+            _ => "unknown",
         }
     }
 
@@ -2681,7 +2686,7 @@ impl PyActivePower {
         match self.inner.unit() {
             powerio_prob::ActivePowerUnit::Watts => "watts",
             powerio_prob::ActivePowerUnit::Megawatts => "megawatts",
-            _ => unreachable!("all active power units have Python spellings"),
+            _ => "unknown",
         }
     }
 
@@ -2727,7 +2732,7 @@ impl PyReactivePower {
         match self.inner.unit() {
             powerio_prob::ReactivePowerUnit::Vars => "vars",
             powerio_prob::ReactivePowerUnit::Megavars => "megavars",
-            _ => unreachable!("all reactive power units have Python spellings"),
+            _ => "unknown",
         }
     }
 
@@ -2773,7 +2778,7 @@ impl PyApparentPower {
         match self.inner.unit() {
             powerio_prob::ApparentPowerUnit::VoltAmperes => "volt_amperes",
             powerio_prob::ApparentPowerUnit::MegavoltAmperes => "megavolt_amperes",
-            _ => unreachable!("all apparent power units have Python spellings"),
+            _ => "unknown",
         }
     }
 
@@ -2795,7 +2800,7 @@ fn operating_update_field(update: &powerio_prob::OperatingPointUpdate) -> &'stat
         U::TransformerTapRatio { .. } => "transformer_tap_ratio",
         U::TransformerPhaseShift { .. } => "transformer_phase_shift",
         U::SwitchClosed { .. } => "switch_closed",
-        _ => unreachable!("all operating point updates have Python spellings"),
+        _ => "unknown",
     }
 }
 
@@ -2979,7 +2984,7 @@ impl PyNetworkUpdate {
     fn field(&self) -> &'static str {
         match self.inner {
             powerio_prob::NetworkUpdate::BranchThermalRating { .. } => "branch_thermal_rating",
-            _ => unreachable!("all network updates have Python spellings"),
+            _ => "unknown",
         }
     }
 
@@ -3023,7 +3028,7 @@ impl PyCalculationUpdate {
         match self.inner {
             powerio_prob::CalculationUpdate::OperatingPoint(_) => "operating_point",
             powerio_prob::CalculationUpdate::Network(_) => "network",
-            _ => unreachable!("all calculation updates have Python spellings"),
+            _ => "unknown",
         }
     }
 
@@ -3046,7 +3051,7 @@ fn updated_field_name(field: powerio_prob::UpdatedField) -> &'static str {
         F::TransformerTapRatio => "transformer_tap_ratio",
         F::TransformerPhaseShift => "transformer_phase_shift",
         F::SwitchClosed => "switch_closed",
-        _ => unreachable!("all updated fields have Python spellings"),
+        _ => "unknown",
     }
 }
 


### PR DESCRIPTION
## Summary

The pre-release FFI safety audit found no memory corruption reachable through a documented sequence except one false contract claim. This PR takes its "before release" and "cheap hardening" items; companion: eigenergy/PowerIO.jl#133.

- **H-1, M-1, L-5** `pio_apply_updates` and `pio_apply_bus_load_active_power` invalidate every plain `Pio*View` struct read from the module handle and need exclusive access to it. The doc comments and the header preamble say so, and the preamble states the alignment and `PTRDIFF_MAX` preconditions on caller pointers. The header is regenerated from the same cbindgen configuration with no other change.
- **M-3** Every `opaque_handle!` payload is checked `Send + Sync` at compile time.
- **L-1** The DC and AC bus specification readers use a checked bus lookup and return `BIND.CAPI.INDEX_OUT_OF_RANGE` instead of a caught panic.
- **L-2, L-10** The unit and updated field getters in the C ABI (four) and the Python extension (nine) return `unknown` for a variant this build does not name instead of aborting or raising `PanicException`.
- **L-12** Dead index clone and stale feature comment in the Python extension removed.

Deferred as the audit suggests: L-3 and L-4 (the emit prologue and two objective getters outside `entry`), L-9 (library resolution order in PowerIO.jl), L-11 (a coded Python panic wrapper).

## Validation
`cargo check`, `cargo clippy -D warnings`, and `cargo test` for `powerio-capi` and `powerio-py` with all features; the PowerIO.jl suite against the rebuilt library; `cargo fmt`; header regeneration diff limited to the contract text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6AaN7mHwhMgqNuimJF4kW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6AaN7mHwhMgqNuimJF4kW)_