### PR TITLE
FFI safety audit: the remaining boundary findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,10 @@ crates.
   range error instead of panicking, and the unit and field name getters in C
   and Python return `unknown` for a variant the build does not name instead of
   aborting.
+- `pio_emit` validates its format inside the panic boundary, the two objective
+  getters run inside it as well, and a Rust panic in the Python extension
+  raises `PowerIOError` with code `BIND.PY.PANIC` instead of escaping as
+  `PanicException`.
 - C ABI 7 replaces ABI 6 with no aliases for earlier generations and no
   Arrow export. Sources, destinations, modules, typed values, collections,
   diagnostics, artifacts, matrices, and vectors use opaque reference counted

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -202,6 +202,9 @@ helpers, and NetworkX only by `to_networkx`.
 Parse failures raise `PowerIOParseError`. Valid data that cannot satisfy an
 operation raises `PowerIODataError`. Both derive from `PowerIOError` and carry
 a stable diagnostic code. Branch on `.code`, not the rendered message.
+A Rust panic inside the extension surfaces as `PowerIOError` with code
+`BIND.PY.PANIC`, never as `pyo3_runtime.PanicException`; module state is
+unchanged because every mutation is built in full before it is installed.
 
 ## MCP server
 

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -15048,7 +15048,7 @@ unsafe fn run_output_operation(
     operation: impl FnOnce(
         &powerio::PioModule<PioValue>,
         Destination,
-    ) -> Result<EmitResult, powerio_core::Error>,
+    ) -> Result<EmitResult, *mut PioError>,
 ) -> *mut PioEmitResult {
     unsafe {
         entry(error, std::ptr::null_mut(), || {
@@ -15064,9 +15064,7 @@ unsafe fn run_output_operation(
             let destination = destination
                 .build()
                 .map_err(|failure| error_from_core(&failure))?;
-            operation(&module.module, destination)
-                .map(emit_result_handle)
-                .map_err(|failure| error_from_core(&failure))
+            operation(&module.module, destination).map(emit_result_handle)
         })
     }
 }
@@ -15080,16 +15078,10 @@ pub unsafe extern "C" fn pio_emit(
     destination: *const PioDestination,
     error: *mut *mut PioError,
 ) -> *mut PioEmitResult {
-    let format = match unsafe { required_str(format, format_len, "format") } {
-        Ok(format) => format.to_owned(),
-        Err(failure) => {
-            unsafe { store_error(error, failure) };
-            return std::ptr::null_mut();
-        }
-    };
     unsafe {
         run_output_operation(module, destination, error, |module, destination| {
-            powerio::emit(module, &format, destination)
+            let format = required_str(format, format_len, "format")?;
+            powerio::emit(module, format, destination).map_err(|failure| error_from_core(&failure))
         })
     }
 }
@@ -15103,7 +15095,7 @@ pub unsafe extern "C" fn pio_module_serialize(
 ) -> *mut PioEmitResult {
     unsafe {
         run_output_operation(module, destination, error, |module, destination| {
-            powerio::serialize(module, destination)
+            powerio::serialize(module, destination).map_err(|failure| error_from_core(&failure))
         })
     }
 }
@@ -15286,23 +15278,29 @@ pub unsafe extern "C" fn pio_calculation_solution_get_objective(
     if out_objective.is_null() {
         return false;
     }
-    let Some(solution) =
-        (unsafe { PioCalculationSolution::get(solution) }).and_then(ValueInner::value)
-    else {
-        return false;
-    };
-    let objective = match solution {
-        PioValue::DcOpfSolution(solution) => Some(solution.objective()),
-        PioValue::AcOpfSolution(solution) => Some(solution.objective()),
-        PioValue::McAcOpfSolution(solution) => Some(solution.objective()),
-        PioValue::AcScucSolution(solution) => solution.objective(),
-        _ => None,
-    };
-    if let Some(objective) = objective {
-        unsafe { *out_objective = objective };
-        true
-    } else {
-        false
+    // No error slot: a missing objective is an ordinary false. `entry` still
+    // turns a panic into false instead of aborting the caller.
+    unsafe {
+        entry(std::ptr::null_mut(), false, || {
+            let Some(solution) = PioCalculationSolution::get(solution).and_then(ValueInner::value)
+            else {
+                return Ok(false);
+            };
+            let objective = match solution {
+                PioValue::DcOpfSolution(solution) => Some(solution.objective()),
+                PioValue::AcOpfSolution(solution) => Some(solution.objective()),
+                PioValue::McAcOpfSolution(solution) => Some(solution.objective()),
+                PioValue::AcScucSolution(solution) => solution.objective(),
+                _ => None,
+            };
+            Ok(match objective {
+                Some(objective) => {
+                    *out_objective = objective;
+                    true
+                }
+                None => false,
+            })
+        })
     }
 }
 
@@ -15314,13 +15312,18 @@ pub unsafe extern "C" fn pio_socwr_opf_solution_get_objective_lower_bound(
     if out_lower_bound.is_null() {
         return false;
     }
-    let Some(PioValue::SocwrOpfSolution(solution)) =
-        (unsafe { PioCalculationSolution::get(solution) }).and_then(ValueInner::value)
-    else {
-        return false;
-    };
-    unsafe { *out_lower_bound = solution.objective_lower_bound() };
-    true
+    // No error slot, as for pio_calculation_solution_get_objective.
+    unsafe {
+        entry(std::ptr::null_mut(), false, || {
+            let Some(PioValue::SocwrOpfSolution(solution)) =
+                PioCalculationSolution::get(solution).and_then(ValueInner::value)
+            else {
+                return Ok(false);
+            };
+            *out_lower_bound = solution.objective_lower_bound();
+            Ok(true)
+        })
+    }
 }
 
 fn balanced_branch_identities(network: &BalancedNetwork) -> impl Iterator<Item = &str> {

--- a/powerio-py/src/lib.rs
+++ b/powerio-py/src/lib.rs
@@ -33,6 +33,15 @@ use powerio_tx::{
     POWER_MODELS_ANGLE_BOUND_PAD, classify_json_text as classify_balanced_json_text,
 };
 
+/// Diagnostic codes this binding raises on its own, beside the codes the core
+/// crates report.
+pub mod codes {
+    powerio_core::diagnostic_codes! {
+        BIND_PY_PANIC = "BIND.PY.PANIC", Error,
+            "a panic was caught at the Python boundary and did not cross it", category = Data;
+    }
+}
+
 pyo3::create_exception!(
     powerio,
     PowerIOError,
@@ -4269,6 +4278,11 @@ fn _powerio(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("PowerIOError", m.py().get_type::<PowerIOError>())?;
     m.add("PowerIOParseError", m.py().get_type::<PowerIOParseError>())?;
     m.add("PowerIODataError", m.py().get_type::<PowerIODataError>())?;
+    m.add(
+        "PanicException",
+        m.py().get_type::<pyo3::panic::PanicException>(),
+    )?;
+    m.add("PANIC_CODE", codes::BIND_PY_PANIC.code)?;
     m.add_class::<PyBalancedNetwork>()?;
     m.add_function(wrap_pyfunction!(parse_display, m)?)?;
     m.add_class::<PyMulticonductorNetwork>()?;

--- a/python/powerio/__init__.py
+++ b/python/powerio/__init__.py
@@ -40,6 +40,8 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Union
 
 from . import _powerio
+from ._guard import guard as _guard
+from ._guard import guard_class as _guard_class
 from ._powerio import (
     ActivePower,
     ApparentPower,
@@ -318,6 +320,7 @@ _BALANCED_DELEGATED_NAMES = frozenset(
 )
 
 
+@_guard_class
 class BalancedNetwork:
     """A parsed balanced power network.
 
@@ -687,17 +690,20 @@ class BalancedNetwork:
         return g
 
 
+@_guard
 def parse_display(path: Any, format: Optional[str] = None) -> DisplayData:
     """Parse a display artifact such as a PowerWorld ``.pwd`` file."""
     return _wrap_display(_powerio.parse_display(str(path), format))
 
 
+@_guard
 def resolve_format(name: str) -> Optional[FormatInfo]:
     """Resolve a format token or common alias to its canonical metadata."""
     resolved = _powerio.resolve_format(name)
     return None if resolved is None else FormatInfo(*resolved)
 
 
+@_guard
 def parse_geo(text: str, name_hint: Optional[str] = None) -> dict[str, Any]:
     """Tolerantly read a geographic sidecar and return its canonical form.
 
@@ -796,6 +802,7 @@ def _ppc_to_matpower_text(ppc) -> str:
     return "\n".join(lines) + "\n"
 
 
+@_guard
 def from_ppc(ppc) -> BalancedNetwork:
     """Case from a PYPOWER dict (``ppc``); the inverse of :meth:`BalancedNetwork.to_ppc`.
 
@@ -824,6 +831,7 @@ from . import dist  # noqa: E402  (needs EmitResult defined above)
 MulticonductorNetwork = dist.MulticonductorNetwork
 
 
+@_guard
 def versions() -> Any:
     """Return the PowerIO release, sole IR identity, and BMOPF schema."""
     return _json.loads(_powerio.versions_json())
@@ -869,6 +877,7 @@ def _bind_collection_entry(
     return value
 
 
+@_guard_class
 class TimeSeries(_TypedValue, Sequence):
     """Values of one type ordered in time."""
 
@@ -935,6 +944,7 @@ class TimeSeries(_TypedValue, Sequence):
         return (self[position] for position in range(len(self)))
 
 
+@_guard_class
 class ScenarioSet(_TypedValue, Mapping):
     """Named alternatives of one type, with optional probabilities."""
 
@@ -997,10 +1007,12 @@ class ScenarioSet(_TypedValue, Mapping):
         )
 
 
+@_guard_class
 class OperatingPoint(_TypedValue):
     """A possibly partial assignment over fixed equipment identities."""
 
 
+@_guard_class
 class _BalancedCalculation(_TypedValue):
     """A calculation over one shared balanced network."""
 
@@ -1010,6 +1022,7 @@ class _BalancedCalculation(_TypedValue):
         return BalancedNetwork(self.module._inner._balanced_calculation_network())
 
 
+@_guard_class
 class _MulticonductorCalculation(_TypedValue):
     """A calculation over one shared multiconductor network."""
 
@@ -1021,6 +1034,7 @@ class _MulticonductorCalculation(_TypedValue):
         )
 
 
+@_guard_class
 class _CalculationSolution(_TypedValue):
     """A solution that retains the exact typed instance it solves."""
 
@@ -1054,6 +1068,7 @@ class McAcOpfInstance(_MulticonductorCalculation):
     """A multiconductor AC optimal power flow calculation instance."""
 
 
+@_guard_class
 class AcScucInstance(_BalancedCalculation):
     """An AC security constrained unit commitment calculation instance."""
 
@@ -1091,6 +1106,7 @@ class McAcOpfSolution(_MulticonductorCalculation, _CalculationSolution):
     """A multiconductor AC optimal power flow solution."""
 
 
+@_guard_class
 class AcScucSolution(_BalancedCalculation, _CalculationSolution):
     """An AC security constrained unit commitment solution."""
 
@@ -1125,6 +1141,7 @@ class AcScucSolution(_BalancedCalculation, _CalculationSolution):
         return self.module._inner._ac_scuc_solution_objective()
 
 
+@_guard_class
 class GeoLayer(_TypedValue):
     """A standalone geographic document: element points and routes keyed by
     element identity, in one coordinate space.
@@ -1170,6 +1187,7 @@ _VALUE_CLASSES: dict[str, type[_TypedValue]] = {
 }
 
 
+@_guard_class
 class PioModule:
     """One typed value with diagnostics, producer, sources, source mappings,
     history, and extensions.
@@ -1288,6 +1306,7 @@ def _refresh_collection_entry(target: Any, location: _CollectionEntry) -> None:
         raise TypeError("the selected value does not support typed updates")
 
 
+@_guard
 def apply_updates(
     target: Any,
     updates: Union[
@@ -1321,6 +1340,7 @@ def apply_updates(
     return report
 
 
+@_guard
 def apply_bus_load_active_power(
     module: PioModule,
     bus_id: int,
@@ -1388,6 +1408,7 @@ def _memory_from_source(source: Any, name: Optional[str]) -> tuple[bytes, str]:
     return data, name
 
 
+@_guard
 def parse(
     source: Any,
     *,
@@ -1458,6 +1479,7 @@ def _emit_to_destination(
     return result
 
 
+@_guard
 def emit(module: PioModule, format: str, destination: Optional[Any] = None) -> EmitResult:
     """Emit a module as one grid exchange format."""
     return _emit_to_destination(
@@ -1468,6 +1490,7 @@ def emit(module: PioModule, format: str, destination: Optional[Any] = None) -> E
     )
 
 
+@_guard
 def serialize(module: PioModule, destination: Optional[Any] = None) -> EmitResult:
     """Serialize a module as PowerIO IR."""
     return _emit_to_destination(
@@ -1478,6 +1501,7 @@ def serialize(module: PioModule, destination: Optional[Any] = None) -> EmitResul
     )
 
 
+@_guard
 def deserialize(source: Any) -> PioModule:
     """Deserialize PowerIO IR from a path, file object, or bytes-like source."""
     path = _path_from_source(source)
@@ -1487,6 +1511,7 @@ def deserialize(source: Any) -> PioModule:
     return PioModule(_powerio._PioModule._deserialize_memory(data))
 
 
+@_guard
 def features() -> dict[str, bool]:
     """The build-time features compiled into this powerio installation.
 

--- a/python/powerio/_guard.py
+++ b/python/powerio/_guard.py
@@ -1,0 +1,52 @@
+"""Convert a Rust panic into a coded :class:`PowerIOError`.
+
+pyo3 reports a panic as ``pyo3_runtime.PanicException``, a ``BaseException``
+that escapes ``except Exception``. Every public entry point of this package is
+wrapped so a panic surfaces as ``PowerIOError`` with code ``BIND.PY.PANIC``,
+the same shape the C ABI gives its callers.
+"""
+
+from __future__ import annotations
+
+import functools
+import types
+from typing import Any, Callable, TypeVar
+
+from ._powerio import PANIC_CODE, PanicException, PowerIOError
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+_C = TypeVar("_C", bound=type)
+
+
+def panic_error(exc: BaseException) -> PowerIOError:
+    error = PowerIOError(f"PowerIO panicked inside the extension: {exc}")
+    error.code = PANIC_CODE
+    return error
+
+
+def guard(fn: _F) -> _F:
+    """Wrap one callable so a panic raises :class:`PowerIOError`."""
+
+    @functools.wraps(fn)
+    def guarded(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except PanicException as exc:
+            raise panic_error(exc) from None
+
+    return guarded  # type: ignore[return-value]
+
+
+def guard_class(cls: _C) -> _C:
+    """Wrap every function, property, classmethod, and staticmethod of ``cls``."""
+    for name, member in list(vars(cls).items()):
+        if isinstance(member, types.FunctionType):
+            setattr(cls, name, guard(member))
+        elif isinstance(member, property):
+            fget = guard(member.fget) if member.fget is not None else None
+            setattr(cls, name, property(fget, member.fset, member.fdel, member.__doc__))
+        elif isinstance(member, classmethod):
+            setattr(cls, name, classmethod(guard(member.__func__)))
+        elif isinstance(member, staticmethod):
+            setattr(cls, name, staticmethod(guard(member.__func__)))
+    return cls

--- a/python/powerio/_powerio.pyi
+++ b/python/powerio/_powerio.pyi
@@ -60,6 +60,11 @@ __all__ = [
     "versions_json",
 ]
 
+PANIC_CODE: str
+
+class PanicException(BaseException):
+    """A Rust panic pyo3 caught at the boundary; the wrapper converts it."""
+
 class PowerIOError(ValueError):
     """Base error from the powerio parser, emitter, or matrix calculations.
 

--- a/python/powerio/dist.py
+++ b/python/powerio/dist.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 import json as _json
 from typing import Any, Optional
 
+from ._guard import guard_class as _guard_class
+
 __all__ = ["MulticonductorNetwork"]
 
 
+@_guard_class
 class MulticonductorNetwork:
     """A parsed multiconductor distribution network in wire coordinates.
 


### PR DESCRIPTION
## Summary

The findings #488 deferred, now fixed. Companion for the Julia side: eigenergy/PowerIO.jl (library resolution).

- **L-3** `pio_emit` validates its format string inside the `entry` wrapper. `run_output_operation` now takes a boundary error from its operation, so a prologue panic reports `BIND.CAPI.PANIC` instead of aborting.
- **L-4** `pio_calculation_solution_get_objective` and `pio_socwr_opf_solution_get_objective_lower_bound` run inside `entry` with no error slot: a missing objective is still an ordinary `false`, and a panic becomes `false` instead of an abort. Signatures and the header are unchanged.
- **L-11** The Python extension exports pyo3's `PanicException` and a registered `BIND.PY.PANIC` code. Every public function and every method, property, and classmethod of the wrapper classes is wrapped by `powerio._guard`, so a Rust panic raises `PowerIOError` with that code rather than a `BaseException` that escapes `except Exception`. Documented under Errors in the Python guide.

## Validation
`cargo check`, `cargo clippy -D warnings`, and `cargo test` for `powerio-capi` and `powerio-py` with all features; header regeneration diff empty; `ruff check`; `mypy python/powerio`; the PowerIO.jl suite against the rebuilt library and the Python suite against a local `maturin develop` build are running as this opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6AaN7mHwhMgqNuimJF4kW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6AaN7mHwhMgqNuimJF4kW)_