### PR TITLE
fix: guard retagged release builds and clarify the 0.11 guide

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -21,6 +21,12 @@ on:
 permissions:
   contents: read
 
+# A moved, unpublished tag supersedes its previous build. Keep one run per
+# ref so its assets cannot race another run for the same draft release.
+concurrency:
+  group: release-binaries-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -262,6 +268,22 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Verify the tag still names this build
+        shell: bash
+        env:
+          RELEASE_REF: ${{ github.ref }}
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          # Annotated tags resolve through ^{}; lightweight tags name the
+          # commit directly. A missing or moved tag must attach no assets.
+          refs="$(git ls-remote --tags origin "$RELEASE_REF" "${RELEASE_REF}^{}")"
+          tag_sha="$(printf '%s\n' "$refs" | awk '$2 !~ /\^\{\}$/ { print $1 }')"
+          peeled_sha="$(printf '%s\n' "$refs" | awk '$2 ~ /\^\{\}$/ { print $1 }')"
+          current_sha="${peeled_sha:-$tag_sha}"
+          if [ "$current_sha" != "$RELEASE_SHA" ]; then
+            echo "::error::Release tag moved or disappeared while this build ran."
+            exit 1
+          fi
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: libpowerio_capi.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,18 @@ The release version lives in `[workspace.package]` and the workspace dependency
 pins in `[workspace.dependencies]`. Update them together; the next Cargo command
 updates `Cargo.lock`. Then:
 
-1. Merge the bump with a `CHANGELOG.md` section headed exactly `## X.Y.Z`,
-   tag the commit `vX.Y.Z`, and push the tag. The release-binaries workflow
+1. Merge the bump with a `CHANGELOG.md` section headed exactly `## X.Y.Z`
+   and wait for main CI. Complete the paired PowerIO.jl review first: its
+   version, changelog, and ready release intent must identify this release,
+   and the intent digest must match the final Julia tree. Follow
+   [PowerIO.jl's release procedure](https://github.com/eigenergy/PowerIO.jl/blob/main/CONTRIBUTING.md#releasing).
+2. Create an annotated `vX.Y.Z` tag on the tested main commit and push it.
+   The release-binaries workflow
    checks the tag against the workspace version and that heading, builds the
    C ABI tarballs, and stages a draft GitHub release whose body is that
    section.
-2. Publish the draft release. The release event fires the PyPI publish
+3. Inspect the draft and its five binary assets, then publish the release.
+   The release event fires the PyPI publish
    (python.yml) and the crates.io publish (crates.yml: powerio-core,
    powerio-tx, powerio-dist, powerio-prob, powerio-matrix, powerio, and
    powerio-cli, in dependency order). Both deploy through reviewer protected
@@ -60,9 +66,13 @@ updates `Cargo.lock`. Then:
    settings). PyPI skips files it already has and crates.io skips versions
    already in the index, so if one of them fails partway you recover by
    running it again.
-3. Follow up in PowerIO.jl: regenerate Artifacts.toml from the new tag and
-   register the new version (see its CONTRIBUTING.md). A breaking C ABI change
-   bumps `PIO_ABI_VERSION` first; see "C ABI changes" above.
+4. Check PowerIO.jl's "Update artifacts" workflow. After publication it
+   validates the release against the ready intent, tests the new library,
+   updates only `Artifacts.toml`, and dispatches registration for the tested
+   commit. The daily schedule retries if repository dispatch is unavailable.
+   Check its reported reason if the update is parked; the Julia contributing
+   guide gives recovery commands. A breaking C ABI change bumps
+   `PIO_ABI_VERSION` first; see "C ABI changes" above.
 
 ## Naming
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ cargo install powerio-cli         # the powerio command
 
 ## Parse and emit
 
+The examples use [case9.m](tests/data/case9.m), the nine-bus MATPOWER case
+included in this repository. Save it in your working directory first, or
+replace `"case9.m"` with the path to your own case.
+
 Rust:
 
 ```rust,ignore
@@ -99,8 +103,14 @@ back byte for byte. If you write it to another format, PowerIO keeps what
 that format can represent and reports each loss as a diagnostic with a stable
 code, so you can see what the conversion dropped. `serialize` and
 `deserialize` write and read PowerIO IR, the JSON document that stores a
-complete module for another PowerIO consumer to read back. PowerIO IR is not
-a grid exchange format.
+complete module for another PowerIO consumer to read back. It preserves the
+typed data and its history; retained source bytes stay in the running process.
+After deserialization, `emit` writes fresh output from the stored value.
+
+Upgrading from 0.10? Start with the
+[migration guide](https://eigenergy.github.io/powerio/guide/migration-0.11.html).
+PowerIO 0.11 uses PowerIO IR generation 2 and C ABI 7; these version numbers
+describe separate interfaces.
 
 ## Formats
 
@@ -143,17 +153,20 @@ checked against its reference implementation.
 
 ## Packages
 
-```text
-powerio-core     Source, PioModule, diagnostics, time series, scenario sets, destinations
-powerio-tx       BalancedNetwork and the balanced format readers and writers
-powerio-dist     MulticonductorNetwork and the OpenDSS, PMD, and BMOPF converters
-powerio-prob     operating points, updates, calculation instances, and solutions
-powerio-matrix   sparse matrices, sensitivities, the DC OPF bundle, and graph data
-powerio          the facade: PioValue, parse, emit, serialize, deserialize
-powerio-cli      the powerio command and its terminal interface
-powerio-py       the extension behind the Python package
-powerio-capi     C ABI 7 for C, C++, Julia, and other bindings
-```
+Start with `powerio` in an application. The component crates let libraries
+depend on just the layer they use.
+
+| Crate | Provides |
+|---|---|
+| `powerio` | `PioValue`, `parse`, `emit`, `serialize`, `deserialize` |
+| `powerio-core` | `Source`, `PioModule`, diagnostics, collections, destinations |
+| `powerio-tx` | `BalancedNetwork` and balanced format readers and writers |
+| `powerio-dist` | `MulticonductorNetwork` and OpenDSS, PMD, BMOPF converters |
+| `powerio-prob` | Operating points, updates, calculation instances and solutions |
+| `powerio-matrix` | Sparse matrices, sensitivities, DC OPF bundles and graph data |
+| `powerio-cli` | The `powerio` command and its terminal interface |
+| `powerio-py` | The native extension used by the Python package |
+| `powerio-capi` | C ABI 7, used by Julia and other FFI bindings |
 
 `powerio-tx` and `powerio-dist` share `powerio-core` and nothing else, so a
 distribution consumer pulls in no transmission code. `powerio-prob` is matrix

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -22,7 +22,7 @@ PioModule<T>
 ```
 
 In Rust you reach the value through `module.value()` and the diagnostics
-through the `diagnostics` field. Python and Julia expose both as properties,
+through `module.diagnostics()`. Python and Julia expose both as properties,
 `value` and `diagnostics`, and C exposes borrowed accessors because its values
 are opaque. Diagnostics belong to the module rather than to the network or
 solution inside it.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -9,6 +9,9 @@ cargo add powerio             # parsing, emission, PowerIO IR
 cargo add powerio -F matrix   # and sparse matrices, sensitivities, graph data
 ```
 
+Use Rust 1.88 or newer. Add the `gridfm` feature when your application reads
+or writes GridFM Parquet directories: `cargo add powerio -F gridfm`.
+
 Python:
 
 ```sh
@@ -39,6 +42,10 @@ cargo build -p powerio-capi --release --features arrow,matrix,gridfm,dist,prob
 ```
 
 ## Parse, inspect, emit
+
+Download [case9.m](https://github.com/eigenergy/powerio/blob/main/tests/data/case9.m)
+to your working directory for these examples. In a repository checkout, the
+same file is `tests/data/case9.m`; pass that path when running from the root.
 
 Rust. The example is a complete program; it imports only `parse`, `emit`, and
 the `PioValue` enum, and `?` hands any failure to `main`.
@@ -99,6 +106,31 @@ Command line:
 powerio convert case9.m --to psse -o case9.raw   # findings on stderr
 powerio summary case9.m                          # counts, bases, and findings as JSON
 ```
+
+## Keep a module for later
+
+Use `serialize` to save the value with its diagnostics and history, then
+`deserialize` to restore it in any PowerIO binding:
+
+```rust,ignore
+powerio::serialize(&module, "case9.pio.json")?;
+let restored = powerio::deserialize("case9.pio.json")?;
+```
+
+```python
+powerio.serialize(module, "case9.pio.json")
+restored = powerio.deserialize("case9.pio.json")
+```
+
+```julia
+serialize(module_, "case9.pio.json")
+restored = deserialize("case9.pio.json")
+```
+
+PowerIO IR stores the typed data and source metadata. Original input bytes
+stay in memory, so an unchanged parsed module can echo them, while a restored
+module produces fresh output. Inspect the returned emission diagnostics when
+exporting to another tool.
 
 ## Where next
 

--- a/docs/src/migration-0.11.md
+++ b/docs/src/migration-0.11.md
@@ -70,7 +70,9 @@ These 0.10 names are removed:
 
 `PioModule<T>` contains the typed value and its diagnostics, producer, sources,
 source mappings, history, and extensions. Rust, Python, and Julia expose
-`value` and `diagnostics` as fields or properties.
+these members using their usual language conventions: Rust has accessor
+methods such as `value()` and `diagnostics()`, and Python and Julia have
+properties such as `.value` and `.diagnostics`.
 
 In Rust, dynamic parsing returns `PioModule<PioValue>`, so match on
 `module.value()` directly. In Python, use


### PR DESCRIPTION
A release build currently attaches assets without checking whether its tag still names the commit it built. Retagging the unpublished 0.11 candidate can leave overlapping runs writing the same draft.

This change serializes runs per ref and checks the remote tag's peeled commit before attachment. Missing or moved tags stop before assets are attached.

The documentation pass supplies a concrete example fixture, explains IR persistence, fixes stale Rust accessor prose, and aligns the contributor release procedure with Julia's reviewed intent and automatic artifact update. Paired Julia documentation: eigenergy/PowerIO.jl#136.

Validation:
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps`
- `mdbook build docs` and `mdbook test docs`
- Documentation-symbol and terminology gates
- Release-tag guard exercised with annotated, lightweight, moved, and deleted tag responses
- `git diff --check`

The quick scan against v0.10.0 covered the release flows, public API migration, IR version rules, and downstream integration. Full PowerIO and Julia CI must pass before this commit becomes v0.11.0.