### PR TITLE
Finalize draft BMOPF integration for PowerIO 0.11

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -90,3 +90,7 @@ jobs:
       run: .venv/bin/python -c "import egret, jsonschema, opendssdirect, pandapower, pypsa"
     - name: Run the validation matrix
       run: bash evals/validation/run_validation.sh
+    - name: Compare explicit BMOPF core admittances with OpenDSS
+      run: |
+        cargo build --release -p powerio-cli
+        .venv/bin/python evals/validation/validate_bmopf_core_shunts.py --powerio "$PWD/target/release/powerio"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.11.0
 
+- Preserve physical transformer exciting-branch locations with the pinned
+  proposal's explicit per-coil `no_load_shunt`. Correct magnetizing signs,
+  WYE/DELTA voltage bases and fixed-tap scaling; retain PMD no-load percentages.
+  Six independent OpenDSS admittance comparisons cover the conversion through IR.
+
 - Preserve three-phase generator counts in OpenDSS conversion, including BMOPF
   inputs whose phase maps omit a neutral. Keep legacy MCP root environment
   aliases compatible with PowerMCP.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.11.0
 
+- Preserve every OpenDSS `Xscarray` winding-pair reactance through the typed
+  model, generation-2 IR, BMOPF and regenerated OpenDSS, including edits.
+
 - Preserve physical transformer exciting-branch locations with the pinned
   proposal's explicit per-coil `no_load_shunt`. Correct magnetizing signs,
   WYE/DELTA voltage bases and fixed-tap scaling; retain PMD no-load percentages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 0.11.0
 
+- Preserve three-phase generator counts in OpenDSS conversion, including BMOPF
+  inputs whose phase maps omit a neutral. Keep legacy MCP root environment
+  aliases compatible with PowerMCP.
+
+- Identify BMOPF 0.2.0 as a pinned proposal, expose explicit legacy/proposal
+  emission profiles and report semantic version, dimension and reference errors.
+- Preserve unequal phase-voltage bounds through IR and conversion, and retain
+  n-winding ratings, taps, neutral impedances and current limits. Legacy output
+  relocates proposed-only subtypes with diagnostics.
+- Reject unsupported transformer equations before multiconductor admittance
+  assembly; the unreleased ABI 7 bus views and Julia binding expose per-phase bounds.
+
+
 PowerIO 0.11 is the stabilization release of the API developed through the
 0.10 beta. Four operations move data: `parse`, `emit`, `serialize`, and
 `deserialize`. `PioModule<T>` holds the value, its diagnostics, sources,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## 0.11.0
 
+- Integrate Burhan Abdullah's electrical-readiness checks (#494). Retain
+  unresolved OpenDSS geometry without fabricated line impedances; reject
+  numerical calculations and canonical conversion until impedance data exists.
+- Read draft BMOPF 0.2 `energy_cost_rate` in $/kWh, including per-phase
+  voltage-source prices, while accepting the deprecated `cost` spelling.
+  Preserve source prices through IR and typed C, Python and Julia access.
+
 - Preserve every OpenDSS `Xscarray` winding-pair reactance through the typed
   model, generation-2 IR, BMOPF and regenerated OpenDSS, including edits.
 
-- Preserve physical transformer exciting-branch locations with the pinned
-  proposal's explicit per-coil `no_load_shunt`. Correct magnetizing signs,
+- Preserve physical transformer exciting-branch locations with draft BMOPF 0.2's explicit per-coil `no_load_shunt`. Correct magnetizing signs,
   WYE/DELTA voltage bases and fixed-tap scaling; retain PMD no-load percentages.
   Six independent OpenDSS admittance comparisons cover the conversion through IR.
 
@@ -14,8 +20,7 @@
   inputs whose phase maps omit a neutral. Keep legacy MCP root environment
   aliases compatible with PowerMCP.
 
-- Identify BMOPF 0.2.0 as a pinned proposal, expose explicit legacy/proposal
-  emission profiles and report semantic version, dimension and reference errors.
+- Identify draft BMOPF 0.2 explicitly, expose schema-version selection and report semantic version, dimension and reference errors.
 - Preserve unequal phase-voltage bounds through IR and conversion, and retain
   n-winding ratings, taps, neutral impedances and current limits. Legacy output
   relocates proposed-only subtypes with diagnostics.
@@ -175,7 +180,7 @@ crates.
 - GridFM Parquet reads keep the stated branch flows and quadratic costs, and
   a GridFM to GridFM conversion has no findings. Scenario batches reject
   duplicate identifiers, differing system bases, and misaligned rows.
-- BMOPF parsing accepts schema 0.1.0 and 0.2.0, resolving the profile from
+- BMOPF parsing accepts schema 0.1.0 and draft BMOPF 0.2, resolving the schema version from
   `meta.schema_version` or `meta.$schema`; fresh output uses 0.2.0 from the
   `distribution-system-opt/dsopt-schema` repository.
 - PowerWorld PWB reading recognizes the bus and generator record families

--- a/docs/electrical-readiness.md
+++ b/docs/electrical-readiness.md
@@ -1,58 +1,48 @@
 # Electrical readiness before analysis
 
-`powerio-dist` separates source parsing from the decision to hand a
-multiconductor network to numerical analysis. Parsing establishes a typed
-model; [`audit_electrical_readiness`](../powerio-dist/src/readiness.rs) checks
-whether that model is electrically complete enough for a solver or semantic
-lowering pass.
+Parsing, preservation and numerical readiness are separate results.
+`powerio_dist::audit_electrical_readiness` reports structural blockers and
+source defaults. `require_electrical_readiness` rejects the first blocker.
+Multiconductor calculation-instance constructors and admittance assembly call
+that check before numerical use.
 
-## Fail-closed rule for deferred OpenDSS geometry
+## OpenDSS line geometry
 
-OpenDSS can define a line through `geometry=`, `spacing=`, `wires=`,
-`cncables=`, or `tscables=`. The geometry family is not yet lowered into
-PowerIO's canonical conductor impedance matrices. Until that work is
-implemented, these properties are **blockers**, not warnings.
+PowerIO does not calculate conductor impedances from OpenDSS `geometry`,
+`spacing`, `wires`, `cncables` or `tscables`. The reader retains a line using any
+of these properties as an untyped source object and reports
+`READ.DSS.GEOMETRY_UNRESOLVED` with error severity. It creates neither a typed
+line nor a synthetic linecode or terminal map for that object. This also
+applies when geometry properties and an explicit linecode occur together.
 
-The readiness audit therefore refuses a geometry-backed line even when the
-parser has produced a syntactically valid `DistLine`. Applications should
-call the audit before numerical lowering or solving and stop when
-`is_ready()` is false.
+The original, unmodified source module can still emit its exact source bytes.
+IR retains the untyped object, but canonical OpenDSS, PMD and BMOPF conversion
+reject unresolved geometry because they cannot reconstruct its electrical
+meaning. Retain the source module or provide explicit conductor impedances
+before requesting those conversions. Numerical calculations reject both these
+untyped records and geometry-dependent typed lines from earlier IR documents.
 
-The regression contract explicitly covers **all five** deferred geometry
-properties. A future geometry-lowering implementation should change the
-corresponding readiness behavior deliberately and update these tests and the
-scope documentation together; a parser accepting one of these properties is
-not evidence that numerical impedance data exists.
+This intentionally rejects calculations and canonical conversions that could
+otherwise use incomplete electrical data. It does not implement Carson's
+equations or infer conductor count from a phase count. Explicit linecode data
+without geometry-dependent properties remains eligible when the remaining
+checks pass.
 
-This is intentionally a non-breaking safety boundary. It does not attempt to
-implement Carson's equations, infer conductor count from `phases`, or replace
-geometry-derived impedance with OpenDSS `Line` factory defaults. Explicit
-`linecode=` data remains eligible for analysis when the rest of the network
-passes the audit.
+## Other structural checks
 
-## Example
+The audit checks source-specific identifier equality, unresolved line endpoints
+and linecodes, terminal references, line lengths, conductor counts, matrix
+shapes and finite matrix entries. It reports source defaults as warnings.
 
 ```rust
-use powerio_dist::{audit_electrical_readiness, parse};
-
-let module = parse(source)?;
-let readiness = audit_electrical_readiness(module.value());
-if !readiness.is_ready() {
-    for finding in readiness.blockers() {
-        eprintln!("{}: {}", finding.code, finding.message);
-    }
-    return Err("electrical model is not ready for analysis".into());
+let readiness = powerio_dist::audit_electrical_readiness(network);
+for finding in readiness.findings {
+    eprintln!("{} {}: {}", finding.code, finding.element, finding.message);
 }
+powerio_dist::require_electrical_readiness(network)?;
 ```
 
-The audit is read-only. It also catches unresolved line endpoints, unresolved
-linecodes, invalid line lengths, duplicate identifiers, zero-conductor
-linecodes, malformed impedance matrices, and non-finite matrix values.
-
-## Scope
-
-This gate addresses the safety half of the deferred-geometry problem tracked
-upstream in `eigenergy/powerio#479`. Full typed geometry support remains a
-separate implementation: it should calculate the conductor impedance from
-the relevant OpenDSS geometry family and preserve the source units and
-conductor topology without relying on parser defaults.
+A passing audit establishes only these structural properties. The selected
+calculation still checks its support for transformer connections, controls,
+loads and other required physics. PowerIO preserves data that a particular
+calculation may not support.

--- a/docs/release-notes/0.11.0-draft.md
+++ b/docs/release-notes/0.11.0-draft.md
@@ -163,18 +163,18 @@ output using 2007.05.01. IEEE Common Data Format is read only. PowerWorld PWB
 is still read only, and it recognizes the bus and generator record families
 the binary corpus covers.
 
-BMOPF parsing accepts schema 0.1.0 and the explicitly pinned 0.2.0 proposal,
+BMOPF parsing accepts schema 0.1.0 and draft BMOPF 0.2,
 checks agreement between `meta.schema_version` and `meta.$schema`, and returns a
 `MulticonductorNetwork`. Calculation instances are constructed separately.
 BMOPF 0.2.0 remains subject to Task Force review; PowerIO does not declare it
 ratified or create a `schema-v0.2.0` tag.
 
 Fresh proposal output identifies immutable proposal commit
-`5e692902329b06342913b1a57c546a5fae51b2f1` and records its SHA-256 schema digest
+`fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12` and records its SHA-256 schema digest
 in producer provenance. Known earlier identifiers remain documented aliases.
-Explicit profile selection produces the requested profile, including reported
+Explicit schema-version selection produces the requested schema version, including reported
 legacy relocations; ordinary same-format emission preserves retained source
-bytes. Rust, CLI, Python, C, Julia and MCP expose the same profile choice.
+bytes. Rust, CLI, Python, C, Julia and MCP expose the same schema-version choice.
 
 Unequal phase voltage bounds remain ordered vectors through conversion,
 generation-2 IR and typed bindings. The unreleased ABI 7 bus view includes these
@@ -186,6 +186,21 @@ data does not imply computational support: matrix construction rejects required
 physics outside its declared formulation.
 
 The [field mapping](../src/bmopf-field-mapping.md),
-[proposal conformance packet](https://github.com/distribution-system-opt/dsopt-schema/blob/5e692902329b06342913b1a57c546a5fae51b2f1/docs/conformance.md),
+[proposal conformance packet](https://github.com/distribution-system-opt/dsopt-schema/blob/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/docs/conformance.md),
 and paired specification proposal document compatibility, intentional validation
 rejections and computational limits.
+
+### Final distribution integration
+
+Burhan Abdullah's electrical-readiness PR #494 provides the shared structural
+checks. Instance construction and multiconductor admittance assembly enforce
+them. Unresolved OpenDSS geometry remains an untyped source object, and the
+reader reports an error instead of creating guessed impedance or terminal data.
+Unmodified same-format source emission remains byte-exact. Canonical conversion
+from such incomplete data is intentionally rejected.
+
+Draft BMOPF 0.2 output uses `energy_cost_rate` in $/kWh; the reader also accepts
+legacy `cost`. Source and generator prices follow the per-phase ordering in Matt Deakin's
+source/objective proposal. Optional IBR prices use that same ordering. Typed source prices survive IR and C/Julia views.
+The proposed naming and objective conventions follow the Task Force's ongoing
+source/objective discussion; this release does not ratify BMOPF 0.2.

--- a/docs/release-notes/0.11.0-draft.md
+++ b/docs/release-notes/0.11.0-draft.md
@@ -163,8 +163,29 @@ output using 2007.05.01. IEEE Common Data Format is read only. PowerWorld PWB
 is still read only, and it recognizes the bus and generator record families
 the binary corpus covers.
 
-BMOPF parsing accepts schema 0.1.0 and 0.2.0, picks the profile from
-`meta.schema_version` or `meta.$schema`, and returns a
-`MulticonductorNetwork`; you construct the `McAcPfInstance` or
-`McAcOpfInstance` yourself. Fresh output uses schema 0.2.0 from the
-`distribution-system-opt/dsopt-schema` repository.
+BMOPF parsing accepts schema 0.1.0 and the explicitly pinned 0.2.0 proposal,
+checks agreement between `meta.schema_version` and `meta.$schema`, and returns a
+`MulticonductorNetwork`. Calculation instances are constructed separately.
+BMOPF 0.2.0 remains subject to Task Force review; PowerIO does not declare it
+ratified or create a `schema-v0.2.0` tag.
+
+Fresh proposal output identifies immutable proposal commit
+`5e692902329b06342913b1a57c546a5fae51b2f1` and records its SHA-256 schema digest
+in producer provenance. Known earlier identifiers remain documented aliases.
+Explicit profile selection produces the requested profile, including reported
+legacy relocations; ordinary same-format emission preserves retained source
+bytes. Rust, CLI, Python, C, Julia and MCP expose the same profile choice.
+
+Unequal phase voltage bounds remain ordered vectors through conversion,
+generation-2 IR and typed bindings. The unreleased ABI 7 bus view includes these
+vectors with owner-rooted borrowing. Consumers must rebuild against the final
+0.11 header and matching Julia binding. Transformer no-load admittance can state
+its physical winding and per-coil SI values explicitly. Independent OpenDSS
+comparisons check its location, phase scaling and tap scaling. Retained equipment
+data does not imply computational support: matrix construction rejects required
+physics outside its declared formulation.
+
+The [field mapping](../src/bmopf-field-mapping.md),
+[proposal conformance packet](https://github.com/distribution-system-opt/dsopt-schema/blob/5e692902329b06342913b1a57c546a5fae51b2f1/docs/conformance.md),
+and paired specification proposal document compatibility, intentional validation
+rejections and computational limits.

--- a/docs/schema/pio-ir/2/schema.json
+++ b/docs/schema/pio-ir/2/schema.json
@@ -5616,7 +5616,7 @@
           "type": "array"
         },
         "xsc_pct": {
-          "description": "Short circuit reactances between winding pairs, percent:\n`[xhl]` for two windings, `[xhl, xht, xlt]` for three.",
+          "description": "Short circuit reactances between winding pairs, percent:\nUpper-triangular order `12, 13, ..., 1n, 23, ..., (n-1)n`,\non winding 1's power base, matching OpenDSS `Xscarray`.",
           "items": {
             "anyOf": [
               {

--- a/docs/schema/pio-ir/2/schema.json
+++ b/docs/schema/pio-ir/2/schema.json
@@ -3689,6 +3689,28 @@
             }
           ]
         },
+        "v_max_phase": {
+          "items": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "v_min": {
           "anyOf": [
             {
@@ -3708,6 +3730,29 @@
             }
           ],
           "description": "Voltage magnitude bounds, volts: the scalar pair plus the phase to\nneutral and phase to phase families, and the per-sequence scalars\n(BMOPF schema 0.1.0: positive sequence has both bounds, negative and\nzero sequence and neutral to ground are magnitude caps whose lower\nbound is always 0)."
+        },
+        "v_min_phase": {
+          "description": "Nonuniform phase-to-ground bounds in phase-terminal order, volts.\nA scalar bound, when present, takes precedence over this vector.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
         },
         "vn_max": {
           "anyOf": [

--- a/docs/schema/pio-ir/2/schema.json
+++ b/docs/schema/pio-ir/2/schema.json
@@ -14985,6 +14985,29 @@
         "bus": {
           "type": "string"
         },
+        "energy_cost_rate": {
+          "description": "Energy cost rate in $/kWh, one entry per phase in terminal-map order.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "double",
+                "type": "number"
+              },
+              {
+                "enum": [
+                  "Infinity",
+                  "-Infinity",
+                  "NaN"
+                ],
+                "type": "string"
+              }
+            ]
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
         "extras": {
           "additionalProperties": true,
           "type": "object"

--- a/docs/src/bmopf-field-mapping.md
+++ b/docs/src/bmopf-field-mapping.md
@@ -10,7 +10,7 @@ repository. `0.1.0` is the version the IEEE PES Task Force on Benchmarking
 Multiconductor OPF accepts, and `0.2.0` is the proposal that adds the element
 classes 0.1.0 has no table for. PowerIO reads both and writes `0.2.0` by
 default; to write `0.1.0`, pass
-`BmopfEmitOptions::with_profile(BmopfProfile::Bmopf010)`.
+`BmopfEmitOptions::with_schema_version(BmopfSchemaVersion::Bmopf010)`.
 
 ## Conventions
 
@@ -36,8 +36,8 @@ parameter field is zero. A field with no typed slot lands in the element's
 | BMOPF | PowerIO | Note |
 | --- | --- | --- |
 | `name` | `PioModule` value name | |
-| `meta.$schema` | resolved by `BmopfProfile::from_schema_id` | Absent raises `READ.BMOPF.SCHEMA_ABSENT`; a value naming no version raises `READ.BMOPF.SCHEMA_UNKNOWN`. Both parse, and both versions are accepted. |
-| `meta.schema_version` | explicit profile identity | The reader checks agreement with `meta.$schema`. Fresh proposal output pins a retrieval URL and records proposal status and schema digest in provenance. |
+| `meta.$schema` | resolved by `BmopfSchemaVersion::from_schema_id` | Absent raises `READ.BMOPF.SCHEMA_ABSENT`; a value naming no version raises `READ.BMOPF.SCHEMA_UNKNOWN`. Both parse, and both versions are accepted. |
+| `meta.schema_version` | explicit schema version | The reader checks agreement with `meta.$schema`. Fresh proposal output pins a retrieval URL and records proposal status and schema digest in provenance. |
 | `meta.frequency` | `MulticonductorNetwork::base_frequency`, Hz | Absent defaults to 60 with `READ.BMOPF.VALUE_DEFAULTED`. |
 | `meta.*` (the rest) | `MulticonductorNetwork::extras["bmopf_meta"]` | Re-emitted, except the three the writer owns. |
 | `terminal_conventions` | `MulticonductorNetwork::extras["bmopf_terminal_conventions"]` | Re-emitted verbatim; authored from the terminal names when the source states none. |
@@ -294,7 +294,7 @@ rather than inferred from the data.
 [BMOPFTools.jl](https://github.com/frederikgeth/BMOPFTools.jl) is publicly
 available and is identified as the generator of `example_ieee13.json`.
 The [PowerIO 0.11 compatibility change](https://github.com/frederikgeth/BMOPFTools.jl/pull/385)
-exercises the typed module API, explicit legacy profile, retained diagnostics,
+exercises the typed module API, explicit legacy schema version, retained diagnostics,
 transformer core-shunt locations and nominal n-winding imports. Its numerical
 suite compares power-flow voltages and transformer admittance with OpenDSS,
 including independently prepared BMOPF cases and native OpenDSS conversions.

--- a/docs/src/bmopf-field-mapping.md
+++ b/docs/src/bmopf-field-mapping.md
@@ -37,7 +37,7 @@ parameter field is zero. A field with no typed slot lands in the element's
 | --- | --- | --- |
 | `name` | `PioModule` value name | |
 | `meta.$schema` | resolved by `BmopfProfile::from_schema_id` | Absent raises `READ.BMOPF.SCHEMA_ABSENT`; a value naming no version raises `READ.BMOPF.SCHEMA_UNKNOWN`. Both parse, and both versions are accepted. |
-| `meta.schema_version` | writer-owned | Stamped on a `0.2.0` write only; `0.1.0` declares no such field. |
+| `meta.schema_version` | explicit profile identity | The reader checks agreement with `meta.$schema`. Fresh proposal output pins a retrieval URL and records proposal status and schema digest in provenance. |
 | `meta.frequency` | `MulticonductorNetwork::base_frequency`, Hz | Absent defaults to 60 with `READ.BMOPF.VALUE_DEFAULTED`. |
 | `meta.*` (the rest) | `MulticonductorNetwork::extras["bmopf_meta"]` | Re-emitted, except the three the writer owns. |
 | `terminal_conventions` | `MulticonductorNetwork::extras["bmopf_terminal_conventions"]` | Re-emitted verbatim; authored from the terminal names when the source states none. |
@@ -51,7 +51,7 @@ parameter field is zero. A field with no typed slot lands in the element's
 | --- | --- | --- |
 | `terminal_names` | `terminals` | Ordered; fixes every per-terminal order on this bus. |
 | `perfectly_grounded_terminals` | `grounded` | |
-| `v_min`, `v_max` | `v_min`, `v_max` | The BMOPF array is per phase terminal; PowerIO holds one value, so a genuine per-phase difference raises `READ.BMOPF.VALUE_COLLAPSED` rather than being dropped. |
+| `v_min`, `v_max` | `v_min_phase`, `v_max_phase` and scalar `v_min`, `v_max` | Unequal bounds remain ordered phase vectors through IR and bindings. A scalar edit explicitly overrides the vector; balanced lowering rejects unequal phase bounds. |
 | `vpn_min`, `vpn_max` | `vpn_min`, `vpn_max` | Per phase terminal, kept as arrays. |
 | `vpp_min`, `vpp_max` | `vpp_min`, `vpp_max` | Per ordered phase pair. |
 | `vpos_min`, `vpos_max` | `vpos_min`, `vpos_max` | Scalars. |
@@ -298,3 +298,25 @@ and the regulator subtypes it adds to the schema read and write as
 `transformer.single_phase_autotransformer` and
 `transformer.open_delta_regulator`. Comparing the numbers a solve produces
 would need the toolchain itself.
+
+## Explicit terminal-coil no-load admittance
+
+`transformer.<subtype>.<id>.no_load_shunt` holds `{winding, g, b}` in transformer
+extras and generation-2 IR. The one-based winding index fixes its physical
+location, and `g + j b` is siemens per coil at the terminal voltage. It cannot
+coexist with the existing from-side `g_no_load` and `b_no_load` fields.
+
+OpenDSS and PMD exciting-branch percentages map to winding 2 with a negative
+magnetizing susceptance. Conversion uses the actual tapped WYE phase-to-neutral
+or DELTA phase-to-phase coil voltage and divides total transformer VA by the
+phase count. A winding-2 shunt converts back to those percentages; other
+locations report that this target parameterization cannot represent them.
+Legacy BMOPF output preserves the object under `extras.transformer` and reports
+the relocation. Nonzero core shunts reject the limited PowerIO passive
+transformer matrix profile before execution.
+
+The independent check `evals/validation/validate_bmopf_core_shunts.py` compares
+six transformer topologies with OpenDSS `Yprim` through an intermediate PowerIO
+IR document. BMOPFTools' 0.11 adapter uses an equivalent bus-shunt matrix and
+retains the original coil object in provenance. Successful parsing alone does
+not establish support for a transformer calculation.

--- a/docs/src/bmopf-field-mapping.md
+++ b/docs/src/bmopf-field-mapping.md
@@ -168,7 +168,7 @@ as two secondary windings.
 | `g_no_load`, `b_no_load` | `extras` | The magnetising branch has no typed slot. |
 | `i_max_from`, `i_max_to` | `extras` | Per winding conductor of that side, in that side's own amperes. |
 | `n_winding.windings[]` | one `DistWinding` each | `bus`, `terminal_map`, `v_nom`, `configuration`, `r_winding`, `delta_roll`, `i_max`. |
-| `n_winding.x_sc` | `xsc_pct`, in `[xhl, xht, xlt]` order | Keyed `i_j` with `i < j` in BMOPF, all referred to winding 1. |
+| `n_winding.x_sc` | `xsc_pct`, ordered `12, 13, ..., 1n, 23, ..., (n-1)n` | Keyed `i_j` with `i < j` in BMOPF, all referred to winding 1. |
 | `single_phase_autotransformer`, `open_delta_regulator` | windings plus `extras["bmopf_subtype"]` | The regulator ratio, its bounds, the ANSI type and the open delta connection ride in `extras`. |
 
 Under schema `0.1.0`, the nine fields that have no subtype slot (`tap`,
@@ -177,6 +177,10 @@ fields) are written to `extras.transformer.<subtype>.<name>` and folded back
 on read, with each move reported under `EMIT.BMOPF.RETAINED_SOURCE_ONLY`.
 Under `0.2.0` the subtypes declare all nine, so nothing moves; only the three
 tap names change, to `tap_ratio`, `tap_ratio_min`, and `tap_ratio_max`.
+
+OpenDSS `Xscarray` populates every winding-pair reactance in this order.
+The reader applies scalar `XHL`/`XHT`/`XLT` updates at edit boundaries;
+regenerated four-or-more-winding records use the complete `Xscarray`.
 
 ## ibr and control_profile
 
@@ -287,17 +291,19 @@ against the specification pages of
 [`math-and-data-model-specifications`](https://github.com/distribution-system-opt/math-and-data-model-specifications)
 rather than inferred from the data.
 
-BMOPFTools.jl is the Task Force toolchain that generated `example_ieee13.json`,
-which lists it in `meta.case_study_generator`. The toolchain is not published
-in the `distribution-system-opt` organization, so the comparison that closed
-issue #414 asked for (against its admittance stamps, constraint activation,
-objective terms, conductor order, and regulator behaviour) is not made here.
-What is checked is the data it writes: the matrix spelling its writer uses,
-with only one triangle filled in, reads back with the mirrored cells filled,
-and the regulator subtypes it adds to the schema read and write as
-`transformer.single_phase_autotransformer` and
-`transformer.open_delta_regulator`. Comparing the numbers a solve produces
-would need the toolchain itself.
+[BMOPFTools.jl](https://github.com/frederikgeth/BMOPFTools.jl) is publicly
+available and is identified as the generator of `example_ieee13.json`.
+The [PowerIO 0.11 compatibility change](https://github.com/frederikgeth/BMOPFTools.jl/pull/385)
+exercises the typed module API, explicit legacy profile, retained diagnostics,
+transformer core-shunt locations and nominal n-winding imports. Its numerical
+suite compares power-flow voltages and transformer admittance with OpenDSS,
+including independently prepared BMOPF cases and native OpenDSS conversions.
+
+PowerIO's structural tests additionally check triangular matrix completion,
+conductor order, regulator fields, proposal provenance and rejected malformed
+records. These checks distinguish data preservation from the equations a
+particular solver supports; retaining a regulator or n-winding record does not
+imply that PowerIO's own matrix compiler implements it.
 
 ## Explicit terminal-coil no-load admittance
 

--- a/docs/src/distribution.md
+++ b/docs/src/distribution.md
@@ -54,15 +54,15 @@ Multiconductor admittance matrices build directly from the multiconductor
 network through `powerio_matrix::calc_multiconductor_admittance_matrix`,
 which is Rust only in 0.11.
 
-## BMOPF proposal profiles
+## BMOPF schema versions
 
-PowerIO v0.11.0 supports a pinned BMOPF 0.2.0 **proposal**, subject to Task Force
+PowerIO v0.11.0 supports **draft BMOPF 0.2**, subject to Task Force
 review. The schema version is separate from the PowerIO release and from
 PowerIO IR generation 2. Producer provenance records the proposal revision and
 schema digest. Previously emitted schema identifiers remain readable aliases.
 
 An unqualified `bmopf-json` emission preserves an unchanged source byte for
-byte. An explicit profile always re-encodes the selected version:
+byte. An explicit schema version always re-encodes the selected version:
 
 ```sh
 powerio convert feeder.json --to bmopf-json@0.1.0 -o legacy.json
@@ -71,7 +71,7 @@ powerio convert feeder.json --to bmopf-json@0.2.0 -o proposal.json
 
 The same format strings work with Rust `powerio::emit`, Python `powerio.emit`,
 C `pio_emit`, Julia `emit` and the PowerIO MCP emission tool. Rust also exposes
-`BmopfProfile` and `BmopfEmitOptions` for the distribution writer.
+`BmopfSchemaVersion` and `BmopfEmitOptions` for the distribution writer.
 
 Legacy output relocates proposed-only equipment and transformer fields into
 `extras`, with diagnostics. A consumer that ignores those extensions cannot be
@@ -98,10 +98,23 @@ transformer coupling and rejects leakage, other winding connections, floating
 neutrals, core shunts or tap decisions that need a different formulation.
 
 The BMOPF proposal schema is pinned to
-[`5e69290`](https://github.com/distribution-system-opt/dsopt-schema/commit/5e692902329b06342913b1a57c546a5fae51b2f1),
-with SHA-256 `e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa`.
+[`fe8671a`](https://github.com/distribution-system-opt/dsopt-schema/commit/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12),
+with SHA-256 `74d6c6de3637d52e42a26c4cb0584f51df70d69f360b236cf5e23afaf7669462`.
 Fresh 0.2.0 output places the immutable retrieval URL in `meta.$schema` and
 records the canonical identity, proposal status, digest and revision under
 `meta.provenance.powerio_bmopf`. Existing provenance is preserved; a name
 collision uses a numbered producer entry. Reading the former canonical or
 version-directory identifiers remains supported without fetching remote data.
+
+### Energy prices
+
+Draft BMOPF 0.2 uses `energy_cost_rate` in $/kWh. Generator entries follow phase
+order, as do voltage-source entries. Neutral terminals have no price entry. PowerIO retains source prices in `VoltageSource.energy_cost_rate` and
+in generation-2 IR. C and Julia expose `energy_cost_rate_per_kwh`; Python's
+voltage-source records expose `energy_cost_rate`.
+
+The reader also accepts the deprecated per-phase `cost` spelling. Explicit
+0.1.0 output keeps generator `cost` and relocates source prices to
+`extras.voltage_source`, with a diagnostic. Only a consumer that reads that
+overlay can use the retained source prices. PowerIO stores the coefficients;
+the selected solver determines whether and how they enter its objective.

--- a/docs/src/distribution.md
+++ b/docs/src/distribution.md
@@ -98,8 +98,8 @@ transformer coupling and rejects leakage, other winding connections, floating
 neutrals, core shunts or tap decisions that need a different formulation.
 
 The BMOPF proposal schema is pinned to
-[`2560b3b`](https://github.com/distribution-system-opt/dsopt-schema/commit/2560b3bb9cdfee89321e02a12c320c9fb6519af0),
-with SHA-256 `7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce`.
+[`5e69290`](https://github.com/distribution-system-opt/dsopt-schema/commit/5e692902329b06342913b1a57c546a5fae51b2f1),
+with SHA-256 `e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa`.
 Fresh 0.2.0 output places the immutable retrieval URL in `meta.$schema` and
 records the canonical identity, proposal status, digest and revision under
 `meta.provenance.powerio_bmopf`. Existing provenance is preserved; a name

--- a/docs/src/distribution.md
+++ b/docs/src/distribution.md
@@ -53,3 +53,55 @@ PowerIO.jl does not bind it.
 Multiconductor admittance matrices build directly from the multiconductor
 network through `powerio_matrix::calc_multiconductor_admittance_matrix`,
 which is Rust only in 0.11.
+
+## BMOPF proposal profiles
+
+PowerIO v0.11.0 supports a pinned BMOPF 0.2.0 **proposal**, subject to Task Force
+review. The schema version is separate from the PowerIO release and from
+PowerIO IR generation 2. Producer provenance records the proposal revision and
+schema digest. Previously emitted schema identifiers remain readable aliases.
+
+An unqualified `bmopf-json` emission preserves an unchanged source byte for
+byte. An explicit profile always re-encodes the selected version:
+
+```sh
+powerio convert feeder.json --to bmopf-json@0.1.0 -o legacy.json
+powerio convert feeder.json --to bmopf-json@0.2.0 -o proposal.json
+```
+
+The same format strings work with Rust `powerio::emit`, Python `powerio.emit`,
+C `pio_emit`, Julia `emit` and the PowerIO MCP emission tool. Rust also exposes
+`BmopfProfile` and `BmopfEmitOptions` for the distribution writer.
+
+Legacy output relocates proposed-only equipment and transformer fields into
+`extras`, with diagnostics. A consumer that ignores those extensions cannot be
+assumed to calculate the same network. Proposal output uses the declared tables
+and preserves winding ratings, taps, neutral impedances and current-limit data.
+
+Unequal bus phase bounds remain individual values through parsing, generation-2
+IR and explicit BMOPF output. Uniform values use `v_min`/`v_max`; unequal values
+use `v_min_phase`/`v_max_phase` in the typed Rust model. A present scalar takes
+precedence over the corresponding vector. PMD voltage arrays instead follow
+terminal order and use engineering voltage units.
+
+The C and Julia bus views expose unequal limits as
+`phase_to_ground_voltage_min_v` and `phase_to_ground_voltage_max_v`, while
+`voltage_min_v` and `voltage_max_v` represent uniform bounds. C spans borrow
+from the network's owner and remain valid for the lifetime of that handle.
+The unreleased ABI 7 layout and Julia definitions are updated together.
+
+Parsing, structural schema validity, semantic consistency and computational
+support are separate checks. Contradictory versions, invalid dimensions,
+unknown electrical references and inconsistent bounds produce error diagnostics.
+The native multiconductor admittance builder supports ideal grounded-WYE
+transformer coupling and rejects leakage, other winding connections, floating
+neutrals, core shunts or tap decisions that need a different formulation.
+
+The BMOPF proposal schema is pinned to
+[`2560b3b`](https://github.com/distribution-system-opt/dsopt-schema/commit/2560b3bb9cdfee89321e02a12c320c9fb6519af0),
+with SHA-256 `7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce`.
+Fresh 0.2.0 output places the immutable retrieval URL in `meta.$schema` and
+records the canonical identity, proposal status, digest and revision under
+`meta.provenance.powerio_bmopf`. Existing provenance is preserved; a name
+collision uses a numbered producer entry. Reading the former canonical or
+version-directory identifiers remains supported without fetching remote data.

--- a/docs/src/ir-reference.md
+++ b/docs/src/ir-reference.md
@@ -635,6 +635,8 @@ Schema definition: `DistBus`.
 | `grounded` | array of string | | | each names a terminal of this bus; zero impedance to ground | required |
 | `v_min` | float or null | volts | | `v_min <= v_max` | null (unbounded) |
 | `v_max` | float or null | volts | | | null (unbounded) |
+| `v_min_phase` | array of float or null | volts | | phase order excludes neutral and earth; scalar `v_min` takes precedence | null |
+| `v_max_phase` | array of float or null | volts | | phase order excludes neutral and earth; scalar `v_max` takes precedence | null |
 | `vpn_min` | array of float or null | volts | | per phase to neutral bound | null |
 | `vpn_max` | array of float or null | volts | | | null |
 | `vpp_min` | array of float or null | volts | | per phase to phase bound | null |

--- a/docs/src/ir-reference.md
+++ b/docs/src/ir-reference.md
@@ -870,6 +870,7 @@ Schema definition: `VoltageSource`.
 | `terminal_map` | array of string | | | terminals of `bus` | required |
 | `v_magnitude` | array of float | volts per terminal | | 0 on a grounded terminal; same length as `terminal_map` | required |
 | `v_angle` | array of float | radians per terminal | | same length as `terminal_map` | required |
+| `energy_cost_rate` | optional array of float | $/kWh | positive injection supplies the network | one entry per phase in terminal-map order; excludes neutral terminals | no stated source-price term |
 | `extras` | object | | | | required |
 
 ### UntypedObject

--- a/evals/validation/mccheck/Cargo.lock
+++ b/evals/validation/mccheck/Cargo.lock
@@ -65,29 +65,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
+name = "crc32fast"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+ "cfg-if",
 ]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -138,10 +122,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
-name = "either"
-version = "1.18.0"
+name = "encoding_rs"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-as-inner"
@@ -239,6 +226,15 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "zlib-rs",
+]
 
 [[package]]
 name = "foldhash"
@@ -708,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-core"
-version = "1.0.0"
+version = "0.11.0"
 dependencies = [
  "libc",
  "serde",
@@ -717,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-dist"
-version = "1.0.0"
+version = "0.11.0"
 dependencies = [
  "powerio-core",
  "serde",
@@ -736,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "powerio-matrix"
-version = "1.0.0"
+version = "0.11.0"
 dependencies = [
  "faer",
  "num-complex",
@@ -746,19 +742,17 @@ dependencies = [
  "powerio-tx",
  "rand",
  "rand_chacha",
- "rayon",
  "rustc-hash",
  "serde",
  "serde_json",
  "sha2",
  "sprs",
  "thiserror 2.0.20",
- "walkdir",
 ]
 
 [[package]]
 name = "powerio-prob"
-version = "1.0.0"
+version = "0.11.0"
 dependencies = [
  "powerio-core",
  "powerio-dist",
@@ -770,15 +764,17 @@ dependencies = [
 
 [[package]]
 name = "powerio-tx"
-version = "1.0.0"
+version = "0.11.0"
 dependencies = [
  "lexical-core",
- "num-complex",
  "petgraph",
  "powerio-core",
+ "quick-xml",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -847,6 +843,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,26 +910,6 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "reborrow"
@@ -994,6 +980,12 @@ dependencies = [
  "serde_core",
  "zmij",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -1112,6 +1104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1120,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "sha1_smol",
+]
 
 [[package]]
 name = "version_check"
@@ -1197,6 +1204,25 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/evals/validation/mccheck/src/main.rs
+++ b/evals/validation/mccheck/src/main.rs
@@ -21,7 +21,11 @@ fn main() {
         .nth(1)
         .expect("usage: powerio-eval-mccheck <deck.dss>");
     let module = powerio_dist::parse(Source::open(&path).unwrap()).unwrap();
-    let net = module.value();
+    let mut passive = module.value().clone();
+    let excluded_transformers = passive.transformers().len();
+    // Transformer buses are excluded by the oracle; this projection checks passive stamps only.
+    passive.transformers_mut().clear();
+    let net = &passive;
     let y = calc_multiconductor_admittance_matrix(net).unwrap();
     let idx = y.index();
     let nodes: Vec<String> = idx
@@ -65,7 +69,7 @@ fn main() {
         .map(|d| format!("{:?}", d.message()))
         .collect();
     println!(
-        "{{\"nodes\": {:?}, \"resolution\": [{}], \"entries\": [{}], \"diagnostics\": [{}], \"constraint_labels\": {:?} }}",
+        "{{\"scope\": \"passive_components\", \"excluded_transformers\": {excluded_transformers}, \"nodes\": {:?}, \"resolution\": [{}], \"entries\": [{}], \"diagnostics\": [{}], \"constraint_labels\": {:?} }}",
         nodes,
         resolution.join(","),
         entries.join(","),

--- a/evals/validation/validate_bmopf_core_shunts.py
+++ b/evals/validation/validate_bmopf_core_shunts.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Compare explicit BMOPF core shunts with OpenDSS terminal admittance stamps."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+import numpy as np
+import opendssdirect as dss
+
+
+def fixtures():
+    for connection in ("wye", "delta"):
+        other = "delta" if connection == "wye" else "wye"
+        source = "src.1.2.3" + (".0" if other == "wye" else "")
+        target = "dst.1.2.3" + (".0" if connection == "wye" else "")
+        yield f"{other}_{connection}", 3, f"windings=2 buses=({source} {target}) conns=({other} {connection}) kvs=(12.47 0.48) kvas=(75 75) taps=(1.025 1.05) %Rs=(1 1) xhl=2"
+    yield "wye_wye", 3, "windings=2 buses=(src.1.2.3.0 dst.1.2.3.0) conns=(wye wye) kvs=(12.47 0.48) kvas=(75 75) taps=(1.025 1.05) %Rs=(1 1) xhl=2"
+    yield "phase_pair", 1, "windings=2 buses=(src.1.2 dst.1.2) kvs=(12.47 0.48) kvas=(25 25) taps=(1.025 1.05) %Rs=(1 1) xhl=2"
+    yield "center_tap", 1, "windings=3 buses=(src.1.0 dst.1.0 dst.0.2) kvs=(7.2 0.12 0.12) kvas=(25 25 25) taps=(1.025 1.05 1.05) %Rs=(1 1 1) xhl=2 xht=2 xlt=2"
+    yield "n_winding", 3, "windings=4 buses=(src.1.2.3.0 dst.1.2.3 third.1.2.3.0 fourth.1.2.3.0) conns=(wye delta wye wye) kvs=(12.47 0.48 4.16 2.4) kvas=(1000 1000 1000 1000) taps=(1.025 1.05 1 1) %Rs=(1 1 1 1) xscarray=(2 2 2 2 2 2)"
+
+
+def opendss_stamp(source):
+    dss.Basic.ClearAll()
+    for command in source.splitlines():
+        dss.Text.Command(command)
+    dss.Solution.Solve()
+    dss.Circuit.SetActiveElement("Transformer.t")
+    nodes = dss.CktElement.NodeOrder()
+    ncond = dss.CktElement.NumConductors()
+    values = np.asarray(dss.CktElement.YPrim()).reshape(-1, 2)
+    matrix = (values[:, 0] + 1j * values[:, 1]).reshape(len(nodes), len(nodes), order="F")
+    return matrix, nodes, ncond
+
+
+def bmopf_stamp(document, nodes, ncond):
+    expected = np.zeros((len(nodes), len(nodes)), dtype=complex)
+    for subtype, table in document["transformer"].items():
+        for transformer in table.values():
+            shunt = transformer["no_load_shunt"]
+            winding = shunt["winding"]
+            if subtype == "n_winding":
+                record = transformer["windings"][winding - 1]
+                bus, terminals = record["bus"], record["terminal_map"]
+                delta = record["configuration"] == "DELTA"
+            else:
+                side = "from" if winding == 1 else "to"
+                bus, terminals = transformer["bus_" + side], transformer["terminal_map_" + side]
+                delta = (subtype == "wye_delta" and winding == 2) or (subtype == "delta_wye" and winding == 1)
+            grounded = document["bus"][bus].get("perfectly_grounded_terminals", [])
+            terminal_nodes = [0 if t in grounded else int(t) for t in terminals]
+            if subtype == "center_tap" and winding > 1:
+                pairs = [(winding - 2, winding - 1)]
+            elif delta:
+                pairs = [(i, (i + 1) % len(terminals)) for i in range(len(terminals))]
+            elif len(terminals) == 2:
+                pairs = [(0, 1)]
+            else:
+                neutral = terminal_nodes.index(0)
+                pairs = [(i, neutral) for i in range(len(terminals)) if i != neutral]
+            winding_nodes = nodes[(winding - 1) * ncond:winding * ncond]
+            for first, second in pairs:
+                incidence = np.zeros(len(nodes))
+                for position, sign in ((first, 1), (second, -1)):
+                    local = winding_nodes.index(terminal_nodes[position])
+                    incidence[(winding - 1) * ncond + local] += sign
+                expected += (shunt["g"] + 1j * shunt["b"]) * np.outer(incidence, incidence)
+    return expected
+
+
+def run(powerio):
+    results = []
+    with tempfile.TemporaryDirectory(prefix="bmopf-core-shunts-") as directory:
+        root = Path(directory)
+        for name, phases, parameters in fixtures():
+            source = f"Clear\nNew Circuit.core basekv=12.47 phases={phases} bus1=src.1.2.3.0\nNew Transformer.t phases={phases} {parameters} ppm_antifloat=0 %noloadloss=0.3 %imag=0.6\n"
+            before, nodes, ncond = opendss_stamp(source.replace("%noloadloss=0.3 %imag=0.6", "%noloadloss=0 %imag=0"))
+            after, _, _ = opendss_stamp(source)
+            case, ir, output = root / (name + ".dss"), root / (name + ".pio.json"), root / (name + ".json")
+            case.write_text(source)
+            for arguments in (("serialize", str(case), "-o", str(ir)), ("convert", str(ir), "--to", "bmopf-json@0.2.0", "-o", str(output))):
+                completed = subprocess.run([powerio, *arguments], text=True, capture_output=True)
+                if completed.returncode:
+                    raise RuntimeError(completed.stderr)
+            document = json.loads(output.read_text())
+            expected = bmopf_stamp(document, nodes, ncond)
+            error = float(np.max(np.abs(after - before - expected)))
+            scale = float(np.max(np.abs(expected)))
+            tolerance = 1e-10 + 1e-9 * scale
+            if error > tolerance:
+                raise AssertionError(f"{name}: admittance error {error} exceeds {tolerance}")
+            results.append({"case": name, "source_sha256": hashlib.sha256(source.encode()).hexdigest(), "matrix_dimension": len(nodes), "max_absolute_error_siemens": error, "absolute_tolerance_siemens": tolerance})
+    return {"comparison": "OpenDSS Yprim(no-load on) minus Yprim(no-load off) versus BMOPF explicit coil stamps", "conversion": "OpenDSS -> PowerIO generation-2 IR -> explicit BMOPF proposal", "opendss": dss.Basic.Version(), "cases": results}
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--powerio", required=True, help="PowerIO CLI executable")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    result = json.dumps(run(args.powerio), indent=2) + "\n"
+    if args.output:
+        args.output.write_text(result)
+    else:
+        print(result, end="")

--- a/evals/validation/validate_opendss_admittance.py
+++ b/evals/validation/validate_opendss_admittance.py
@@ -2,15 +2,14 @@
 OpenDSS's own element primitive admittances (CktElement.YPrim), the
 authoritative per element matrix OpenDSS itself stamps from.
 
-Only the passive classes powerio stamps into G + jB are assembled here: Line
-(non switch), Capacitor, Reactor. A transformer, a voltage source, and every
-other active or controlled element enter powerio's system as an augmented
-constraint row over the node voltages, not as a fabricated admittance, so
-their buses are excluded from this comparison by element rather than folded
-in and hoped to cancel. powerio's own node resolution (from the
-`powerio-eval-mccheck` helper, evals/validation/mccheck/) folds closed switch
-merges before the comparison, so the two sides already agree on which
-terminals share one electrical node.
+Only the passive classes PowerIO stamps into G + jB are assembled here: Line
+(non switch), Capacitor and Reactor. The helper explicitly removes transformers
+from its local copy before building this passive projection. Transformer buses,
+voltage-source buses and every other active or controlled element's buses are
+excluded on both sides. This comparison does not establish transformer physics
+support. The separate core-shunt comparison checks the proposed winding-local
+admittances against OpenDSS. PowerIO's node resolution folds closed switch merges
+before comparison, so both sides use the same electrical nodes.
 
 Caveat that motivated building this leg on YPrim instead of the more obvious
 YMatrix.getYsparse() (OpenDSS's assembled system Y, "SystemY"): on
@@ -108,10 +107,14 @@ def pio(deck: Path):
             "MCCHECK must point at the built powerio-eval-mccheck binary "
             "(cargo build --release --manifest-path evals/validation/mccheck/Cargo.toml)"
         )
-    out = subprocess.run(
-        [MCCHECK_BIN, str(deck)], capture_output=True, text=True, check=True
-    ).stdout
-    d = json.loads(out)
+    result = subprocess.run(
+        [MCCHECK_BIN, str(deck)], capture_output=True, text=True, check=False
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or "passive admittance helper failed")
+    d = json.loads(result.stdout)
+    if d.get("scope") != "passive_components":
+        raise RuntimeError("admittance helper did not declare its passive projection")
     n = len(d["nodes"])
     Y = np.zeros((n, n), dtype=complex)
     for r, c, re, im in d["entries"]:

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -2102,6 +2102,11 @@ typedef struct {
     size_t terminal_map_count;
     PioF64View voltage_magnitude_v;
     PioF64View voltage_angle_rad;
+    /**
+     * Dollars/kWh in phase order, excluding neutral terminals.
+     */
+    PioF64View energy_cost_rate_per_kwh;
+    bool has_energy_cost_rate;
 } PioVoltageSourceView;
 
 /**

--- a/powerio-capi/include/powerio.h
+++ b/powerio-capi/include/powerio.h
@@ -1854,6 +1854,13 @@ typedef struct {
     bool has_voltage_min;
     double voltage_max_v;
     bool has_voltage_max;
+    /**
+     * Nonuniform phase bounds, in phase-terminal order, used when the scalar is absent.
+     */
+    PioF64View phase_to_ground_voltage_min_v;
+    bool has_phase_to_ground_voltage_min;
+    PioF64View phase_to_ground_voltage_max_v;
+    bool has_phase_to_ground_voltage_max;
     PioF64View phase_to_neutral_voltage_min_v;
     bool has_phase_to_neutral_voltage_min;
     PioF64View phase_to_neutral_voltage_max_v;

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1334,6 +1334,11 @@ pub struct PioMulticonductorBusView {
     pub has_voltage_min: bool,
     pub voltage_max_v: f64,
     pub has_voltage_max: bool,
+    /// Nonuniform phase bounds, in phase-terminal order, used when the scalar is absent.
+    pub phase_to_ground_voltage_min_v: PioF64View,
+    pub has_phase_to_ground_voltage_min: bool,
+    pub phase_to_ground_voltage_max_v: PioF64View,
+    pub has_phase_to_ground_voltage_max: bool,
     pub phase_to_neutral_voltage_min_v: PioF64View,
     pub has_phase_to_neutral_voltage_min: bool,
     pub phase_to_neutral_voltage_max_v: PioF64View,
@@ -12285,6 +12290,10 @@ fn multiconductor_bus_view(bus: &powerio_dist::DistBus) -> PioMulticonductorBusV
         has_voltage_min: bus.v_min.is_some(),
         voltage_max_v: bus.v_max.unwrap_or(0.0),
         has_voltage_max: bus.v_max.is_some(),
+        phase_to_ground_voltage_min_v: optional_f64_view(bus.v_min_phase.as_deref()).0,
+        has_phase_to_ground_voltage_min: bus.v_min_phase.is_some(),
+        phase_to_ground_voltage_max_v: optional_f64_view(bus.v_max_phase.as_deref()).0,
+        has_phase_to_ground_voltage_max: bus.v_max_phase.is_some(),
         phase_to_neutral_voltage_min_v: vpn_min,
         has_phase_to_neutral_voltage_min: has_vpn_min,
         phase_to_neutral_voltage_max_v: vpn_max,
@@ -16762,6 +16771,40 @@ mod tests {
 
             pio_balanced_network_release(network);
             pio_diagnostics_release(diagnostics);
+        }
+    }
+
+    #[test]
+    fn abi_seven_bus_views_preserve_phase_bounds_after_owner_release() {
+        unsafe {
+            let mut network = complete_multiconductor_network();
+            network.buses_mut()[0].v_min = None;
+            network.buses_mut()[0].v_min_phase = Some(vec![210.0, 215.0]);
+            let module = module_handle(powerio::PioModule::new(PioValue::from(network)));
+            let value = pio_module_value(module);
+            let mut error = std::ptr::null_mut();
+            let network = pio_value_multiconductor_network(value, &mut error);
+            assert!(!network.is_null());
+            let mut bus = std::mem::MaybeUninit::<PioMulticonductorBusView>::uninit();
+            pio_module_release(module);
+            pio_value_release(value);
+            assert!(pio_multiconductor_network_bus_at(
+                network,
+                0,
+                bus.as_mut_ptr(),
+                &mut error
+            ));
+            let bus = bus.assume_init();
+            assert!(bus.has_phase_to_ground_voltage_min);
+            assert!(!bus.has_voltage_min);
+            assert_eq!(
+                std::slice::from_raw_parts(
+                    bus.phase_to_ground_voltage_min_v.data,
+                    bus.phase_to_ground_voltage_min_v.len
+                ),
+                &[210.0, 215.0]
+            );
+            pio_multiconductor_network_release(network);
         }
     }
 

--- a/powerio-capi/src/lib.rs
+++ b/powerio-capi/src/lib.rs
@@ -1580,6 +1580,9 @@ pub struct PioVoltageSourceView {
     pub terminal_map_count: usize,
     pub voltage_magnitude_v: PioF64View,
     pub voltage_angle_rad: PioF64View,
+    /// Dollars/kWh in phase order, excluding neutral terminals.
+    pub energy_cost_rate_per_kwh: PioF64View,
+    pub has_energy_cost_rate: bool,
 }
 
 /// One source object retained without a typed PowerIO representation.
@@ -13810,6 +13813,10 @@ pub unsafe extern "C" fn pio_multiconductor_network_voltage_source_at(
                 terminal_map_count: source.terminal_map.len(),
                 voltage_magnitude_v: PioF64View::new(&source.v_magnitude),
                 voltage_angle_rad: PioF64View::new(&source.v_angle),
+                energy_cost_rate_per_kwh: PioF64View::new(
+                    source.energy_cost_rate.as_deref().unwrap_or(&[]),
+                ),
+                has_energy_cost_rate: source.energy_cost_rate.is_some(),
             };
             Ok(true)
         })
@@ -16429,6 +16436,7 @@ mod tests {
             vec![240.0],
             vec![0.0],
         ));
+        network.sources_mut()[0].energy_cost_rate = Some(vec![0.125]);
         network
             .untyped_objects_mut()
             .push(powerio_dist::UntypedObject::new(
@@ -17054,7 +17062,11 @@ mod tests {
                 source.as_mut_ptr(),
                 &mut error,
             ));
-            assert_eq!(*source.assume_init().voltage_magnitude_v.data, 240.0);
+            let source = source.assume_init();
+            assert_eq!(*source.voltage_magnitude_v.data, 240.0);
+            assert!(source.has_energy_cost_rate);
+            assert_eq!(source.energy_cost_rate_per_kwh.len, 1);
+            assert_eq!(*source.energy_cost_rate_per_kwh.data, 0.125);
 
             let mut object = std::mem::MaybeUninit::<PioMulticonductorUntypedObjectView>::uninit();
             assert!(pio_multiconductor_network_untyped_object_at(

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -508,6 +508,12 @@ enum FormatArg {
     /// IEEE BMOPF JSON distribution case (parse and emit).
     #[value(name = "bmopf-json", alias = "bmopf")]
     BmopfJson,
+    /// Re-encode against the legacy BMOPF 0.1.0 profile.
+    #[value(name = "bmopf-json@0.1.0")]
+    Bmopf010,
+    /// Re-encode against the pinned BMOPF 0.2.0 proposal.
+    #[value(name = "bmopf-json@0.2.0")]
+    Bmopf020,
 }
 
 impl FormatArg {
@@ -545,7 +551,9 @@ impl FormatArg {
             | FormatArg::IeeeCdf
             | FormatArg::Dss
             | FormatArg::PmdJson
-            | FormatArg::BmopfJson => return None,
+            | FormatArg::BmopfJson
+            | FormatArg::Bmopf010
+            | FormatArg::Bmopf020 => return None,
         })
     }
 
@@ -558,7 +566,9 @@ impl FormatArg {
         match self {
             FormatArg::Dss => Some(DistTargetFormat::Dss),
             FormatArg::PmdJson => Some(DistTargetFormat::PmdJson),
-            FormatArg::BmopfJson => Some(DistTargetFormat::BmopfJson),
+            FormatArg::BmopfJson | FormatArg::Bmopf010 | FormatArg::Bmopf020 => {
+                Some(DistTargetFormat::BmopfJson)
+            }
             FormatArg::Matpower
             | FormatArg::PowerModelsJson
             | FormatArg::EgretJson
@@ -614,6 +624,8 @@ impl FormatArg {
             FormatArg::Dss => "dss",
             FormatArg::PmdJson => "pmd-json",
             FormatArg::BmopfJson => "bmopf-json",
+            FormatArg::Bmopf010 => "bmopf-json@0.1.0",
+            FormatArg::Bmopf020 => "bmopf-json@0.2.0",
         }
     }
 
@@ -2060,8 +2072,13 @@ fn convert_multiconductor_module(
             to.name()
         )
     })?;
-    let emission = module_io::emit_multiconductor_module(module, target)
-        .with_context(|| format!("emitting {}", target.name()))?;
+    let emission = if matches!(to, FormatArg::Bmopf010 | FormatArg::Bmopf020) {
+        let result = powerio::emit(module, to.name(), powerio::Destination::memory("output")?)?;
+        module_io::unpack_memory_emission(result, None)?
+    } else {
+        module_io::emit_multiconductor_module(module, target)
+            .with_context(|| format!("emitting {}", target.name()))?
+    };
     finish_memory_emission(module.diagnostics(), &emission, output)
 }
 

--- a/powerio-cli/src/main.rs
+++ b/powerio-cli/src/main.rs
@@ -508,10 +508,10 @@ enum FormatArg {
     /// IEEE BMOPF JSON distribution case (parse and emit).
     #[value(name = "bmopf-json", alias = "bmopf")]
     BmopfJson,
-    /// Re-encode against the legacy BMOPF 0.1.0 profile.
+    /// Re-encode against the BMOPF 0.1.0 schema.
     #[value(name = "bmopf-json@0.1.0")]
     Bmopf010,
-    /// Re-encode against the pinned BMOPF 0.2.0 proposal.
+    /// Re-encode against draft BMOPF 0.2.
     #[value(name = "bmopf-json@0.2.0")]
     Bmopf020,
 }

--- a/powerio-cli/src/module_io.rs
+++ b/powerio-cli/src/module_io.rs
@@ -23,7 +23,7 @@ impl MemoryEmission {
     }
 }
 
-fn unpack_memory_emission(
+pub(crate) fn unpack_memory_emission(
     result: powerio_core::EmitResult,
     primary_name: Option<&str>,
 ) -> anyhow::Result<MemoryEmission> {

--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -1566,7 +1566,8 @@ const DISTRIBUTION_FORMATS: [DistributionFormat; 3] = [
 // fields the target cannot represent. Phase voltage limits survive the PMD
 // projection; OpenDSS reports their omission. Retained PMD neutral limits
 // require an additional diagnostic only when they carry nondefault data.
-const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 66, 88], [21, 0, 16], [27, 41, 0]];
+// PMD emergency transformer ratings remain available for targets to report.
+const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 66, 88], [21, 0, 16], [27, 44, 0]];
 
 const DISTRIBUTION_CASES: [(&str, &str, DistributionFormat); 7] = [
     (

--- a/powerio-cli/tests/conversion_matrix_report.rs
+++ b/powerio-cli/tests/conversion_matrix_report.rs
@@ -1562,30 +1562,11 @@ const DISTRIBUTION_FORMATS: [DistributionFormat; 3] = [
     },
 ];
 
-// BMOPF schema 0.2.0 carries transformer tap ratios and no-load admittance in
-// schema fields; neutral impedance remains available under
-// `extras.transformer`. The BMOPF source rows use the re-vendored 0.2.0
-// examples.
-// The dss leg splits an unbalanced load into one single phase `Load` per phase
-// (#266 item 2), so a case carrying one arrives at the next hop as several. Each
-// part restates the `kv`/`phases`/`conn` extras the dss reader attaches, and
-// each of those is dropped again on the way into BMOPF or PMD: +8 on the two
-// rows whose source is a dss deck, +2 on the BMOPF→dss row.
-// BMOPF -> PMD drops by 12: the scalar bus voltage bounds now ride PMD's
-// `vm_lb`/`vm_ub` (one entry per terminal, volts over `voltage_scale_factor`)
-// instead of being reported as having no ENGINEERING field. PMD -> dss rises
-// by the same 12: the PMD hop used to lose those bounds silently, so the dss
-// leg had nothing to report; now they arrive and dss — which has no per-bus
-// voltage bound — drops them loudly. What remains on the BMOPF source row is
-// the genuine superset-to-subset loss: named terminals and generator cost,
-// which neither dss nor ENGINEERING states, and the bounds on the dss leg.
-// The PMD reader no longer copies an array vm_nom into the `kv` extra: the
-// typed voltage model carries those volts entry for entry, so the copy only
-// fed a token dss could not parse and BMOPF could only drop — −1 on both
-// cells of the PMD source row.
-// The dss→bmopf and pmd→bmopf cells dropped when the BMOPF writer began
-// aggregating its per-field extras drops into one finding per field (#377).
-const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 66, 88], [20, 0, 15], [26, 42, 0]];
+// Counts include conductor remapping, explicit neutral materialization, and
+// fields the target cannot represent. Phase voltage limits survive the PMD
+// projection; OpenDSS reports their omission. Retained PMD neutral limits
+// require an additional diagnostic only when they carry nondefault data.
+const DISTRIBUTION_WARNING_BASELINE: [[usize; 3]; 3] = [[0, 66, 88], [21, 0, 16], [27, 41, 0]];
 
 const DISTRIBUTION_CASES: [(&str, &str, DistributionFormat); 7] = [
     (

--- a/powerio-dist/examples/bmopf/4bus_dy.json
+++ b/powerio-dist/examples/bmopf/4bus_dy.json
@@ -223,12 +223,24 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
     },
     "frequency": 60.0,
+    "provenance": {
+      "powerio_bmopf": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "2560b3bb9cdfee89321e02a12c320c9fb6519af0",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      }
+    },
     "schema_version": "0.2.0"
   },
   "name": "4busDYBal",

--- a/powerio-dist/examples/bmopf/4bus_dy.json
+++ b/powerio-dist/examples/bmopf/4bus_dy.json
@@ -223,7 +223,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -247,6 +247,26 @@
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
         "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
         "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      },
+      "powerio_bmopf_2": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "d83cfc9ce61a81e78c544c0561d0d418fa69a4ff",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/d83cfc9ce61a81e78c544c0561d0d418fa69a4ff/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "15405bb43be48ce77fa6e59be67b5fee58ad10474c8db67306f837df5e9846b2",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      },
+      "powerio_bmopf_3": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "74d6c6de3637d52e42a26c4cb0584f51df70d69f360b236cf5e23afaf7669462",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/4bus_dy.json
+++ b/powerio-dist/examples/bmopf/4bus_dy.json
@@ -223,7 +223,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -237,6 +237,16 @@
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
         "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
         "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      },
+      "powerio_bmopf_1": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "5e692902329b06342913b1a57c546a5fae51b2f1",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/README.md
+++ b/powerio-dist/examples/bmopf/README.md
@@ -1,6 +1,6 @@
 # IEEE cases in BMOPF JSON
 
-Reference encodings of IEEE distribution test cases in the pinned BMOPF 0.2.0 proposal,
+Reference encodings of IEEE distribution test cases in draft BMOPF 0.2,
 produced by `powerio-dist`. They validate against that schema and
 exercise parsers and data profilers such as `BMOPFTools.jl`. Regenerate them
 rather than editing by hand.
@@ -9,7 +9,7 @@ rather than editing by hand.
 |---|---|---|---|
 | IEEE 34 | `tests/data/dist/opendss/ieee34/ieee34Mod1.dss` (vendored) | 80,822 bytes | 23 |
 | IEEE 123 | `tests/data/dist/opendss/ieee123/IEEE123Master.dss` (vendored) | 120,747 bytes | 43 |
-| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 8,321 bytes | 0 |
+| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 8,980 bytes | 0 |
 
 34 and 123 are recognizable feeders. The Kersting 4 bus case isolates a single
 delta to wye service transformer, the four wire winding that the BMOPF schema's
@@ -34,8 +34,7 @@ Each document carries a top level `meta` block. `meta.case_study_generator`
 names the writing tool and version. `meta.$schema` gives an immutable proposal
 retrieval URL, while `meta.provenance.powerio_bmopf` records its canonical
 identity, commit, schema digest and proposal status.
-The block is deterministic (no timestamp) so output stays byte stable. Per phase
-generator `cost` is an array, as schema 0.2.0 requires.
+The block is deterministic (no timestamp) so output stays byte stable. Generator `energy_cost_rate` is a per-phase array in $/kWh.
 
 ## Source provenance
 

--- a/powerio-dist/examples/bmopf/README.md
+++ b/powerio-dist/examples/bmopf/README.md
@@ -1,15 +1,15 @@
 # IEEE cases in BMOPF JSON
 
-Reference encodings of IEEE distribution test cases in BMOPF schema 0.2.0,
+Reference encodings of IEEE distribution test cases in the pinned BMOPF 0.2.0 proposal,
 produced by `powerio-dist`. They validate against that schema and
 exercise parsers and data profilers such as `BMOPFTools.jl`. Regenerate them
 rather than editing by hand.
 
 | Case | Source `.dss` | Size | Write diagnostics |
 |---|---|---|---|
-| IEEE 34 | `tests/data/dist/opendss/ieee34/ieee34Mod1.dss` (vendored) | 80,069 bytes | 306 |
-| IEEE 123 | `tests/data/dist/opendss/ieee123/IEEE123Master.dss` (vendored) | 119,902 bytes | 453 |
-| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 6,913 bytes | 0 |
+| IEEE 34 | `tests/data/dist/opendss/ieee34/ieee34Mod1.dss` (vendored) | 80,822 bytes | 23 |
+| IEEE 123 | `tests/data/dist/opendss/ieee123/IEEE123Master.dss` (vendored) | 120,747 bytes | 43 |
+| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 8,321 bytes | 0 |
 
 34 and 123 are recognizable feeders. The Kersting 4 bus case isolates a single
 delta to wye service transformer, the four wire winding that the BMOPF schema's
@@ -23,13 +23,17 @@ cargo run -p powerio-dist --example regen_bmopf_examples -- --check
 
 Every document validates against the vendored schema
 (`tests/data/dist/bmopf/bmopf-0.2.0.schema.json`), and the writer reports each
-field the schema cannot carry as a fidelity warning on stderr, so nothing drops
-silently. The dss reader materializes every OpenDSS class default explicitly, so
-the output is fully explicit, and writing back to `.dss` reproduces the source
-byte for byte.
+field or conversion the selected target cannot represent. Diagnostic counts
+count aggregated records; each record retains its occurrence count. These are
+canonical conversions. Re-emitting them as OpenDSS does not reconstruct the
+source file bytes. Byte-exact preservation applies only to an unchanged module
+emitted in the same format in which that module was parsed.
+
 
 Each document carries a top level `meta` block. `meta.case_study_generator`
-names the writing tool and version, and `meta.$schema` pins the schema identity.
+names the writing tool and version. `meta.$schema` gives an immutable proposal
+retrieval URL, while `meta.provenance.powerio_bmopf` records its canonical
+identity, commit, schema digest and proposal status.
 The block is deterministic (no timestamp) so output stays byte stable. Per phase
 generator `cost` is an array, as schema 0.2.0 requires.
 

--- a/powerio-dist/examples/bmopf/README.md
+++ b/powerio-dist/examples/bmopf/README.md
@@ -9,7 +9,7 @@ rather than editing by hand.
 |---|---|---|---|
 | IEEE 34 | `tests/data/dist/opendss/ieee34/ieee34Mod1.dss` (vendored) | 80,822 bytes | 23 |
 | IEEE 123 | `tests/data/dist/opendss/ieee123/IEEE123Master.dss` (vendored) | 120,747 bytes | 43 |
-| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 8,980 bytes | 0 |
+| 4 bus delta wye | `4Bus-DY-Bal/4Bus-DY-Bal.DSS` from the OpenDSS distribution | 9,639 bytes | 0 |
 
 34 and 123 are recognizable feeders. The Kersting 4 bus case isolates a single
 delta to wye service transformer, the four wire winding that the BMOPF schema's

--- a/powerio-dist/examples/bmopf/ieee123.json
+++ b/powerio-dist/examples/bmopf/ieee123.json
@@ -5731,7 +5731,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -5741,10 +5741,10 @@
       "powerio_bmopf": {
         "producer": "powerio",
         "producer_version": "0.11.0",
-        "schema_commit": "5e692902329b06342913b1a57c546a5fae51b2f1",
+        "schema_commit": "fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12",
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "74d6c6de3637d52e42a26c4cb0584f51df70d69f360b236cf5e23afaf7669462",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/ieee123.json
+++ b/powerio-dist/examples/bmopf/ieee123.json
@@ -5731,7 +5731,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -5741,10 +5741,10 @@
       "powerio_bmopf": {
         "producer": "powerio",
         "producer_version": "0.11.0",
-        "schema_commit": "2560b3bb9cdfee89321e02a12c320c9fb6519af0",
+        "schema_commit": "5e692902329b06342913b1a57c546a5fae51b2f1",
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/ieee123.json
+++ b/powerio-dist/examples/bmopf/ieee123.json
@@ -757,6 +757,13 @@
         "3"
       ]
     },
+    "610": {
+      "terminal_names": [
+        "1",
+        "2",
+        "3"
+      ]
+    },
     "61s": {
       "terminal_names": [
         "1",
@@ -5724,12 +5731,24 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
     },
     "frequency": 60.0,
+    "provenance": {
+      "powerio_bmopf": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "2560b3bb9cdfee89321e02a12c320c9fb6519af0",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      }
+    },
     "schema_version": "0.2.0"
   },
   "name": "ieee123",
@@ -5942,12 +5961,13 @@
     }
   },
   "terminal_conventions": {
-    "neutral": [],
+    "neutral": [
+      "4"
+    ],
     "phase": [
       "1",
       "2",
-      "3",
-      "4"
+      "3"
     ]
   },
   "transformer": {

--- a/powerio-dist/examples/bmopf/ieee34.json
+++ b/powerio-dist/examples/bmopf/ieee34.json
@@ -3362,7 +3362,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -3372,10 +3372,10 @@
       "powerio_bmopf": {
         "producer": "powerio",
         "producer_version": "0.11.0",
-        "schema_commit": "2560b3bb9cdfee89321e02a12c320c9fb6519af0",
+        "schema_commit": "5e692902329b06342913b1a57c546a5fae51b2f1",
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/ieee34.json
+++ b/powerio-dist/examples/bmopf/ieee34.json
@@ -3362,7 +3362,7 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
@@ -3372,10 +3372,10 @@
       "powerio_bmopf": {
         "producer": "powerio",
         "producer_version": "0.11.0",
-        "schema_commit": "5e692902329b06342913b1a57c546a5fae51b2f1",
+        "schema_commit": "fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12",
         "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json",
-        "schema_sha256": "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "74d6c6de3637d52e42a26c4cb0584f51df70d69f360b236cf5e23afaf7669462",
         "schema_status": "proposal",
         "schema_version": "0.2.0"
       }

--- a/powerio-dist/examples/bmopf/ieee34.json
+++ b/powerio-dist/examples/bmopf/ieee34.json
@@ -3362,12 +3362,24 @@
     }
   },
   "meta": {
-    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+    "$schema": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
     "case_study_generator": {
       "tool": "powerio",
       "version": "0.11.0"
     },
     "frequency": 60.0,
+    "provenance": {
+      "powerio_bmopf": {
+        "producer": "powerio",
+        "producer_version": "0.11.0",
+        "schema_commit": "2560b3bb9cdfee89321e02a12c320c9fb6519af0",
+        "schema_id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_retrieval_url": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json",
+        "schema_sha256": "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce",
+        "schema_status": "proposal",
+        "schema_version": "0.2.0"
+      }
+    },
     "schema_version": "0.2.0"
   },
   "name": "ieee34-1",
@@ -3426,12 +3438,13 @@
     }
   },
   "terminal_conventions": {
-    "neutral": [],
+    "neutral": [
+      "4"
+    ],
     "phase": [
       "1",
       "2",
-      "3",
-      "4"
+      "3"
     ]
   },
   "transformer": {

--- a/powerio-dist/src/bmopf/mod.rs
+++ b/powerio-dist/src/bmopf/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! # Two schema versions
 //!
-//! [`BmopfProfile`] names the version. Schema 0.1.0 is what the task force
+//! [`BmopfSchemaVersion`] names the version. Schema 0.1.0 is what the task force
 //! accepts: ten element classes and four transformer subtypes. Schema 0.2.0
 //! is the proposal that declares the classes 0.1.0 has no table for, and
 //! gives the transformer taps, winding neutral impedance, and no load
@@ -104,7 +104,9 @@ mod profile;
 pub(crate) mod read;
 mod write;
 
-pub use profile::{BMOPF_PROPOSAL_COMMIT, BMOPF_PROPOSAL_SHA256, BMOPF_PROPOSAL_URL, BmopfProfile};
+pub use profile::{
+    BMOPF_PROPOSAL_COMMIT, BMOPF_PROPOSAL_SHA256, BMOPF_PROPOSAL_URL, BmopfSchemaVersion,
+};
 pub(crate) use write::emit_bmopf_json_text_with_options;
 pub use write::{BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfEmitOptions};
 

--- a/powerio-dist/src/bmopf/mod.rs
+++ b/powerio-dist/src/bmopf/mod.rs
@@ -3,8 +3,8 @@
 //!
 //! Everything is explicit SI: volts, watts, vars, ohms, siemens, meters,
 //! radians, string bus ids and terminal names. Both schema versions set
-//! `additionalProperties: false` on every element and offer one free form
-//! top level `extras` object, so the strict emitter drops what the target
+//! `additionalProperties: false` on electrical elements and permit free-form
+//! top-level `extras` and `meta.provenance` objects, so the strict emitter drops what the target
 //! version cannot carry and says so per field.
 //!
 //! # Two schema versions
@@ -23,8 +23,7 @@
 //! layout of such a document is stated nowhere, and a consumer that assumes
 //! one reads a different network on the other.
 //!
-//! The writer targets one version, 0.2.0 by default. Writing 0.2.0 relocates
-//! nothing. Writing 0.1.0 relocates what that version has no slot for, listed
+//! The writer targets one version, 0.2.0 by default. Writing 0.2.0 keeps supported proposal fields in place. Writing 0.1.0 relocates what that version has no slot for, listed
 //! below, and reports each move.
 //!
 //! # What a 0.1.0 write parks under `extras`
@@ -34,7 +33,7 @@
 //! rather than dropped, with a warning per element. A consumer that reads the
 //! document and ignores `extras` gets a network that differs physically from
 //! the source and no error saying so: a tapped transformer reads as nominal
-//! tap, an impedance grounded neutral as solidly grounded, and the
+//! tap, an impedance grounded neutral loses its internal grounding branch, and the
 //! magnetizing branch disappears.
 //!
 //! ## Transformer fields
@@ -81,7 +80,7 @@
 //! Schema 0.1.0 defines no regulator subtype; the task force's BMOPFTools
 //! toolchain extends it with `single_phase_autotransformer` and
 //! `open_delta_regulator`, and schema 0.2.0 declares both. This emitter
-//! writes them under either version, for interoperation with that toolchain.
+//! writes them at top level under 0.2.0 and in `extras.transformer` under 0.1.0.
 //! An OpenDSS transformer a RegControl targets emits as
 //! `transformer.single_phase_autotransformer` when it reads as a series
 //! regulator (one phase, two windings of equal connection, voltage, and
@@ -94,8 +93,8 @@
 //!
 //! The emitted `terminal_conventions` block is the source document's own
 //! block re-emitted verbatim, or, absent that, one authored from the terminal
-//! names in the model: a terminal named `n` in any case is a neutral, every
-//! other name is a phase. Either way the block describes the terminal naming
+//! names in the model: `n` and `N` are neutral, and `4` in the complete
+//! `1,2,3,4` convention is neutral; other names are phase labels. Either way the block describes the terminal naming
 //! of the document that carries it and nothing else. A consumer that renames
 //! terminals must delete the block and recompute it from the renamed
 //! terminals; carried across a rename it sorts names no bus has any more, and
@@ -105,6 +104,8 @@ mod profile;
 pub(crate) mod read;
 mod write;
 
-pub use profile::BmopfProfile;
+pub use profile::{BMOPF_PROPOSAL_COMMIT, BMOPF_PROPOSAL_SHA256, BMOPF_PROPOSAL_URL, BmopfProfile};
 pub(crate) use write::emit_bmopf_json_text_with_options;
 pub use write::{BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfEmitOptions};
+
+mod validate;

--- a/powerio-dist/src/bmopf/profile.rs
+++ b/powerio-dist/src/bmopf/profile.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 /// A schema version fixes which element classes exist and where they live.
 /// `0.1.0` declares the ten element classes and four transformer subtypes the
 /// task force accepts today, sets `additionalProperties: false` on every
-/// object, and offers one free form `extras` object; the classes outside it
+/// object, and permits free-form `extras` and `meta.provenance`; the classes outside it
 /// travel there. `0.2.0` declares those classes at the top level and gives the
 /// transformer taps, winding neutral impedance, and no load admittance their
-/// own slots, so nothing travels.
+/// own slots. Unsupported malformed records still require diagnostics.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -31,6 +31,14 @@ const SCHEMA_ID_010: &str = "https://raw.githubusercontent.com/distribution-syst
 /// The `$id` of schema 0.2.0.
 const SCHEMA_ID_020: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json";
 
+/// Immutable revision of the proposed BMOPF 0.2.0 schema.
+pub const BMOPF_PROPOSAL_COMMIT: &str = "2560b3bb9cdfee89321e02a12c320c9fb6519af0";
+/// SHA-256 of the exact UTF-8 schema document at the pinned revision.
+pub const BMOPF_PROPOSAL_SHA256: &str =
+    "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce";
+/// Immutable retrieval location, distinct from the schema's canonical `$id`.
+pub const BMOPF_PROPOSAL_URL: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json";
+
 impl BmopfProfile {
     /// The schema version string, as `meta.schema_version` states it.
     #[must_use]
@@ -41,12 +49,21 @@ impl BmopfProfile {
         }
     }
 
-    /// The `$id` of the schema document, as `meta.$schema` states it.
+    /// The canonical `$id` of the schema document, independent of retrieval revision.
     #[must_use]
     pub const fn schema_id(self) -> &'static str {
         match self {
             Self::Bmopf010 => SCHEMA_ID_010,
             Self::Bmopf020 => SCHEMA_ID_020,
+        }
+    }
+
+    /// Retrieval URL for fresh output. Proposal output pins an immutable commit.
+    #[must_use]
+    pub const fn retrieval_url(self) -> &'static str {
+        match self {
+            Self::Bmopf010 => SCHEMA_ID_010,
+            Self::Bmopf020 => BMOPF_PROPOSAL_URL,
         }
     }
 

--- a/powerio-dist/src/bmopf/profile.rs
+++ b/powerio-dist/src/bmopf/profile.rs
@@ -32,12 +32,12 @@ const SCHEMA_ID_010: &str = "https://raw.githubusercontent.com/distribution-syst
 const SCHEMA_ID_020: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json";
 
 /// Immutable revision of the proposed BMOPF 0.2.0 schema.
-pub const BMOPF_PROPOSAL_COMMIT: &str = "2560b3bb9cdfee89321e02a12c320c9fb6519af0";
+pub const BMOPF_PROPOSAL_COMMIT: &str = "5e692902329b06342913b1a57c546a5fae51b2f1";
 /// SHA-256 of the exact UTF-8 schema document at the pinned revision.
 pub const BMOPF_PROPOSAL_SHA256: &str =
-    "7f8ab08476b610d7bc9ecf3539d209b3bc212e8472bc38987afedc1163d71bce";
+    "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa";
 /// Immutable retrieval location, distinct from the schema's canonical `$id`.
-pub const BMOPF_PROPOSAL_URL: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/2560b3bb9cdfee89321e02a12c320c9fb6519af0/schema/bmopf/0.2.0/bmopf.schema.json";
+pub const BMOPF_PROPOSAL_URL: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json";
 
 impl BmopfProfile {
     /// The schema version string, as `meta.schema_version` states it.

--- a/powerio-dist/src/bmopf/profile.rs
+++ b/powerio-dist/src/bmopf/profile.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub enum BmopfProfile {
+pub enum BmopfSchemaVersion {
     /// Schema 0.1.0, the version the task force accepts.
     Bmopf010,
     /// Schema 0.2.0, the proposal in
@@ -32,14 +32,14 @@ const SCHEMA_ID_010: &str = "https://raw.githubusercontent.com/distribution-syst
 const SCHEMA_ID_020: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json";
 
 /// Immutable revision of the proposed BMOPF 0.2.0 schema.
-pub const BMOPF_PROPOSAL_COMMIT: &str = "5e692902329b06342913b1a57c546a5fae51b2f1";
+pub const BMOPF_PROPOSAL_COMMIT: &str = "fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12";
 /// SHA-256 of the exact UTF-8 schema document at the pinned revision.
 pub const BMOPF_PROPOSAL_SHA256: &str =
-    "e08521ca45c5406194019c31e0389ba070545b4b720bfbefa2947f5446b581fa";
+    "74d6c6de3637d52e42a26c4cb0584f51df70d69f360b236cf5e23afaf7669462";
 /// Immutable retrieval location, distinct from the schema's canonical `$id`.
-pub const BMOPF_PROPOSAL_URL: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/5e692902329b06342913b1a57c546a5fae51b2f1/schema/bmopf/0.2.0/bmopf.schema.json";
+pub const BMOPF_PROPOSAL_URL: &str = "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/fe8671a74d2fc1a15a499c5b1f66cbb80fc22e12/schema/bmopf/0.2.0/bmopf.schema.json";
 
-impl BmopfProfile {
+impl BmopfSchemaVersion {
     /// The schema version string, as `meta.schema_version` states it.
     #[must_use]
     pub const fn version(self) -> &'static str {
@@ -95,15 +95,15 @@ mod tests {
 
     #[test]
     fn the_default_output_version_is_the_one_that_states_every_class() {
-        assert_eq!(BmopfProfile::default(), BmopfProfile::Bmopf020);
-        assert_eq!(BmopfProfile::default().version(), "0.2.0");
+        assert_eq!(BmopfSchemaVersion::default(), BmopfSchemaVersion::Bmopf020);
+        assert_eq!(BmopfSchemaVersion::default().version(), "0.2.0");
     }
 
     #[test]
     fn a_version_resolves_from_its_own_schema_id() {
-        for expected in [BmopfProfile::Bmopf010, BmopfProfile::Bmopf020] {
+        for expected in [BmopfSchemaVersion::Bmopf010, BmopfSchemaVersion::Bmopf020] {
             assert_eq!(
-                BmopfProfile::from_schema_id(expected.schema_id()),
+                BmopfSchemaVersion::from_schema_id(expected.schema_id()),
                 Some(expected)
             );
         }
@@ -117,8 +117,8 @@ mod tests {
             "https://raw.githubusercontent.com/frederikgeth/bmopf-report/main/draft_schema_and_networks/draft_bmopf_schema.json",
         ] {
             assert_eq!(
-                BmopfProfile::from_schema_id(id),
-                Some(BmopfProfile::Bmopf010),
+                BmopfSchemaVersion::from_schema_id(id),
+                Some(BmopfSchemaVersion::Bmopf010),
                 "{id}"
             );
         }
@@ -126,9 +126,9 @@ mod tests {
 
     #[test]
     fn a_schema_location_naming_no_version_resolves_to_none() {
-        assert_eq!(BmopfProfile::from_schema_id(""), None);
+        assert_eq!(BmopfSchemaVersion::from_schema_id(""), None);
         assert_eq!(
-            BmopfProfile::from_schema_id("https://example.org/bmopf/schema/v1/bmopf.json"),
+            BmopfSchemaVersion::from_schema_id("https://example.org/bmopf/schema/v1/bmopf.json"),
             None
         );
     }
@@ -136,8 +136,10 @@ mod tests {
     #[test]
     fn a_version_resolves_from_a_relocated_schema_of_the_same_version() {
         assert_eq!(
-            BmopfProfile::from_schema_id("file:///cases/schema/bmopf/0.2.0/bmopf.schema.json"),
-            Some(BmopfProfile::Bmopf020)
+            BmopfSchemaVersion::from_schema_id(
+                "file:///cases/schema/bmopf/0.2.0/bmopf.schema.json"
+            ),
+            Some(BmopfSchemaVersion::Bmopf020)
         );
     }
 }

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -46,6 +46,7 @@ pub(crate) fn parse_bmopf_collecting(
     });
     report_non_numeric_fields(&doc, diags);
     report_schema_version(&doc, diags);
+    super::validate::report(&doc, diags);
     let mut rd = Reader {
         net: &mut net,
         diagnostics: crate::diagnostics::Diagnostics::new(),
@@ -58,23 +59,26 @@ pub(crate) fn parse_bmopf_collecting(
     Ok(net)
 }
 
-/// Resolve the schema version the document declares, and report when it
-/// cannot be resolved.
-///
-/// `meta.$schema` is the one field that states which version a document was
-/// written against, so it is the only thing to detect from. The reader accepts
-/// both versions whatever it finds, since every class 0.2.0 adds at the top
-/// level also reads from `extras` where 0.1.0 puts it. What the version
-/// changes is what a consumer may assume: an unresolved version means the
-/// class layout of the document is not stated anywhere, and a consumer that
-/// assumes one reads a different network on the other. Both findings are
-/// warnings for that reason, not errors.
+/// Report unresolved schema identities and reject contradictory version declarations.
 fn report_schema_version(doc: &Map<String, Value>, diags: &mut crate::collect::Diagnostics) {
     let stated = doc
         .get("meta")
         .and_then(Value::as_object)
         .and_then(|m| m.get("$schema"))
         .and_then(Value::as_str);
+    if let (Some(profile), Some(version)) = (
+        stated.and_then(BmopfProfile::from_schema_id),
+        doc.get("meta").and_then(|meta| meta.get("schema_version")),
+    ) && version.as_str() != Some(profile.version())
+    {
+        diags.push(
+            &C::READ_BMOPF_SCHEMA_MISMATCH,
+            format!(
+                "meta.schema_version {version} disagrees with the {} schema URI",
+                profile.version()
+            ),
+        );
+    }
     match stated {
         None => diags.push(
             &C::READ_BMOPF_SCHEMA_ABSENT,
@@ -96,6 +100,22 @@ fn report_schema_version(doc: &Map<String, Value>, diags: &mut crate::collect::D
         ),
         Some(_) => {}
     }
+}
+
+fn uniform_bound(value: Option<&Value>) -> Option<f64> {
+    let values = floats(value)?;
+    let first = *values.first()?;
+    values
+        .iter()
+        .all(|&v| v.to_bits() == first.to_bits())
+        .then_some(first)
+}
+
+fn nonuniform_bound(value: Option<&Value>) -> Option<Vec<f64>> {
+    uniform_bound(value)
+        .is_none()
+        .then(|| floats(value))
+        .flatten()
 }
 
 /// Schema 0.1.0 field names typed `number` or an array of them. Derived from
@@ -273,28 +293,6 @@ fn delta_roll_value(v: Option<&Value>) -> Option<i64> {
         .filter(|roll| matches!(*roll, -1 | 1))
 }
 
-/// Like [`first_float`], but the field is per-phase-terminal in the schema
-/// while powerio's model holds one value; warn when collapsing loses a
-/// genuine per-phase difference instead of dropping it silently.
-fn first_float_collapsed(
-    v: Option<&Value>,
-    what: &str,
-    diagnostics: &mut crate::diagnostics::Diagnostics,
-) -> Option<f64> {
-    match v? {
-        Value::Array(a) => {
-            let vals: Vec<f64> = a.iter().map(f).collect();
-            if vals.windows(2).any(|w| w[0].to_bits() != w[1].to_bits()) {
-                diagnostics.push(&C::READ_BMOPF_VALUE_COLLAPSED, format!(
-                    "{what}: per-phase-terminal bound is non-uniform; collapsed to the first entry"
-                ));
-            }
-            vals.first().copied()
-        }
-        v => Some(f(v)),
-    }
-}
-
 fn value_alias<'a>(o: &'a Map<String, Value>, primary: &str, legacy: &str) -> Option<&'a Value> {
     o.get(primary).or_else(|| o.get(legacy))
 }
@@ -311,6 +309,19 @@ fn merge_transformer_overlay(
         let Value::Object(names) = names else {
             continue;
         };
+        if matches!(
+            subtype.as_str(),
+            "n_winding" | "single_phase_autotransformer" | "open_delta_regulator"
+        ) {
+            let table = merged
+                .entry(subtype.clone())
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let Some(table) = table.as_object_mut() {
+                for (name, fields) in names {
+                    table.entry(name.clone()).or_insert_with(|| fields.clone());
+                }
+            }
+        }
         let Some(Value::Object(table)) = merged.get_mut(subtype) else {
             continue;
         };
@@ -593,24 +604,19 @@ impl Reader<'_> {
                 }
             }
         }
-        if let Some(Value::Object(items)) = doc.get("transformer") {
-            // The writer relocates schema-less transformer fields (taps,
-            // neutral impedance, no load admittance) to
-            // `extras.transformer.<subtype>.<name>`; fold them back onto the
-            // raw objects before parsing.
-            let overlay = doc
-                .get("extras")
-                .and_then(Value::as_object)
-                .and_then(|e| e.get("transformer"))
-                .and_then(Value::as_object)
-                .filter(|o| !o.is_empty());
-            match overlay {
-                Some(overlay) => {
-                    let merged = merge_transformer_overlay(items, overlay);
-                    self.transformers(&merged);
-                }
-                None => self.transformers(items),
-            }
+        let empty = Map::new();
+        let items = doc
+            .get("transformer")
+            .and_then(Value::as_object)
+            .unwrap_or(&empty);
+        let overlay = doc
+            .get("extras")
+            .and_then(|e| e.get("transformer"))
+            .and_then(Value::as_object);
+        if let Some(overlay) = overlay {
+            self.transformers(&merge_transformer_overlay(items, overlay));
+        } else {
+            self.transformers(items);
         }
 
         self.warn_orphan_transformer_overlay(doc);
@@ -619,11 +625,7 @@ impl Reader<'_> {
         }
     }
 
-    /// The `extras.transformer` overlay carries the transformer fields that
-    /// schema 0.1.0 has no slot for. The transformer arm folds it back onto
-    /// the raw objects, so an overlay with no transformer table to attach to
-    /// has no reader at all. Name the loss; `extras_block` skips the overlay
-    /// deliberately, so nothing else reports it.
+    /// Report parameter overlays that have no declared transformer target.
     fn warn_orphan_transformer_overlay(&mut self, doc: &Map<String, Value>) {
         let overlay = doc
             .get("extras")
@@ -866,9 +868,6 @@ impl Reader<'_> {
         }
     }
 
-    // One block per object field; splitting it would scatter a list that
-    // reads end to end.
-    #[expect(clippy::too_many_lines)]
     fn buses(&mut self, items: &Map<String, Value>) {
         for (id, v) in items {
             let Value::Object(o) = v else { continue };
@@ -957,16 +956,10 @@ impl Reader<'_> {
                 id: id.clone(),
                 terminals: strings(o.get("terminal_names")),
                 grounded: strings(o.get("perfectly_grounded_terminals")),
-                v_min: first_float_collapsed(
-                    o.get("v_min"),
-                    &format!("bus {id} v_min"),
-                    &mut self.diagnostics,
-                ),
-                v_max: first_float_collapsed(
-                    o.get("v_max"),
-                    &format!("bus {id} v_max"),
-                    &mut self.diagnostics,
-                ),
+                v_min: uniform_bound(o.get("v_min")),
+                v_max: uniform_bound(o.get("v_max")),
+                v_min_phase: nonuniform_bound(o.get("v_min")),
+                v_max_phase: nonuniform_bound(o.get("v_max")),
                 vpn_min: floats(o.get("vpn_min")),
                 vpn_max: floats(o.get("vpn_max")),
                 vpp_min: floats(o.get("vpp_min")),
@@ -1879,6 +1872,7 @@ impl Reader<'_> {
         let s = o.get("s_rating").map_or(f64::NAN, f);
         let mut windings = Vec::new();
         let mut delta_rolls = Map::new();
+        let mut winding_metadata = Map::new();
         if let Some(items) = o.get("windings").and_then(Value::as_array) {
             for (idx, item) in self.bounded_windings(name, items).iter().enumerate() {
                 let Some(w) = item.as_object() else {
@@ -1894,6 +1888,14 @@ impl Reader<'_> {
                 let terminal_map = strings(w.get("terminal_map"));
                 let bmopf_v_nom = value_alias(w, "v_nom", "v_ref").map_or(f64::NAN, f);
                 let r_winding = w.get("r_winding").map_or(0.0, f);
+                let rating = w.get("s_rating").map_or(s, f);
+                let retained: Map<String, Value> = ["i_max", "tap_ratio_min", "tap_ratio_max"]
+                    .iter()
+                    .filter_map(|key| w.get(*key).map(|v| ((*key).to_owned(), v.clone())))
+                    .collect();
+                if !retained.is_empty() {
+                    winding_metadata.insert(idx.to_string(), Value::Object(retained));
+                }
                 let connection = w
                     .get("configuration")
                     .or_else(|| w.get("connection"))
@@ -1915,7 +1917,7 @@ impl Reader<'_> {
                     delta_rolls.insert((idx + 1).to_string(), Value::from(delta_roll));
                 }
                 let r_pct = if let Some(base_z) =
-                    n_winding_base_from_bmopf(conn, &terminal_map, bmopf_v_nom, s)
+                    n_winding_base_from_bmopf(conn, &terminal_map, bmopf_v_nom, rating)
                 {
                     r_winding / base_z * 100.0
                 } else {
@@ -1926,11 +1928,11 @@ impl Reader<'_> {
                     terminal_map: terminal_map.clone(),
                     conn,
                     v_ref: n_winding_internal_v_ref(conn, &terminal_map, bmopf_v_nom),
-                    s_rating: s,
+                    s_rating: rating,
                     r_pct,
-                    tap: 1.0,
-                    r_neutral: None,
-                    x_neutral: None,
+                    tap: w.get("tap_ratio").map_or(1.0, f),
+                    r_neutral: w.get("r_neutral").map(f),
+                    x_neutral: w.get("x_neutral").map(f),
                 });
             }
         }
@@ -1957,6 +1959,13 @@ impl Reader<'_> {
             &[],
         );
         extras.insert("bmopf_subtype".into(), "n_winding".into());
+        extras.insert("bmopf_power_base".into(), Value::from(s));
+        if !winding_metadata.is_empty() {
+            extras.insert(
+                "bmopf_winding_metadata".into(),
+                Value::Object(winding_metadata),
+            );
+        }
         if !delta_rolls.is_empty() {
             extras.insert(BMOPF_DELTA_ROLLS_EXTRA.into(), Value::Object(delta_rolls));
         }

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -592,7 +592,7 @@ impl Reader<'_> {
                 other => {
                     self.diagnostics.push(
                         &C::READ_BMOPF_RETAINED_SOURCE_ONLY,
-                        format!("top level `{other}` is outside the schema; kept untyped"),
+                        format!("top level `{other}` has no typed PowerIO representation; kept as named JSON data"),
                     );
                     for (name, v) in items {
                         self.net.untyped_objects_mut().push(UntypedObject {
@@ -1441,6 +1441,7 @@ impl Reader<'_> {
             "v_ref_to",
             "g_no_load",
             "b_no_load",
+            "no_load_shunt",
             "r_series",
             "x_series",
             "r_series_from",
@@ -1586,7 +1587,7 @@ impl Reader<'_> {
                 extras.insert(key.into(), value.clone());
             }
         }
-        for key in ["g_no_load", "b_no_load"] {
+        for key in ["g_no_load", "b_no_load", "no_load_shunt"] {
             if let Some(v) = o.get(key) {
                 extras.insert(key.into(), v.clone());
             }
@@ -1752,6 +1753,7 @@ impl Reader<'_> {
             "x_series_to",
             "g_no_load",
             "b_no_load",
+            "no_load_shunt",
             "tap_ratio",
             "tap_ratio_min",
             "tap_ratio_max",
@@ -1840,6 +1842,7 @@ impl Reader<'_> {
         for key in [
             "g_no_load",
             "b_no_load",
+            "no_load_shunt",
             "tap_ratio_min",
             "tap_ratio_max",
             "regulator_type",
@@ -1868,7 +1871,14 @@ impl Reader<'_> {
     // reads end to end.
     #[expect(clippy::too_many_lines)]
     fn n_winding_transformer(&mut self, name: &str, o: &Map<String, Value>) -> DistTransformer {
-        let known = ["windings", "x_sc", "s_rating", "g_no_load", "b_no_load"];
+        let known = [
+            "windings",
+            "x_sc",
+            "s_rating",
+            "g_no_load",
+            "b_no_load",
+            "no_load_shunt",
+        ];
         let s = o.get("s_rating").map_or(f64::NAN, f);
         let mut windings = Vec::new();
         let mut delta_rolls = Map::new();
@@ -1969,7 +1979,7 @@ impl Reader<'_> {
         if !delta_rolls.is_empty() {
             extras.insert(BMOPF_DELTA_ROLLS_EXTRA.into(), Value::Object(delta_rolls));
         }
-        for key in ["g_no_load", "b_no_load"] {
+        for key in ["g_no_load", "b_no_load", "no_load_shunt"] {
             if let Some(v) = o.get(key) {
                 extras.insert(key.into(), v.clone());
             }

--- a/powerio-dist/src/bmopf/read.rs
+++ b/powerio-dist/src/bmopf/read.rs
@@ -11,7 +11,7 @@
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
 
-use super::BmopfProfile;
+use super::BmopfSchemaVersion;
 use crate::diagnostics::codes as C;
 use crate::error::{Error, Result};
 use crate::geo::{CoordinateSpace, DistCoordsKind, DistGeoMeta, DistLocation};
@@ -67,7 +67,7 @@ fn report_schema_version(doc: &Map<String, Value>, diags: &mut crate::collect::D
         .and_then(|m| m.get("$schema"))
         .and_then(Value::as_str);
     if let (Some(profile), Some(version)) = (
-        stated.and_then(BmopfProfile::from_schema_id),
+        stated.and_then(BmopfSchemaVersion::from_schema_id),
         doc.get("meta").and_then(|meta| meta.get("schema_version")),
     ) && version.as_str() != Some(profile.version())
     {
@@ -85,17 +85,17 @@ fn report_schema_version(doc: &Map<String, Value>, diags: &mut crate::collect::D
             format!(
                 "the document states no `meta.$schema`, so the BMOPF schema version it was \
                  written against is unknown; both {} and {} are accepted",
-                BmopfProfile::Bmopf010.version(),
-                BmopfProfile::Bmopf020.version()
+                BmopfSchemaVersion::Bmopf010.version(),
+                BmopfSchemaVersion::Bmopf020.version()
             ),
         ),
-        Some(id) if BmopfProfile::from_schema_id(id).is_none() => diags.push(
+        Some(id) if BmopfSchemaVersion::from_schema_id(id).is_none() => diags.push(
             &C::READ_BMOPF_SCHEMA_UNKNOWN,
             format!(
                 "`meta.$schema` is `{id}`, which names no known BMOPF schema version; both {} \
                  and {} are accepted",
-                BmopfProfile::Bmopf010.version(),
-                BmopfProfile::Bmopf020.version()
+                BmopfSchemaVersion::Bmopf010.version(),
+                BmopfSchemaVersion::Bmopf020.version()
             ),
         ),
         Some(_) => {}
@@ -118,7 +118,7 @@ fn nonuniform_bound(value: Option<&Value>) -> Option<Vec<f64>> {
         .flatten()
 }
 
-/// Schema 0.1.0 field names typed `number` or an array of them. Derived from
+/// Numeric field names shared with 0.1.0, plus draft energy prices. Derived from
 /// the vendored schema; `schema_numeric_fields_match_the_vendored_schema`
 /// holds the two together.
 const NUMERIC_FIELDS: &[&str] = &[
@@ -129,6 +129,7 @@ const NUMERIC_FIELDS: &[&str] = &[
     "beta_p",
     "beta_z",
     "cost",
+    "energy_cost_rate",
     "frequency",
     "gamma_p",
     "gamma_q",
@@ -569,7 +570,7 @@ impl Reader<'_> {
                 "generator" => self.generators(items),
                 "capacitor" => self.capacitors(items),
                 "shunt" => self.shunts(items),
-                "voltage_source" => self.sources(items),
+                "voltage_source" => self.sources_with_overlay(items, doc),
                 "extras" => self.extras_block(items),
                 // The phase/neutral label conventions block: no typed slot,
                 // stashed whole so a round trip keeps it (the meta pattern).
@@ -1274,6 +1275,7 @@ impl Reader<'_> {
                 "s_max",
                 "i_max",
                 "cost",
+                "energy_cost_rate",
                 "bus",
                 "configuration",
                 "terminal_map",
@@ -1291,7 +1293,7 @@ impl Reader<'_> {
             // Cost is a per-phase array in the schema, kept exactly as
             // stated. A bare scalar is still accepted for documents written
             // before v0.0.1 and reads as a one-entry statement.
-            let cost = match o.get("cost") {
+            let cost = match o.get("energy_cost_rate").or_else(|| o.get("cost")) {
                 Some(Value::Array(a)) => Some(a.iter().map(f).collect::<Vec<f64>>()),
                 Some(v) => Some(vec![f(v)]),
                 None => None,
@@ -1359,16 +1361,46 @@ impl Reader<'_> {
         }
     }
 
+    fn sources_with_overlay(&mut self, items: &Map<String, Value>, doc: &Map<String, Value>) {
+        let mut merged = items.clone();
+        if let Some(overlay) = doc
+            .get("extras")
+            .and_then(|e| e.get("voltage_source"))
+            .and_then(Value::as_object)
+        {
+            for (name, fields) in overlay {
+                if let (Some(target), Some(fields)) = (
+                    merged.get_mut(name).and_then(Value::as_object_mut),
+                    fields.as_object(),
+                ) {
+                    for (key, value) in fields {
+                        target.entry(key.clone()).or_insert_with(|| value.clone());
+                    }
+                }
+            }
+        }
+        self.sources(&merged);
+    }
+
     fn sources(&mut self, items: &Map<String, Value>) {
         for (name, v) in items {
             let Value::Object(o) = v else { continue };
-            let known = ["v_magnitude", "v_angle", "bus", "terminal_map"];
+            let known = [
+                "v_magnitude",
+                "v_angle",
+                "bus",
+                "terminal_map",
+                "energy_cost_rate",
+                "cost",
+            ];
+            let energy_cost_rate = floats(o.get("energy_cost_rate").or_else(|| o.get("cost")));
             self.net.sources_mut().push(VoltageSource {
                 name: name.clone(),
                 bus: string(o.get("bus")),
                 terminal_map: strings(o.get("terminal_map")),
                 v_magnitude: floats(o.get("v_magnitude")).unwrap_or_default(),
                 v_angle: floats(o.get("v_angle")).unwrap_or_default(),
+                energy_cost_rate,
                 extras: take_extras(
                     o,
                     &known,
@@ -2273,7 +2305,12 @@ mod tests {
                 "the reader does not know `{sample}` (from `{pattern}`)"
             );
         }
-        // And nothing the reader claims is numeric is absent from the schema.
+        let draft_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../tests/data/dist/bmopf/bmopf-0.2.0.schema.json");
+        let draft: Value =
+            serde_json::from_str(&std::fs::read_to_string(draft_path).unwrap()).unwrap();
+        walk(&draft, &mut names, &mut patterns);
+        // Each recognized numeric name belongs to a supported schema.
         for name in super::NUMERIC_FIELDS {
             assert!(
                 names.iter().any(|n| n == name),

--- a/powerio-dist/src/bmopf/validate.rs
+++ b/powerio-dist/src/bmopf/validate.rs
@@ -348,6 +348,41 @@ impl Check<'_> {
         }
     }
 
+    fn no_load_shunt(&mut self, record: &Map<String, Value>, path: &str) {
+        if let Some(shunt) = record.get("no_load_shunt") {
+            let count = record
+                .get("windings")
+                .and_then(Value::as_array)
+                .map_or_else(
+                    || {
+                        if path.starts_with("transformer.center_tap.") {
+                            3
+                        } else {
+                            2
+                        }
+                    },
+                    Vec::len,
+                );
+            let winding = shunt.get("winding").and_then(Value::as_u64);
+            if winding.is_none_or(|index| index == 0 || index > count as u64) {
+                self.error(
+                    &format!("{path}.no_load_shunt.winding"),
+                    "no-load shunt winding does not exist",
+                );
+            }
+            if shunt
+                .get("g")
+                .and_then(Value::as_f64)
+                .is_none_or(|v| v < 0.0)
+                || shunt.get("b").and_then(Value::as_f64).is_none()
+                || record.contains_key("g_no_load")
+                || record.contains_key("b_no_load")
+            {
+                self.error(&format!("{path}.no_load_shunt"), "requires nonnegative g, finite b and no competing g_no_load/b_no_load representation");
+            }
+        }
+    }
+
     fn walk(&mut self, value: &Value, path: &str) {
         match value {
             Value::Array(items) => {
@@ -422,6 +457,7 @@ impl Check<'_> {
                         self.dimension(value, "i_max", &[np, map.len()], path);
                     }
                 }
+                self.no_load_shunt(record, path);
                 self.tap_bounds(value, record, path);
                 self.references_and_profiles(value, record, path);
                 for (key, item) in record {

--- a/powerio-dist/src/bmopf/validate.rs
+++ b/powerio-dist/src/bmopf/validate.rs
@@ -383,6 +383,19 @@ impl Check<'_> {
         }
     }
 
+    fn cost_aliases(&mut self, record: &Map<String, Value>, path: &str) {
+        if let (Some(old), Some(new)) = (
+            record.get("cost").and_then(Value::as_array),
+            record.get("energy_cost_rate").and_then(Value::as_array),
+        ) {
+            let old: Vec<_> = old.iter().map(Value::as_f64).collect();
+            let new: Vec<_> = new.iter().map(Value::as_f64).collect();
+            if old != new {
+                self.error(path, "cost and energy_cost_rate must agree in phase order");
+            }
+        }
+    }
+
     fn walk(&mut self, value: &Value, path: &str) {
         match value {
             Value::Array(items) => {
@@ -432,7 +445,7 @@ impl Check<'_> {
                         for key in ["v_magnitude", "v_angle"] {
                             self.dimension(value, key, &[map.len()], path);
                         }
-                        for key in ["p_min", "p_max", "cost"] {
+                        for key in ["p_min", "p_max", "cost", "energy_cost_rate"] {
                             self.dimension(value, key, &[np], path);
                         }
                     }
@@ -451,12 +464,21 @@ impl Check<'_> {
                         }
                     }
                     if path.starts_with("generator.") || path.starts_with("ibr.") {
-                        for key in ["p_min", "p_max", "q_min", "q_max", "s_max", "cost"] {
+                        for key in [
+                            "p_min",
+                            "p_max",
+                            "q_min",
+                            "q_max",
+                            "s_max",
+                            "cost",
+                            "energy_cost_rate",
+                        ] {
                             self.dimension(value, key, &[np], path);
                         }
                         self.dimension(value, "i_max", &[np, map.len()], path);
                     }
                 }
+                self.cost_aliases(record, path);
                 self.no_load_shunt(record, path);
                 self.tap_bounds(value, record, path);
                 self.references_and_profiles(value, record, path);

--- a/powerio-dist/src/bmopf/validate.rs
+++ b/powerio-dist/src/bmopf/validate.rs
@@ -1,0 +1,443 @@
+//! Cross-field checks over source data before conversion can normalize its shape.
+
+use crate::{collect::Diagnostics, diagnostics::codes as C, model::DistBus};
+use serde_json::{Map, Value};
+use std::collections::BTreeSet;
+
+pub(super) fn report(doc: &Map<String, Value>, diagnostics: &mut Diagnostics) {
+    let mut check = Check { doc, diagnostics };
+    if let Some(roles) = doc.get("terminal_conventions") {
+        let mut seen = BTreeSet::new();
+        for role in ["phase", "neutral", "earth"] {
+            for label in strings(roles.get(role)) {
+                if !seen.insert(label) {
+                    check.error(
+                        &format!("terminal_conventions.{role}"),
+                        "role lists must be unique and disjoint",
+                    );
+                }
+            }
+        }
+    }
+    if let Some(buses) = doc.get("bus").and_then(Value::as_object) {
+        for (id, bus) in buses {
+            let path = format!("bus.{id}");
+            let names = strings(bus.get("terminal_names"));
+            if names.is_empty()
+                || names.contains(&"g")
+                || names.iter().collect::<BTreeSet<_>>().len() != names.len()
+            {
+                check.error(
+                    &path,
+                    "terminal_names must be nonempty, unique and exclude implicit ground g",
+                );
+            }
+            for name in strings(bus.get("perfectly_grounded_terminals")) {
+                if !names.contains(&name) {
+                    check.error(
+                        &path,
+                        "a perfectly grounded terminal is absent from terminal_names",
+                    );
+                }
+            }
+            let phases = phase_count(&names, doc.get("terminal_conventions"));
+            for key in ["v_min", "v_max", "vpn_min", "vpn_max"] {
+                check.dimension(bus, key, &[phases], &path);
+            }
+            for key in ["vpp_min", "vpp_max"] {
+                check.dimension(bus, key, &[phases * phases.saturating_sub(1) / 2], &path);
+            }
+            for (lo, hi) in [
+                ("v_min", "v_max"),
+                ("vpn_min", "vpn_max"),
+                ("vpp_min", "vpp_max"),
+            ] {
+                if let (Some(low), Some(high)) = (
+                    bus.get(lo).and_then(Value::as_array),
+                    bus.get(hi).and_then(Value::as_array),
+                ) && low
+                    .iter()
+                    .zip(high)
+                    .any(|(a, b)| a.as_f64().zip(b.as_f64()).is_some_and(|(a, b)| a > b))
+                {
+                    check.error(&path, "a minimum voltage exceeds its maximum");
+                }
+            }
+        }
+    }
+    for (kind, table) in doc {
+        if matches!(
+            kind.as_str(),
+            "meta" | "extras" | "terminal_conventions" | "bus"
+        ) {
+            continue;
+        }
+        check.walk(table, kind);
+    }
+}
+
+fn strings(value: Option<&Value>) -> Vec<&str> {
+    value
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect()
+}
+
+fn phase_count(names: &[&str], roles: Option<&Value>) -> usize {
+    DistBus::new("", names.iter().map(|s| (*s).to_owned()).collect())
+        .phase_indices(roles)
+        .len()
+}
+
+struct Check<'a> {
+    doc: &'a Map<String, Value>,
+    diagnostics: &'a mut Diagnostics,
+}
+
+impl Check<'_> {
+    fn error(&mut self, path: &str, message: &str) {
+        self.diagnostics.push(
+            &C::READ_BMOPF_SEMANTIC_INVALID,
+            format!("{path}: {message}"),
+        );
+    }
+
+    fn dimension(&mut self, record: &Value, key: &str, expected: &[usize], path: &str) {
+        if let Some(values) = record.get(key).and_then(Value::as_array)
+            && !expected.contains(&values.len())
+        {
+            self.error(
+                &format!("{path}.{key}"),
+                &format!("expected array length {expected:?}, found {}", values.len()),
+            );
+        }
+    }
+
+    fn map(&mut self, record: &Value, bus_key: &str, map_key: &str, path: &str) {
+        self.map_table(record, "bus", bus_key, map_key, path);
+    }
+
+    fn map_table(&mut self, record: &Value, table: &str, bus_key: &str, map_key: &str, path: &str) {
+        let Some(bus_id) = record.get(bus_key).and_then(Value::as_str) else {
+            return;
+        };
+        let Some(bus) = self.doc.get(table).and_then(|b| b.get(bus_id)) else {
+            self.error(
+                &format!("{path}.{bus_key}"),
+                "referenced bus does not exist",
+            );
+            return;
+        };
+        let terminals = strings(bus.get("terminal_names"));
+        let map = record
+            .get(map_key)
+            .and_then(Value::as_str)
+            .map_or_else(|| strings(record.get(map_key)), |terminal| vec![terminal]);
+        for terminal in map {
+            if terminal != "g" && !terminals.contains(&terminal) {
+                self.error(
+                    &format!("{path}.{map_key}"),
+                    &format!("terminal {terminal} does not exist on bus {bus_id}"),
+                );
+            }
+        }
+    }
+
+    fn matrices(&mut self, record: &Map<String, Value>, n: usize, path: &str) {
+        for key in record.keys() {
+            let parts: Vec<_> = key.rsplitn(3, '_').collect();
+            if parts.len() != 3
+                || !matches!(
+                    parts[2],
+                    "R_series"
+                        | "X_series"
+                        | "G_shunt"
+                        | "B_shunt"
+                        | "G_from"
+                        | "B_from"
+                        | "G_to"
+                        | "B_to"
+                        | "G"
+                        | "B"
+                )
+            {
+                continue;
+            }
+            if let (Ok(i), Ok(j)) = (parts[1].parse::<usize>(), parts[0].parse::<usize>())
+                && (i == 0 || j == 0 || i > n || j > n)
+            {
+                self.error(
+                    &format!("{path}.{key}"),
+                    &format!("matrix index exceeds conductor dimension {n}"),
+                );
+            }
+        }
+    }
+
+    fn tap_bounds(&mut self, value: &Value, record: &Map<String, Value>, path: &str) {
+        for root in ["tap", "tap_ratio"] {
+            let count = if path.starts_with("transformer.open_delta_regulator.") {
+                2
+            } else {
+                1
+            };
+            let at = |key: &str, index: usize| {
+                record.get(key).and_then(|v| {
+                    v.as_f64().or_else(|| {
+                        v.as_array()
+                            .and_then(|a| a.get(index))
+                            .and_then(Value::as_f64)
+                    })
+                })
+            };
+            for key in [
+                root.to_owned(),
+                format!("{root}_min"),
+                format!("{root}_max"),
+            ] {
+                self.dimension(value, &key, &[count], path);
+            }
+            for i in 0..count {
+                let lo = at(&format!("{root}_min"), i);
+                let hi = at(&format!("{root}_max"), i);
+                let tap = at(root, i);
+                if lo.zip(hi).is_some_and(|(lo, hi)| lo > hi)
+                    || tap.is_some_and(|t| {
+                        t <= 0.0 || lo.is_some_and(|v| t < v) || hi.is_some_and(|v| t > v)
+                    })
+                {
+                    self.error(path, "tap must be positive and consistent with its bounds");
+                }
+            }
+        }
+    }
+
+    fn references_and_profiles(&mut self, value: &Value, record: &Map<String, Value>, path: &str) {
+        for field in ["control_profile", "line_geometry", "wire_data"] {
+            if let Some(id) = record.get(field).and_then(Value::as_str)
+                && self
+                    .doc
+                    .get(field)
+                    .and_then(|table| table.get(id))
+                    .is_none()
+            {
+                self.error(
+                    &format!("{path}.{field}"),
+                    "referenced record does not exist",
+                );
+            }
+        }
+        for (bus, map) in [
+            ("dc_bus", "terminal_map"),
+            ("dc_bus_from", "terminal_map_from"),
+            ("dc_bus_to", "terminal_map_to"),
+        ] {
+            self.map_table(
+                value,
+                "dc_bus",
+                bus,
+                if record.contains_key("dc_terminal_map") {
+                    "dc_terminal_map"
+                } else {
+                    map
+                },
+                path,
+            );
+        }
+        if path.starts_with("dc_grounding.") {
+            self.map_table(value, "dc_bus", "dc_bus", "terminal", path);
+        }
+        if path.starts_with("dc_branch.") && record.contains_key("dc_bus_from") {
+            let count = strings(record.get("terminal_map_from")).len();
+            for key in ["terminal_map_to", "r", "i_max"] {
+                self.dimension(value, key, &[count], path);
+            }
+        }
+        if path.starts_with("dc_bus.") && record.contains_key("terminal_names") {
+            let names = strings(record.get("terminal_names"));
+            if names.iter().collect::<BTreeSet<_>>().len() != names.len()
+                || strings(record.get("perfectly_grounded_terminals"))
+                    .iter()
+                    .any(|n| !names.contains(n))
+                || record
+                    .get("pole")
+                    .and_then(Value::as_object)
+                    .is_some_and(|p| p.keys().any(|n| !names.contains(&n.as_str())))
+            {
+                self.error(path, "DC terminals must be unique and include every grounded terminal and pole label");
+            }
+            for key in ["v_dc_nom", "v_dc_min", "v_dc_max"] {
+                self.dimension(value, key, &[names.len()], path);
+            }
+            if let (Some(lo), Some(hi)) = (
+                record.get("v_dc_min").and_then(Value::as_array),
+                record.get("v_dc_max").and_then(Value::as_array),
+            ) && lo
+                .iter()
+                .zip(hi)
+                .any(|(a, b)| a.as_f64().zip(b.as_f64()).is_some_and(|(a, b)| a > b))
+            {
+                self.error(path, "minimum DC voltage exceeds maximum");
+            }
+        }
+        self.profiles_and_windings(value, record, path);
+    }
+
+    fn profiles_and_windings(&mut self, value: &Value, record: &Map<String, Value>, path: &str) {
+        if let Some(profiles) = record.get("time_series").and_then(Value::as_object) {
+            for (field, id) in profiles {
+                if !record.get(field).is_some_and(numeric_value) {
+                    self.error(
+                        &format!("{path}.time_series.{field}"),
+                        "profile requires a stated numeric field on the element",
+                    );
+                }
+                if id
+                    .as_str()
+                    .and_then(|id| self.doc.get("time_series").and_then(|table| table.get(id)))
+                    .is_none()
+                {
+                    self.error(
+                        &format!("{path}.time_series.{field}"),
+                        "referenced time profile does not exist",
+                    );
+                }
+            }
+        }
+        if path.starts_with("time_series.") && record.contains_key("values") {
+            let count = record
+                .get("values")
+                .and_then(Value::as_array)
+                .map_or(0, Vec::len);
+            self.dimension(value, "time", &[count], path);
+            if let Some(time) = record.get("time").and_then(Value::as_array)
+                && time.windows(2).any(|pair| {
+                    pair[0]
+                        .as_f64()
+                        .zip(pair[1].as_f64())
+                        .is_some_and(|(a, b)| a >= b)
+                })
+            {
+                self.error(path, "profile time must be strictly increasing");
+            }
+        }
+        if let Some(windings) = record.get("windings").and_then(Value::as_array)
+            && let Some(pairs) = record.get("x_sc").and_then(Value::as_object)
+        {
+            let n = windings.len();
+            for key in pairs.keys() {
+                let valid = key
+                    .split_once('_')
+                    .and_then(|(a, b)| a.parse::<usize>().ok().zip(b.parse::<usize>().ok()))
+                    .is_some_and(|(a, b)| a > 0 && a < b && b <= n);
+                if !valid {
+                    self.error(
+                        &format!("{path}.x_sc.{key}"),
+                        "expected winding pair i_j with 1 <= i < j <= winding count",
+                    );
+                }
+            }
+            if pairs.len() != n * n.saturating_sub(1) / 2 {
+                self.error(
+                    &format!("{path}.x_sc"),
+                    "short-circuit table must state every winding pair",
+                );
+            }
+        }
+    }
+
+    fn walk(&mut self, value: &Value, path: &str) {
+        match value {
+            Value::Array(items) => {
+                for (i, item) in items.iter().enumerate() {
+                    self.walk(item, &format!("{path}[{i}]"));
+                }
+            }
+            Value::Object(record) => {
+                for (bus, map) in [
+                    ("bus", "terminal_map"),
+                    ("bus_from", "terminal_map_from"),
+                    ("bus_to", "terminal_map_to"),
+                ] {
+                    self.map(value, bus, map, path);
+                }
+                let map = strings(record.get("terminal_map"));
+                let from = strings(record.get("terminal_map_from"));
+                let np = phase_count(&map, self.doc.get("terminal_conventions"));
+                if record.contains_key("terminal_map_from")
+                    && (path.starts_with("line.") || path.starts_with("switch."))
+                {
+                    self.dimension(value, "terminal_map_to", &[from.len()], path);
+                    self.matrices(record, from.len(), path);
+                    self.dimension(value, "i_max", &[from.len()], path);
+                    self.dimension(
+                        value,
+                        "s_max",
+                        &[phase_count(&from, self.doc.get("terminal_conventions"))],
+                        path,
+                    );
+                    if let Some(id) = record.get("linecode").and_then(Value::as_str) {
+                        if let Some(code) = self
+                            .doc
+                            .get("linecode")
+                            .and_then(|c| c.get(id))
+                            .and_then(Value::as_object)
+                        {
+                            self.matrices(code, from.len(), &format!("{path}.linecode"));
+                        } else {
+                            self.error(path, "referenced linecode does not exist");
+                        }
+                    }
+                }
+                if record.contains_key("terminal_map") {
+                    self.matrices(record, map.len(), path);
+                    if path.starts_with("voltage_source.") {
+                        for key in ["v_magnitude", "v_angle"] {
+                            self.dimension(value, key, &[map.len()], path);
+                        }
+                        for key in ["p_min", "p_max", "cost"] {
+                            self.dimension(value, key, &[np], path);
+                        }
+                    }
+                    if path.starts_with("load.") {
+                        let n = match record.get("configuration").and_then(Value::as_str) {
+                            Some("SINGLE_PHASE") => 1,
+                            Some("WYE") => map.len().saturating_sub(1),
+                            Some("DELTA") => map.len() * map.len().saturating_sub(1) / 2,
+                            _ => np,
+                        };
+                        for key in [
+                            "p_nom", "q_nom", "v_nom", "alpha_p", "alpha_i", "alpha_z", "beta_p",
+                            "beta_i", "beta_z", "gamma_p", "gamma_q",
+                        ] {
+                            self.dimension(value, key, &[n], path);
+                        }
+                    }
+                    if path.starts_with("generator.") || path.starts_with("ibr.") {
+                        for key in ["p_min", "p_max", "q_min", "q_max", "s_max", "cost"] {
+                            self.dimension(value, key, &[np], path);
+                        }
+                        self.dimension(value, "i_max", &[np, map.len()], path);
+                    }
+                }
+                self.tap_bounds(value, record, path);
+                self.references_and_profiles(value, record, path);
+                for (key, item) in record {
+                    if !matches!(key.as_str(), "meta" | "extras" | "provenance") {
+                        self.walk(item, &format!("{path}.{key}"));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn numeric_value(value: &Value) -> bool {
+    value.is_number()
+        || value
+            .as_array()
+            .is_some_and(|values| !values.is_empty() && values.iter().all(numeric_value))
+}

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -24,10 +24,8 @@ use crate::model::{
     open_delta_connection, open_delta_pairable, pair_keys, winding_phase_pair,
 };
 
-/// The `$id` of the schema the writer targets by default, and the value it
-/// stamps into `meta.$schema`. It is
-/// [`BmopfProfile::default`]`().schema_id()`; a writer targeting the other
-/// version reads the `$id` from that version instead.
+/// Canonical identity of the default schema. Fresh proposal output uses
+/// [`BmopfProfile::retrieval_url`] in `meta.$schema`.
 pub const BMOPF_SCHEMA_ID: &str = BmopfProfile::Bmopf020.schema_id();
 
 /// The version of the schema the writer targets by default, and the value it
@@ -96,7 +94,9 @@ const BMOPF_DELTA_ROLLS_EXTRA: &str = "bmopf_delta_rolls";
 /// element comes near this bound.
 const MAX_DIM: usize = 64;
 
-const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 5] = [
+const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 7] = [
+    "bmopf_power_base",
+    "bmopf_winding_metadata",
     "g_no_load",
     "b_no_load",
     "%noloadloss",
@@ -373,10 +373,13 @@ impl Writer {
     /// provenance. Deterministic and round-trip stable — no generated
     /// timestamp, and nothing that depends on the immediate source format
     /// (which a round trip would change) — so canonical output is idempotent.
-    /// The vintage lives in `$schema` (the canonical bmopf-report `$id`).
+    /// The selected schema is identified by its retrieval URI and provenance.
     fn meta(&mut self, net: &MulticonductorNetwork) -> Value {
         let mut m = Map::new();
-        m.insert("$schema".into(), json!(self.options.profile.schema_id()));
+        m.insert(
+            "$schema".into(),
+            json!(self.options.profile.retrieval_url()),
+        );
         // Schema 0.1.0 has no `schema_version` field, and its `meta` rejects
         // what it does not declare, so only 0.2.0 states the version twice.
         if self.options.profile == BmopfProfile::Bmopf020 {
@@ -411,6 +414,9 @@ impl Writer {
                     ),
                 }
             }
+        }
+        if self.options.profile == BmopfProfile::Bmopf020 {
+            proposal_provenance(&mut m);
         }
         Value::Object(m)
     }
@@ -465,7 +471,6 @@ impl Writer {
             doc.insert("extras".into(), Value::Object(extras));
         }
         self.warn_unemitted_untyped(net);
-        self.prune_unreferenced_buses(&mut doc);
         Value::Object(doc)
     }
 
@@ -477,11 +482,21 @@ impl Writer {
             if !b.grounded.is_empty() {
                 o.insert("perfectly_grounded_terminals".into(), json!(b.grounded));
             }
-            if let Some(v) = b.v_min {
-                o.insert("v_min".into(), Value::Array(vec![self.num(v, "bus v_min")]));
-            }
-            if let Some(v) = b.v_max {
-                o.insert("v_max".into(), Value::Array(vec![self.num(v, "bus v_max")]));
+            for (key, scalar, phases) in [
+                ("v_min", b.v_min, &b.v_min_phase),
+                ("v_max", b.v_max, &b.v_max_phase),
+            ] {
+                if let Some(v) = scalar {
+                    o.insert(
+                        key.into(),
+                        Value::Array(vec![
+                            self.num(v, key);
+                            b.phase_indices(doc.get("terminal_conventions")).len()
+                        ]),
+                    );
+                } else if let Some(values) = phases {
+                    o.insert(key.into(), self.nums(values, key));
+                }
             }
             for (key, bound) in [
                 ("vpn_min", &b.vpn_min),
@@ -795,66 +810,6 @@ impl Writer {
                     ),
                 );
                 extras.insert(class.to_string(), Value::Object(Map::new()));
-            }
-        }
-    }
-
-    fn prune_unreferenced_buses(&mut self, doc: &mut Map<String, Value>) {
-        let mut refs = BTreeMap::new();
-        for (key, value) in doc.iter() {
-            if key != "bus" {
-                collect_bus_usage(value, &mut refs);
-            }
-        }
-        let Some(buses) = doc.get_mut("bus").and_then(Value::as_object_mut) else {
-            return;
-        };
-        let ids: Vec<String> = buses.keys().cloned().collect();
-        for id in ids {
-            let Some(used) = refs.get(&id) else {
-                buses.remove(&id);
-                self.warn(&C::EMIT_BMOPF_RECORD_DROPPED, format!(
-                    "bus {id}: no emitted BMOPF element references this bus; dropped from the output"
-                ));
-                continue;
-            };
-            let Some(bus) = buses.get_mut(&id).and_then(Value::as_object_mut) else {
-                continue;
-            };
-            // A perfectly grounded terminal is referenced by ground itself:
-            // pruning it would silently lose the grounding, and a dss round
-            // trip would come back with different bus connectivity. Collect
-            // those few names beside `used` rather than cloning the whole
-            // referenced set once per bus.
-            let grounded: BTreeSet<String> = match bus.get("perfectly_grounded_terminals") {
-                Some(Value::Array(terms)) => terms
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(str::to_string)
-                    .collect(),
-                _ => BTreeSet::new(),
-            };
-            prune_string_array(
-                bus,
-                "terminal_names",
-                used,
-                &grounded,
-                &mut self.warnings,
-                &format!("bus {id}"),
-            );
-            prune_string_array(
-                bus,
-                "perfectly_grounded_terminals",
-                used,
-                &grounded,
-                &mut self.warnings,
-                &format!("bus {id}"),
-            );
-            if matches!(
-                bus.get("perfectly_grounded_terminals"),
-                Some(Value::Array(terms)) if terms.is_empty()
-            ) {
-                bus.remove("perfectly_grounded_terminals");
             }
         }
     }
@@ -1500,6 +1455,17 @@ impl Writer {
             rename_tap_fields(by_subtype);
             return;
         }
+        for subtype in [
+            "n_winding",
+            "single_phase_autotransformer",
+            "open_delta_regulator",
+        ] {
+            if let Some(table) = by_subtype.remove(subtype) {
+                self.transformer_overflow.insert(subtype.into(), table);
+                self.warnings.push(&C::EMIT_BMOPF_RETAINED_SOURCE_ONLY,
+                    format!("transformer.{subtype} is represented under extras.transformer in schema 0.1.0"));
+            }
+        }
         for subtype in ["single_phase", "center_tap", "wye_delta", "delta_wye"] {
             let Some(Value::Object(table)) = by_subtype.get_mut(subtype) else {
                 continue;
@@ -2051,26 +2017,11 @@ impl Writer {
     }
 
     fn n_winding(&mut self, t: &DistTransformer) -> Value {
-        let s = t.windings.first().map_or(f64::NAN, |w| w.s_rating);
-        if t.windings
-            .iter()
-            .any(|w| w.s_rating.to_bits() != s.to_bits())
-        {
-            let mut details = Map::new();
-            details.insert(
-                "s_ratings".into(),
-                json!(t.windings.iter().map(|w| w.s_rating).collect::<Vec<_>>()),
-            );
-            self.transformer_diagnostic(
-                t,
-                &C::EMIT_BMOPF_TRANSFORMER_N_WINDING_RATING_COLLAPSED,
-                format!(
-                    "transformer {}: n_winding BMOPF carries one s_rating; emitted the first winding rating",
-                    t.name
-                ),
-                details,
-            );
-        }
+        let s = t
+            .extras
+            .get("bmopf_power_base")
+            .and_then(Value::as_f64)
+            .unwrap_or_else(|| t.windings.first().map_or(f64::NAN, |w| w.s_rating));
         let mut o = Map::new();
         o.insert("s_rating".into(), self.num(s, "transformer s_rating"));
         let windings: Vec<Value> = t
@@ -2092,11 +2043,23 @@ impl Writer {
                         DistWindingConn::Delta => "DELTA",
                     }),
                 );
-                let zbase = n_winding_base(w, s).unwrap_or(f64::NAN);
+                let zbase = n_winding_base(w, w.s_rating).unwrap_or(f64::NAN);
                 wj.insert(
                     "r_winding".into(),
                     self.num(w.r_pct / 100.0 * zbase, "transformer winding r_winding"),
                 );
+                wj.insert("s_rating".into(), self.num(w.s_rating, "winding s_rating"));
+                wj.insert("tap_ratio".into(), self.num(w.tap, "winding tap_ratio"));
+                if w.r_neutral.is_some_and(|r| r < 0.0) {
+                    self.warn(&C::EMIT_BMOPF_FIELD_DROPPED, format!("transformer {} winding {idx}: open OpenDSS neutral has no internal impedance branch; neutral impedance fields omitted", t.name));
+                } else {
+                    for (key, value) in [("r_neutral", w.r_neutral), ("x_neutral", w.x_neutral)] {
+                        if let Some(value) = value { wj.insert(key.into(), self.num(value, key)); }
+                    }
+                }
+                if let Some(metadata) = t.extras.get("bmopf_winding_metadata").and_then(|v| v.get(idx.to_string())).and_then(Value::as_object) {
+                    for (key, value) in metadata { wj.insert(key.clone(), value.clone()); }
+                }
                 if let Some(delta_roll) = bmopf_delta_roll(t, idx, w) {
                     wj.insert("delta_roll".into(), json!(delta_roll));
                 }
@@ -2114,8 +2077,6 @@ impl Writer {
         if let Some(first) = t.windings.first() {
             self.transformer_no_load_fields(&mut o, t, first, s);
         }
-        self.warn_unrepresented_neutral_fields(t, "n_winding BMOPF");
-        self.taps_dropped(t);
         self.transformer_extras_dropped(t, &TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS);
         o.into()
     }
@@ -2214,24 +2175,6 @@ impl Writer {
         out
     }
 
-    fn taps_dropped(&mut self, t: &DistTransformer) {
-        for w in &t.windings {
-            if (w.tap - 1.0).abs() > 1e-12 {
-                let mut details = Map::new();
-                details.insert("tap".into(), json!(w.tap));
-                self.transformer_diagnostic(
-                    t,
-                    &C::EMIT_BMOPF_TRANSFORMER_TAP_DROPPED,
-                    format!(
-                        "transformer {}: off nominal tap {} has no BMOPF field; dropped",
-                        t.name, w.tap
-                    ),
-                    details,
-                );
-            }
-        }
-    }
-
     fn transformer_tap_fields(
         &mut self,
         o: &mut Map<String, Value>,
@@ -2304,10 +2247,19 @@ impl Writer {
         from: &DistWinding,
         to: &DistWinding,
     ) {
-        self.transformer_neutral_field(o, t, "r_neutral_from", from.r_neutral);
-        self.transformer_neutral_field(o, t, "x_neutral_from", from.x_neutral);
-        self.transformer_neutral_field(o, t, "r_neutral_to", to.r_neutral);
-        self.transformer_neutral_field(o, t, "x_neutral_to", to.x_neutral);
+        for (side, winding) in [("from", from), ("to", to)] {
+            let resistance = format!("r_neutral_{side}");
+            let reactance = format!("x_neutral_{side}");
+            self.transformer_neutral_field(o, t, &resistance, winding.r_neutral);
+            if winding.r_neutral.is_some_and(|r| r < 0.0) {
+                if let Some(x) = winding.x_neutral {
+                    self.warn(&C::EMIT_BMOPF_TRANSFORMER_NEUTRAL_DROPPED,
+                        format!("transformer {}: {reactance}={x} omitted with the open neutral encoded by negative {resistance}", t.name));
+                }
+            } else {
+                self.transformer_neutral_field(o, t, &reactance, winding.x_neutral);
+            }
+        }
     }
 
     fn transformer_neutral_field(
@@ -2580,80 +2532,6 @@ fn rename_tap_fields(by_subtype: &mut Map<String, Value>) {
             }
         }
     }
-}
-
-fn collect_bus_usage(value: &Value, refs: &mut BTreeMap<String, BTreeSet<String>>) {
-    match value {
-        Value::Object(o) => {
-            add_bus_usage(o, refs, "bus", "terminal_map");
-            add_bus_usage(o, refs, "bus_from", "terminal_map_from");
-            add_bus_usage(o, refs, "bus_to", "terminal_map_to");
-            for value in o.values() {
-                collect_bus_usage(value, refs);
-            }
-        }
-        Value::Array(values) => {
-            for value in values {
-                collect_bus_usage(value, refs);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn add_bus_usage(
-    o: &Map<String, Value>,
-    refs: &mut BTreeMap<String, BTreeSet<String>>,
-    bus_key: &str,
-    map_key: &str,
-) {
-    let Some(id) = o.get(bus_key).and_then(Value::as_str) else {
-        return;
-    };
-    let entry = refs.entry(id.to_string()).or_default();
-    if let Some(terms) = o.get(map_key).and_then(Value::as_array) {
-        entry.extend(terms.iter().filter_map(Value::as_str).map(str::to_string));
-    }
-}
-
-/// Drop the entries of a string array that no emitted element names. A name in
-/// `used` or in `also` is kept; `also` carries the few names this bus keeps for
-/// a reason of its own, so the caller does not have to merge them into `used`.
-fn prune_string_array(
-    o: &mut Map<String, Value>,
-    key: &str,
-    used: &BTreeSet<String>,
-    also: &BTreeSet<String>,
-    warnings: &mut crate::diagnostics::Diagnostics,
-    what: &str,
-) {
-    let Some(Value::Array(values)) = o.get_mut(key) else {
-        return;
-    };
-    let old = std::mem::take(values);
-    let mut kept = Vec::new();
-    let mut dropped = Vec::new();
-    for value in old {
-        if value
-            .as_str()
-            .is_some_and(|s| used.contains(s) || also.contains(s))
-        {
-            kept.push(value);
-        } else {
-            dropped.push(value);
-        }
-    }
-    if !dropped.is_empty() {
-        let names: Vec<String> = dropped
-            .iter()
-            .filter_map(Value::as_str)
-            .map(str::to_string)
-            .collect();
-        warnings.push(&C::EMIT_BMOPF_RECORD_DROPPED, format!(
-            "{what}: `{key}` entries {names:?} are not referenced by emitted BMOPF elements; dropped from the output"
-        ));
-    }
-    *values = kept;
 }
 
 #[derive(Clone)]
@@ -3148,21 +3026,61 @@ fn bmopf_delta_roll(t: &DistTransformer, idx: usize, w: &DistWinding) -> Option<
 /// The phase and neutral label lists, from the bus terminal names. The rule
 /// is the one the schema prescribes for an absent `terminal_conventions`
 /// block: an `n` or `N` label is neutral, every other label is a phase.
-/// Labels keep first-seen order. A network with no bus terminal gives `None`.
+/// Add deterministic producer provenance without replacing source metadata.
+fn proposal_provenance(meta: &mut Map<String, Value>) {
+    let record = json!({
+        "producer": "powerio", "producer_version": env!("CARGO_PKG_VERSION"),
+        "schema_status": "proposal", "schema_version": "0.2.0",
+        "schema_commit": super::BMOPF_PROPOSAL_COMMIT,
+        "schema_sha256": super::BMOPF_PROPOSAL_SHA256,
+        "schema_id": BmopfProfile::Bmopf020.schema_id(),
+        "schema_retrieval_url": super::BMOPF_PROPOSAL_URL
+    });
+    let provenance = meta.entry("provenance").or_insert_with(|| json!({}));
+    let Some(provenance) = provenance.as_object_mut() else {
+        return;
+    };
+    let mut index = 0;
+    loop {
+        let key = if index == 0 {
+            "powerio_bmopf".to_owned()
+        } else {
+            format!("powerio_bmopf_{index}")
+        };
+        match provenance.get(&key) {
+            Some(existing) if existing == &record => break,
+            Some(_) => index += 1,
+            None => {
+                provenance.insert(key, record);
+                break;
+            }
+        }
+    }
+}
+
+/// Labels keep first-seen order and case-sensitive identity.
 fn authored_terminal_conventions(net: &MulticonductorNetwork) -> Option<Value> {
-    let mut phase: Vec<&String> = Vec::new();
-    let mut neutral: Vec<&String> = Vec::new();
-    for b in net.buses() {
-        for term in &b.terminals {
-            let labels = if term.eq_ignore_ascii_case("n") {
+    let neutral_names: BTreeSet<&String> = net
+        .buses()
+        .iter()
+        .flat_map(|bus| {
+            let phases = bus.phase_indices(None);
+            bus.terminals
+                .iter()
+                .enumerate()
+                .filter_map(move |(index, name)| (!phases.contains(&index)).then_some(name))
+        })
+        .collect();
+    let mut phase = Vec::new();
+    let mut neutral = Vec::new();
+    for bus in net.buses() {
+        for term in &bus.terminals {
+            let labels = if neutral_names.contains(term) {
                 &mut neutral
             } else {
                 &mut phase
             };
-            // Bucketing is case insensitive, so the dedup has to be too:
-            // `N` and `n` are one label, and emitting both would tell a
-            // consumer the network has two neutrals.
-            if !labels.iter().any(|l| l.eq_ignore_ascii_case(term)) {
+            if !labels.contains(&term) {
                 labels.push(term);
             }
         }

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -11,7 +11,7 @@ use std::f64::consts::{FRAC_PI_2, PI, TAU};
 
 use serde_json::{Map, Value, json};
 
-use super::BmopfProfile;
+use super::BmopfSchemaVersion;
 use crate::convert::TextEmission;
 use crate::diagnostics::codes as C;
 use crate::diagnostics::{Diagnostic, DiagnosticInfo};
@@ -25,13 +25,13 @@ use crate::model::{
 };
 
 /// Canonical identity of the default schema. Fresh proposal output uses
-/// [`BmopfProfile::retrieval_url`] in `meta.$schema`.
-pub const BMOPF_SCHEMA_ID: &str = BmopfProfile::Bmopf020.schema_id();
+/// [`BmopfSchemaVersion::retrieval_url`] in `meta.$schema`.
+pub const BMOPF_SCHEMA_ID: &str = BmopfSchemaVersion::Bmopf020.schema_id();
 
 /// The version of the schema the writer targets by default, and the value it
 /// stamps into `meta.schema_version`. It is
-/// [`BmopfProfile::default`]`().version()`.
-pub const BMOPF_SCHEMA_VERSION: &str = BmopfProfile::Bmopf020.version();
+/// [`BmopfSchemaVersion::default`]`().version()`.
+pub const BMOPF_SCHEMA_VERSION: &str = BmopfSchemaVersion::Bmopf020.version();
 
 /// Untyped classes that belong to the BMOPF ecosystem. Schema 0.1.0 has no
 /// top-level table for them (`additionalProperties: false` plus the free form
@@ -80,6 +80,7 @@ const IBR_EXTRA_FIELDS: &[&str] = &[
     "grid_forming",
     "v_ref_internal",
     "cost",
+    "energy_cost_rate",
     "time_series",
 ];
 
@@ -163,12 +164,12 @@ fn regulator_allowed_extras() -> Vec<&'static str> {
 pub struct BmopfEmitOptions {
     /// The schema version to write against.
     ///
-    /// The default is [`BmopfProfile::Bmopf020`], the version that states
+    /// The default is [`BmopfSchemaVersion::Bmopf020`], the version that states
     /// every class the model carries, so output relocates nothing. Set
-    /// [`BmopfProfile::Bmopf010`] to write the version the task force
+    /// [`BmopfSchemaVersion::Bmopf010`] to write the version the task force
     /// accepts, which moves the classes it has no table for under `extras`
     /// and reports each move.
-    pub profile: BmopfProfile,
+    pub schema_version: BmopfSchemaVersion,
     /// Emit the BMOPFTools coordinate sideload fields on buses.
     ///
     /// The default stays schema strict because the BMOPF schema rejects these
@@ -179,8 +180,8 @@ pub struct BmopfEmitOptions {
 impl BmopfEmitOptions {
     /// The options with the schema version replaced.
     #[must_use]
-    pub const fn with_profile(mut self, profile: BmopfProfile) -> Self {
-        self.profile = profile;
+    pub const fn with_schema_version(mut self, schema_version: BmopfSchemaVersion) -> Self {
+        self.schema_version = schema_version;
         self
     }
 }
@@ -374,14 +375,14 @@ impl Writer {
         let mut m = Map::new();
         m.insert(
             "$schema".into(),
-            json!(self.options.profile.retrieval_url()),
+            json!(self.options.schema_version.retrieval_url()),
         );
         // Schema 0.1.0 has no `schema_version` field, and its `meta` rejects
         // what it does not declare, so only 0.2.0 states the version twice.
-        if self.options.profile == BmopfProfile::Bmopf020 {
+        if self.options.schema_version == BmopfSchemaVersion::Bmopf020 {
             m.insert(
                 "schema_version".into(),
-                json!(self.options.profile.version()),
+                json!(self.options.schema_version.version()),
             );
         }
         m.insert(
@@ -411,7 +412,7 @@ impl Writer {
                 }
             }
         }
-        if self.options.profile == BmopfProfile::Bmopf020 {
+        if self.options.schema_version == BmopfSchemaVersion::Bmopf020 {
             proposal_provenance(&mut m);
         }
         Value::Object(m)
@@ -448,12 +449,12 @@ impl Writer {
         if let Some(Value::Object(stash)) = net.extras().get(BMOPF_EXTRAS_STASH) {
             extras.extend(stash.clone());
         }
-        match self.options.profile {
-            BmopfProfile::Bmopf010 => {
+        match self.options.schema_version {
+            BmopfSchemaVersion::Bmopf010 => {
                 self.control_profiles(net, &mut extras);
                 self.ibrs(net, &mut extras);
             }
-            BmopfProfile::Bmopf020 => {
+            BmopfSchemaVersion::Bmopf020 => {
                 self.control_profiles(net, &mut doc);
                 self.ibrs(net, &mut doc);
             }
@@ -463,11 +464,57 @@ impl Writer {
             let overflow = std::mem::take(&mut self.transformer_overflow);
             extras.insert("transformer".into(), Value::Object(overflow));
         }
+        self.cost_version(&mut doc, &mut extras);
         if !extras.is_empty() {
             doc.insert("extras".into(), Value::Object(extras));
         }
         self.warn_unemitted_untyped(net);
         Value::Object(doc)
+    }
+
+    fn cost_version(&mut self, doc: &mut Map<String, Value>, extras: &mut Map<String, Value>) {
+        for class in ["generator", "ibr", "voltage_source"] {
+            let Some(table) = doc.get_mut(class).and_then(Value::as_object_mut) else {
+                continue;
+            };
+            for (name, value) in table {
+                let Some(record) = value.as_object_mut() else {
+                    continue;
+                };
+                if self.options.schema_version == BmopfSchemaVersion::Bmopf020 {
+                    if let Some(cost) = record.remove("cost") {
+                        record.entry("energy_cost_rate").or_insert(cost);
+                    }
+                } else if class == "voltage_source" {
+                    for field in ["cost", "energy_cost_rate"] {
+                        if let Some(cost) = record.remove(field) {
+                            let table = extras.entry(class).or_insert_with(|| json!({}));
+                            if !table.is_object() {
+                                self.warn(
+                                    &C::EMIT_BMOPF_FIELD_DROPPED,
+                                    "voltage-source extension is not an object",
+                                );
+                                continue;
+                            }
+                            let source = table
+                                .as_object_mut()
+                                .unwrap()
+                                .entry(name)
+                                .or_insert_with(|| json!({}));
+                            if !source.is_object() {
+                                self.warn(
+                                    &C::EMIT_BMOPF_FIELD_DROPPED,
+                                    "voltage-source extension record is not an object",
+                                );
+                                continue;
+                            }
+                            source.as_object_mut().unwrap().insert(field.into(), cost);
+                            self.warn(&C::EMIT_BMOPF_RETAINED_SOURCE_ONLY, format!("voltage source {name}: {field} retained in extras.voltage_source for BMOPF 0.1.0"));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn buses(&mut self, net: &MulticonductorNetwork, doc: &mut Map<String, Value>) {
@@ -776,7 +823,7 @@ impl Writer {
     /// too malformed to type still has no slot in it and keeps its raw
     /// properties under `extras`.
     fn raw_table_at_top_level(&self, class: &str) -> bool {
-        self.options.profile == BmopfProfile::Bmopf020 && class != "capacitor"
+        self.options.schema_version == BmopfSchemaVersion::Bmopf020 && class != "capacitor"
     }
 
     /// `extras` is seeded from the source document's own `extras` object, so
@@ -937,6 +984,10 @@ impl Writer {
             }
             doc.insert("shunt".into(), Value::Object(shunts));
         }
+        self.voltage_sources(net, doc);
+    }
+
+    fn voltage_sources(&mut self, net: &MulticonductorNetwork, doc: &mut Map<String, Value>) {
         let emitted_sources = bmopf_voltage_sources(net);
         let mut sources = Map::new();
         if emitted_sources.is_empty() {
@@ -969,6 +1020,14 @@ impl Writer {
             o.insert("bus".into(), json!(&vs.bus));
             o.insert("terminal_map".into(), json!(&vs.terminal_map));
             let mut extras = vs.extras.clone();
+            if let Some(rates) = &vs.energy_cost_rate {
+                o.insert(
+                    "energy_cost_rate".into(),
+                    self.nums(rates, "voltage source energy cost rate"),
+                );
+                extras.remove("energy_cost_rate");
+                extras.remove("cost");
+            }
             if let Some(cost) = extras.remove("cost") {
                 o.insert("cost".into(), cost);
             }
@@ -1448,7 +1507,7 @@ impl Writer {
             "b_no_load",
             "no_load_shunt",
         ];
-        if self.options.profile == BmopfProfile::Bmopf020 {
+        if self.options.schema_version == BmopfSchemaVersion::Bmopf020 {
             rename_tap_fields(by_subtype);
             return;
         }
@@ -2489,6 +2548,7 @@ struct SourceEmit {
     terminal_map: Vec<String>,
     v_magnitude: Vec<f64>,
     v_angle: Vec<f64>,
+    energy_cost_rate: Option<Vec<f64>>,
     extras: Extras,
     dropped_extras: Vec<(String, Extras)>,
 }
@@ -2501,6 +2561,7 @@ impl From<&VoltageSource> for SourceEmit {
             terminal_map: source.terminal_map.clone(),
             v_magnitude: source.v_magnitude.clone(),
             v_angle: source.v_angle.clone(),
+            energy_cost_rate: source.energy_cost_rate.clone(),
             extras: source.extras.clone(),
             dropped_extras: Vec::new(),
         }
@@ -2576,7 +2637,7 @@ fn merge_voltage_source_group(
     let mut seen = BTreeSet::new();
     for index in &sorted {
         let source = &sources[*index];
-        if source_has_bounds_or_cost(&source.extras) {
+        if source.energy_cost_rate.is_some() || source_has_bounds_or_cost(&source.extras) {
             return None;
         }
         let (rank, phase) = single_phase_source(source)?;
@@ -2635,9 +2696,16 @@ fn merge_voltage_source_group(
 }
 
 fn source_has_bounds_or_cost(extras: &Extras) -> bool {
-    ["p_min", "p_max", "q_min", "q_max", "cost"]
-        .iter()
-        .any(|key| extras.contains_key(*key))
+    [
+        "p_min",
+        "p_max",
+        "q_min",
+        "q_max",
+        "cost",
+        "energy_cost_rate",
+    ]
+    .iter()
+    .any(|key| extras.contains_key(*key))
 }
 
 fn single_phase_source(source: &SourceEmit) -> Option<(usize, PhaseSource)> {
@@ -2981,7 +3049,7 @@ fn proposal_provenance(meta: &mut Map<String, Value>) {
         "schema_status": "proposal", "schema_version": "0.2.0",
         "schema_commit": super::BMOPF_PROPOSAL_COMMIT,
         "schema_sha256": super::BMOPF_PROPOSAL_SHA256,
-        "schema_id": BmopfProfile::Bmopf020.schema_id(),
+        "schema_id": BmopfSchemaVersion::Bmopf020.schema_id(),
         "schema_retrieval_url": super::BMOPF_PROPOSAL_URL
     });
     let provenance = meta.entry("provenance").or_insert_with(|| json!({}));
@@ -3065,7 +3133,7 @@ mod tests {
         // relocates a transformer field, and only that version relocates.
         let mut w = Writer {
             options: BmopfEmitOptions {
-                profile: BmopfProfile::Bmopf010,
+                schema_version: BmopfSchemaVersion::Bmopf010,
                 ..BmopfEmitOptions::default()
             },
             warnings: crate::diagnostics::Diagnostics::new(),

--- a/powerio-dist/src/bmopf/write.rs
+++ b/powerio-dist/src/bmopf/write.rs
@@ -94,11 +94,12 @@ const BMOPF_DELTA_ROLLS_EXTRA: &str = "bmopf_delta_rolls";
 /// element comes near this bound.
 const MAX_DIM: usize = 64;
 
-const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 7] = [
+const TRANSFORMER_NO_LOAD_ALLOWED_EXTRAS: [&str; 8] = [
     "bmopf_power_base",
     "bmopf_winding_metadata",
     "g_no_load",
     "b_no_load",
+    "no_load_shunt",
     "%noloadloss",
     "%imag",
     BMOPF_DELTA_ROLLS_EXTRA,
@@ -123,7 +124,7 @@ const REGULATOR_STATED_OHMS: [&str; 4] = [
     "x_series_to",
 ];
 
-const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
+const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 19] = [
     "tap_min",
     "tap_max",
     "mintap",
@@ -136,6 +137,7 @@ const TRANSFORMER_TWO_WINDING_ALLOWED_EXTRAS: [&str; 18] = [
     "pmd_tm_step",
     "g_no_load",
     "b_no_load",
+    "no_load_shunt",
     "r_neutral_from",
     "x_neutral_from",
     "r_neutral_to",
@@ -214,11 +216,6 @@ pub(crate) fn emit_bmopf_json_text_with_options(
     let mut w = Writer {
         options,
         warnings: crate::diagnostics::Diagnostics::new(),
-        grounded: net
-            .buses()
-            .iter()
-            .map(|b| (b.id.to_ascii_lowercase(), b.grounded.clone()))
-            .collect(),
         transformer_overflow: Map::new(),
         dropped_extras: BTreeMap::new(),
     };
@@ -234,7 +231,6 @@ pub(crate) fn emit_bmopf_json_text_with_options(
 struct Writer {
     options: BmopfEmitOptions,
     warnings: crate::diagnostics::Diagnostics,
-    grounded: BTreeMap<String, Vec<String>>,
     /// Transformer fields with no slot in the schema 0.1.0 subtype defs
     /// (taps, neutral impedance, no load admittance), relocated to
     /// `extras.transformer.<subtype>.<name>` instead of dropped.
@@ -1450,6 +1446,7 @@ impl Writer {
             "x_neutral_to",
             "g_no_load",
             "b_no_load",
+            "no_load_shunt",
         ];
         if self.options.profile == BmopfProfile::Bmopf020 {
             rename_tap_fields(by_subtype);
@@ -2155,6 +2152,7 @@ impl Writer {
             let to_1 = per(to);
             let mut t1 = t.clone();
             t1.windings = vec![f.clone(), to_1.clone()];
+            t1.phases = 1;
             split_no_load_extras(&mut t1, t.phases);
             let v = self.two_winding(&t1, &f, &to_1, 1.0, true, false);
             out.push((format!("{}_{}", t.name, k + 1), v));
@@ -2338,104 +2336,54 @@ impl Writer {
         &mut self,
         o: &mut Map<String, Value>,
         t: &DistTransformer,
-        from: &DistWinding,
+        _from: &DistWinding,
         s: f64,
     ) {
-        if let Some(v) = t.extras.get("g_no_load") {
-            o.insert("g_no_load".into(), v.clone());
-        } else if let Some(loss_pct) = extras_number(&t.extras, "%noloadloss") {
-            if self.is_phase_to_phase_single_phase(from) {
-                let mut details = Map::new();
-                details.insert("field".into(), json!("%noloadloss"));
-                details.insert("reason".into(), json!("phase_to_phase_single_phase"));
-                self.transformer_diagnostic(
-                    t,
-                    &C::EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_DROPPED,
-                    format!(
-                        "transformer {}: phase-to-phase %noloadloss cannot be represented as a BMOPF no-load shunt; dropped",
-                        t.name
-                    ),
-                    details,
-                );
-            } else {
-                let v_stamp = no_load_voltage_base(from);
-                if s.is_finite() && s > 0.0 && v_stamp.is_finite() && v_stamp > 0.0 {
-                    let y_base = s / (v_stamp * v_stamp);
-                    o.insert(
-                        "g_no_load".into(),
-                        self.num(loss_pct / 100.0 * y_base, "transformer g_no_load"),
-                    );
-                } else {
-                    let mut details = Map::new();
-                    details.insert("field".into(), json!("%noloadloss"));
-                    details.insert("s_rating".into(), json!(s));
-                    details.insert("v_nom_from".into(), json!(v_stamp));
-                    self.transformer_diagnostic(
-                        t,
-                        &C::EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_UNCONVERTIBLE,
-                        format!(
-                            "transformer {}: %noloadloss cannot be converted without a positive s_rating and v_nom_from",
-                            t.name
-                        ),
-                        details,
-                    );
-                }
-            }
+        if let Some(shunt) = t.extras.get("no_load_shunt") {
+            o.insert("no_load_shunt".into(), shunt.clone());
+            return;
         }
-
-        if let Some(v) = t.extras.get("b_no_load") {
-            o.insert("b_no_load".into(), v.clone());
-        } else if let Some(imag_pct) = extras_number(&t.extras, "%imag") {
-            if self.is_phase_to_phase_single_phase(from) {
-                let mut details = Map::new();
-                details.insert("field".into(), json!("%imag"));
-                details.insert("reason".into(), json!("phase_to_phase_single_phase"));
-                self.transformer_diagnostic(
-                    t,
-                    &C::EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_DROPPED,
-                    format!(
-                        "transformer {}: phase-to-phase %imag cannot be represented as a BMOPF no-load shunt; dropped",
-                        t.name
-                    ),
-                    details,
-                );
-            } else {
-                let v_stamp = no_load_voltage_base(from);
-                if s.is_finite() && s > 0.0 && v_stamp.is_finite() && v_stamp > 0.0 {
-                    let y_base = s / (v_stamp * v_stamp);
-                    o.insert(
-                        "b_no_load".into(),
-                        self.num(imag_pct / 100.0 * y_base, "transformer b_no_load"),
-                    );
-                } else {
-                    let mut details = Map::new();
-                    details.insert("field".into(), json!("%imag"));
-                    details.insert("s_rating".into(), json!(s));
-                    details.insert("v_nom_from".into(), json!(v_stamp));
-                    self.transformer_diagnostic(
-                        t,
-                        &C::EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_UNCONVERTIBLE,
-                        format!(
-                            "transformer {}: %imag cannot be converted without a positive s_rating and v_nom_from",
-                            t.name
-                        ),
-                        details,
-                    );
+        if t.extras.contains_key("g_no_load") || t.extras.contains_key("b_no_load") {
+            for key in ["g_no_load", "b_no_load"] {
+                if let Some(value) = t.extras.get(key) {
+                    o.insert(key.into(), value.clone());
                 }
             }
-        } else if !self.is_phase_to_phase_single_phase(from)
-            && extras_number(&t.extras, "%noloadloss").is_some()
+            return;
+        }
+        let loss = extras_number(&t.extras, "%noloadloss");
+        let imag = extras_number(&t.extras, "%imag");
+        if loss.is_none() && imag.is_none() {
+            return;
+        }
+        // OpenDSS places the exciting branch on physical winding 2. Its
+        // terminal admittance includes the winding tap and the per-coil base.
+        let voltage = t
+            .windings
+            .get(1)
+            .map(|w| crate::model::winding_coil_voltage(w, t.phases));
+        if let Some(voltage) = voltage
+            && voltage.is_finite()
+            && voltage > 0.0
+            && s.is_finite()
+            && s > 0.0
+            && loss.is_none_or(|v| v >= 0.0)
+            && imag.is_none_or(|v| v >= 0.0)
         {
-            o.insert("b_no_load".into(), json!(0.0));
+            let y_base = s / t.phases.max(1) as f64 / voltage.powi(2);
+            o.insert(
+                "no_load_shunt".into(),
+                json!({
+                    "winding": 2,
+                    "g": loss.unwrap_or(0.0) / 100.0 * y_base,
+                    "b": -imag.unwrap_or(0.0) / 100.0 * y_base,
+                }),
+            );
+        } else {
+            let details = Map::from_iter([("field".into(), json!("no_load_shunt"))]);
+            self.transformer_diagnostic(t, &C::EMIT_BMOPF_TRANSFORMER_NO_LOAD_SHUNT_UNCONVERTIBLE,
+                format!("transformer {}: no-load percentages require nonnegative values, a positive power base and a positive winding-2 coil voltage", t.name), details);
         }
-    }
-
-    fn is_phase_to_phase_single_phase(&self, winding: &DistWinding) -> bool {
-        n_winding_phase_count(winding) == 1
-            && !self
-                .grounded
-                .get(&winding.bus.to_ascii_lowercase())
-                .is_some_and(|g| winding.terminal_map.iter().any(|t| g.contains(t)))
     }
 
     fn transformer_extras_dropped(&mut self, t: &DistTransformer, allowed: &[&str]) {
@@ -3088,18 +3036,6 @@ fn authored_terminal_conventions(net: &MulticonductorNetwork) -> Option<Value> {
     (!phase.is_empty() || !neutral.is_empty()).then(|| json!({"phase": phase, "neutral": neutral}))
 }
 
-fn no_load_voltage_base(from: &DistWinding) -> f64 {
-    let phases = match from.conn {
-        DistWindingConn::Wye => from.terminal_map.len().saturating_sub(1),
-        DistWindingConn::Delta => from.terminal_map.len(),
-    };
-    if phases >= 3 {
-        from.v_ref / 3f64.sqrt()
-    } else {
-        from.v_ref
-    }
-}
-
 fn config_str(c: Configuration) -> &'static str {
     match c {
         Configuration::Wye => "WYE",
@@ -3133,7 +3069,6 @@ mod tests {
                 ..BmopfEmitOptions::default()
             },
             warnings: crate::diagnostics::Diagnostics::new(),
-            grounded: BTreeMap::new(),
             transformer_overflow: Map::new(),
             dropped_extras: BTreeMap::new(),
         };

--- a/powerio-dist/src/convert.rs
+++ b/powerio-dist/src/convert.rs
@@ -454,22 +454,21 @@ impl DistTargetFormat {
     }
 }
 
-/// Prepare a parsed module for emission to `format`. Emitting an unchanged
-/// parsed module to its source format returns the retained source bytes
-/// exactly, including a byte order mark; any other target serializes the typed
-/// value.
-#[must_use]
+/// Prepare exact retained-source text or validated canonical output.
 pub(crate) fn emit_text_with_options(
     module: &powerio_core::PioModule<MulticonductorNetwork>,
     format: DistTargetFormat,
     options: &EmitOptions,
-) -> TextEmission {
-    if options.is_default_for(format)
+) -> Result<TextEmission, powerio_core::Error> {
+    let output = if options.is_default_for(format)
         && let Some(text) = echo_text(module, format)
     {
-        return TextEmission::faithful(text);
-    }
-    emit_value_text_with_options(module.value(), format, options)
+        TextEmission::faithful(text)
+    } else {
+        crate::readiness::require_resolved_geometry(module.value())?;
+        emit_value_text_with_options(module.value(), format, options)
+    };
+    Ok(output)
 }
 
 /// The retained source text when emitting `module` back to its source format:
@@ -571,7 +570,7 @@ pub fn emit_with_options(
     options: &EmitOptions,
     destination: powerio_core::Destination,
 ) -> std::result::Result<powerio_core::EmitResult, powerio_core::Error> {
-    let conv = emit_text_with_options(module, format, options);
+    let conv = emit_text_with_options(module, format, options)?;
     match format {
         DistTargetFormat::Dss => {
             let mut artifacts = vec![powerio_core::MemoryArtifact::new(

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -59,6 +59,10 @@ pub mod codes {
             "an include the case names could not be loaded";
         READ_DSS_INCLUDE_DEPTH_LIMIT = "READ.DSS.INCLUDE_DEPTH_LIMIT", Warning,
             "the reader stopped following includes at the nesting depth limit";
+        READ_DSS_GEOMETRY_UNRESOLVED = "READ.DSS.GEOMETRY_UNRESOLVED", Error,
+            "line geometry remains source data without calculated conductor impedances";
+        BUILD_DIST_ELECTRICAL_INCOMPLETE = "BUILD.DIST.ELECTRICAL_INCOMPLETE", Error,
+            "distribution equipment lacks the electrical data required for numerical use", category = Data;
         READ_DSS_LINECODE_UNKNOWN = "READ.DSS.LINECODE_UNKNOWN", Warning,
             "a line names a linecode the case does not declare";
 

--- a/powerio-dist/src/diagnostics.rs
+++ b/powerio-dist/src/diagnostics.rs
@@ -140,6 +140,10 @@ pub mod codes {
         /// The document states a `meta.$schema` that names no known version.
         READ_BMOPF_SCHEMA_UNKNOWN = "READ.BMOPF.SCHEMA_UNKNOWN", Warning,
             "a BMOPF document states a schema naming no known version";
+        READ_BMOPF_SEMANTIC_INVALID = "READ.BMOPF.SEMANTIC_INVALID", Error,
+            "the BMOPF document has inconsistent dimensions, references, or bounds";
+        READ_BMOPF_SCHEMA_MISMATCH = "READ.BMOPF.SCHEMA_MISMATCH", Error,
+            "the schema URI and explicit schema version disagree";
 
         // EMIT.BMOPF: the general families beside the nineteen transformer
         // codes the writer already publishes.

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -844,6 +844,7 @@ impl Reader<'_> {
             terminal_map: map,
             v_magnitude,
             v_angle,
+            energy_cost_rate: None,
             extras,
         }
     }
@@ -855,6 +856,19 @@ impl Reader<'_> {
     #[expect(clippy::too_many_lines)]
     fn line(&mut self, obj: &RawObject) {
         let props = Props::new(obj);
+        if crate::readiness::DEFERRED_GEOMETRY_KEYS
+            .iter()
+            .any(|key| props.by_name.contains_key(*key))
+        {
+            self.warn(&C::READ_DSS_GEOMETRY_UNRESOLVED, format!(
+                "line {}: geometry-derived conductor impedances are unresolved; the complete source object is retained without a synthetic linecode or terminal map",
+                obj.name
+            ));
+            self.net
+                .untyped_objects_mut()
+                .push(UntypedObject::from(obj));
+            return;
+        }
         // `linecode=` assigns the line's phase count from the code
         // (Line.cpp FetchLineCode) exactly like `phases=`; properties
         // apply in order, so the later of the two wins. Bus node lists

--- a/powerio-dist/src/dss/read.rs
+++ b/powerio-dist/src/dss/read.rs
@@ -1253,67 +1253,59 @@ impl Reader<'_> {
         let mut xht = dd::transformer::XHT;
         let mut xlt = dd::transformer::XLT;
         let mut xhl_specified = false;
-        let mut x_pairs: BTreeMap<(usize, usize), f64> = BTreeMap::new();
+        let mut xsc_pct = vec![dd::transformer::XHL];
         let mut extras = Extras::new();
         let conn_is_delta =
             |t: &str| t.to_ascii_lowercase().starts_with('d') || t.eq_ignore_ascii_case("ll");
-        for p in &obj.props {
-            let Some(name) = &p.name else { continue };
-            let v = &p.value;
-            match name.as_str() {
-                "phases" => {
-                    phases = self.usize_prop(Some(v)).unwrap_or(phases);
-                }
-                "windings" => {
-                    n_windings = self.usize_prop(Some(v)).unwrap_or(n_windings).max(1);
-                    windings = vec![WindingRaw::default(); n_windings];
-                    active = 0;
-                }
-                "wdg" => {
-                    let k = self.usize_prop(Some(v)).unwrap_or(1).max(1);
-                    grow(
-                        &mut windings,
-                        k,
-                        &mut n_windings,
-                        &obj.name,
-                        &mut self.diags,
-                    );
-                    active = k - 1;
-                }
-                "bus" => windings[active].bus = Some(v.to_bus_spec()),
-                "conn" => windings[active].conn_delta = conn_is_delta(&v.text),
-                "kv" | "kva" | "tap" | "%r" | "rneut" | "xneut" => {
-                    let parsed = self.f64_prop(Some(v));
-                    let w = &mut windings[active];
-                    match name.as_str() {
-                        "kv" => {
-                            w.kv = parsed.unwrap_or(w.kv);
-                            w.kv_specified = true;
-                        }
-                        "kva" => {
-                            w.kva = parsed.unwrap_or(w.kva);
-                            w.kva_specified = true;
-                        }
-                        "tap" => w.tap = parsed.unwrap_or(w.tap),
-                        "%r" => w.r_pct = parsed.unwrap_or(w.r_pct),
-                        "rneut" => w.r_neutral = parsed,
-                        "xneut" => w.x_neutral = parsed,
-                        _ => unreachable!("matched transformer scalar property"),
+        let mut begin = 0;
+        for end in obj.edit_bounds() {
+            let mut scalar_reactance_changed = false;
+            for p in &obj.props[begin..end] {
+                let Some(name) = &p.name else { continue };
+                let v = &p.value;
+                match name.as_str() {
+                    "phases" => {
+                        phases = self.usize_prop(Some(v)).unwrap_or(phases);
                     }
-                }
-                "buses" | "conns" => {
-                    let items = v.to_string_list(Some(self.vars));
-                    grow(
-                        &mut windings,
-                        items.len(),
-                        &mut n_windings,
-                        &obj.name,
-                        &mut self.diags,
-                    );
-                    apply_winding_strings(&mut windings, name, &items);
-                }
-                "kvs" | "kvas" | "taps" | "%rs" => match v.to_vector(Some(self.vars)) {
-                    Ok(items) => {
+                    "windings" => {
+                        n_windings = self.usize_prop(Some(v)).unwrap_or(n_windings).max(1);
+                        windings = vec![WindingRaw::default(); n_windings];
+                        active = 0;
+                    }
+                    "wdg" => {
+                        let k = self.usize_prop(Some(v)).unwrap_or(1).max(1);
+                        grow(
+                            &mut windings,
+                            k,
+                            &mut n_windings,
+                            &obj.name,
+                            &mut self.diags,
+                        );
+                        active = k - 1;
+                    }
+                    "bus" => windings[active].bus = Some(v.to_bus_spec()),
+                    "conn" => windings[active].conn_delta = conn_is_delta(&v.text),
+                    "kv" | "kva" | "tap" | "%r" | "rneut" | "xneut" => {
+                        let parsed = self.f64_prop(Some(v));
+                        let w = &mut windings[active];
+                        match name.as_str() {
+                            "kv" => {
+                                w.kv = parsed.unwrap_or(w.kv);
+                                w.kv_specified = true;
+                            }
+                            "kva" => {
+                                w.kva = parsed.unwrap_or(w.kva);
+                                w.kva_specified = true;
+                            }
+                            "tap" => w.tap = parsed.unwrap_or(w.tap),
+                            "%r" => w.r_pct = parsed.unwrap_or(w.r_pct),
+                            "rneut" => w.r_neutral = parsed,
+                            "xneut" => w.x_neutral = parsed,
+                            _ => unreachable!("matched transformer scalar property"),
+                        }
+                    }
+                    "buses" | "conns" => {
+                        let items = v.to_string_list(Some(self.vars));
                         grow(
                             &mut windings,
                             items.len(),
@@ -1321,48 +1313,89 @@ impl Reader<'_> {
                             &obj.name,
                             &mut self.diags,
                         );
-                        apply_winding_numbers(&mut windings, name, &items);
+                        apply_winding_strings(&mut windings, name, &items);
                     }
-                    Err(e) => self.warn(
-                        &C::READ_DSS_VALUE_DEFAULTED,
-                        format!("transformer {}: {name}: {e}", obj.name),
-                    ),
-                },
-                "%loadloss" => {
-                    // The engine splits load loss across the first two
-                    // windings: %R each = %loadloss / 2 (Transformer.cpp,
-                    // property 26). The written value also rides in extras
-                    // for the canonical echo.
-                    if let Some(ll) = self.f64_prop(Some(v)) {
-                        for w in windings.iter_mut().take(2) {
-                            w.r_pct = ll / 2.0;
+                    "kvs" | "kvas" | "taps" | "%rs" => match v.to_vector(Some(self.vars)) {
+                        Ok(items) => {
+                            grow(
+                                &mut windings,
+                                items.len(),
+                                &mut n_windings,
+                                &obj.name,
+                                &mut self.diags,
+                            );
+                            apply_winding_numbers(&mut windings, name, &items);
+                        }
+                        Err(e) => self.warn(
+                            &C::READ_DSS_VALUE_DEFAULTED,
+                            format!("transformer {}: {name}: {e}", obj.name),
+                        ),
+                    },
+                    "%loadloss" => {
+                        // The engine splits load loss across the first two
+                        // windings: %R each = %loadloss / 2 (Transformer.cpp,
+                        // property 26). The written value also rides in extras
+                        // for the canonical echo.
+                        if let Some(ll) = self.f64_prop(Some(v)) {
+                            for w in windings.iter_mut().take(2) {
+                                w.r_pct = ll / 2.0;
+                            }
+                        }
+                        extras.insert("%loadloss".to_string(), v.text.clone().into());
+                    }
+                    "xhl" | "x12" => {
+                        xhl = self.f64_prop(Some(v)).unwrap_or(xhl);
+                        xhl_specified = true;
+                        scalar_reactance_changed = true;
+                    }
+                    "xht" | "x13" => {
+                        xht = self.f64_prop(Some(v)).unwrap_or(xht);
+                        scalar_reactance_changed = true;
+                    }
+                    "xlt" | "x23" => {
+                        xlt = self.f64_prop(Some(v)).unwrap_or(xlt);
+                        scalar_reactance_changed = true;
+                    }
+                    "xscarray" => match v.to_vector(Some(self.vars)) {
+                        Ok(items) if items.len() == n_windings * (n_windings - 1) / 2 => {
+                            xsc_pct = items;
+                            xhl_specified = true;
+                        }
+                        Ok(items) => self.warn(
+                            &C::READ_DSS_VALUE_DEFAULTED,
+                            format!(
+                                "transformer {}: xscarray has {} values; expected {} for {n_windings} windings; retained reactances apply",
+                                obj.name, items.len(), n_windings * (n_windings - 1) / 2,
+                            ),
+                        ),
+                        Err(e) => self.warn(
+                            &C::READ_DSS_VALUE_DEFAULTED,
+                            format!("transformer {}: xscarray: {e}", obj.name),
+                        ),
+                    },
+                    other if x_pair_key(other).is_some() => {
+                        if let Some((i, j)) = x_pair_key(other) {
+                            let x = self.f64_prop(Some(v)).unwrap_or(0.0);
+                            if let Some(index) = pair_keys(n_windings).iter().position(|pair| *pair == (i, j)) {
+                                xsc_pct[index] = x;
+                            }
                         }
                     }
-                    extras.insert("%loadloss".to_string(), v.text.clone().into());
-                }
-                "xhl" | "x12" => {
-                    xhl = self.f64_prop(Some(v)).unwrap_or(xhl);
-                    xhl_specified = true;
-                    x_pairs.insert((0, 1), xhl);
-                }
-                "xht" | "x13" => {
-                    xht = self.f64_prop(Some(v)).unwrap_or(xht);
-                    x_pairs.insert((0, 2), xht);
-                }
-                "xlt" | "x23" => {
-                    xlt = self.f64_prop(Some(v)).unwrap_or(xlt);
-                    x_pairs.insert((1, 2), xlt);
-                }
-                other if x_pair_key(other).is_some() => {
-                    if let Some((i, j)) = x_pair_key(other) {
-                        let x = self.f64_prop(Some(v)).unwrap_or(0.0);
-                        x_pairs.insert((i, j), x);
+                    other => {
+                        extras.insert(other.to_string(), v.text.clone().into());
                     }
                 }
-                other => {
-                    extras.insert(other.to_string(), v.text.clone().into());
+                xsc_pct.resize(n_windings * (n_windings - 1) / 2, dd::transformer::XLT);
+            }
+            // OpenDSS reapplies all scalar reactances at the end of an edit.
+            if scalar_reactance_changed && (2..=3).contains(&n_windings) {
+                xsc_pct[0] = xhl;
+                if n_windings == 3 {
+                    xsc_pct[1] = xht;
+                    xsc_pct[2] = xlt;
                 }
             }
+            begin = end;
         }
 
         if !xhl_specified {
@@ -1370,21 +1403,6 @@ impl Reader<'_> {
         }
         let out = self.finish_windings(&windings, phases, &obj.name);
 
-        let xsc_pct = if n_windings >= 3 {
-            pair_keys(n_windings)
-                .into_iter()
-                .map(|pair| {
-                    x_pairs.get(&pair).copied().unwrap_or(match pair {
-                        (0, 1) => xhl,
-                        (0, 2) => xht,
-                        (1, 2) => xlt,
-                        _ => 0.0,
-                    })
-                })
-                .collect()
-        } else {
-            vec![xhl]
-        };
         DistTransformer {
             name: obj.name.clone(),
             windings: out,

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -1505,20 +1505,12 @@ impl DssWriter {
             winding_array(&mut s, &mut edits, "kvs", "kv", &kvs);
             winding_array(&mut s, &mut edits, "kvas", "kva", &kvas);
             let _ = write!(s, " %Rs=({}) taps=({})", rs.join(", "), taps.join(", "));
-            if let Some(xhl) = t.xsc_pct.first() {
-                let _ = write!(s, " xhl={}", num(*xhl));
-                if t.xsc_pct.len() >= 3 {
-                    let xlt = self.star_xlt(t);
-                    let _ = write!(s, " xht={} xlt={}", num(t.xsc_pct[1]), num(xlt));
-                }
-            } else {
-                self.warn(
-                    &C::EMIT_DSS_VALUE_DEFAULTED,
-                    format!("transformer {}: xsc_pct is empty; emitted xhl=0", t.name),
-                );
-                s.push_str(" xhl=0");
-            }
+            self.transformer_reactances(t, &mut s);
             let mut extras = t.extras.clone();
+            // Typed reactances determine output after an IR load or mutation.
+            if nw > 3 && t.xsc_pct.len() == nw * (nw - 1) / 2 {
+                extras.remove("xscarray");
+            }
             if let Some((loss, imag)) = crate::model::transformer_no_load_percentages(t) {
                 extras.remove("no_load_shunt");
                 extras.insert("%noloadloss".into(), serde_json::json!(loss));
@@ -1541,6 +1533,34 @@ impl DssWriter {
             }
         }
         self.out.push('\n');
+    }
+
+    /// Emit the complete pair table for four or more windings.
+    fn transformer_reactances(&mut self, t: &DistTransformer, output: &mut String) {
+        let nw = t.windings.len();
+        if nw > 3 {
+            let expected = nw * (nw - 1) / 2;
+            if t.xsc_pct.len() != expected {
+                self.warn(
+                    &C::EMIT_DSS_VALUE_DEFAULTED,
+                    format!("transformer {}: xsc_pct has {} values; expected {expected}; OpenDSS defaults apply to absent pairs", t.name, t.xsc_pct.len()),
+                );
+            }
+            let values: Vec<_> = t.xsc_pct.iter().map(|x| num(*x)).collect();
+            let _ = write!(output, " xscarray=({})", values.join(", "));
+        } else if let Some(xhl) = t.xsc_pct.first() {
+            let _ = write!(output, " xhl={}", num(*xhl));
+            if t.xsc_pct.len() >= 3 {
+                let xlt = self.star_xlt(t);
+                let _ = write!(output, " xht={} xlt={}", num(t.xsc_pct[1]), num(xlt));
+            }
+        } else {
+            self.warn(
+                &C::EMIT_DSS_VALUE_DEFAULTED,
+                format!("transformer {}: xsc_pct is empty; emitted xhl=0", t.name),
+            );
+            output.push_str(" xhl=0");
+        }
     }
 
     /// The `xlt=` value for a three winding record. dss cannot solve a star

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -1518,7 +1518,13 @@ impl DssWriter {
                 );
                 s.push_str(" xhl=0");
             }
-            s.push_str(&self.extras_tail("transformer", &t.name, &t.extras));
+            let mut extras = t.extras.clone();
+            if let Some((loss, imag)) = crate::model::transformer_no_load_percentages(t) {
+                extras.remove("no_load_shunt");
+                extras.insert("%noloadloss".into(), serde_json::json!(loss));
+                extras.insert("%imag".into(), serde_json::json!(imag));
+            }
+            s.push_str(&self.extras_tail("transformer", &t.name, &extras));
             self.line_out(&s);
             for (idx, w) in t.windings.iter().enumerate() {
                 if let Some(r) = w.r_neutral {

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -838,6 +838,19 @@ impl DssWriter {
         ));
         self.out.push('\n');
 
+        for source in net
+            .sources()
+            .iter()
+            .filter(|source| source.energy_cost_rate.is_some())
+        {
+            self.warn(
+                &C::EMIT_DSS_FIELD_DROPPED,
+                format!(
+                    "voltage source {}: energy_cost_rate has no target field",
+                    source.name
+                ),
+            );
+        }
         self.buscoords(net);
         self.sources(net);
         self.line_codes(net);
@@ -3017,6 +3030,7 @@ mod tests {
                 terminal_map: strings(&["1", "2", "3", "4"]),
                 v_magnitude: vec![vln, vln, vln, 0.0],
                 v_angle: vec![0.0, -third, third, 0.0],
+                energy_cost_rate: None,
                 extras: Extras::new(),
             },
         )
@@ -4573,6 +4587,7 @@ mod tests {
             terminal_map: strings(&["1", "2", "3", "4"]),
             v_magnitude: vec![20_000.0, 20_000.0, 20_000.0, 0.0],
             v_angle: vec![0.0, -third, third, 0.0],
+            energy_cost_rate: None,
             extras: Extras::new(),
         };
         let wind = VoltageSource {
@@ -4586,6 +4601,7 @@ mod tests {
                 third / 2.0,
                 0.0,
             ],
+            energy_cost_rate: None,
             extras: Extras::new(),
         };
         let net = MulticonductorNetwork::from_tables(MulticonductorNetworkTables {
@@ -4646,6 +4662,7 @@ mod tests {
             terminal_map: strings(&["1", "2", "3"]),
             v_magnitude: vec![2400.0; 3],
             v_angle: vec![0.0, -third, third],
+            energy_cost_rate: None,
             extras: Extras::new(),
         };
         let load = load_on("sb", &["1"], Configuration::Wye);

--- a/powerio-dist/src/dss/write.rs
+++ b/powerio-dist/src/dss/write.rs
@@ -949,8 +949,8 @@ impl DssWriter {
             );
         }
         for (field, present) in [
-            ("v_min", b.v_min.is_some()),
-            ("v_max", b.v_max.is_some()),
+            ("v_min", b.v_min.is_some() || b.v_min_phase.is_some()),
+            ("v_max", b.v_max.is_some() || b.v_max_phase.is_some()),
             ("vpn_min", b.vpn_min.is_some()),
             ("vpn_max", b.vpn_max.is_some()),
             ("vpp_min", b.vpp_min.is_some()),
@@ -2225,13 +2225,32 @@ impl DssWriter {
         for g in net.generators() {
             self.check_name("generator", &g.name);
             let node_map = self.return_last("generator", &g.name, &g.bus, &g.terminal_map);
-            let phases = self.element_phases(
-                &g.extras,
-                &g.terminal_map,
-                g.configuration,
-                "generator",
-                &g.name,
-            );
+            let phases = extras_usize(&g.extras, "phases")
+                .or_else(|| {
+                    let count = [
+                        Some(g.p_nom.as_slice()),
+                        g.p_min.as_deref(),
+                        g.p_max.as_deref(),
+                        g.q_min.as_deref(),
+                        g.q_max.as_deref(),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .map(<[f64]>::len)
+                    .max()
+                    .unwrap_or(0);
+                    (count > 0).then_some(count)
+                })
+                .unwrap_or_else(|| {
+                    self.element_phases(
+                        &g.extras,
+                        &g.terminal_map,
+                        g.configuration,
+                        "generator",
+                        &g.name,
+                    )
+                })
+                .max(1);
             let conn = self.element_conn(&g.extras, g.configuration, &g.bus, &g.terminal_map);
             let nconds = nconds_for(conn, phases);
             self.warn_map_arity("generator", &g.name, g.terminal_map.len(), nconds);

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -61,7 +61,7 @@ pub mod readiness;
 #[cfg(test)]
 pub(crate) mod testkit;
 
-pub use bmopf::{BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfEmitOptions, BmopfProfile};
+pub use bmopf::{BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfEmitOptions, BmopfSchemaVersion};
 pub use convert::{
     DistTargetFormat, EmitOptions, classify_distribution_json, emit, emit_with_options, parse,
     parse_dist_target_format,
@@ -83,5 +83,6 @@ pub use model::{
     UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, find_unresolved_references,
 };
 pub use readiness::{
-    audit_electrical_readiness, ElectricalReadiness, ReadinessFinding, ReadinessSeverity,
+    ElectricalReadiness, ReadinessFinding, ReadinessSeverity, audit_electrical_readiness,
+    require_electrical_readiness,
 };

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -1372,6 +1372,40 @@ pub(crate) fn square_from_rows(rows: &[Vec<f64>], n: usize) -> Option<ConductorM
     Some(m)
 }
 
+/// Actual coil voltage base, including the fixed winding tap.
+pub(crate) fn winding_coil_voltage(winding: &DistWinding, phases: usize) -> f64 {
+    let divisor = if winding.conn == DistWindingConn::Wye && matches!(phases, 2 | 3) {
+        3f64.sqrt()
+    } else {
+        1.0
+    };
+    winding.v_ref * winding.tap / divisor
+}
+
+/// OpenDSS no-load percentages for an explicit winding-2 terminal-coil shunt.
+/// Other winding locations cannot use the OpenDSS exciting-branch parameters.
+pub(crate) fn transformer_no_load_percentages(t: &DistTransformer) -> Option<(f64, f64)> {
+    let shunt = t.extras.get("no_load_shunt")?;
+    if shunt.get("winding")?.as_u64()? != 2 {
+        return None;
+    }
+    let g = shunt.get("g")?.as_f64()?;
+    let b = shunt.get("b")?.as_f64()?;
+    let voltage = winding_coil_voltage(t.windings.get(1)?, t.phases);
+    let rating = t.windings.first()?.s_rating;
+    if !voltage.is_finite()
+        || voltage <= 0.0
+        || !rating.is_finite()
+        || rating <= 0.0
+        || g < 0.0
+        || b > 0.0
+    {
+        return None;
+    }
+    let scale = 100.0 * t.phases.max(1) as f64 * voltage.powi(2) / rating;
+    Some((g * scale, -b * scale))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -783,7 +783,8 @@ pub struct DistTransformer {
     pub name: String,
     pub windings: Vec<DistWinding>,
     /// Short circuit reactances between winding pairs, percent:
-    /// `[xhl]` for two windings, `[xhl, xht, xlt]` for three.
+    /// Upper-triangular order `12, 13, ..., 1n, 23, ..., (n-1)n`,
+    /// on winding 1's power base, matching OpenDSS `Xscarray`.
     pub xsc_pct: Vec<f64>,
     pub phases: usize,
     pub extras: Extras,

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -63,6 +63,12 @@ pub struct DistBus {
     /// bound is always 0).
     pub v_min: Option<f64>,
     pub v_max: Option<f64>,
+    /// Nonuniform phase-to-ground bounds in phase-terminal order, volts.
+    /// A scalar bound, when present, takes precedence over this vector.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v_min_phase: Option<Vec<f64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub v_max_phase: Option<Vec<f64>>,
     pub vpn_min: Option<Vec<f64>>,
     pub vpn_max: Option<Vec<f64>>,
     pub vpp_min: Option<Vec<f64>>,
@@ -84,6 +90,36 @@ pub struct DistBus {
 }
 
 impl DistBus {
+    /// Phase positions in terminal order, using explicit BMOPF roles when supplied.
+    #[must_use]
+    pub fn phase_indices(&self, conventions: Option<&serde_json::Value>) -> Vec<usize> {
+        let numeric_four = self.terminals.len() == 4
+            && ["1", "2", "3", "4"]
+                .iter()
+                .all(|t| self.terminals.iter().any(|v| v == t));
+        self.terminals
+            .iter()
+            .enumerate()
+            .filter_map(|(index, terminal)| {
+                let nonphase = if let Some(roles) = conventions {
+                    ["neutral", "earth"].iter().any(|role| {
+                        roles
+                            .get(role)
+                            .and_then(serde_json::Value::as_array)
+                            .is_some_and(|names| {
+                                names
+                                    .iter()
+                                    .any(|name| name.as_str() == Some(terminal.as_str()))
+                            })
+                    })
+                } else {
+                    terminal.eq_ignore_ascii_case("n") || (numeric_four && terminal == "4")
+                };
+                (!nonphase).then_some(index)
+            })
+            .collect()
+    }
+
     #[must_use]
     pub fn new(id: impl Into<String>, terminals: Vec<String>) -> Self {
         Self {
@@ -92,6 +128,8 @@ impl DistBus {
             grounded: Vec::new(),
             v_min: None,
             v_max: None,
+            v_min_phase: None,
+            v_max_phase: None,
             vpn_min: None,
             vpn_max: None,
             vpp_min: None,

--- a/powerio-dist/src/model.rs
+++ b/powerio-dist/src/model.rs
@@ -819,6 +819,9 @@ pub struct VoltageSource {
     pub v_magnitude: Vec<f64>,
     /// Radians per terminal.
     pub v_angle: Vec<f64>,
+    /// Energy cost rate in $/kWh, one entry per phase in terminal-map order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub energy_cost_rate: Option<Vec<f64>>,
     pub extras: Extras,
 }
 
@@ -837,6 +840,7 @@ impl VoltageSource {
             terminal_map,
             v_magnitude,
             v_angle,
+            energy_cost_rate: None,
             extras: Extras::new(),
         }
     }

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -1073,6 +1073,24 @@ impl Reader<'_> {
                 "sm_ub",
             ],
         );
+        for (field, extra) in [
+            ("noloadloss", "%noloadloss"),
+            ("cmag", "%imag"),
+            ("sm_ub", "emerghkva"),
+        ] {
+            if let Some(value) = o.get(field) {
+                if let Some(number) = value.as_f64().filter(|v| v.is_finite() && *v >= 0.0) {
+                    extras.insert(
+                        extra.into(),
+                        serde_json::json!(number * if field == "sm_ub" { 1.0 } else { 100.0 }),
+                    );
+                } else {
+                    extras.insert(field.into(), value.clone());
+                    self.diagnostics.push(&C::READ_PMD_SOURCE_MALFORMED,
+                        format!("transformer {name}: {field} requires a finite nonnegative number; retained in extras"));
+                }
+            }
+        }
         for key in ["tm_set", "tm_lb", "tm_ub", "tm_fix", "tm_step"] {
             if let Some(v) = o.get(key) {
                 extras.insert(format!("pmd_{key}"), v.clone());

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -935,6 +935,7 @@ impl Reader<'_> {
                     .iter()
                     .map(|a| a.to_radians())
                     .collect(),
+                energy_cost_rate: None,
                 extras,
             });
         }

--- a/powerio-dist/src/pmd/read.rs
+++ b/powerio-dist/src/pmd/read.rs
@@ -383,8 +383,67 @@ const SECTIONS: &[&str] = &[
     "transformer",
 ];
 
+fn inferred_terminal_roles(doc: &Map<String, Value>) -> Option<Value> {
+    let mut neutral = BTreeSet::new();
+    for class in ["load", "generator", "voltage_source", "shunt"] {
+        for component in doc
+            .get(class)
+            .and_then(Value::as_object)
+            .into_iter()
+            .flat_map(|v| v.values())
+        {
+            let wye = component.get("configuration").and_then(Value::as_str) == Some("WYE");
+            let connections = ints_as_strings(component.get("connections"));
+            let has_neutral = if class == "voltage_source" {
+                component
+                    .get("vm")
+                    .and_then(Value::as_array)
+                    .and_then(|v| v.last())
+                    .and_then(Value::as_f64)
+                    == Some(0.0)
+            } else {
+                connections.len() == 2 || connections.len() == 4
+            };
+            if wye
+                && has_neutral
+                && let Some(terminal) = connections.last()
+            {
+                neutral.insert(terminal.clone());
+            }
+        }
+    }
+    for transformer in doc
+        .get("transformer")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|v| v.values())
+    {
+        if let (Some(configurations), Some(connections)) = (
+            transformer.get("configuration").and_then(Value::as_array),
+            transformer.get("connections").and_then(Value::as_array),
+        ) {
+            for (configuration, terminals) in configurations.iter().zip(connections) {
+                if configuration.as_str() == Some("WYE")
+                    && terminals
+                        .as_array()
+                        .is_some_and(|v| v.len() == 2 || v.len() == 4)
+                    && let Some(terminal) = ints_as_strings(Some(terminals)).last()
+                {
+                    neutral.insert(terminal.clone());
+                }
+            }
+        }
+    }
+    (!neutral.is_empty()).then(|| serde_json::json!({"neutral": neutral}))
+}
+
 impl Reader<'_> {
     fn document(&mut self, doc: &Map<String, Value>) {
+        if let Some(roles) = inferred_terminal_roles(doc) {
+            self.net
+                .extras_mut()
+                .insert("bmopf_terminal_conventions".into(), roles);
+        }
         if let Some(name) = doc.get("name").and_then(Value::as_str) {
             *self.net.name_mut() = Some(name.to_string());
         }
@@ -487,33 +546,50 @@ impl Reader<'_> {
                 extras.insert("xg".into(), o.get("xg").cloned().unwrap_or(Value::Null));
             }
             stash_status(o, &mut extras, &format!("bus {id}"), &mut self.diagnostics);
-            // `vm_lb`/`vm_ub` are per-terminal vectors in the ENGINEERING
-            // voltage unit (volts over `voltage_scale_factor`); the model's
-            // scalar bound takes the uniform value, the same collapse the
-            // BMOPF reader applies to its per-terminal arrays.
-            let bound = |key: &str,
-                         diagnostics: &mut crate::diagnostics::Diagnostics|
-             -> Option<f64> {
-                let vals = floats(key, o.get(key))?;
-                let first = vals.first().copied()?;
-                if vals.iter().any(|v| v.to_bits() != first.to_bits()) {
-                    diagnostics.push(&C::READ_PMD_VALUE_COLLAPSED, format!(
-                        "bus {id}: `{key}` is non-uniform across terminals; collapsed to the first entry"
-                    ));
-                }
-                Some(first * 1e3)
-            };
-            let v_min = bound("vm_lb", &mut self.diagnostics);
-            let v_max = bound("vm_ub", &mut self.diagnostics);
-            self.net.buses_mut().push(DistBus {
+            let mut bus = DistBus {
                 id: id.clone(),
                 terminals: ints_as_strings(o.get("terminals")),
                 grounded: ints_as_strings(o.get("grounded")),
-                v_min,
-                v_max,
                 extras,
                 ..DistBus::default()
-            });
+            };
+            let indices = bus.phase_indices(self.net.extras().get("bmopf_terminal_conventions"));
+            let bound = |key: &str| -> (Option<f64>, Option<Vec<f64>>) {
+                let Some(values) = floats(key, o.get(key)) else {
+                    return (None, None);
+                };
+                let phase_values: Option<Vec<_>> = indices
+                    .iter()
+                    .map(|&i| values.get(i).map(|v| v * 1e3))
+                    .collect();
+                let Some(phase_values) = phase_values else {
+                    return (None, None);
+                };
+                if let Some(&first) = phase_values.first()
+                    && phase_values.iter().all(|&v| v.to_bits() == first.to_bits())
+                {
+                    (Some(first), None)
+                } else {
+                    (None, Some(phase_values))
+                }
+            };
+            (bus.v_min, bus.v_min_phase) = bound("vm_lb");
+            (bus.v_max, bus.v_max_phase) = bound("vm_ub");
+            for (key, default) in [("vm_lb", serde_json::json!(0.0)), ("vm_ub", Value::Null)] {
+                if let Some(value) = o.get(key) {
+                    let needs_retention = value.as_array().is_none_or(|values| {
+                        values.len() != bus.terminals.len()
+                            || values
+                                .iter()
+                                .enumerate()
+                                .any(|(i, v)| !indices.contains(&i) && *v != default)
+                    });
+                    if needs_retention {
+                        bus.extras.insert(format!("pmd_{key}"), value.clone());
+                    }
+                }
+            }
+            self.net.buses_mut().push(bus);
         }
     }
 

--- a/powerio-dist/src/pmd/write.rs
+++ b/powerio-dist/src/pmd/write.rs
@@ -432,15 +432,28 @@ impl Writer {
             o.insert("grounded".into(), json!(grounded));
             o.insert("status".into(), Self::status(&b.extras));
             self.bus_coordinates(&mut o, b, net);
-            // The scalar magnitude bounds have ENGINEERING fields: `vm_lb` and
-            // `vm_ub` are per-terminal vectors in the same unit every other
-            // voltage here uses (volts over `voltage_scale_factor`, the rule
-            // `vm_nom` follows above). The model's scalar broadcasts over the
-            // terminals, which is the inverse of the reader's uniform-vector
-            // collapse.
-            for (key, bound) in [("vm_lb", b.v_min), ("vm_ub", b.v_max)] {
-                if let Some(v) = bound {
-                    o.insert(key.into(), json!(vec![v / 1e3; b.terminals.len().max(1)]));
+            let phase_indices = b.phase_indices(net.extras().get("bmopf_terminal_conventions"));
+            for (key, scalar, phases, default) in [
+                ("vm_lb", b.v_min, &b.v_min_phase, 0.0),
+                ("vm_ub", b.v_max, &b.v_max_phase, f64::INFINITY),
+            ] {
+                let retained = b.extras.get(&format!("pmd_{key}"));
+                let mut values = retained
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .filter(|values| values.len() == b.terminals.len())
+                    .unwrap_or_else(|| vec![json!(default); b.terminals.len()]);
+                if scalar.is_some() || phases.is_some() {
+                    for (phase, &terminal) in phase_indices.iter().enumerate() {
+                        if let Some(v) =
+                            scalar.or_else(|| phases.as_ref().and_then(|v| v.get(phase)).copied())
+                        {
+                            values[terminal] = json!(v / 1e3);
+                        }
+                    }
+                    o.insert(key.into(), Value::Array(values));
+                } else if let Some(retained) = retained {
+                    o.insert(key.into(), retained.clone());
                 }
             }
             // The phase-to-neutral, phase-to-phase, and sequence bound families

--- a/powerio-dist/src/pmd/write.rs
+++ b/powerio-dist/src/pmd/write.rs
@@ -1073,21 +1073,36 @@ impl Writer {
         if let Some(controls) = t.extras.get("controls") {
             o.insert("controls".into(), controls.clone());
         }
-        let noloadloss = Self::extras_f64(&t.extras, "%noloadloss").unwrap_or(0.0) / 100.0;
-        let cmag = Self::extras_f64(&t.extras, "%imag").unwrap_or(0.0) / 100.0;
-        o.insert("noloadloss".into(), json!(noloadloss));
-        o.insert("cmag".into(), json!(cmag));
+        self.transformer_no_load_fields(t, &mut o, &what);
         o.insert("status".into(), Self::status(&t.extras));
         o.insert(
             "source_id".into(),
             json!(format!("transformer.{}", t.name.to_lowercase())),
         );
-        self.extras_dropped(
-            &t.extras,
-            &["controls", "%loadloss", "%noloadloss", "%imag", "emerghkva"],
-            &what,
-        );
         Value::Object(o)
+    }
+    fn transformer_no_load_fields(
+        &mut self,
+        t: &DistTransformer,
+        o: &mut Map<String, Value>,
+        what: &str,
+    ) {
+        let explicit_shunt = crate::model::transformer_no_load_percentages(t);
+        let (loss, imag) = explicit_shunt.unwrap_or_else(|| {
+            (
+                Self::extras_f64(&t.extras, "%noloadloss").unwrap_or(0.0),
+                Self::extras_f64(&t.extras, "%imag").unwrap_or(0.0),
+            )
+        });
+        let noloadloss = loss / 100.0;
+        let cmag = imag / 100.0;
+        o.insert("noloadloss".into(), json!(noloadloss));
+        o.insert("cmag".into(), json!(cmag));
+        let mut allowed = vec!["controls", "%loadloss", "%noloadloss", "%imag", "emerghkva"];
+        if explicit_shunt.is_some() {
+            allowed.push("no_load_shunt");
+        }
+        self.extras_dropped(&t.extras, &allowed, what);
     }
 }
 

--- a/powerio-dist/src/pmd/write.rs
+++ b/powerio-dist/src/pmd/write.rs
@@ -34,6 +34,19 @@ pub(crate) fn emit_pmd_json_text(net: &MulticonductorNetwork) -> TextEmission {
         warnings: crate::diagnostics::Diagnostics::new(),
         renamed_terminals: renamed_terminals(net),
     };
+    for source in net
+        .sources()
+        .iter()
+        .filter(|source| source.energy_cost_rate.is_some())
+    {
+        w.warn(
+            &C::EMIT_PMD_FIELD_DROPPED,
+            format!(
+                "voltage source {}: energy_cost_rate has no target field",
+                source.name
+            ),
+        );
+    }
     let doc = w.document(net);
     TextEmission::new(
         serde_json::to_string_pretty(&doc).expect("maps and finite numbers") + "\n",

--- a/powerio-dist/src/readiness.rs
+++ b/powerio-dist/src/readiness.rs
@@ -9,7 +9,44 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::model::{DistLineCode, Extras, MulticonductorNetwork};
+use crate::model::{DistLineCode, MulticonductorNetwork};
+
+pub(crate) const DEFERRED_GEOMETRY_KEYS: [&str; 5] =
+    ["geometry", "spacing", "wires", "cncables", "tscables"];
+
+/// Reject incomplete electrical data before numerical use.
+pub fn require_electrical_readiness(
+    net: &MulticonductorNetwork,
+) -> Result<(), powerio_core::Error> {
+    let report = audit_electrical_readiness(net);
+    if let Some(finding) = report.blockers().next() {
+        return Err(powerio_core::Error::new(
+            &crate::diagnostics::codes::BUILD_DIST_ELECTRICAL_INCOMPLETE,
+            format!("{} {}: {}", finding.code, finding.element, finding.message),
+        ));
+    }
+    Ok(())
+}
+
+/// Reject source-only electrical equipment that a canonical writer cannot reconstruct.
+pub(crate) fn require_resolved_geometry(
+    net: &MulticonductorNetwork,
+) -> Result<(), powerio_core::Error> {
+    let report = audit_electrical_readiness(net);
+    if let Some(finding) = report
+        .blockers()
+        .find(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+    {
+        return Err(powerio_core::Error::new(
+            &crate::diagnostics::codes::BUILD_DIST_ELECTRICAL_INCOMPLETE,
+            format!(
+                "{}: {}; retain the source module or provide explicit conductor impedances before canonical conversion",
+                finding.element, finding.message
+            ),
+        ));
+    }
+    Ok(())
+}
 
 /// Severity of an electrical-readiness finding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -103,13 +140,41 @@ pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalRead
         );
     }
 
-    let mut buses = BTreeSet::new();
+    let identity = |value: &str| {
+        if *net.source_format() == Some(crate::model::DistSourceFormat::Dss) {
+            value.to_ascii_lowercase()
+        } else {
+            value.to_owned()
+        }
+    };
+    for object in net.untyped_objects() {
+        if object.class.eq_ignore_ascii_case("line")
+            && object.props.iter().any(|(key, _)| {
+                key.as_ref().is_some_and(|key| {
+                    DEFERRED_GEOMETRY_KEYS
+                        .iter()
+                        .any(|candidate| key.eq_ignore_ascii_case(candidate))
+                })
+            })
+        {
+            report.block("READINESS.DSS.GEOMETRY_DEFERRED", &object.name,
+                "source line geometry has no calculated conductor impedances or resolved terminal map");
+        }
+    }
+    for (element, fields) in net.defaulted() {
+        report.warn(
+            "READINESS.SOURCE.DEFAULTED",
+            element,
+            format!("source defaults supplied {}", fields.join(", ")),
+        );
+    }
+    let mut buses = BTreeMap::new();
     for bus in net.buses() {
-        if !buses.insert(bus.id.to_ascii_lowercase()) {
+        if buses.insert(identity(&bus.id), bus).is_some() {
             report.block(
                 "READINESS.BUS.DUPLICATE",
                 &bus.id,
-                "bus identifier is duplicated case-insensitively",
+                "bus identifier is duplicated under the source identifier convention",
             );
         }
         if bus.terminals.is_empty() {
@@ -123,34 +188,73 @@ pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalRead
 
     let mut linecodes = BTreeMap::new();
     for code in net.line_codes() {
-        let key = code.name.to_ascii_lowercase();
+        let key = identity(&code.name);
         if linecodes.insert(key, code).is_some() {
             report.block(
                 "READINESS.LINECODE.DUPLICATE",
                 &code.name,
-                "linecode name is duplicated case-insensitively",
+                "linecode name is duplicated under the source identifier convention",
             );
         }
         audit_linecode(code, &mut report);
     }
 
+    audit_lines(net, &buses, &linecodes, identity, &mut report);
+
+    report
+}
+
+fn audit_lines(
+    net: &MulticonductorNetwork,
+    buses: &BTreeMap<String, &crate::model::DistBus>,
+    linecodes: &BTreeMap<String, &DistLineCode>,
+    identity: impl Fn(&str) -> String,
+    report: &mut ElectricalReadiness,
+) {
+    let mut lines = BTreeSet::new();
     for line in net.lines() {
+        if !lines.insert(identity(&line.name)) {
+            report.block(
+                "READINESS.LINE.DUPLICATE",
+                &line.name,
+                "line identifier is duplicated",
+            );
+        }
+        for (bus_id, terminals) in [
+            (&line.bus_from, &line.terminal_map_from),
+            (&line.bus_to, &line.terminal_map_to),
+        ] {
+            if let Some(bus) = buses.get(&identity(bus_id)) {
+                for terminal in terminals {
+                    if !bus.terminals.contains(terminal) {
+                        report.block(
+                            "READINESS.LINE.TERMINAL_UNRESOLVED",
+                            &line.name,
+                            format!("bus {bus_id} does not declare terminal {terminal}"),
+                        );
+                    }
+                }
+            }
+        }
         if !line.length.is_finite() || line.length <= 0.0 {
             report.block(
                 "READINESS.LINE.LENGTH_INVALID",
                 &line.name,
-                format!("line length must be finite and greater than zero; got {}", line.length),
+                format!(
+                    "line length must be finite and greater than zero; got {}",
+                    line.length
+                ),
             );
         }
 
-        if !buses.contains(&line.bus_from.to_ascii_lowercase()) {
+        if !buses.contains_key(&identity(&line.bus_from)) {
             report.block(
                 "READINESS.LINE.BUS_FROM_UNRESOLVED",
                 &line.name,
                 format!("from-bus {:?} does not exist", line.bus_from),
             );
         }
-        if !buses.contains(&line.bus_to.to_ascii_lowercase()) {
+        if !buses.contains_key(&identity(&line.bus_to)) {
             report.block(
                 "READINESS.LINE.BUS_TO_UNRESOLVED",
                 &line.name,
@@ -158,9 +262,9 @@ pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalRead
             );
         }
 
-        audit_deferred_geometry(line, &mut report);
+        audit_deferred_geometry(line, report);
 
-        let Some(code) = linecodes.get(&line.linecode.to_ascii_lowercase()) else {
+        let Some(code) = linecodes.get(&identity(&line.linecode)) else {
             report.block(
                 "READINESS.LINE.LINECODE_UNRESOLVED",
                 &line.name,
@@ -184,13 +288,10 @@ pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalRead
             );
         }
     }
-
-    report
 }
 
 fn audit_deferred_geometry(line: &crate::model::DistLine, report: &mut ElectricalReadiness) {
-    const GEOMETRY_KEYS: [&str; 5] = ["geometry", "spacing", "wires", "cncables", "tscables"];
-    let keys: Vec<&str> = GEOMETRY_KEYS
+    let keys: Vec<&str> = DEFERRED_GEOMETRY_KEYS
         .into_iter()
         .filter(|key| line.extras.contains_key(*key))
         .collect();
@@ -200,8 +301,7 @@ fn audit_deferred_geometry(line: &crate::model::DistLine, report: &mut Electrica
             "READINESS.DSS.GEOMETRY_DEFERRED",
             &line.name,
             format!(
-                "OpenDSS geometry-family property/properties {:?} are deferred; no geometry-derived impedance may be assumed",
-                keys
+                "OpenDSS geometry-family properties {keys:?} are deferred; no geometry-derived impedance may be assumed"
             ),
         );
     }
@@ -217,10 +317,34 @@ fn audit_linecode(code: &DistLineCode, report: &mut ElectricalReadiness) {
         return;
     }
 
-    audit_square_matrix(&code.name, "r_series", &code.r_series, code.n_conductors, report);
-    audit_square_matrix(&code.name, "x_series", &code.x_series, code.n_conductors, report);
-    audit_square_matrix(&code.name, "g_from", &code.g_from, code.n_conductors, report);
-    audit_square_matrix(&code.name, "b_from", &code.b_from, code.n_conductors, report);
+    audit_square_matrix(
+        &code.name,
+        "r_series",
+        &code.r_series,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "x_series",
+        &code.x_series,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "g_from",
+        &code.g_from,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "b_from",
+        &code.b_from,
+        code.n_conductors,
+        report,
+    );
     audit_square_matrix(&code.name, "g_to", &code.g_to, code.n_conductors, report);
     audit_square_matrix(&code.name, "b_to", &code.b_to, code.n_conductors, report);
 }
@@ -252,14 +376,13 @@ fn audit_square_matrix(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DistBus, DistLine, DistLineCode, MulticonductorNetwork};
+    use crate::{DistBus, DistLine, DistLineCode, Extras, MulticonductorNetwork};
 
     fn network_with_line(extras: Extras) -> MulticonductorNetwork {
         let mut net = MulticonductorNetwork::new();
         net.buses_mut()
             .push(DistBus::new("source", vec!["1".into()]));
-        net.buses_mut()
-            .push(DistBus::new("load", vec!["1".into()]));
+        net.buses_mut().push(DistBus::new("load", vec!["1".into()]));
         net.line_codes_mut().push(DistLineCode::new(
             "explicit",
             vec![vec![0.1]],
@@ -292,9 +415,11 @@ mod tests {
         extras.insert("geometry".into(), serde_json::json!("g601"));
         let report = audit_electrical_readiness(&network_with_line(extras));
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+        );
     }
 
     #[test]
@@ -324,9 +449,11 @@ mod tests {
         net.lines_mut()[0].terminal_map_to = vec!["1".into()];
         let report = audit_electrical_readiness(&net);
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+        );
     }
 
     #[test]
@@ -335,8 +462,10 @@ mod tests {
         net.line_codes_mut()[0].n_conductors = 2;
         let report = audit_electrical_readiness(&net);
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.MATRIX.SHAPE_MISMATCH"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.MATRIX.SHAPE_MISMATCH")
+        );
     }
 }

--- a/powerio-dist/src/testkit.rs
+++ b/powerio-dist/src/testkit.rs
@@ -38,6 +38,7 @@ impl Parsed {
             target,
             &crate::convert::EmitOptions::default(),
         )
+        .expect("fixture supports the requested conversion")
     }
 
     /// Write from the typed value, bypassing the echo tier.

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use powerio_dist::{
-    BmopfEmitOptions, BmopfProfile, Configuration, CoordinateSpace, DiagnosticSeverity,
+    BmopfEmitOptions, BmopfSchemaVersion, Configuration, CoordinateSpace, DiagnosticSeverity,
     DiagnosticStage, DistBus, DistCoordsKind, DistGeoMeta, DistLineCode, DistLocation,
     DistTransformer, DistWinding, DistWindingConn, Extras, MulticonductorNetwork, VoltageSource,
 };
@@ -61,7 +61,7 @@ fn nonuniform_phase_bounds_survive_value_serialization_and_emission() {
 fn contradictory_schema_versions_are_reported_as_errors() {
     let input = format!(
         r#"{{"meta":{{"$schema":"{}","schema_version":"0.1.0"}},"bus":{{}}}}"#,
-        BmopfProfile::Bmopf020.retrieval_url()
+        BmopfSchemaVersion::Bmopf020.retrieval_url()
     );
     let parsed = parse_bmopf_str(&input).unwrap();
     assert!(
@@ -74,10 +74,10 @@ fn contradictory_schema_versions_are_reported_as_errors() {
 }
 
 /// The validator for one vendored schema version.
-fn schema_validator_for(profile: BmopfProfile) -> jsonschema::Validator {
+fn schema_validator_for(profile: BmopfSchemaVersion) -> jsonschema::Validator {
     let file = match profile {
-        BmopfProfile::Bmopf010 => "bmopf/draft_bmopf_schema.json",
-        BmopfProfile::Bmopf020 => "bmopf/bmopf-0.2.0.schema.json",
+        BmopfSchemaVersion::Bmopf010 => "bmopf/draft_bmopf_schema.json",
+        BmopfSchemaVersion::Bmopf020 => "bmopf/bmopf-0.2.0.schema.json",
         _ => unreachable!("every schema version has a vendored document"),
     };
     let schema: serde_json::Value =
@@ -87,7 +87,7 @@ fn schema_validator_for(profile: BmopfProfile) -> jsonschema::Validator {
 
 /// The validator for the version the writer targets by default.
 fn schema_validator() -> jsonschema::Validator {
-    schema_validator_for(BmopfProfile::default())
+    schema_validator_for(BmopfSchemaVersion::default())
 }
 
 fn errors(validator: &jsonschema::Validator, text: &str) -> Vec<String> {
@@ -155,7 +155,7 @@ fn vendored_examples_validate_after_canonicalization() {
 /// mismatch.
 #[test]
 fn vendored_examples_raw_validation_is_known_and_bounded() {
-    let v = schema_validator_for(BmopfProfile::Bmopf010);
+    let v = schema_validator_for(BmopfSchemaVersion::Bmopf010);
     for example in ["bmopf/example_ieee13.json", "bmopf/example_enwl_n1_f2.json"] {
         let text = std::fs::read_to_string(fixture(example)).unwrap();
         assert_eq!(errors(&v, &text), Vec::<String>::new(), "{example}");
@@ -747,7 +747,7 @@ fn dss_fixed_generator_emits_as_bmopf_generator() {
     assert_eq!(g["p_max"], serde_json::json!([10_000.0]));
     assert_eq!(g["q_min"], serde_json::json!([2_000.0]));
     assert_eq!(g["q_max"], serde_json::json!([2_000.0]));
-    assert_eq!(g["cost"], serde_json::json!([0.0]));
+    assert_eq!(g["energy_cost_rate"], serde_json::json!([0.0]));
 }
 
 #[test]
@@ -802,7 +802,10 @@ fn fixed_bmopf_generators_with_cost_stay_generators() {
     );
     assert_eq!(doc["generator"]["g"]["p_min"], serde_json::json!([100.0]));
     assert_eq!(doc["generator"]["g"]["p_max"], serde_json::json!([100.0]));
-    assert_eq!(doc["generator"]["g"]["cost"], serde_json::json!([0.001]));
+    assert_eq!(
+        doc["generator"]["g"]["energy_cost_rate"],
+        serde_json::json!([0.001])
+    );
     let again = parse_bmopf_str(&out.text).unwrap();
     assert_model_eq(&net, &again);
 }
@@ -1004,7 +1007,7 @@ fn voltage_source_cost_round_trips_as_extra() {
 
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     assert_eq!(
-        doc["voltage_source"]["source"]["cost"],
+        doc["voltage_source"]["source"]["energy_cost_rate"],
         serde_json::json!([1.0])
     );
     assert!(
@@ -2748,7 +2751,7 @@ fn source_extras_value_that_is_not_a_table_does_not_panic() {
         let net = parse_bmopf_str(&text).unwrap();
         let out = emit_bmopf_json_with_options(
             &net,
-            BmopfEmitOptions::default().with_profile(BmopfProfile::Bmopf010),
+            BmopfEmitOptions::default().with_schema_version(BmopfSchemaVersion::Bmopf010),
         );
         assert!(
             out.warnings
@@ -2780,7 +2783,7 @@ fn source_extras_entry_replaced_by_the_top_level_table_warns() {
     let net = parse_bmopf_str(&text).unwrap();
     let out = emit_bmopf_json_with_options(
         &net,
-        BmopfEmitOptions::default().with_profile(BmopfProfile::Bmopf010),
+        BmopfEmitOptions::default().with_schema_version(BmopfSchemaVersion::Bmopf010),
     );
     assert!(
         out.warnings
@@ -3762,10 +3765,12 @@ fn regulator_banks_survive_a_dss_bmopf_dss_round_trip() {
 /// resolves that same value back to the version.
 #[test]
 fn the_written_schema_version_reads_back_as_the_version_written() {
-    for profile in [BmopfProfile::Bmopf010, BmopfProfile::Bmopf020] {
+    for profile in [BmopfSchemaVersion::Bmopf010, BmopfSchemaVersion::Bmopf020] {
         let net = parse_bmopf_file(fixture("bmopf/example_ieee13.json")).unwrap();
-        let out =
-            emit_bmopf_json_with_options(&net, BmopfEmitOptions::default().with_profile(profile));
+        let out = emit_bmopf_json_with_options(
+            &net,
+            BmopfEmitOptions::default().with_schema_version(profile),
+        );
         assert_eq!(
             errors(&schema_validator_for(profile), &out.text),
             Vec::<String>::new(),
@@ -3775,13 +3780,13 @@ fn the_written_schema_version_reads_back_as_the_version_written() {
         let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
         assert_eq!(doc["meta"]["$schema"], profile.retrieval_url());
         assert_eq!(
-            BmopfProfile::from_schema_id(doc["meta"]["$schema"].as_str().unwrap()),
+            BmopfSchemaVersion::from_schema_id(doc["meta"]["$schema"].as_str().unwrap()),
             Some(profile)
         );
         // Only 0.2.0 declares the version field, and its `meta` rejects what
         // it does not declare.
         match profile {
-            BmopfProfile::Bmopf010 => assert!(doc["meta"]["schema_version"].is_null()),
+            BmopfSchemaVersion::Bmopf010 => assert!(doc["meta"]["schema_version"].is_null()),
             _ => assert_eq!(doc["meta"]["schema_version"], profile.version()),
         }
         let reparsed = parse_bmopf_str(&out.text).unwrap();
@@ -3865,7 +3870,7 @@ fn the_tables_schema_0_1_0_relocates_stay_in_place_under_0_2_0() {
 
     let out = emit_bmopf_json_with_options(
         &net,
-        BmopfEmitOptions::default().with_profile(BmopfProfile::Bmopf010),
+        BmopfEmitOptions::default().with_schema_version(BmopfSchemaVersion::Bmopf010),
     );
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     for table in ["ibr", "time_series", "dc_bus"] {
@@ -3873,7 +3878,10 @@ fn the_tables_schema_0_1_0_relocates_stay_in_place_under_0_2_0() {
         assert!(doc[table].is_null(), "{table}: {}", out.text);
     }
     assert_eq!(
-        errors(&schema_validator_for(BmopfProfile::Bmopf010), &out.text),
+        errors(
+            &schema_validator_for(BmopfSchemaVersion::Bmopf010),
+            &out.text
+        ),
         Vec::<String>::new(),
         "{}",
         out.text
@@ -3898,13 +3906,13 @@ fn n_winding_ratings_taps_neutrals_and_limits_survive_serialization() {
     let parsed = parse_bmopf_str(&input.to_string()).unwrap();
     let restored: MulticonductorNetwork =
         serde_json::from_str(&serde_json::to_string(&*parsed).unwrap()).unwrap();
-    for profile in [BmopfProfile::Bmopf020, BmopfProfile::Bmopf010] {
+    for profile in [BmopfSchemaVersion::Bmopf020, BmopfSchemaVersion::Bmopf010] {
         let mut options = BmopfEmitOptions::default();
-        options.profile = profile;
+        options.schema_version = profile;
         let output = emit_bmopf_json_with_options(&restored, options);
         let doc: serde_json::Value = serde_json::from_str(&output.text).unwrap();
         assert!(schema_validator_for(profile).is_valid(&doc), "{doc}");
-        let encoded = if profile == BmopfProfile::Bmopf020 {
+        let encoded = if profile == BmopfSchemaVersion::Bmopf020 {
             &doc["transformer"]["n_winding"]["t"]
         } else {
             &doc["extras"]["transformer"]["n_winding"]["t"]

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -11,8 +11,8 @@ use powerio_dist::{
 
 mod helpers;
 use helpers::{
-    emit_bmopf_json, emit_bmopf_json_with_options, emit_dss, parse_bmopf_file, parse_bmopf_str,
-    parse_dss_file, parse_dss_str, parse_pmd_str,
+    emit_bmopf_json, emit_bmopf_json_with_options, emit_dss, emit_pmd_json, parse_bmopf_file,
+    parse_bmopf_str, parse_dss_file, parse_dss_str, parse_pmd_str,
 };
 
 /// The findings beside the schema version notice.
@@ -1723,11 +1723,12 @@ fn dss_noloadloss_derives_bmopf_no_load_fields() {
     let out = emit_bmopf_json(&net);
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
     let t = &doc["transformer"]["single_phase"]["t1"];
-    let expected_g = 0.2 / 100.0 * 25_000.0 / (7200.0 * 7200.0);
-    let g = t["g_no_load"].as_f64().unwrap();
+    assert_eq!(t["no_load_shunt"]["winding"], 2);
+    let expected_g = 0.2 / 100.0 * 25_000.0 / (240.0 * 240.0);
+    let g = t["no_load_shunt"]["g"].as_f64().unwrap();
     assert!((g - expected_g).abs() < 1e-18, "g_no_load = {g}");
-    let expected_b = 0.5 / 100.0 * 25_000.0 / (7200.0 * 7200.0);
-    let b = t["b_no_load"].as_f64().unwrap();
+    let expected_b = -0.5 / 100.0 * 25_000.0 / (240.0 * 240.0);
+    let b = t["no_load_shunt"]["b"].as_f64().unwrap();
     assert!((b - expected_b).abs() < 1e-18, "b_no_load = {b}");
     assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
 }
@@ -1809,13 +1810,10 @@ fn dss_phase_to_phase_noloadloss_does_not_emit_bmopf_ground_shunt() {
     let t = &doc["transformer"]["single_phase"]["t1"];
     assert!(t.get("g_no_load").is_none(), "{t}");
     assert!(t.get("b_no_load").is_none(), "{t}");
-    assert!(
-        out.warnings
-            .iter()
-            .any(|w| w.contains("phase-to-phase") && w.contains("%noloadloss")),
-        "{:?}",
-        out.warnings
-    );
+    assert_eq!(t["no_load_shunt"]["winding"], 2);
+    let shunt = &t["no_load_shunt"];
+    assert!((shunt["g"].as_f64().unwrap() * 480.0_f64.powi(2) - 50.0).abs() < 1e-10);
+    assert!((shunt["b"].as_f64().unwrap() * 480.0_f64.powi(2) + 125.0).abs() < 1e-10);
     assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
 }
 
@@ -1871,13 +1869,13 @@ fn wye_wye_3_neutral_grounding_decomposes_once_not_per_phase() {
     assert_eq!(sp["t_1"]["x_neutral_from"], serde_json::json!(6.0));
     assert_eq!(sp["t_1"]["r_neutral_to"], serde_json::json!(7.0));
     assert_eq!(sp["t_1"]["x_neutral_to"], serde_json::json!(8.0));
-    let expected_g = 0.3 / 100.0 * (75_000.0 / 3.0) / ((12_470.0 / 3f64.sqrt()).powi(2));
-    let expected_b = 0.6 / 100.0 * (75_000.0 / 3.0) / ((12_470.0 / 3f64.sqrt()).powi(2));
+    let expected_g = 0.3 / 100.0 * (75_000.0 / 3.0) / ((480.0 / 3f64.sqrt()).powi(2));
+    let expected_b = -0.6 / 100.0 * (75_000.0 / 3.0) / ((480.0 / 3f64.sqrt()).powi(2));
     for name in ["t_1", "t_2", "t_3"] {
         let t = &sp[name];
-        let g = t["g_no_load"].as_f64().unwrap();
+        let g = t["no_load_shunt"]["g"].as_f64().unwrap();
         assert!((g - expected_g).abs() < 1e-18, "{name} g_no_load = {g}");
-        let b = t["b_no_load"].as_f64().unwrap();
+        let b = t["no_load_shunt"]["b"].as_f64().unwrap();
         assert!((b - expected_b).abs() < 1e-18, "{name} b_no_load = {b}");
     }
     for name in ["t_2", "t_3"] {
@@ -4006,4 +4004,57 @@ fn three_phase_generator_without_neutral_keeps_phase_count_in_dss() {
         "{:?}",
         parsed.warnings
     );
+}
+
+#[test]
+fn no_load_shunt_preserves_winding_units_and_tap_after_conversion() {
+    for connection in ["wye", "delta"] {
+        let (from, source_bus, target_bus) = if connection == "wye" {
+            ("delta", "src.1.2.3", "dst.1.2.3.0")
+        } else {
+            ("wye", "src.1.2.3.0", "dst.1.2.3")
+        };
+        let dss = format!(
+            "Clear\nNew Circuit.core basekv=12.47 phases=3 bus1=src.1.2.3.0\nNew Transformer.t phases=3 windings=2 buses=({source_bus} {target_bus}) conns=({from} {connection}) kvs=(12.47 0.48) kvas=(75 75) taps=(1 1.05) %Rs=(1 1) xhl=2 %noloadloss=0.3 %imag=0.6\n"
+        );
+        let source = parse_dss_str(&dss);
+        let output = emit_bmopf_json(&source);
+        assert_eq!(
+            errors(&schema_validator(), &output.text),
+            Vec::<String>::new()
+        );
+        let converted = parse_bmopf_str(&output.text).unwrap();
+        let t = &converted.transformers()[0];
+        let shunt = &t.extras["no_load_shunt"];
+        let voltage = 480.0 * 1.05
+            / if connection == "wye" {
+                3f64.sqrt()
+            } else {
+                1.0
+            };
+        let loss = 3.0 * voltage.powi(2) * shunt["g"].as_f64().unwrap();
+        let q = -3.0 * voltage.powi(2) * shunt["b"].as_f64().unwrap();
+        assert!((loss - 225.0).abs() < 1e-8, "{connection}: {loss}");
+        assert!((q - 450.0).abs() < 1e-8, "{connection}: {q}");
+        assert_eq!(shunt["winding"], 2);
+        let pmd_output = emit_pmd_json(&converted);
+        let pmd_network = parse_pmd_str(&pmd_output.text).unwrap();
+        let pmd_bmopf = emit_bmopf_json(&pmd_network);
+        let pmd_again = parse_bmopf_str(&pmd_bmopf.text).unwrap();
+        let pmd_shunt = &pmd_again.transformers()[0].extras["no_load_shunt"];
+        for key in ["g", "b"] {
+            assert!(
+                (pmd_shunt[key].as_f64().unwrap() - shunt[key].as_f64().unwrap()).abs() < 1e-12
+            );
+        }
+        // Conversion materializes the winding-2 shunt at its terminal voltage.
+        let dss_output = emit_dss(&converted);
+        let restored = parse_dss_str(&dss_output.text);
+        let roundtrip = emit_bmopf_json(&restored);
+        let net = parse_bmopf_str(&roundtrip.text).unwrap();
+        let actual = &net.transformers()[0].extras["no_load_shunt"];
+        for key in ["g", "b"] {
+            assert!((actual[key].as_f64().unwrap() - shunt[key].as_f64().unwrap()).abs() < 1e-12);
+        }
+    }
 }

--- a/powerio-dist/tests/bmopf.rs
+++ b/powerio-dist/tests/bmopf.rs
@@ -33,6 +33,46 @@ fn fixture(rel: &str) -> PathBuf {
         .join(rel)
 }
 
+#[test]
+fn nonuniform_phase_bounds_survive_value_serialization_and_emission() {
+    let input = r#"{"bus":{"b":{"terminal_names":["a","b","c","n"],"v_min":[210,215,220],"v_max":[240,245,250]}},"voltage_source":{"s":{"bus":"b","terminal_map":["a","b","c","n"],"v_magnitude":[230,230,230,0],"v_angle":[0,-2.094,2.094,0]}}}"#;
+    let net = parse_bmopf_str(input).unwrap();
+    assert_eq!(net.buses()[0].v_min, None);
+    assert_eq!(
+        net.buses()[0].v_min_phase.as_deref(),
+        Some([210.0, 215.0, 220.0].as_slice())
+    );
+    let encoded = serde_json::to_string(&*net).unwrap();
+    let restored: MulticonductorNetwork = serde_json::from_str(&encoded).unwrap();
+    let output = emit_bmopf_json(&restored);
+    let doc: serde_json::Value = serde_json::from_str(&output.text).unwrap();
+    assert_eq!(
+        doc["bus"]["b"]["v_min"],
+        serde_json::json!([210.0, 215.0, 220.0])
+    );
+    assert_eq!(
+        doc["bus"]["b"]["v_max"],
+        serde_json::json!([240.0, 245.0, 250.0])
+    );
+    assert!(schema_validator().is_valid(&doc));
+}
+
+#[test]
+fn contradictory_schema_versions_are_reported_as_errors() {
+    let input = format!(
+        r#"{{"meta":{{"$schema":"{}","schema_version":"0.1.0"}},"bus":{{}}}}"#,
+        BmopfProfile::Bmopf020.retrieval_url()
+    );
+    let parsed = parse_bmopf_str(&input).unwrap();
+    assert!(
+        parsed
+            .diagnostics
+            .iter()
+            .any(|d| d.code() == "READ.BMOPF.SCHEMA_MISMATCH"
+                && d.severity() == DiagnosticSeverity::Error)
+    );
+}
+
 /// The validator for one vendored schema version.
 fn schema_validator_for(profile: BmopfProfile) -> jsonschema::Validator {
     let file = match profile {
@@ -181,8 +221,7 @@ fn written_output_validates_and_round_trips() {
     let net = parse_bmopf_file(fixture("bmopf/example_ieee13.json")).unwrap();
     let out = emit_bmopf_json(&net);
     assert_eq!(errors(&v, &out.text), Vec::<String>::new());
-    // The example lists neutral terminals no element references; the writer
-    // prunes them with a warning. Nothing else should drop.
+    // All bus terminals remain available for subsequent interventions.
     assert!(
         out.warnings
             .iter()
@@ -191,8 +230,7 @@ fn written_output_validates_and_round_trips() {
         out.warnings
     );
 
-    // The fixture is not canonical under our writer (the terminal prune), so
-    // idempotence starts from the canonical form: parse(write(parse(x))).
+    // Canonical output preserves the electrical model on each round trip.
     let canonical = parse_bmopf_str(&out.text).unwrap();
     let out2 = emit_bmopf_json(&canonical);
     assert_eq!(errors(&v, &out2.text), Vec::<String>::new());
@@ -210,8 +248,7 @@ fn enwl_round_trips() {
     let net = parse_bmopf_file(fixture("bmopf/example_enwl_n1_f2.json")).unwrap();
     let out = emit_bmopf_json(&net);
     assert_eq!(errors(&v, &out.text), Vec::<String>::new());
-    // Canonical-form model idempotence (the unreferenced-terminal prune makes
-    // the raw fixture non-canonical, as in written_output_validates_and_round_trips).
+    // Canonical emission is idempotent.
     let canonical = parse_bmopf_str(&out.text).unwrap();
     let out2 = emit_bmopf_json(&canonical);
     let again = parse_bmopf_str(&out2.text).unwrap();
@@ -3054,7 +3091,7 @@ fn schema_fields_survive_a_round_trip_without_wrong_warnings() {
         serde_json::json!([{"name": "measurement campaign"}])
     );
     assert_eq!(meta["created"], serde_json::json!("2026-01-01"));
-    assert_eq!(meta["provenance"], serde_json::json!({"note": "synthetic"}));
+    assert_eq!(meta["provenance"]["note"], "synthetic");
     // Writer-owned: powerio's stamp and the model frequency, whatever the
     // source declared.
     assert_eq!(meta["case_study_generator"]["tool"], "powerio");
@@ -3193,11 +3230,10 @@ fn dss_network_authors_terminal_conventions_from_its_naming() {
     let out = emit_bmopf_json(&net);
     assert_eq!(errors(&schema_validator(), &out.text), Vec::<String>::new());
     let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
-    // The dss reader makes the grounded neutral terminal `4` on the source
-    // bus. Every numeric label is a phase under the schema rule.
+    // The source uses terminal 4 as its grounded neutral.
     assert_eq!(
         doc["terminal_conventions"],
-        serde_json::json!({"phase": ["1", "2", "3", "4"], "neutral": []})
+        serde_json::json!({"phase": ["1", "2", "3"], "neutral": ["4"]})
     );
     assert!(
         !out.warnings
@@ -3739,7 +3775,7 @@ fn the_written_schema_version_reads_back_as_the_version_written() {
             profile.version()
         );
         let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
-        assert_eq!(doc["meta"]["$schema"], profile.schema_id());
+        assert_eq!(doc["meta"]["$schema"], profile.retrieval_url());
         assert_eq!(
             BmopfProfile::from_schema_id(doc["meta"]["$schema"].as_str().unwrap()),
             Some(profile)
@@ -3843,5 +3879,131 @@ fn the_tables_schema_0_1_0_relocates_stay_in_place_under_0_2_0() {
         Vec::<String>::new(),
         "{}",
         out.text
+    );
+}
+
+#[test]
+fn n_winding_ratings_taps_neutrals_and_limits_survive_serialization() {
+    let input = serde_json::json!({
+        "bus": {"p": {"terminal_names": ["a", "n"]}, "s": {"terminal_names": ["a", "n"]}},
+        "transformer": {"n_winding": {"t": {
+            "s_rating": 10000.0,
+            "windings": [
+                {"bus": "p", "terminal_map": ["a", "n"], "configuration": "WYE", "v_nom": 1000.0,
+                 "s_rating": 9000.0, "r_winding": 2.0, "tap_ratio": 1.02, "r_neutral": 5.0,
+                 "x_neutral": 1.0, "i_max": 9.0, "tap_ratio_min": 0.95, "tap_ratio_max": 1.05},
+                {"bus": "s", "terminal_map": ["a", "n"], "configuration": "WYE", "v_nom": 100.0,
+                 "s_rating": 8000.0, "r_winding": 0.03, "tap_ratio": 0.98}
+            ], "x_sc": {"1_2": 1.5}
+        }}}
+    });
+    let parsed = parse_bmopf_str(&input.to_string()).unwrap();
+    let restored: MulticonductorNetwork =
+        serde_json::from_str(&serde_json::to_string(&*parsed).unwrap()).unwrap();
+    for profile in [BmopfProfile::Bmopf020, BmopfProfile::Bmopf010] {
+        let mut options = BmopfEmitOptions::default();
+        options.profile = profile;
+        let output = emit_bmopf_json_with_options(&restored, options);
+        let doc: serde_json::Value = serde_json::from_str(&output.text).unwrap();
+        assert!(schema_validator_for(profile).is_valid(&doc), "{doc}");
+        let encoded = if profile == BmopfProfile::Bmopf020 {
+            &doc["transformer"]["n_winding"]["t"]
+        } else {
+            &doc["extras"]["transformer"]["n_winding"]["t"]
+        };
+        assert_eq!(encoded["windings"][0]["i_max"], 9.0);
+        assert_eq!(encoded["windings"][0]["tap_ratio_min"], 0.95);
+        let back = parse_bmopf_str(&output.text).unwrap();
+        let transformer = &back.transformers()[0];
+        assert_eq!(
+            transformer.windings[0].s_rating.to_bits(),
+            9000.0_f64.to_bits()
+        );
+        assert_eq!(
+            transformer.windings[1].s_rating.to_bits(),
+            8000.0_f64.to_bits()
+        );
+        assert_eq!(transformer.windings[0].tap.to_bits(), 1.02_f64.to_bits());
+        assert_eq!(transformer.windings[0].r_neutral, Some(5.0));
+        assert!(
+            (transformer.windings[0].r_pct - restored.transformers()[0].windings[0].r_pct).abs()
+                < 1e-12
+        );
+        assert_eq!(encoded["x_sc"]["1_2"], 1.5);
+    }
+}
+
+#[test]
+fn proposal_provenance_is_pinned_and_preserves_existing_keys() {
+    use powerio_dist::bmopf::{BMOPF_PROPOSAL_COMMIT, BMOPF_PROPOSAL_SHA256, BMOPF_PROPOSAL_URL};
+    let mut net = parse_bmopf_file(fixture("bmopf/example_ieee13.json")).unwrap();
+    net.extras_mut().insert(
+        "bmopf_meta".into(),
+        serde_json::json!({"provenance":{"powerio_bmopf":{"note":"keep"}}}),
+    );
+    let out = emit_bmopf_json(&net);
+    let doc: serde_json::Value = serde_json::from_str(&out.text).unwrap();
+    assert_eq!(doc["meta"]["$schema"], BMOPF_PROPOSAL_URL);
+    let provenance = &doc["meta"]["provenance"];
+    assert_eq!(provenance["powerio_bmopf"]["note"], "keep");
+    assert_eq!(provenance["powerio_bmopf_1"]["schema_status"], "proposal");
+    assert_eq!(
+        provenance["powerio_bmopf_1"]["schema_sha256"],
+        BMOPF_PROPOSAL_SHA256
+    );
+    assert_eq!(
+        provenance["powerio_bmopf_1"]["schema_commit"],
+        BMOPF_PROPOSAL_COMMIT
+    );
+    assert_eq!(
+        emit_bmopf_json(&parse_bmopf_str(&out.text).unwrap()).text,
+        out.text
+    );
+}
+
+#[test]
+fn emitted_micro_cases_keep_valid_conductor_references() {
+    for name in [
+        "xfmr_single_phase.dss",
+        "xfmr_center_tap.dss",
+        "switch.dss",
+        "fourwire_linecode.dss",
+        "linecode_10x10.dss",
+    ] {
+        let net =
+            parse_dss_str(&std::fs::read_to_string(fixture(&format!("micro/{name}"))).unwrap());
+        let text = emit_bmopf_json(&net).text;
+        let parsed = parse_bmopf_str(&text).unwrap();
+        assert!(
+            !parsed
+                .warnings
+                .iter()
+                .any(|d| d.contains("SEMANTIC_INVALID")),
+            "{name}: {:?}",
+            parsed.warnings
+        );
+    }
+}
+
+#[test]
+fn three_phase_generator_without_neutral_keeps_phase_count_in_dss() {
+    let net = parse_bmopf_file(fixture("bmopf/example_ieee13.json")).unwrap();
+    let dss = emit_dss(&net);
+    let generator = dss
+        .text
+        .lines()
+        .find(|line| line.starts_with("New Generator.gen_634 "))
+        .unwrap();
+    assert!(generator.contains("phases=3"), "{generator}");
+    let reread = parse_dss_str(&dss.text);
+    let output = emit_bmopf_json(&reread);
+    let parsed = parse_bmopf_str(&output.text).unwrap();
+    assert!(
+        !parsed
+            .warnings
+            .iter()
+            .any(|d| d.contains("SEMANTIC_INVALID")),
+        "{:?}",
+        parsed.warnings
     );
 }

--- a/powerio-dist/tests/dss_reader.rs
+++ b/powerio-dist/tests/dss_reader.rs
@@ -253,6 +253,69 @@ fn defaults_materialize_with_provenance() {
 }
 
 #[test]
+fn transformer_xscarray_preserves_every_pair_after_mutation() {
+    for (count, array) in [(2, "8"), (3, "8 9 6"), (4, "8 9 10 6 7 4")] {
+        let source = format!(
+            "New Circuit.test basekv=115\nNew Transformer.t phases=3 windings={count} xscarray=[{array}]"
+        );
+        let mut parsed = parse_dss_str(&source);
+        let expected: Vec<f64> = array
+            .split_whitespace()
+            .map(|v| v.parse().unwrap())
+            .collect();
+        assert_eq!(parsed.transformers()[0].xsc_pct, expected);
+        assert!(!parsed.transformers()[0].extras.contains_key("xscarray"));
+        parsed.transformers_mut()[0].xsc_pct[0] = 11.0;
+        let emitted = emit_dss(&parsed);
+        let restored = parse_dss_str(&emitted.text);
+        let mut changed = expected;
+        changed[0] = 11.0;
+        assert_eq!(restored.transformers()[0].xsc_pct, changed);
+    }
+}
+
+#[test]
+fn transformer_reactances_follow_opendss_edit_boundaries() {
+    let cases = [
+        ("windings=3 xscarray=[8 9 6] xhl=11", vec![11.0, 35.0, 30.0]),
+        ("windings=3 xhl=11 xscarray=[8 9 6]", vec![11.0, 35.0, 30.0]),
+        (
+            "windings=3 xhl=11\nEdit Transformer.t xscarray=[8 9 6]",
+            vec![8.0, 9.0, 6.0],
+        ),
+        (
+            "windings=3 xscarray=[8 9 6]\nEdit Transformer.t xhl=11",
+            vec![11.0, 35.0, 30.0],
+        ),
+        (
+            "windings=4 xscarray=[8 9 10 6 7 4]\nEdit Transformer.t xhl=11",
+            vec![8.0, 9.0, 10.0, 6.0, 7.0, 4.0],
+        ),
+        ("windings=4", vec![7.0, 30.0, 30.0, 30.0, 30.0, 30.0]),
+        ("windings=3", vec![7.0, 30.0, 30.0]),
+        (
+            "windings=4 xscarray=[8 9 10 6 7 4] windings=3",
+            vec![8.0, 9.0, 10.0],
+        ),
+    ];
+    for (properties, expected) in cases {
+        let parsed = parse_dss_str(&format!("New Circuit.test\nNew Transformer.t {properties}"));
+        assert_eq!(parsed.transformers()[0].xsc_pct, expected, "{properties}");
+    }
+}
+
+#[test]
+fn transformer_xscarray_wrong_dimensions_report_defaulting() {
+    let parsed = parse_dss_str("New Circuit.test\nNew Transformer.t windings=4 xscarray=[8 8 8]");
+    assert!(
+        parsed
+            .diagnostics
+            .iter()
+            .any(|d| d.message().contains("xscarray has 3 values; expected 6"))
+    );
+}
+
+#[test]
 fn micro_transformers_type_correctly() {
     let net = parse("micro/xfmr_center_tap.dss");
     let t = net.transformers().iter().find(|t| t.name == "t1").unwrap();

--- a/powerio-dist/tests/electrical_readiness.rs
+++ b/powerio-dist/tests/electrical_readiness.rs
@@ -3,7 +3,10 @@ use std::fs;
 use powerio_core::Source;
 use powerio_dist::{audit_electrical_readiness, parse};
 
-fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
+fn parse_text(
+    name: &str,
+    text: &str,
+) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
     let dir = std::env::temp_dir().join(format!(
         "powerio-dss-readiness-{name}-{}",
         std::process::id()
@@ -19,7 +22,7 @@ fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::M
 fn parsed_geometry_is_blocked_before_analysis() {
     let module = parse_text(
         "geometry",
-        r#"clear
+        r"clear
 new circuit.t basekv=4.16 phases=3 bus1=sourcebus
 new wiredata.w rac=0.1859 gmr=0.0313 radius=0.4635 runits=mi gmrunits=ft radunits=in
 new linegeometry.g nconds=4 nphases=3 reduce=no
@@ -28,32 +31,36 @@ new linegeometry.g nconds=4 nphases=3 reduce=no
 ~ cond=3 wire=w x=7 h=29 units=ft
 ~ cond=4 wire=w x=4 h=25 units=ft
 new line.l bus1=sourcebus bus2=b geometry=g length=1 units=m
-"#,
+",
     );
 
     let report = audit_electrical_readiness(module.value());
     assert!(!report.is_ready());
-    assert!(report
-        .blockers()
-        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    assert!(
+        report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+    );
 }
 
 #[test]
 fn parsed_swer_geometry_is_also_blocked() {
     let module = parse_text(
         "swer",
-        r#"clear
+        r"clear
 new circuit.swer basekv=19.1 phases=1 bus1=sourcebus
 new wiredata.w rac=1.093 gmr=0.00296 radius=0.00318 runits=km gmrunits=m radunits=m
 new linegeometry.g nconds=1 nphases=1 reduce=no
 ~ cond=1 wire=w x=0 h=8.5 units=m
 new line.l bus1=sourcebus.1 bus2=b.1 geometry=g length=1 units=m
-"#,
+",
     );
 
     let report = audit_electrical_readiness(module.value());
     assert!(!report.is_ready());
-    assert!(report
-        .blockers()
-        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    assert!(
+        report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+    );
 }

--- a/powerio-dist/tests/matrix.rs
+++ b/powerio-dist/tests/matrix.rs
@@ -980,24 +980,9 @@ fn terminal_maps(net: &MulticonductorNetwork) -> Vec<(String, String, Vec<String
     out
 }
 
-/// The renumbering scheme itself, which the arity fallback in
-/// `assert_maps_eq` cannot check (issue #266 item 3).
-///
-/// dss spells terminals as node positions and PMD requires integer
-/// connections, so a named terminal takes a new name on those legs. The
-/// rename must be a position-stable bijection per bus:
-///
-/// - every element keeps its arity, and position `k` before the leg is
-///   position `k` after it, so no phase order permutation can hide;
-/// - within one bus, a source name always takes the same new name, so two
-///   elements that shared a conductor still share it;
-/// - within one bus, two source names never take one new name, so two
-///   conductors do not merge.
-///
-/// The scope is one bus because dss numbers a terminal by its position in
-/// its own bus, so the same name at two buses can legitimately differ.
-/// A permutation, a merge, or an inconsistent rename each fails here even
-/// though all of them keep the arity.
+/// Supplied conductor positions form a bijection per bus across OpenDSS and
+/// PMD renumbering. OpenDSS can append a grounded neutral to a WYE generator
+/// whose map lists only its phases; that addition must carry a diagnostic.
 #[test]
 fn renumbering_legs_are_position_stable_bijections() {
     for case in CASES {
@@ -1027,9 +1012,18 @@ fn renumbering_legs_are_position_stable_bijections() {
                     // job; this test only pins the rename.
                     continue;
                 };
-                assert_eq!(
-                    source_map.len(),
-                    target_map.len(),
+                let grounded_generator_return = matches!(target, Fmt::Dss)
+                    && key.starts_with("generator ")
+                    && target_map.len() == source_map.len() + 1
+                    && round_tripped
+                        .bus(bus)
+                        .is_some_and(|b| target_map.last().is_some_and(|t| b.grounded.contains(t)))
+                    && conv
+                        .warnings
+                        .iter()
+                        .any(|d| d.starts_with("EMIT.DSS.VALUE_COLLAPSED:") && d.contains(key));
+                assert!(
+                    source_map.len() == target_map.len() || grounded_generator_return,
                     "{what}: {key} changed arity: {source_map:?} vs {target_map:?}"
                 );
                 for (position, (source, renamed)) in

--- a/powerio-dist/tests/pmd.rs
+++ b/powerio-dist/tests/pmd.rs
@@ -1122,14 +1122,7 @@ fn a_saturating_numeric_terminal_name_does_not_merge_renamed_conductors() {
     assert!(load <= 64 && generator <= 64, "{load} and {generator}");
 }
 
-/// A BMOPF bus states per-terminal voltage magnitude bounds in volts; PMD's
-/// ENGINEERING bus states the same bounds as `vm_lb`/`vm_ub`, per terminal, in
-/// the unit `voltage_scale_factor` scales to volts — the rule `vm_nom` already
-/// follows. The scalar bound broadcasts on the way out and the uniform vector
-/// collapses on the way back, so the pair survives the trip exactly and the
-/// writer no longer reports a loss the format does not have to take. A
-/// non-uniform vector from a third-party file collapses to its first entry
-/// with a warning, the same rule the BMOPF reader applies to its arrays.
+/// Phase voltage bounds convert between SI volts and PMD engineering kV.
 #[test]
 fn bus_voltage_bounds_ride_vm_lb_and_vm_ub() {
     let base = crate::helpers::parse_file(fixture("bmopf/example_ieee13.json"), None).unwrap();
@@ -1153,16 +1146,11 @@ fn bus_voltage_bounds_ride_vm_lb_and_vm_ub() {
         assert_eq!(a.v_max, b.v_max, "bus {} v_max", a.id);
     }
 
-    // Third-party input with a non-uniform vector: first entry, said loudly.
     let doc = r#"{"data_model":"ENGINEERING","settings":{"voltage_scale_factor":1000.0},
         "bus":{"b1":{"terminals":[1,2],"grounded":[],"vm_lb":[2.02,2.04]}}}"#;
     let net = parse_pmd_str(doc).unwrap();
-    assert_eq!(net.buses()[0].v_min, Some(2020.0));
-    assert!(
-        net.warnings.iter().any(|w| w.contains("non-uniform")),
-        "{:?}",
-        net.warnings
-    );
+    assert_eq!(net.buses()[0].v_min, None);
+    assert_eq!(net.buses()[0].v_min_phase, Some(vec![2020.0, 2040.0]));
 }
 
 /// #376: a rated capacitor bank converts to an ENGINEERING shunt — the

--- a/powerio-matrix/src/diagnostics.rs
+++ b/powerio-matrix/src/diagnostics.rs
@@ -25,6 +25,8 @@ pub mod codes {
             "a nodal quadratic projection cannot carry the prepared generator cost", category = Request;
         BUILD_AC_PF_SPECIFICATION_UNSUPPORTED = "BUILD.AC_PF.SPECIFICATION_UNSUPPORTED", Error,
             "the AC power flow preparation does not support a bus specification", category = Data;
+        BUILD_MULTI_PHYSICS_UNSUPPORTED = "BUILD.MULTI.PHYSICS_UNSUPPORTED", Error,
+            "the requested multiconductor calculation requires unsupported equipment equations", category = Data;
         BUILD_MULTI_UNSUPPORTED_STAMP = "BUILD.MULTI.UNSUPPORTED_STAMP", Warning,
             "an element has no exact multiconductor admittance or ideal stamp and was omitted loudly";
         BUILD_SENSITIVITY_SINGULAR = "BUILD.SENSITIVITY.SINGULAR", Error,

--- a/powerio-matrix/src/matrix/multiconductor.rs
+++ b/powerio-matrix/src/matrix/multiconductor.rs
@@ -336,6 +336,7 @@ impl Stamper {
 pub fn calc_multiconductor_admittance_matrix(
     network: &MulticonductorNetwork,
 ) -> Result<MulticonductorAdmittance> {
+    powerio_dist::require_electrical_readiness(network)?;
     let index = MulticonductorNodeIndex::build(network)?;
     for transformer in network.transformers() {
         let supported = transformer.windings.len() == 2

--- a/powerio-matrix/src/matrix/multiconductor.rs
+++ b/powerio-matrix/src/matrix/multiconductor.rs
@@ -352,6 +352,11 @@ pub fn calc_multiconductor_admittance_matrix(
             })
             && transformer.windings[0].terminal_map.len()
                 == transformer.windings[1].terminal_map.len()
+            && transformer.extras.get("no_load_shunt").is_none_or(|shunt| {
+                ["g", "b"]
+                    .iter()
+                    .all(|key| shunt.get(key).and_then(serde_json::Value::as_f64) == Some(0.0))
+            })
             && ["g_no_load", "b_no_load", "%noloadloss", "%imag"]
                 .iter()
                 .all(|key| {

--- a/powerio-matrix/src/matrix/multiconductor.rs
+++ b/powerio-matrix/src/matrix/multiconductor.rs
@@ -14,10 +14,9 @@
 //! the linecode), shunts, and capacitor banks. Ideal equipment — two winding
 //! transformer coupling and voltage sources — enters the augmented system as
 //! exact constraint rows over the node voltages with their coupled ideal
-//! currents, never as fabricated impedances; the winding leakage reactance is
-//! a real impedance and stamps into the passive matrix. Element stamps the
-//! builder does not support produce structured diagnostics and are omitted
-//! loudly.
+//! currents. Transformer leakage, non-WYE connections, floating winding
+//! neutrals, core shunts and tap decisions require a different augmented
+//! formulation and return an unsupported-physics error before assembly.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -338,6 +337,38 @@ pub fn calc_multiconductor_admittance_matrix(
     network: &MulticonductorNetwork,
 ) -> Result<MulticonductorAdmittance> {
     let index = MulticonductorNodeIndex::build(network)?;
+    for transformer in network.transformers() {
+        let supported = transformer.windings.len() == 2
+            && transformer.xsc_pct.iter().all(|&x| x == 0.0)
+            && transformer.windings.iter().all(|w| {
+                w.conn == powerio_dist::DistWindingConn::Wye
+                    && w.r_pct == 0.0
+                    && w.r_neutral.is_none_or(|r| r == 0.0)
+                    && w.x_neutral.is_none_or(|x| x == 0.0)
+                    && (w.terminal_map.len() == 1
+                        || w.terminal_map.last().is_some_and(|terminal| {
+                            index.resolve(&w.bus, terminal) == Some(NodeRef::Ground)
+                        }))
+            })
+            && transformer.windings[0].terminal_map.len()
+                == transformer.windings[1].terminal_map.len()
+            && ["g_no_load", "b_no_load", "%noloadloss", "%imag"]
+                .iter()
+                .all(|key| {
+                    transformer
+                        .extras
+                        .get(*key)
+                        .and_then(serde_json::Value::as_f64)
+                        .is_none_or(|v| v == 0.0)
+                })
+            && !["tap_min", "tap_max", "tap_ratio_min", "tap_ratio_max"]
+                .iter()
+                .any(|key| transformer.extras.contains_key(*key));
+        if !supported {
+            return Err(powerio_core::Error::new(&codes::BUILD_MULTI_PHYSICS_UNSUPPORTED,
+                format!("transformer `{}` requires leakage, winding connection, neutral, core-loss, or tap-control equations outside the ideal grounded-WYE admittance profile", transformer.name)).into());
+        }
+    }
     let n = index.len();
     let mut stamper = Stamper::new(n);
     let mut diagnostics = Vec::new();
@@ -553,11 +584,8 @@ pub fn calc_multiconductor_admittance_matrix(
         }
     }
 
-    // Two winding transformers: the leakage reactance is a real impedance in
-    // series with an exact ideal ratio link. The leakage stamps into the
-    // passive matrix on the primary side; the ideal coupling is the
-    // constraint v_primary - a v_secondary = 0 per phase pair. Anything past
-    // two windings is a structured diagnostic.
+    // Grounded WYE winding pairs use an exact voltage-ratio constraint.
+    // Unsupported transformer physics is rejected before assembly.
     for transformer in network.transformers() {
         if transformer.windings.len() != 2 {
             diagnostics.push(
@@ -627,27 +655,6 @@ pub fn calc_multiconductor_admittance_matrix(
                     rows += 1;
                 }
                 (NodeRef::Ground, NodeRef::Ground) => {}
-            }
-        }
-        // Leakage: xsc on the primary winding base, an ordinary series
-        // reactance between the primary terminals and the ideal link. With
-        // the link exact, stamping it across the primary terminal pairs
-        // preserves the two winding short circuit behavior.
-        if let Some(&xsc_pct) = transformer.xsc_pct.first()
-            && primary.s_rating > 0.0
-            && primary.v_ref > 0.0
-            && xsc_pct != 0.0
-        {
-            let z_base = primary.v_ref * primary.v_ref / primary.s_rating;
-            let x = xsc_pct / 100.0 * z_base;
-            let y = Complex64::new(0.0, -1.0 / x);
-            for pair in 0..pairs {
-                let p = resolve(
-                    &primary.bus,
-                    &primary.terminal_map[pair],
-                    &format!("transformer `{}`", transformer.name),
-                )?;
-                stamper.add(p, p, y);
             }
         }
     }

--- a/powerio-matrix/tests/multiconductor.rs
+++ b/powerio-matrix/tests/multiconductor.rs
@@ -214,7 +214,7 @@ fn sources_and_ideal_transformers_enter_the_augmented_system() {
     net.transformers_mut().push(DistTransformer::new(
         "t1",
         vec![primary, secondary],
-        vec![2.0],
+        vec![0.0],
         1,
     ));
 
@@ -253,17 +253,7 @@ fn sources_and_ideal_transformers_enter_the_augmented_system() {
     assert!((constraints[ratio_row][s_node] + 30.0).abs() < 1e-12);
     assert!(augmented.rhs_re[ratio_row].abs() < 1e-15);
 
-    // The leakage reactance is a real impedance on the primary base:
-    // z_base = 7200^2 / 25000, x = 2% of it, stamped as -1/x on the primary
-    // diagonal susceptance.
-    let b = dense(system.susceptance());
-    let z_base = 7200.0f64 * 7200.0 / 25_000.0;
-    let expected = -1.0 / (0.02 * z_base);
-    assert!(
-        (b[p_node][p_node] - expected).abs() < 1e-12,
-        "{} vs {expected}",
-        b[p_node][p_node]
-    );
+    assert_eq!(system.susceptance().nnz(), 0);
 }
 
 #[test]
@@ -279,15 +269,8 @@ fn unsupported_stamps_are_structured_diagnostics() {
         vec![1.0, 1.0, 1.0],
         1,
     ));
-    let system = calc_multiconductor_admittance_matrix(&net).unwrap();
-    assert!(
-        system
-            .diagnostics()
-            .iter()
-            .any(|d| d.code() == "BUILD.MULTI.UNSUPPORTED_STAMP" && d.message().contains("three")),
-        "{:?}",
-        system.diagnostics()
-    );
+    let error = calc_multiconductor_admittance_matrix(&net).unwrap_err();
+    assert!(error.to_string().contains("outside the ideal grounded-WYE"));
 }
 
 #[test]
@@ -343,4 +326,22 @@ fn a_parsed_micro_feeder_assembles_end_to_end() {
     assert!(system.susceptance().nnz() > 0);
     // The source anchors the system through the augmented rows.
     assert!(!system.augmented().labels.is_empty());
+}
+
+#[test]
+fn transformer_leakage_requires_a_series_equation() {
+    let mut net = MulticonductorNetwork::default();
+    net.buses_mut().push(DistBus::new("p", strings(&["1"])));
+    net.buses_mut().push(DistBus::new("s", strings(&["1"])));
+    net.transformers_mut().push(DistTransformer::new(
+        "t",
+        vec![
+            DistWinding::new("p", strings(&["1"]), DistWindingConn::Wye, 7200.0, 25000.0),
+            DistWinding::new("s", strings(&["1"]), DistWindingConn::Wye, 240.0, 25000.0),
+        ],
+        vec![2.0],
+        1,
+    ));
+    let error = calc_multiconductor_admittance_matrix(&net).unwrap_err();
+    assert_eq!(error.code().code, "BUILD.MULTI.PHYSICS_UNSUPPORTED");
 }

--- a/powerio-prob/src/instance/multiconductor.rs
+++ b/powerio-prob/src/instance/multiconductor.rs
@@ -80,6 +80,7 @@ impl McAcPfInstance {
     /// A network with no voltage source: a distribution power flow has no
     /// boundary condition without one.
     pub fn from_network(network: MulticonductorNetwork) -> Result<Self, Error> {
+        powerio_dist::require_electrical_readiness(&network)?;
         if network.sources().is_empty() {
             return Err(Error::new(
                 &codes::BUILD_INSTANCE_SHAPE_MISMATCH,
@@ -216,6 +217,7 @@ impl McAcOpfInstance {
     /// # Errors
     /// A network with no voltage source.
     pub fn from_network(network: MulticonductorNetwork) -> Result<Self, Error> {
+        powerio_dist::require_electrical_readiness(&network)?;
         if network.sources().is_empty() {
             return Err(Error::new(
                 &codes::BUILD_INSTANCE_SHAPE_MISMATCH,
@@ -262,6 +264,7 @@ impl McAcOpfInstance {
     /// Replace the network while preserving this instance's objective,
     /// constraint selections, and a compatible initial point.
     pub fn with_network(mut self, network: MulticonductorNetwork) -> Result<Self, Error> {
+        powerio_dist::require_electrical_readiness(&network)?;
         if network.sources().is_empty() {
             return Err(Error::new(
                 &codes::BUILD_INSTANCE_SHAPE_MISMATCH,

--- a/powerio/src/formats.rs
+++ b/powerio/src/formats.rs
@@ -52,6 +52,12 @@ const fn info(
 ///
 #[must_use]
 pub fn resolve_format(name: &str) -> Option<FormatInfo> {
+    match name {
+        "bmopf-json@0.1.0" => return Some(info("bmopf-json@0.1.0", Some("json"), false, true)),
+        "bmopf-json@0.2.0" => return Some(info("bmopf-json@0.2.0", Some("json"), false, true)),
+        _ => {}
+    }
+
     if crate::is_geo_layer_token(name) {
         return Some(info(
             "geo-json",

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -144,7 +144,7 @@ pub type Result<T> = std::result::Result<T, powerio_core::Error>;
 /// available at the facade root.
 pub use powerio_dist as dist;
 pub use powerio_dist::{
-    BmopfEmitOptions, BmopfProfile, ConductorMatrix, DistGeoMeta, DistGraphEdgeKind,
+    BmopfEmitOptions, BmopfSchemaVersion, ConductorMatrix, DistGeoMeta, DistGraphEdgeKind,
     MulticonductorNetwork,
 };
 

--- a/powerio/src/lib.rs
+++ b/powerio/src/lib.rs
@@ -143,7 +143,10 @@ pub type Result<T> = std::result::Result<T, powerio_core::Error>;
 /// overlap with balanced network types. Common unambiguous records are also
 /// available at the facade root.
 pub use powerio_dist as dist;
-pub use powerio_dist::{ConductorMatrix, DistGeoMeta, DistGraphEdgeKind, MulticonductorNetwork};
+pub use powerio_dist::{
+    BmopfEmitOptions, BmopfProfile, ConductorMatrix, DistGeoMeta, DistGraphEdgeKind,
+    MulticonductorNetwork,
+};
 
 pub use powerio_prob::solution::{SocwrOpfDuals, SocwrOpfSolution, SocwrOpfValues};
 /// The balanced calculation types used by solver consumers. The full problem

--- a/powerio/src/transform.rs
+++ b/powerio/src/transform.rs
@@ -2143,6 +2143,14 @@ fn check_bus_conductor_sets(
     let neutral_terminals = global_neutral_terminals(net);
     let mut saw_neutral = false;
     for (i, bus) in net.buses().iter().enumerate() {
+        if (bus.v_min.is_none() && bus.v_min_phase.is_some())
+            || (bus.v_max.is_none() && bus.v_max_phase.is_some())
+        {
+            report.diagnostics.push(Diagnostic::of(
+                &codes::TRANSFORM_MULTI_TO_BALANCED_UNSUPPORTED_OBJECT,
+                format!("bus {} has nonuniform phase voltage bounds that a balanced bus cannot represent", bus.id),
+            ).with_value_target(format!("/buses/{i}")));
+        }
         let active_count = active_terminal_count(&bus.terminals, Some(bus), &neutral_terminals);
         if active_count < bus.terminals.len() {
             saw_neutral = true;

--- a/powerio/src/write.rs
+++ b/powerio/src/write.rs
@@ -876,8 +876,8 @@ fn emit_dynamic(
 ) -> Result<EmitResult, Error> {
     if let Some(version) = format.strip_prefix("bmopf-json@") {
         let profile = match version {
-            "0.1.0" => powerio_dist::BmopfProfile::Bmopf010,
-            "0.2.0" => powerio_dist::BmopfProfile::Bmopf020,
+            "0.1.0" => powerio_dist::BmopfSchemaVersion::Bmopf010,
+            "0.2.0" => powerio_dist::BmopfSchemaVersion::Bmopf020,
             _ => return Err(unknown_format(format)),
         };
         let (network, diagnostics) = match module.value() {
@@ -905,7 +905,7 @@ fn emit_dynamic(
         };
         let typed = typed_sibling(module, network)?.sever_source();
         let mut options = powerio_dist::EmitOptions::default();
-        options.bmopf.profile = profile;
+        options.bmopf.schema_version = profile;
         return powerio_dist::emit_with_options(
             &typed,
             powerio_dist::DistTargetFormat::BmopfJson,

--- a/powerio/src/write.rs
+++ b/powerio/src/write.rs
@@ -874,6 +874,46 @@ fn emit_dynamic(
     format: &str,
     destination: Destination,
 ) -> Result<EmitResult, Error> {
+    if let Some(version) = format.strip_prefix("bmopf-json@") {
+        let profile = match version {
+            "0.1.0" => powerio_dist::BmopfProfile::Bmopf010,
+            "0.2.0" => powerio_dist::BmopfProfile::Bmopf020,
+            _ => return Err(unknown_format(format)),
+        };
+        let (network, diagnostics) = match module.value() {
+            PioValue::MulticonductorNetwork(network) => (network.clone(), Vec::new()),
+            PioValue::McAcPfInstance(instance) => (
+                instance.network().clone(),
+                vec![calculation_data_omitted(module.value().type_name(), format)],
+            ),
+            PioValue::McAcOpfInstance(instance) => (
+                instance.network().clone(),
+                vec![calculation_data_omitted(module.value().type_name(), format)],
+            ),
+            PioValue::MulticonductorOperatingPoint(point) => {
+                network_with_multiconductor_operating_point(point, format)
+            }
+            PioValue::McAcPfSolution(solution) => (
+                solution.instance().network().clone(),
+                vec![solution_data_omitted(module.value().type_name(), format)],
+            ),
+            PioValue::McAcOpfSolution(solution) => (
+                solution.instance().network().clone(),
+                vec![solution_data_omitted(module.value().type_name(), format)],
+            ),
+            _ => return Err(unsupported_type(module, format)),
+        };
+        let typed = typed_sibling(module, network)?.sever_source();
+        let mut options = powerio_dist::EmitOptions::default();
+        options.bmopf.profile = profile;
+        return powerio_dist::emit_with_options(
+            &typed,
+            powerio_dist::DistTargetFormat::BmopfJson,
+            &options,
+            destination,
+        )
+        .map(|result| result.__with_diagnostics(diagnostics));
+    }
     if let Some(artifacts) = echo_retained_directory(module, format)? {
         return destination.__commit_artifacts(
             true,

--- a/powerio/tests/bmopf_profiles.rs
+++ b/powerio/tests/bmopf_profiles.rs
@@ -85,3 +85,69 @@ fn generation_two_ir_preserves_phase_limits_without_source_bytes() {
     let value: Value = serde_json::from_slice(bytes(&output)).unwrap();
     assert_eq!(value["bus"]["b"]["v_min"], json!([210.0, 212.0, 214.0]));
 }
+
+#[test]
+fn dss_four_winding_reactances_survive_ir_and_bmopf() {
+    let source = b"New Circuit.test basekv=115\nNew Transformer.t phases=3 windings=4 buses=[h m l v] conns=[delta wye wye wye] kvs=[115 24.9 4.16 2.4] kvas=[30000 30000 30000 30000] xscarray=[8 9 10 6 7 4]";
+    let module = powerio::parse(Source::from_memory("case.dss", source.to_vec()).unwrap()).unwrap();
+    let ir = powerio::serialize(&module, Destination::memory("case.pio.json").unwrap()).unwrap();
+    let restored =
+        powerio::deserialize(Source::from_memory("case.pio.json", bytes(&ir).to_vec()).unwrap())
+            .unwrap();
+    let emitted = powerio::emit(
+        &restored,
+        "bmopf-json@0.2.0",
+        Destination::memory("case.json").unwrap(),
+    )
+    .unwrap();
+    let value: Value = serde_json::from_slice(bytes(&emitted)).unwrap();
+    let table = &value["transformer"]["n_winding"]["t"]["x_sc"];
+    for (key, percent) in [
+        ("1_2", 8.0),
+        ("1_3", 9.0),
+        ("1_4", 10.0),
+        ("2_3", 6.0),
+        ("2_4", 7.0),
+        ("3_4", 4.0),
+    ] {
+        assert!((table[key].as_f64().unwrap() - percent / 100.0 * 1322.5).abs() < 1e-9);
+    }
+    let back = powerio::parse(
+        Source::from_memory("roundtrip.bmopf.json", bytes(&emitted).to_vec()).unwrap(),
+    )
+    .unwrap();
+    let PioValue::MulticonductorNetwork(network) = back.value() else {
+        panic!("expected network")
+    };
+    for (actual, expected) in network.transformers()[0]
+        .xsc_pct
+        .iter()
+        .zip([8.0, 9.0, 10.0, 6.0, 7.0, 4.0])
+    {
+        assert!((actual - expected).abs() < 1e-9);
+    }
+    let mut changed = network.clone();
+    changed.transformers_mut()[0].xsc_pct[5] = 5.5;
+    let changed = powerio::PioModule::new(PioValue::MulticonductorNetwork(changed));
+    for target in ["bmopf-json@0.2.0", "pmd"] {
+        let emitted = powerio::emit(
+            &changed,
+            target,
+            Destination::memory("changed.json").unwrap(),
+        )
+        .unwrap();
+        let restored =
+            powerio::parse(Source::from_memory("changed.json", bytes(&emitted).to_vec()).unwrap())
+                .unwrap();
+        let PioValue::MulticonductorNetwork(network) = restored.value() else {
+            panic!("expected network")
+        };
+        for (actual, expected) in network.transformers()[0]
+            .xsc_pct
+            .iter()
+            .zip([8.0, 9.0, 10.0, 6.0, 7.0, 5.5])
+        {
+            assert!((actual - expected).abs() < 1e-9, "{target}");
+        }
+    }
+}

--- a/powerio/tests/bmopf_profiles.rs
+++ b/powerio/tests/bmopf_profiles.rs
@@ -1,0 +1,87 @@
+//! Explicit BMOPF profiles and IR persistence bypass retained-source emission.
+
+use powerio::{Destination, EmittedOutput, PioValue, Source};
+use serde_json::{Value, json};
+
+fn bytes(result: &powerio::EmitResult) -> &[u8] {
+    let EmittedOutput::Memory { artifacts } = result.output() else {
+        panic!("expected memory output")
+    };
+    assert_eq!(artifacts.len(), 1);
+    artifacts[0].bytes()
+}
+
+fn case() -> Vec<u8> {
+    serde_json::to_vec(&json!({
+        "meta": {"$schema": powerio::BmopfProfile::Bmopf010.schema_id(),
+            "provenance": {"research": {"id": "independent-example", "revision": 3}}},
+        "bus": {"b": {"terminal_names": ["a", "b", "c", "n"],
+            "v_min": [210.0, 212.0, 214.0], "v_max": [250.0, 248.0, 246.0]}},
+        "voltage_source": {"s": {"bus": "b", "terminal_map": ["a", "b", "c", "n"],
+            "v_magnitude": [230.0,230.0,230.0,0.0], "v_angle": [0.0,-2.094,2.094,0.0]}}
+    }))
+    .unwrap()
+}
+
+#[test]
+fn explicit_profile_reencodes_and_plain_format_echoes() {
+    let source = case();
+    let module =
+        powerio::parse(Source::from_memory("case.bmopf.json", source.clone()).unwrap()).unwrap();
+    let echoed = powerio::emit(
+        &module,
+        "bmopf-json",
+        Destination::memory("case.json").unwrap(),
+    )
+    .unwrap();
+    assert_eq!(bytes(&echoed), source);
+    for profile in ["0.1.0", "0.2.0"] {
+        let emitted = powerio::emit(
+            &module,
+            &format!("bmopf-json@{profile}"),
+            Destination::memory("case.json").unwrap(),
+        )
+        .unwrap();
+        let output: Value = serde_json::from_slice(bytes(&emitted)).unwrap();
+        assert!(
+            output["meta"]["$schema"]
+                .as_str()
+                .unwrap()
+                .contains(profile)
+        );
+        assert_eq!(output["bus"]["b"]["v_min"], json!([210.0, 212.0, 214.0]));
+        assert_eq!(output["meta"]["provenance"]["research"]["revision"], 3);
+    }
+    assert!(
+        powerio::emit(
+            &module,
+            "bmopf-json@9.0.0",
+            Destination::memory("case.json").unwrap()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn generation_two_ir_preserves_phase_limits_without_source_bytes() {
+    let module = powerio::parse(Source::from_memory("case.bmopf.json", case()).unwrap()).unwrap();
+    let ir = powerio::serialize(&module, Destination::memory("case.pio.json").unwrap()).unwrap();
+    let restored =
+        powerio::deserialize(Source::from_memory("case.pio.json", bytes(&ir).to_vec()).unwrap())
+            .unwrap();
+    let PioValue::MulticonductorNetwork(network) = restored.value() else {
+        panic!("expected network")
+    };
+    assert_eq!(
+        network.buses()[0].v_min_phase.as_deref(),
+        Some([210.0, 212.0, 214.0].as_slice())
+    );
+    let output = powerio::emit(
+        &restored,
+        "bmopf-json",
+        Destination::memory("case.json").unwrap(),
+    )
+    .unwrap();
+    let value: Value = serde_json::from_slice(bytes(&output)).unwrap();
+    assert_eq!(value["bus"]["b"]["v_min"], json!([210.0, 212.0, 214.0]));
+}

--- a/powerio/tests/bmopf_profiles.rs
+++ b/powerio/tests/bmopf_profiles.rs
@@ -1,4 +1,4 @@
-//! Explicit BMOPF profiles and IR persistence bypass retained-source emission.
+//! Explicit BMOPF schema versions and IR persistence bypass retained-source emission.
 
 use powerio::{Destination, EmittedOutput, PioValue, Source};
 use serde_json::{Value, json};
@@ -13,7 +13,7 @@ fn bytes(result: &powerio::EmitResult) -> &[u8] {
 
 fn case() -> Vec<u8> {
     serde_json::to_vec(&json!({
-        "meta": {"$schema": powerio::BmopfProfile::Bmopf010.schema_id(),
+        "meta": {"$schema": powerio::BmopfSchemaVersion::Bmopf010.schema_id(),
             "provenance": {"research": {"id": "independent-example", "revision": 3}}},
         "bus": {"b": {"terminal_names": ["a", "b", "c", "n"],
             "v_min": [210.0, 212.0, 214.0], "v_max": [250.0, 248.0, 246.0]}},
@@ -24,7 +24,7 @@ fn case() -> Vec<u8> {
 }
 
 #[test]
-fn explicit_profile_reencodes_and_plain_format_echoes() {
+fn explicit_schema_version_reencodes_and_plain_format_echoes() {
     let source = case();
     let module =
         powerio::parse(Source::from_memory("case.bmopf.json", source.clone()).unwrap()).unwrap();
@@ -149,5 +149,148 @@ fn dss_four_winding_reactances_survive_ir_and_bmopf() {
         {
             assert!((actual - expected).abs() < 1e-9, "{target}");
         }
+    }
+}
+
+#[test]
+fn energy_costs_keep_phase_order_through_mutation_ir_and_schema_conversion() {
+    let mut input: Value = serde_json::from_slice(&case()).unwrap();
+    input["meta"]["$schema"] = json!(powerio::BmopfSchemaVersion::Bmopf020.schema_id());
+    input["meta"]["schema_version"] = json!("0.2.0");
+    input["voltage_source"]["s"]["energy_cost_rate"] = json!([0.10, 0.20, 0.30]);
+    input["generator"] = json!({"g": {"bus":"b", "configuration":"WYE",
+        "terminal_map":["a","b","c","n"], "p_min":[0,0,0], "p_max":[100,100,100],
+        "energy_cost_rate":[0.03,0.04,0.05]}});
+    let module = powerio::parse(
+        Source::from_memory("rates.json", serde_json::to_vec(&input).unwrap()).unwrap(),
+    )
+    .unwrap();
+    let PioValue::MulticonductorNetwork(network) = module.value() else {
+        panic!("expected network")
+    };
+    let mut changed = network.clone();
+    changed.sources_mut()[0].energy_cost_rate.as_mut().unwrap()[1] = 0.25;
+    let changed = powerio::PioModule::new(PioValue::MulticonductorNetwork(changed));
+    let ir = powerio::serialize(&changed, Destination::memory("rates.pio.json").unwrap()).unwrap();
+    let restored =
+        powerio::deserialize(Source::from_memory("rates.pio.json", bytes(&ir).to_vec()).unwrap())
+            .unwrap();
+    for version in ["0.1.0", "0.2.0"] {
+        let output = powerio::emit(
+            &restored,
+            &format!("bmopf-json@{version}"),
+            Destination::memory("rates.json").unwrap(),
+        )
+        .unwrap();
+        let emitted: Value = serde_json::from_slice(bytes(&output)).unwrap();
+        if version == "0.2.0" {
+            assert_eq!(
+                emitted["voltage_source"]["s"]["energy_cost_rate"],
+                json!([0.1, 0.25, 0.3])
+            );
+            assert_eq!(
+                emitted["generator"]["g"]["energy_cost_rate"],
+                json!([0.03, 0.04, 0.05])
+            );
+            assert!(emitted["generator"]["g"].get("cost").is_none());
+        } else {
+            assert!(
+                emitted["voltage_source"]["s"]
+                    .get("energy_cost_rate")
+                    .is_none()
+            );
+            assert_eq!(
+                emitted["extras"]["voltage_source"]["s"]["energy_cost_rate"],
+                json!([0.1, 0.25, 0.3])
+            );
+            assert_eq!(emitted["generator"]["g"]["cost"], json!([0.03, 0.04, 0.05]));
+        }
+        let back =
+            powerio::parse(Source::from_memory("rates.json", bytes(&output).to_vec()).unwrap())
+                .unwrap();
+        let PioValue::MulticonductorNetwork(network) = back.value() else {
+            panic!("expected network")
+        };
+        assert_eq!(
+            network.sources()[0].energy_cost_rate,
+            Some(vec![0.1, 0.25, 0.3])
+        );
+        assert_eq!(network.generators()[0].cost, Some(vec![0.03, 0.04, 0.05]));
+    }
+}
+
+#[test]
+fn unresolved_geometry_cannot_reach_instances_matrices_or_canonical_exports() {
+    let text = b"New Circuit.test phases=1 basekv=19.1\nNew Line.l bus1=sourcebus.1 bus2=load.1 phases=1 geometry=unresolved length=1 units=m\n";
+    let module =
+        powerio::parse(Source::from_memory("geometry.dss", text.to_vec()).unwrap()).unwrap();
+    assert!(
+        module
+            .diagnostics()
+            .iter()
+            .any(|d| d.code() == "READ.DSS.GEOMETRY_UNRESOLVED")
+    );
+    let PioValue::MulticonductorNetwork(network) = module.value() else {
+        panic!("expected network")
+    };
+    assert!(network.lines().is_empty());
+    assert!(network.line_codes().is_empty());
+    assert!(powerio_prob::McAcPfInstance::from_network(network.clone()).is_err());
+    assert!(powerio_prob::McAcOpfInstance::from_network(network.clone()).is_err());
+    assert!(powerio_matrix::calc_multiconductor_admittance_matrix(network).is_err());
+    let echoed = powerio::emit(&module, "dss", Destination::memory("source").unwrap()).unwrap();
+    assert_eq!(bytes(&echoed), text);
+    let ir =
+        powerio::serialize(&module, Destination::memory("geometry.pio.json").unwrap()).unwrap();
+    let restored = powerio::deserialize(
+        Source::from_memory("geometry.pio.json", bytes(&ir).to_vec()).unwrap(),
+    )
+    .unwrap();
+    for format in ["bmopf-json@0.2.0", "pmd", "dss"] {
+        let error =
+            powerio::emit(&restored, format, Destination::memory("out").unwrap()).unwrap_err();
+        assert!(error.to_string().contains("geometry"), "{format}: {error}");
+    }
+}
+
+#[test]
+fn inverter_energy_prices_survive_ir_and_legacy_relocation() {
+    let mut input: Value = serde_json::from_slice(&case()).unwrap();
+    input["meta"]["$schema"] = json!(powerio::BmopfSchemaVersion::Bmopf020.schema_id());
+    input["ibr"] = json!({"pv":{"bus":"b", "terminal_map":["a","b","c","n"],
+        "topology":"FOUR_LEG", "prime_mover":"PV", "s_max":[1000,1000,1000],
+        "energy_cost_rate":[0.01,0.02,0.03]}});
+    let module = powerio::parse(
+        Source::from_memory("rates.json", serde_json::to_vec(&input).unwrap()).unwrap(),
+    )
+    .unwrap();
+    let ir = powerio::serialize(&module, Destination::memory("rates.pio.json").unwrap()).unwrap();
+    let restored =
+        powerio::deserialize(Source::from_memory("rates.pio.json", bytes(&ir).to_vec()).unwrap())
+            .unwrap();
+    for version in ["0.1.0", "0.2.0"] {
+        let output = powerio::emit(
+            &restored,
+            &format!("bmopf-json@{version}"),
+            Destination::memory("rates.json").unwrap(),
+        )
+        .unwrap();
+        let doc: Value = serde_json::from_slice(bytes(&output)).unwrap();
+        let table = if version == "0.1.0" {
+            &doc["extras"]["ibr"]
+        } else {
+            &doc["ibr"]
+        };
+        assert_eq!(table["pv"]["energy_cost_rate"], json!([0.01, 0.02, 0.03]));
+        let back =
+            powerio::parse(Source::from_memory("rates.json", bytes(&output).to_vec()).unwrap())
+                .unwrap();
+        let PioValue::MulticonductorNetwork(network) = back.value() else {
+            panic!("expected network")
+        };
+        assert_eq!(
+            network.ibrs()[0].extras["energy_cost_rate"],
+            json!([0.01, 0.02, 0.03])
+        );
     }
 }

--- a/python/powerio/mcp/sandbox.py
+++ b/python/powerio/mcp/sandbox.py
@@ -10,8 +10,9 @@ at all, can apply the same rules. Use :func:`checked_path` for one file,
 :func:`staged_file_write` for a file writer, and
 :func:`staged_directory_write` for a directory writer.
 
-When the variable is unset or empty, the policy is off and every path is
-allowed.
+When the primary variable is unset or empty, `POWERIO_MCP_ROOT` and then
+`POWERIO_MCP_ALLOWED_ROOT` provide the allowed roots. The first nonempty value
+wins. With none configured, every path is allowed.
 
     >>> from powerio.mcp.sandbox import checked_path
     >>> checked_path("case9.m", purpose="path")            # doctest: +SKIP
@@ -33,8 +34,12 @@ from urllib.parse import unquote, urlparse
 ALLOWED_ROOTS_ENV = "POWERIO_MCP_ALLOWED_ROOTS"
 """Primary variable: an ``os.pathsep`` separated list of allowed roots."""
 
+LEGACY_ROOT_ENVS = ("POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT")
+"""Compatibility spellings, read in order when the primary is unset."""
+
 __all__ = [
     "ALLOWED_ROOTS_ENV",
+    "LEGACY_ROOT_ENVS",
     "PathNotAllowed",
     "admitting_root",
     "allowed_roots",
@@ -58,7 +63,8 @@ class PathNotAllowed(ValueError):
 
 def allowed_roots() -> tuple[Path, ...]:
     """Roots the policy confines paths to, empty when the policy is off."""
-    raw = os.environ.get(ALLOWED_ROOTS_ENV) or ""
+    raw = next((os.environ[name] for name in (ALLOWED_ROOTS_ENV, *LEGACY_ROOT_ENVS)
+                if os.environ.get(name)), "")
     if not raw:
         return ()
     roots = []

--- a/python/tests/test_dist.py
+++ b/python/tests/test_dist.py
@@ -393,3 +393,29 @@ def test_parse_confines_includes_to_the_case_directory(tmp_path):
         for diagnostic in confined.diagnostics
     )
     assert "include_root" not in inspect.signature(powerio.parse).parameters
+
+
+def test_source_energy_prices_and_draft_schema_digest_survive_ir():
+    import hashlib
+
+    document = {
+        "meta": {"schema_version": "0.2.0"},
+        "bus": {"b": {"terminal_names": ["a", "n"]}},
+        "voltage_source": {"s": {
+            "bus": "b", "terminal_map": ["a", "n"],
+            "v_magnitude": [230, 0], "v_angle": [0, 0],
+            "energy_cost_rate": [0.1],
+        }},
+    }
+    module = powerio.parse(io.StringIO(json.dumps(document)), format="bmopf-json")
+    restored = _parse_module(_emit_module(module))
+    assert restored.value.voltage_sources[0]["energy_cost_rate"] == [0.1]
+    output = json.loads(powerio.emit(restored, "bmopf-json@0.2.0").text)
+    provenance = output["meta"]["provenance"]["powerio_bmopf"]
+    schema = (DATA / "bmopf" / "bmopf-0.2.0.schema.json").read_bytes()
+    assert provenance["schema_sha256"] == hashlib.sha256(schema).hexdigest()
+    assert provenance["schema_status"] == "proposal"
+    assert provenance["schema_commit"] in output["meta"]["$schema"]
+    legacy = json.loads(powerio.emit(restored, "bmopf-json@0.1.0").text)
+    assert "energy_cost_rate" not in legacy["voltage_source"]["s"]
+    assert legacy["extras"]["voltage_source"]["s"]["energy_cost_rate"] == [0.1]

--- a/python/tests/test_mcp_sandbox.py
+++ b/python/tests/test_mcp_sandbox.py
@@ -13,7 +13,7 @@ import pytest
 from powerio.mcp import sandbox
 
 DATA = Path(__file__).resolve().parents[2] / "tests" / "data"
-ENV_NAMES = ("POWERIO_MCP_ALLOWED_ROOTS",)
+ENV_NAMES = ("POWERIO_MCP_ALLOWED_ROOTS", "POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT")
 
 
 @pytest.fixture(autouse=True)
@@ -322,3 +322,17 @@ def test_staged_directory_write_rolls_back_a_failed_swap(monkeypatch, tmp_path):
     assert not [
         path for path in tmp_path.iterdir() if path.name.startswith(".dataset.")
     ]
+
+
+@pytest.mark.parametrize("name", ("POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT"))
+def test_compatibility_root_settings_keep_containment(name, monkeypatch, tmp_path):
+    for key in ("POWERIO_MCP_ALLOWED_ROOTS", "POWERIO_MCP_ROOT", "POWERIO_MCP_ALLOWED_ROOT"):
+        monkeypatch.delenv(key, raising=False)
+    inside = tmp_path / "inside"
+    inside.mkdir()
+    monkeypatch.setenv(name, str(inside))
+    assert sandbox.allowed_roots() == (inside,)
+    with pytest.raises(sandbox.PathNotAllowed):
+        sandbox.checked_path(str(tmp_path / "outside.txt"))
+    monkeypatch.setenv("POWERIO_MCP_ALLOWED_ROOTS", str(tmp_path))
+    assert sandbox.allowed_roots() == (tmp_path,)

--- a/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
+++ b/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/distribution-system-opt/dsopt-schema/main/schema/bmopf/0.2.0/bmopf.schema.json",
   "title": "BMOPF network case schema 0.2.0",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -1705,6 +1705,9 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "no_load_shunt": {
+            "$ref": "#/$defs/transformer_no_load_shunt"
           }
         },
         "required": [
@@ -1715,6 +1718,27 @@
           "s_rating",
           "v_nom_from",
           "v_nom_to"
+        ],
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "no_load_shunt"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "g_no_load"
+                  ]
+                },
+                {
+                  "required": [
+                    "b_no_load"
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
     },
@@ -1810,6 +1834,9 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "no_load_shunt": {
+            "$ref": "#/$defs/transformer_no_load_shunt"
           }
         },
         "required": [
@@ -1820,6 +1847,27 @@
           "s_rating",
           "v_nom_from",
           "v_nom_to"
+        ],
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "no_load_shunt"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "g_no_load"
+                  ]
+                },
+                {
+                  "required": [
+                    "b_no_load"
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
     },
@@ -2084,6 +2132,9 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "no_load_shunt": {
+            "$ref": "#/$defs/transformer_no_load_shunt"
           }
         },
         "required": [
@@ -2091,6 +2142,27 @@
           "bus_to",
           "terminal_map_from",
           "terminal_map_to"
+        ],
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "no_load_shunt"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "g_no_load"
+                  ]
+                },
+                {
+                  "required": [
+                    "b_no_load"
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
     },
@@ -2191,6 +2263,9 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "no_load_shunt": {
+            "$ref": "#/$defs/transformer_no_load_shunt"
           }
         },
         "required": [
@@ -2199,6 +2274,27 @@
           "terminal_map_from",
           "terminal_map_to",
           "connection"
+        ],
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "no_load_shunt"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "g_no_load"
+                  ]
+                },
+                {
+                  "required": [
+                    "b_no_load"
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
     },
@@ -2240,15 +2336,65 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "no_load_shunt": {
+            "$ref": "#/$defs/transformer_no_load_shunt"
           }
         },
         "required": [
           "windings",
           "x_sc",
           "s_rating"
+        ],
+        "allOf": [
+          {
+            "not": {
+              "required": [
+                "no_load_shunt"
+              ],
+              "anyOf": [
+                {
+                  "required": [
+                    "g_no_load"
+                  ]
+                },
+                {
+                  "required": [
+                    "b_no_load"
+                  ]
+                }
+              ]
+            }
+          }
         ]
       }
+    },
+    "transformer_no_load_shunt": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Explicit terminal-coil no-load admittance. Each coil of the selected physical winding receives this admittance, in siemens, at the stated operating tap. The object is mutually exclusive with g_no_load and b_no_load.",
+      "properties": {
+        "winding": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "One-based physical winding index. Two-winding subtypes use 1=from, 2=to. A center tap uses 1=from, 2=first to terminal to centre, 3=centre to last to terminal. An n_winding transformer uses its windings array order."
+        },
+        "g": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Conductance per coil [S], giving real loss g*abs(u)^2 for coil voltage u."
+        },
+        "b": {
+          "type": "number",
+          "description": "Susceptance per coil [S]; negative for lagging magnetizing current. Consumed reactive power is -b*abs(u)^2."
+        }
+      },
+      "required": [
+        "winding",
+        "g",
+        "b"
+      ]
     }
   },
-  "description": "Proposed BMOPF 0.2.0 structural schema, subject to IEEE PES BMOPF Task Force review. Electrical quantities use absolute SI units. Element IDs are table keys; ordered terminal maps establish conductor identity. Cross-field dimensions, references, role lists and bounds require semantic validation in addition to JSON Schema. Unknown electrical fields are rejected; top-level extras and meta.provenance are free-form extension locations. Neither location establishes computational support. The canonical $id identifies this schema; a case may retrieve its pinned revision from an immutable commit URL. See the proposal documentation for compatibility and implementation status."
+  "description": "Proposed BMOPF 0.2.0 network data contract, subject to Task Force review. An immutable retrieval URL identifies a particular proposal snapshot."
 }

--- a/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
+++ b/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
@@ -16,7 +16,7 @@
       "properties": {
         "$schema": {
           "type": "string",
-          "description": "The `$id` of the schema document this dataset is written against. A reader selects the schema version from this field; a dataset that omits it declares no version and a reader cannot resolve one."
+          "description": "Schema retrieval URI or documented canonical identifier. A pinned proposal uses an immutable commit URL. Its resolved version must agree with meta.schema_version when both are supplied."
         },
         "version": {
           "type": "string",
@@ -1681,7 +1681,7 @@
           },
           "r_neutral_from": {
             "$ref": "#/$defs/nonnegative_number",
-            "description": "Grounding resistance [Ohm] of the 'from'-side winding's own neutral: an internal branch from the winding's shared neutral to earth. Zero or absent grounds that neutral solidly. Groundings outside the transformer stay on buses and shunts."
+            "description": "Grounding resistance [Ohm] of the 'from' winding's own neutral. Absence of both neutral impedance fields adds no internal grounding branch. Explicitly zero impedance grounds that winding neutral solidly. External bus grounding remains separate."
           },
           "x_neutral_from": {
             "$ref": "#/$defs/nonnegative_number",
@@ -1689,7 +1689,7 @@
           },
           "r_neutral_to": {
             "$ref": "#/$defs/nonnegative_number",
-            "description": "Grounding resistance [Ohm] of the 'to'-side winding's own neutral: an internal branch from the winding's shared neutral to earth. Zero or absent grounds that neutral solidly. Groundings outside the transformer stay on buses and shunts."
+            "description": "Grounding resistance [Ohm] of the 'to' winding's own neutral. Absence of both neutral impedance fields adds no internal grounding branch. Explicitly zero impedance grounds that winding neutral solidly. External bus grounding remains separate."
           },
           "x_neutral_to": {
             "$ref": "#/$defs/nonnegative_number",
@@ -1786,7 +1786,7 @@
           },
           "r_neutral_from": {
             "$ref": "#/$defs/nonnegative_number",
-            "description": "Grounding resistance [Ohm] of the 'from'-side winding's own neutral: an internal branch from the winding's shared neutral to earth. Zero or absent grounds that neutral solidly. Groundings outside the transformer stay on buses and shunts."
+            "description": "Grounding resistance [Ohm] of the 'from' winding's own neutral. Absence of both neutral impedance fields adds no internal grounding branch. Explicitly zero impedance grounds that winding neutral solidly. External bus grounding remains separate."
           },
           "x_neutral_from": {
             "$ref": "#/$defs/nonnegative_number",
@@ -1794,7 +1794,7 @@
           },
           "r_neutral_to": {
             "$ref": "#/$defs/nonnegative_number",
-            "description": "Grounding resistance [Ohm] of the 'to'-side winding's own neutral: an internal branch from the winding's shared neutral to earth. Zero or absent grounds that neutral solidly. Groundings outside the transformer stay on buses and shunts."
+            "description": "Grounding resistance [Ohm] of the 'to' winding's own neutral. Absence of both neutral impedance fields adds no internal grounding branch. Explicitly zero impedance grounds that winding neutral solidly. External bus grounding remains separate."
           },
           "x_neutral_to": {
             "$ref": "#/$defs/nonnegative_number",
@@ -1959,6 +1959,35 @@
         "i_max": {
           "$ref": "#/$defs/nonnegative_number",
           "description": "Current-magnitude limit [A] applied to each phase coil current of this winding, referred to this winding's own voltage. A per-coil limit, not a per-terminal one: a DELTA winding's coil current is not its terminal current."
+        },
+        "s_rating": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Winding rating [VA]. Defaults to the transformer s_rating when absent; the transformer s_rating remains the common short-circuit base."
+        },
+        "tap_ratio": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "default": 1,
+          "description": "Dimensionless multiplier on this winding nominal coil voltage. Referred ideal coil voltages divide by v_nom * tap_ratio."
+        },
+        "tap_ratio_min": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Lower bound on this winding tap multiplier; a nonfixed interval requires a supported tap decision."
+        },
+        "tap_ratio_max": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Upper bound on this winding tap multiplier."
+        },
+        "r_neutral": {
+          "$ref": "#/$defs/nonnegative_number",
+          "description": "Winding-neutral-to-earth resistance [Ohm]. Absence of both neutral impedance fields adds no internal grounding branch; explicitly zero impedance gives solid grounding."
+        },
+        "x_neutral": {
+          "type": "number",
+          "description": "Winding-neutral-to-earth reactance [Ohm]; see r_neutral."
         }
       },
       "required": [
@@ -1975,9 +2004,6 @@
         "type": "string",
         "description": "Id of an entry of the top-level `time_series` table"
       }
-    },
-    "ideal_equipment": {
-      "$comment": "Ideal equipment states an exact algebraic relation between its terminal quantities, with no impedance and no loss. A document declares ideal equipment by omitting the impedance fields, which default to zero; it never states a zero impedance and a nonzero loss.\nIdeal two-winding transformer, per phase coil k, with turns ratio n = v_nom_from / v_nom_to: v_from_k = n * v_to_k and i_to_k = -n * i_from_k, so s_from + s_to = 0. The `configuration` of each winding maps coil quantities to terminal quantities: a WYE winding's coil k spans terminal k and the winding's neutral terminal, and a DELTA winding's coil k spans terminals k and k + delta_roll, with the index taken modulo the phase count.\nIdeal n-winding transformer, windings j = 1..m with winding 1 the reference: v_j / v_nom_j is equal for every j, and the coil powers sum to zero. Pairwise `x_sc` entries and `r_winding` then place the leakage impedance around that ideal core.\nIdeal single-phase autotransformer regulator with regulation ratio a and `regulator_type` B: v_to = a * v_from and i_from = -a * i_to. Type A inverts the ratio, n_eff = 1 / a.\nIdeal closed switch: v_from_k = v_to_k and i_from_k + i_to_k = 0 for every conductor k. Ideal open switch: i_from_k = i_to_k = 0, and the two terminal voltages are unrelated.\nIdeal voltage source: the terminal voltage is fixed at the stated `v_magnitude` and `v_angle` and the terminal current is free.\nIdeal DC grounding, `r` absent or zero: v_dc = 0 at the terminal and the earth-return current is free."
     },
     "single_phase_autotransformer": {
       "type": "object",
@@ -2124,21 +2150,27 @@
             "items": {
               "$ref": "#/$defs/nonnegative_number"
             },
-            "description": "Per-regulator regulation ratios [a1, a2] (length 2). Start values when free."
+            "description": "Per-regulator regulation ratios [a1, a2] (length 2). Start values when free.",
+            "minItems": 2,
+            "maxItems": 2
           },
           "tap_ratio_min": {
             "type": "array",
             "items": {
               "$ref": "#/$defs/nonnegative_number"
             },
-            "description": "Per-regulator lower bounds [a1_min, a2_min]. With tap_ratio_min < tap_ratio_max (element-wise) that regulator's tap is a free OPF variable."
+            "description": "Per-regulator lower bounds [a1_min, a2_min]. With tap_ratio_min < tap_ratio_max (element-wise) that regulator's tap is a free OPF variable.",
+            "minItems": 2,
+            "maxItems": 2
           },
           "tap_ratio_max": {
             "type": "array",
             "items": {
               "$ref": "#/$defs/nonnegative_number"
             },
-            "description": "Per-regulator upper bounds [a1_max, a2_max] (see tap_ratio_min)."
+            "description": "Per-regulator upper bounds [a1_max, a2_max] (see tap_ratio_min).",
+            "minItems": 2,
+            "maxItems": 2
           },
           "regulator_type": {
             "$ref": "#/$defs/regulator_type"
@@ -2218,5 +2250,5 @@
       }
     }
   },
-  "description": "Data schema for four-wire multiconductor distribution optimal power flow network cases, released by the IEEE PES Task Force on Benchmarking Multiconductor OPF for Distribution Systems. Every quantity is SI and absolute: volts, amperes, watts, vars, volt-amperes, ohms, siemens, metres, radians, hertz, degrees Celsius. There are no per-unit values and no scaling factors. Element identity is the key of the object in its table, and a terminal is named by a string, so a document states conductor identity everywhere.\n\nUnknown fields are rejected. Every object in this schema sets additionalProperties to false, and the matrix element names are the only pattern-matched keys. The single place a document may carry data this schema does not define is the top-level `extras` object, which is free-form and carries no defined meaning; a reader that ignores `extras` reads a different network than the writer wrote, so a writer that moves data there states so.\n\nArray dimensions. A per-terminal array has one entry for each name in the element's own `terminal_map`, in that order; a per-phase array has one entry for each phase conductor of the element, which is the number of names in `terminal_map` that `terminal_conventions` classifies as a phase, in `terminal_map` order. A bus voltage bound array is per phase terminal of the bus, in `terminal_names` order, and never carries an entry for the neutral, which bounds through `vn_max`. A matrix `prefix_i_j` index is one-based and indexes the element's own conductor ordering: for a line or a switch, position i of `terminal_map_from`, which position i of `terminal_map_to` connects to; for a linecode, position i of the `terminal_map_from` of every line that references it, so a linecode's conductor count is fixed and every referencing line states a terminal map of that width; for a line geometry, position i of `conductors`, whose `terminal` names the conductor the compiled row carries. A matrix is symmetric, so a document may state one triangle; a stated cell wins over its mirror.\n\nSchema version against dataset version. `meta.schema_version` is the version of this schema document and is fixed at 0.2.0; `meta.$schema` is the `$id` of the schema document the dataset is written against, and it carries the same version. `meta.version` is the version of the dataset itself and is unrelated to either: a case may revise its own data many times against one schema version."
+  "description": "Proposed BMOPF 0.2.0 structural schema, subject to IEEE PES BMOPF Task Force review. Electrical quantities use absolute SI units. Element IDs are table keys; ordered terminal maps establish conductor identity. Cross-field dimensions, references, role lists and bounds require semantic validation in addition to JSON Schema. Unknown electrical fields are rejected; top-level extras and meta.provenance are free-form extension locations. Neither location establishes computational support. The canonical $id identifies this schema; a case may retrieve its pinned revision from an immutable commit URL. See the proposal documentation for compatibility and implementation status."
 }

--- a/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
+++ b/tests/data/dist/bmopf/bmopf-0.2.0.schema.json
@@ -347,7 +347,8 @@
             "items": {
               "type": "number"
             },
-            "description": "Linear active-power cost [$/kWh] of each phase conductor of the source, one entry per phase conductor in `terminal_map` order. The source is not special in the objective: a positive injection is an import, so a positive entry is the import price and an export is credited at the same price. A scalar is rejected. Absent, the source carries no objective term."
+            "description": "Linear active-power cost [$/kWh] of each phase conductor of the source, one entry per phase conductor in `terminal_map` order. The source is not special in the objective: a positive injection is an import, so a positive entry is the import price and an export is credited at the same price. A scalar is rejected. Absent, the source carries no objective term. Legacy spelling accepted for compatibility with earlier drafts. Fresh output uses energy_cost_rate.",
+            "deprecated": true
           },
           "p_min": {
             "type": "array",
@@ -362,6 +363,13 @@
               "type": "number"
             },
             "description": "Maximum active power [W] delivered by each phase conductor of the source, one entry per phase conductor in `terminal_map` order."
+          },
+          "energy_cost_rate": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Energy cost rate [$/kWh], one entry per phase conductor in terminal_map order. Neutral terminals have no price entry."
           }
         },
         "required": [
@@ -615,7 +623,8 @@
             "items": {
               "type": "number"
             },
-            "description": "Linear active-power generating cost [$/kWh] of each phase conductor, one entry per phase conductor in `terminal_map` order. A scalar is rejected."
+            "description": "Linear active-power generating cost [$/kWh] of each phase conductor, one entry per phase conductor in `terminal_map` order. A scalar is rejected. Legacy spelling accepted for compatibility with earlier drafts. Fresh output uses energy_cost_rate.",
+            "deprecated": true
           },
           "bus": {
             "$ref": "#/$defs/bus_type"
@@ -628,13 +637,35 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "energy_cost_rate": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Energy cost rate [$/kWh], one entry per phase conductor in terminal_map order. Neutral terminals have no price entry."
           }
         },
         "required": [
-          "cost",
           "bus",
           "configuration",
           "terminal_map"
+        ],
+        "allOf": [
+          {
+            "anyOf": [
+              {
+                "required": [
+                  "energy_cost_rate"
+                ]
+              },
+              {
+                "required": [
+                  "cost"
+                ]
+              }
+            ]
+          }
         ]
       }
     },
@@ -991,7 +1022,8 @@
             "items": {
               "type": "number"
             },
-            "description": "Linear active-power dispatch cost [$/kWh] of each phase conductor, one entry per phase conductor in `terminal_map` order. The objective sums this rate against the active power the phase injects into the network, so a positive entry minimises injection and a negative entry maximises it. A scalar is rejected."
+            "description": "Linear active-power dispatch cost [$/kWh] of each phase conductor, one entry per phase conductor in `terminal_map` order. The objective sums this rate against the active power the phase injects into the network, so a positive entry minimises injection and a negative entry maximises it. A scalar is rejected. Legacy spelling accepted for compatibility with earlier drafts. Fresh output uses energy_cost_rate.",
+            "deprecated": true
           },
           "control_profile": {
             "type": "string",
@@ -1007,6 +1039,13 @@
           },
           "time_series": {
             "$ref": "#/$defs/time_series_ref"
+          },
+          "energy_cost_rate": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Energy cost rate [$/kWh], one entry per phase conductor in terminal_map order. Neutral terminals have no price entry."
           }
         },
         "required": [


### PR DESCRIPTION
Prepare PowerIO v0.11.0 with draft BMOPF 0.2 support that builds on [Matt Deakin's source/objective proposal](https://github.com/distribution-system-opt/math-and-data-model-specifications/pull/36). Preserve per-phase energy prices and unequal voltage limits through IR and typed bindings, retain complete transformer winding data, and report unsupported calculations explicitly. Schema-version selection produces the requested version while ordinary same-format emission preserves source bytes.

This includes the normally merged [Burhan Abdullah contribution #494](https://github.com/eigenergy/powerio/pull/494), with its readiness checks enforced before numerical use and unresolved OpenDSS geometry retained without guessed impedances. The companion is [PowerIO.jl #137](https://github.com/eigenergy/PowerIO.jl/pull/137). [Schema alignment and evidence](https://github.com/distribution-system-opt/dsopt-schema/blob/propose-bmopf-0.2.0/docs/upstream-alignment.md) distinguish Matt's definitions, additive compatibility and remaining Task Force questions.

Validation covers Rust and C ABI tests, the full Clippy matrix, installed Python and Julia bindings, mutation/IR/schema-conversion regressions, regenerated examples and independent OpenDSS comparisons. Draft BMOPF 0.2 remains subject to Task Force review; publishing PowerIO does not ratify it.
