### PR TITLE
feat(dist): add pre-solver electrical readiness audit

### DIFF
--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -5,8 +5,40 @@
 //! <https://github.com/frederikgeth/bmopf-report>).
 //!
 //! The model uses wire coordinates: string bus IDs, ordered terminal names,
-//! explicit grounding, terminal maps, SI units, and radians. The transmission
-//! model in `powerio` is positive sequence and remains a separate type.
+//! explicit grounding, terminal maps on every element, SI units, and radians.
+//! The transmission model in `powerio` is positive sequence and remains a
+//! separate type.
+//!
+//! ```no_run
+//! let source = powerio_core::Source::open("feeder.dss")?;
+//! let module = powerio_dist::parse(source)?;
+//! for line in powerio_dist::diagnostics::render_diagnostics(module.diagnostics()) {
+//!     eprintln!("parse: {line}");
+//! }
+//! let conv = powerio_dist::write_as(&module, powerio_dist::DistTargetFormat::PmdJson);
+//! # Ok::<(), powerio_core::Error>(())
+//! ```
+//!
+//! # Fidelity rules
+//!
+//! Writing to the retained source format returns the original bytes. Cross
+//! format conversion writes from the typed model and reports fields the target
+//! cannot represent in [`Conversion::diagnostics`]. The DSS reader expands OpenDSS
+//! class defaults into explicit model values and records them in
+//! [`MulticonductorNetwork::defaulted`]. BMOPF output includes those values.
+//! The per fixture results live in `docs/conversion-matrix.md`.
+//!
+//! # Float formatting
+//!
+//! Canonical output formats every number as its shortest round trip
+//! representation: Rust's `Display` for `.dss`, serde_json (ryu) for both
+//! JSON formats. The readers parse with serde_json's `float_roundtrip`
+//! feature, so a parse of canonical output recovers the exact bit pattern
+//! and canonical writes are idempotent. JSON cannot carry `Inf`/`NaN`: the
+//! PMD writer emits `null` (PMD restores the value from the field name
+//! suffix), and the BMOPF writer emits `0` with a warning, since the schema
+//! requires numbers. The byte exact echo tier is unaffected; it never
+//! reformats.
 
 pub mod bmopf;
 mod collect;
@@ -17,9 +49,9 @@ pub mod error;
 pub mod geo;
 pub mod graph;
 pub mod model;
+pub(crate) mod nonfinite;
 pub mod pmd;
 pub mod readiness;
-pub(crate) mod nonfinite;
 #[cfg(test)]
 pub(crate) mod testkit;
 
@@ -47,7 +79,7 @@ pub use model::{
     MulticonductorNetwork, PowerFactorControl, ReactivePowerReference, ReactivePowerUnit,
     UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, unresolved_references,
 };
+pub use pmd::write_pmd_json;
 pub use readiness::{
     audit_electrical_readiness, ElectricalReadiness, ReadinessFinding, ReadinessSeverity,
 };
-pub use pmd::write_pmd_json;

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -2,7 +2,7 @@
 //! `.dss`, PowerModelsDistribution ENGINEERING
 //! JSON ("PMD JSON"), and the draft JSON schema of the IEEE PES Task Force on
 //! Benchmarking Multiconductor OPF ("BMOPF JSON",
-//! <https://github.com/frederikgeth/bmopf-report>).
+//! <https://github.com/distribution-system-opt/dsopt-schema>).
 //!
 //! The model uses wire coordinates: string bus IDs, ordered terminal names,
 //! explicit grounding, terminal maps on every element, SI units, and radians.
@@ -15,15 +15,22 @@
 //! for line in powerio_dist::diagnostics::render_diagnostics(module.diagnostics()) {
 //!     eprintln!("parse: {line}");
 //! }
-//! let conv = powerio_dist::write_as(&module, powerio_dist::DistTargetFormat::PmdJson);
+//! let emitted = powerio_dist::emit(
+//!     &module,
+//!     powerio_dist::DistTargetFormat::PmdJson,
+//!     powerio_core::Destination::memory("feeder.pmd.json")?,
+//! )?;
+//! for line in powerio_dist::diagnostics::render_diagnostics(emitted.diagnostics()) {
+//!     eprintln!("emit: {line}");
+//! }
 //! # Ok::<(), powerio_core::Error>(())
 //! ```
 //!
 //! # Fidelity rules
 //!
-//! Writing to the retained source format returns the original bytes. Cross
-//! format conversion writes from the typed model and reports fields the target
-//! cannot represent in [`Conversion::diagnostics`]. The DSS reader expands OpenDSS
+//! Emitting to the retained source format returns the original bytes. Cross
+//! format emission uses the typed model and reports fields the target cannot
+//! represent through [`powerio_core::EmitResult::diagnostics`]. The DSS reader expands OpenDSS
 //! class defaults into explicit model values and records them in
 //! [`MulticonductorNetwork::defaulted`]. BMOPF output includes those values.
 //! The per fixture results live in `docs/conversion-matrix.md`.
@@ -34,9 +41,9 @@
 //! representation: Rust's `Display` for `.dss`, serde_json (ryu) for both
 //! JSON formats. The readers parse with serde_json's `float_roundtrip`
 //! feature, so a parse of canonical output recovers the exact bit pattern
-//! and canonical writes are idempotent. JSON cannot carry `Inf`/`NaN`: the
-//! PMD writer emits `null` (PMD restores the value from the field name
-//! suffix), and the BMOPF writer emits `0` with a warning, since the schema
+//! and canonical emissions are idempotent. JSON cannot carry `Inf`/`NaN`: the
+//! PMD emitter uses `null` (PMD restores the value from the field name
+//! suffix), and the BMOPF emitter uses `0` with a warning, since the schema
 //! requires numbers. The byte exact echo tier is unaffected; it never
 //! reformats.
 
@@ -49,22 +56,18 @@ pub mod error;
 pub mod geo;
 pub mod graph;
 pub mod model;
-pub(crate) mod nonfinite;
 pub mod pmd;
 pub mod readiness;
 #[cfg(test)]
 pub(crate) mod testkit;
 
-pub use bmopf::{
-    BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfWriteOptions, write_bmopf_json,
-    write_bmopf_json_with_options,
-};
+pub use bmopf::{BMOPF_SCHEMA_ID, BMOPF_SCHEMA_VERSION, BmopfEmitOptions, BmopfProfile};
 pub use convert::{
-    Conversion, ConversionSidecar, DistTargetFormat, classify_distribution_json, convert_source,
-    dist_target_from_name, parse, write, write_as, write_network,
+    DistTargetFormat, EmitOptions, classify_distribution_json, emit, emit_with_options, parse,
+    parse_dist_target_format,
 };
 pub use diagnostics::{Diagnostic, DiagnosticCode, DiagnosticSeverity, DiagnosticStage};
-pub use dss::{DssLoadVoltageBounds, DssWriteOptions, write_dss, write_dss_with_options};
+pub use dss::{DssEmitOptions, DssLoadVoltageBounds};
 pub use error::{Error, Result};
 pub use geo::{CoordinateSpace, DistCanvas, DistCoordsKind, DistGeoMeta, DistLocation};
 pub use graph::{
@@ -72,12 +75,12 @@ pub use graph::{
     DistGraphEdgeKind,
 };
 pub use model::{
-    ActivePowerReference, ActivePowerUnit, Configuration, ControlVoltageReference, DistBus,
-    DistCapacitor, DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode, DistLoad,
-    DistLoadVoltageModel, DistShunt, DistSourceFormat, DistSwitch, DistTransformer, DistWinding,
-    DistWindingConn, Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation, Mat,
+    ActivePowerReference, ActivePowerUnit, ConductorMatrix, Configuration, ControlVoltageReference,
+    DistBus, DistCapacitor, DistControlProfile, DistGenerator, DistIbr, DistLine, DistLineCode,
+    DistLoad, DistLoadVoltageModel, DistShunt, DistSourceFormat, DistSwitch, DistTransformer,
+    DistWinding, DistWindingConn, Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation,
     MulticonductorNetwork, PowerFactorControl, ReactivePowerReference, ReactivePowerUnit,
-    UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, unresolved_references,
+    UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, find_unresolved_references,
 };
 pub use pmd::write_pmd_json;
 pub use readiness::{

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -5,40 +5,8 @@
 //! <https://github.com/frederikgeth/bmopf-report>).
 //!
 //! The model uses wire coordinates: string bus IDs, ordered terminal names,
-//! explicit grounding, terminal maps on every element, SI units, and radians.
-//! The transmission model in `powerio` is positive sequence and remains a
-//! separate type.
-//!
-//! ```no_run
-//! let source = powerio_core::Source::open("feeder.dss")?;
-//! let module = powerio_dist::parse(source)?;
-//! for line in powerio_dist::diagnostics::render_diagnostics(module.diagnostics()) {
-//!     eprintln!("parse: {line}");
-//! }
-//! let conv = powerio_dist::write_as(&module, powerio_dist::DistTargetFormat::PmdJson);
-//! # Ok::<(), powerio_core::Error>(())
-//! ```
-//!
-//! # Fidelity rules
-//!
-//! Writing to the retained source format returns the original bytes. Cross
-//! format conversion writes from the typed model and reports fields the target
-//! cannot represent in [`Conversion::diagnostics`]. The DSS reader expands OpenDSS
-//! class defaults into explicit model values and records them in
-//! [`MulticonductorNetwork::defaulted`]. BMOPF output includes those values.
-//! The per fixture results live in `docs/conversion-matrix.md`.
-//!
-//! # Float formatting
-//!
-//! Canonical output formats every number as its shortest round trip
-//! representation: Rust's `Display` for `.dss`, serde_json (ryu) for both
-//! JSON formats. The readers parse with serde_json's `float_roundtrip`
-//! feature, so a parse of canonical output recovers the exact bit pattern
-//! and canonical writes are idempotent. JSON cannot carry `Inf`/`NaN`: the
-//! PMD writer emits `null` (PMD restores the value from the field name
-//! suffix), and the BMOPF writer emits `0` with a warning, since the schema
-//! requires numbers. The byte exact echo tier is unaffected; it never
-//! reformats.
+//! explicit grounding, terminal maps, SI units, and radians. The transmission
+//! model in `powerio` is positive sequence and remains a separate type.
 
 pub mod bmopf;
 mod collect;
@@ -49,8 +17,9 @@ pub mod error;
 pub mod geo;
 pub mod graph;
 pub mod model;
-pub(crate) mod nonfinite;
 pub mod pmd;
+pub mod readiness;
+pub(crate) mod nonfinite;
 #[cfg(test)]
 pub(crate) mod testkit;
 
@@ -77,5 +46,8 @@ pub use model::{
     DistWindingConn, Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation, Mat,
     MulticonductorNetwork, PowerFactorControl, ReactivePowerReference, ReactivePowerUnit,
     UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, unresolved_references,
+};
+pub use readiness::{
+    audit_electrical_readiness, ElectricalReadiness, ReadinessFinding, ReadinessSeverity,
 };
 pub use pmd::write_pmd_json;

--- a/powerio-dist/src/readiness.rs
+++ b/powerio-dist/src/readiness.rs
@@ -1,0 +1,174 @@
+//! Pre-solver structural and numerical readiness checks for distribution models.
+//!
+//! Parsing answers whether a source can be decoded. Readiness answers a
+//! different question: whether the resulting typed network is safe to hand to
+//! a numerical solver or lowering pass without silently repairing topology or
+//! fabricating electrical data. The audit is deliberately read-only and does
+//! not mutate or default the model.
+
+use std::collections::BTreeSet;
+
+use crate::model::{DistLineCode, MulticonductorNetwork};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessSeverity { Blocker, Warning }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessFinding {
+    pub severity: ReadinessSeverity,
+    pub code: &'static str,
+    pub element: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ElectricalReadiness { pub findings: Vec<ReadinessFinding> }
+
+impl ElectricalReadiness {
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        !self.findings.iter().any(|f| f.severity == ReadinessSeverity::Blocker)
+    }
+    #[must_use]
+    pub fn blockers(&self) -> impl Iterator<Item = &ReadinessFinding> {
+        self.findings.iter().filter(|f| f.severity == ReadinessSeverity::Blocker)
+    }
+    #[must_use]
+    pub fn warnings(&self) -> impl Iterator<Item = &ReadinessFinding> {
+        self.findings.iter().filter(|f| f.severity == ReadinessSeverity::Warning)
+    }
+    fn block(&mut self, code: &'static str, element: &str, message: String) {
+        self.findings.push(ReadinessFinding { severity: ReadinessSeverity::Blocker, code, element: element.to_owned(), message });
+    }
+    fn warn(&mut self, code: &'static str, element: &str, message: String) {
+        self.findings.push(ReadinessFinding { severity: ReadinessSeverity::Warning, code, element: element.to_owned(), message });
+    }
+}
+
+/// Audit a multiconductor network before numerical lowering or solving.
+///
+/// The audit is intentionally conservative. Unresolved topology, malformed
+/// impedance matrices, non-finite frequency/length, and terminal-count
+/// mismatches block the model. Parser-recorded defaults remain visible as
+/// warnings instead of being mistaken for explicit source data.
+#[must_use]
+pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalReadiness {
+    let mut out = ElectricalReadiness::default();
+
+    if !net.base_frequency().is_finite() || net.base_frequency() <= 0.0 {
+        out.block("READINESS.FREQUENCY.INVALID", "network", format!("base frequency must be finite and greater than zero; got {}", net.base_frequency()));
+    }
+
+    let mut bus_ids = BTreeSet::new();
+    for bus in net.buses() {
+        if !bus_ids.insert(bus.id.to_ascii_lowercase()) {
+            out.block("READINESS.BUS.DUPLICATE", &bus.id, "bus identifier is duplicated (case-insensitively)".into());
+        }
+        if bus.terminals.is_empty() {
+            out.block("READINESS.BUS.TERMINALS_EMPTY", &bus.id, "bus has no terminals".into());
+        }
+    }
+
+    let mut linecode_names = BTreeSet::new();
+    for code in net.linecodes() {
+        if !linecode_names.insert(code.name.to_ascii_lowercase()) {
+            out.block("READINESS.LINECODE.DUPLICATE", &code.name, "linecode name is duplicated (case-insensitively)".into());
+        }
+        audit_linecode(code, &mut out);
+    }
+
+    let mut line_names = BTreeSet::new();
+    for line in net.lines() {
+        if !line_names.insert(line.name.to_ascii_lowercase()) {
+            out.block("READINESS.LINE.DUPLICATE", &line.name, "line name is duplicated (case-insensitively)".into());
+        }
+        if !line.length.is_finite() || line.length <= 0.0 {
+            out.block("READINESS.LINE.LENGTH_INVALID", &line.name, format!("line length must be finite and greater than zero; got {}", line.length));
+        }
+        if net.bus(&line.bus_from).is_none() {
+            out.block("READINESS.LINE.BUS_FROM_UNRESOLVED", &line.name, format!("from-bus {:?} does not exist", line.bus_from));
+        }
+        if net.bus(&line.bus_to).is_none() {
+            out.block("READINESS.LINE.BUS_TO_UNRESOLVED", &line.name, format!("to-bus {:?} does not exist", line.bus_to));
+        }
+        let Some(code) = net.linecode(&line.linecode) else {
+            out.block("READINESS.LINE.LINECODE_UNRESOLVED", &line.name, format!("linecode {:?} does not exist", line.linecode));
+            continue;
+        };
+        if line.terminal_map_from.len() != code.n_conductors || line.terminal_map_to.len() != code.n_conductors {
+            out.block("READINESS.LINE.TERMINAL_COUNT_MISMATCH", &line.name, format!("terminal maps have lengths {}/{} but linecode requires {} conductors", line.terminal_map_from.len(), line.terminal_map_to.len(), code.n_conductors));
+        }
+    }
+
+    for (element, fields) in net.defaulted() {
+        for field in fields {
+            out.warn("READINESS.SOURCE.DEFAULTED", element, format!("field {field:?} was materialized from a source-format default"));
+        }
+    }
+    out
+}
+
+fn audit_linecode(code: &DistLineCode, out: &mut ElectricalReadiness) {
+    if code.n_conductors == 0 {
+        out.block("READINESS.LINECODE.CONDUCTOR_COUNT_ZERO", &code.name, "linecode has zero conductors".into());
+        return;
+    }
+    audit_square_matrix(&code.name, "r_series", &code.r_series, code.n_conductors, out);
+    audit_square_matrix(&code.name, "x_series", &code.x_series, code.n_conductors, out);
+    audit_square_matrix(&code.name, "g_from", &code.g_from, code.n_conductors, out);
+    audit_square_matrix(&code.name, "b_from", &code.b_from, code.n_conductors, out);
+    audit_square_matrix(&code.name, "g_to", &code.g_to, code.n_conductors, out);
+    audit_square_matrix(&code.name, "b_to", &code.b_to, code.n_conductors, out);
+}
+
+fn audit_square_matrix(element: &str, field: &str, matrix: &[Vec<f64>], n: usize, out: &mut ElectricalReadiness) {
+    if matrix.len() != n || matrix.iter().any(|row| row.len() != n) {
+        out.block("READINESS.MATRIX.SHAPE_MISMATCH", element, format!("{field} must be a {n}x{n} matrix"));
+        return;
+    }
+    if matrix.iter().flatten().any(|value| !value.is_finite()) {
+        out.block("READINESS.MATRIX.NONFINITE", element, format!("{field} contains a non-finite value"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DistBus, DistLine, DistLineCode, MulticonductorNetwork};
+
+    fn linecode() -> DistLineCode { DistLineCode::new("lc", vec![vec![0.1]], vec![vec![0.2]]) }
+
+    #[test]
+    fn valid_network_is_ready() {
+        let mut net = MulticonductorNetwork::new();
+        net.buses_mut().push(DistBus::new("a", vec!["1".into()]));
+        net.buses_mut().push(DistBus::new("b", vec!["1".into()]));
+        net.linecodes_mut().push(linecode());
+        net.lines_mut().push(DistLine::new("l", "a", "b", vec!["1".into()], vec!["1".into()], "lc", 100.0));
+        assert!(audit_electrical_readiness(&net).is_ready());
+    }
+
+    #[test]
+    fn unresolved_linecode_blocks() {
+        let mut net = MulticonductorNetwork::new();
+        net.buses_mut().push(DistBus::new("a", vec!["1".into()]));
+        net.buses_mut().push(DistBus::new("b", vec!["1".into()]));
+        net.lines_mut().push(DistLine::new("l", "a", "b", vec!["1".into()], vec!["1".into()], "missing", 100.0));
+        let report = audit_electrical_readiness(&net);
+        assert!(!report.is_ready());
+        assert!(report.blockers().any(|f| f.code == "READINESS.LINE.LINECODE_UNRESOLVED"));
+    }
+
+    #[test]
+    fn malformed_matrix_blocks() {
+        let mut net = MulticonductorNetwork::new();
+        net.buses_mut().push(DistBus::new("a", vec!["1", "2"]));
+        net.buses_mut().push(DistBus::new("b", vec!["1", "2"]));
+        let mut code = linecode();
+        code.n_conductors = 2;
+        net.linecodes_mut().push(code);
+        let report = audit_electrical_readiness(&net);
+        assert!(!report.is_ready());
+        assert!(report.blockers().any(|f| f.code == "READINESS.MATRIX.SHAPE_MISMATCH"));
+    }
+}


### PR DESCRIPTION
## Summary

Add a read-only electrical readiness audit for multiconductor distribution networks before numerical lowering or solving.

### What it checks
- invalid/non-finite base frequency
- duplicate bus, linecode, and line identifiers
- buses without terminals
- unresolved line bus/linecode references
- invalid line lengths
- line terminal-count versus linecode conductor-count mismatches
- zero-conductor linecodes
- malformed or non-finite linecode impedance/admittance matrices
- parser-recorded defaulted fields remain visible as readiness warnings

The audit is intentionally fail-closed for structural/numerical blockers and never mutates or silently repairs the network.

## Why

This provides a reusable boundary between parsing and numerical use. In particular, it makes the existing `defaulted` provenance observable before a model reaches a solver/lowering path, complementing the deferred-geometry fail-closed work in #480/#484.

## Tests

Unit tests are included for a valid network, unresolved linecode, and malformed impedance matrix. I have not claimed an executed workspace test run because the GitHub-connected environment does not provide a local Cargo build/test environment.
