### PR TITLE
feat(dist): add fail-closed electrical readiness gate

### DIFF
--- a/docs/electrical-readiness.md
+++ b/docs/electrical-readiness.md
@@ -1,0 +1,52 @@
+# Electrical readiness before analysis
+
+`powerio-dist` separates source parsing from the decision to hand a
+multiconductor network to numerical analysis. Parsing establishes a typed
+model; [`audit_electrical_readiness`](../powerio-dist/src/readiness.rs) checks
+whether that model is electrically complete enough for a solver or semantic
+lowering pass.
+
+## Fail-closed rule for deferred OpenDSS geometry
+
+OpenDSS can define a line through `geometry=`, `spacing=`, `wires=`,
+`cncables=`, or `tscables=`. The geometry family is not yet lowered into
+PowerIO's canonical conductor impedance matrices. Until that work is
+implemented, these properties are **blockers**, not warnings.
+
+The readiness audit therefore refuses a geometry-backed line even when the
+parser has produced a syntactically valid `DistLine`. Applications should
+call the audit before numerical lowering or solving and stop when
+`is_ready()` is false.
+
+This is intentionally a non-breaking safety boundary. It does not attempt to
+implement Carson's equations, infer conductor count from `phases`, or replace
+geometry-derived impedance with OpenDSS `Line` factory defaults. Explicit
+`linecode=` data remains eligible for analysis when the rest of the network
+passes the audit.
+
+## Example
+
+```rust
+use powerio_dist::{audit_electrical_readiness, parse};
+
+let module = parse(source)?;
+let readiness = audit_electrical_readiness(module.value());
+if !readiness.is_ready() {
+    for finding in readiness.blockers() {
+        eprintln!("{}: {}", finding.code, finding.message);
+    }
+    return Err("electrical model is not ready for analysis".into());
+}
+```
+
+The audit is read-only. It also catches unresolved line endpoints, unresolved
+linecodes, invalid line lengths, duplicate identifiers, zero-conductor
+linecodes, malformed impedance matrices, and non-finite matrix values.
+
+## Scope
+
+This gate addresses the safety half of the deferred-geometry problem tracked
+upstream in `eigenergy/powerio#479`. Full typed geometry support remains a
+separate implementation: it should calculate the conductor impedance from
+the relevant OpenDSS geometry family and preserve the source units and
+conductor topology without relying on parser defaults.

--- a/docs/electrical-readiness.md
+++ b/docs/electrical-readiness.md
@@ -18,6 +18,12 @@ parser has produced a syntactically valid `DistLine`. Applications should
 call the audit before numerical lowering or solving and stop when
 `is_ready()` is false.
 
+The regression contract explicitly covers **all five** deferred geometry
+properties. A future geometry-lowering implementation should change the
+corresponding readiness behavior deliberately and update these tests and the
+scope documentation together; a parser accepting one of these properties is
+not evidence that numerical impedance data exists.
+
 This is intentionally a non-breaking safety boundary. It does not attempt to
 implement Carson's equations, infer conductor count from `phases`, or replace
 geometry-derived impedance with OpenDSS `Line` factory defaults. Explicit

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -57,6 +57,7 @@ pub mod geo;
 pub mod graph;
 pub mod model;
 pub mod pmd;
+pub mod readiness;
 #[cfg(test)]
 pub(crate) mod testkit;
 
@@ -80,4 +81,7 @@ pub use model::{
     DistWinding, DistWindingConn, Extras, IbrPrimeMover, IbrTopology, IbrVoltageAggregation,
     MulticonductorNetwork, PowerFactorControl, ReactivePowerReference, ReactivePowerUnit,
     UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, find_unresolved_references,
+};
+pub use readiness::{
+    audit_electrical_readiness, ElectricalReadiness, ReadinessFinding, ReadinessSeverity,
 };

--- a/powerio-dist/src/lib.rs
+++ b/powerio-dist/src/lib.rs
@@ -83,5 +83,5 @@ pub use model::{
     UntypedObject, VoltVarControl, VoltWattControl, VoltageSource, find_unresolved_references,
 };
 pub use readiness::{
-    audit_electrical_readiness, ElectricalReadiness, ReadinessFinding, ReadinessSeverity,
+    ElectricalReadiness, ReadinessFinding, ReadinessSeverity, audit_electrical_readiness,
 };

--- a/powerio-dist/src/readiness.rs
+++ b/powerio-dist/src/readiness.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::model::{DistLineCode, MulticonductorNetwork};
+use crate::model::{DistLineCode, Extras, MulticonductorNetwork};
 
 /// Severity of an electrical-readiness finding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -295,6 +295,24 @@ mod tests {
         assert!(report
             .blockers()
             .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    }
+
+    #[test]
+    fn all_deferred_geometry_families_are_hard_blockers() {
+        for key in ["geometry", "spacing", "wires", "cncables", "tscables"] {
+            let mut extras = Extras::new();
+            extras.insert(key.into(), serde_json::json!("deferred"));
+            let report = audit_electrical_readiness(&network_with_line(extras));
+            assert!(!report.is_ready(), "{key} must block readiness");
+            assert_eq!(
+                report
+                    .blockers()
+                    .filter(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+                    .count(),
+                1,
+                "{key} must produce exactly one deferred-geometry blocker"
+            );
+        }
     }
 
     #[test]

--- a/powerio-dist/src/readiness.rs
+++ b/powerio-dist/src/readiness.rs
@@ -9,7 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use crate::model::{DistLineCode, Extras, MulticonductorNetwork};
+use crate::model::{DistLineCode, MulticonductorNetwork};
 
 /// Severity of an electrical-readiness finding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,15 +62,6 @@ impl ElectricalReadiness {
     fn block(&mut self, code: &'static str, element: &str, message: impl Into<String>) {
         self.findings.push(ReadinessFinding {
             severity: ReadinessSeverity::Blocker,
-            code,
-            element: element.to_owned(),
-            message: message.into(),
-        });
-    }
-
-    fn warn(&mut self, code: &'static str, element: &str, message: impl Into<String>) {
-        self.findings.push(ReadinessFinding {
-            severity: ReadinessSeverity::Warning,
             code,
             element: element.to_owned(),
             message: message.into(),
@@ -139,7 +130,10 @@ pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalRead
             report.block(
                 "READINESS.LINE.LENGTH_INVALID",
                 &line.name,
-                format!("line length must be finite and greater than zero; got {}", line.length),
+                format!(
+                    "line length must be finite and greater than zero; got {}",
+                    line.length
+                ),
             );
         }
 
@@ -200,8 +194,7 @@ fn audit_deferred_geometry(line: &crate::model::DistLine, report: &mut Electrica
             "READINESS.DSS.GEOMETRY_DEFERRED",
             &line.name,
             format!(
-                "OpenDSS geometry-family property/properties {:?} are deferred; no geometry-derived impedance may be assumed",
-                keys
+                "OpenDSS geometry-family properties {keys:?} are deferred; no geometry-derived impedance may be assumed"
             ),
         );
     }
@@ -217,10 +210,34 @@ fn audit_linecode(code: &DistLineCode, report: &mut ElectricalReadiness) {
         return;
     }
 
-    audit_square_matrix(&code.name, "r_series", &code.r_series, code.n_conductors, report);
-    audit_square_matrix(&code.name, "x_series", &code.x_series, code.n_conductors, report);
-    audit_square_matrix(&code.name, "g_from", &code.g_from, code.n_conductors, report);
-    audit_square_matrix(&code.name, "b_from", &code.b_from, code.n_conductors, report);
+    audit_square_matrix(
+        &code.name,
+        "r_series",
+        &code.r_series,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "x_series",
+        &code.x_series,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "g_from",
+        &code.g_from,
+        code.n_conductors,
+        report,
+    );
+    audit_square_matrix(
+        &code.name,
+        "b_from",
+        &code.b_from,
+        code.n_conductors,
+        report,
+    );
     audit_square_matrix(&code.name, "g_to", &code.g_to, code.n_conductors, report);
     audit_square_matrix(&code.name, "b_to", &code.b_to, code.n_conductors, report);
 }
@@ -252,14 +269,13 @@ fn audit_square_matrix(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DistBus, DistLine, DistLineCode, MulticonductorNetwork};
+    use crate::{DistBus, DistLine, DistLineCode, Extras, MulticonductorNetwork};
 
     fn network_with_line(extras: Extras) -> MulticonductorNetwork {
         let mut net = MulticonductorNetwork::new();
         net.buses_mut()
             .push(DistBus::new("source", vec!["1".into()]));
-        net.buses_mut()
-            .push(DistBus::new("load", vec!["1".into()]));
+        net.buses_mut().push(DistBus::new("load", vec!["1".into()]));
         net.line_codes_mut().push(DistLineCode::new(
             "explicit",
             vec![vec![0.1]],
@@ -292,9 +308,11 @@ mod tests {
         extras.insert("geometry".into(), serde_json::json!("g601"));
         let report = audit_electrical_readiness(&network_with_line(extras));
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+        );
     }
 
     #[test]
@@ -324,9 +342,11 @@ mod tests {
         net.lines_mut()[0].terminal_map_to = vec!["1".into()];
         let report = audit_electrical_readiness(&net);
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+        );
     }
 
     #[test]
@@ -335,8 +355,10 @@ mod tests {
         net.line_codes_mut()[0].n_conductors = 2;
         let report = audit_electrical_readiness(&net);
         assert!(!report.is_ready());
-        assert!(report
-            .blockers()
-            .any(|finding| finding.code == "READINESS.MATRIX.SHAPE_MISMATCH"));
+        assert!(
+            report
+                .blockers()
+                .any(|finding| finding.code == "READINESS.MATRIX.SHAPE_MISMATCH")
+        );
     }
 }

--- a/powerio-dist/src/readiness.rs
+++ b/powerio-dist/src/readiness.rs
@@ -1,0 +1,324 @@
+//! Pre-solver structural readiness checks for distribution networks.
+//!
+//! Parsing and electrical readiness are deliberately separate. A source can be
+//! syntactically valid while the resulting typed network is not safe to hand
+//! to a solver or semantic writer. In particular, OpenDSS line geometry is
+//! still deferred: until Carson/geometry lowering exists, a geometry-defined
+//! line must not be treated as electrically complete merely because the
+//! parser has a placeholder linecode.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::model::{DistLineCode, MulticonductorNetwork};
+
+/// Severity of an electrical-readiness finding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadinessSeverity {
+    /// The network must not be passed to numerical lowering or solving.
+    Blocker,
+    /// The network can be used, but the caller should inspect the finding.
+    Warning,
+}
+
+/// A deterministic finding emitted by the readiness audit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadinessFinding {
+    pub severity: ReadinessSeverity,
+    pub code: &'static str,
+    pub element: String,
+    pub message: String,
+}
+
+/// Result of [`audit_electrical_readiness`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ElectricalReadiness {
+    pub findings: Vec<ReadinessFinding>,
+}
+
+impl ElectricalReadiness {
+    /// Returns `true` only when no blocker is present.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        !self
+            .findings
+            .iter()
+            .any(|finding| finding.severity == ReadinessSeverity::Blocker)
+    }
+
+    /// Returns the findings that make the network unsafe to solve.
+    pub fn blockers(&self) -> impl Iterator<Item = &ReadinessFinding> {
+        self.findings
+            .iter()
+            .filter(|finding| finding.severity == ReadinessSeverity::Blocker)
+    }
+
+    /// Returns non-fatal findings.
+    pub fn warnings(&self) -> impl Iterator<Item = &ReadinessFinding> {
+        self.findings
+            .iter()
+            .filter(|finding| finding.severity == ReadinessSeverity::Warning)
+    }
+
+    fn block(&mut self, code: &'static str, element: &str, message: impl Into<String>) {
+        self.findings.push(ReadinessFinding {
+            severity: ReadinessSeverity::Blocker,
+            code,
+            element: element.to_owned(),
+            message: message.into(),
+        });
+    }
+
+    fn warn(&mut self, code: &'static str, element: &str, message: impl Into<String>) {
+        self.findings.push(ReadinessFinding {
+            severity: ReadinessSeverity::Warning,
+            code,
+            element: element.to_owned(),
+            message: message.into(),
+        });
+    }
+}
+
+/// Audit a multiconductor network before numerical lowering or solving.
+///
+/// This check is intentionally conservative and read-only. It does not repair
+/// topology, invent conductor counts, or replace missing electrical data with
+/// source-format defaults. OpenDSS `geometry=`, `spacing=`, `wires=`,
+/// `cncables=`, and `tscables=` metadata are treated as a hard blocker because
+/// the geometry family is not yet lowered into the canonical impedance
+/// matrices. The audit therefore provides an explicit fail-closed boundary
+/// for applications that need to decide whether a parsed network is safe to
+/// analyse.
+#[must_use]
+pub fn audit_electrical_readiness(net: &MulticonductorNetwork) -> ElectricalReadiness {
+    let mut report = ElectricalReadiness::default();
+
+    if !net.base_frequency().is_finite() || net.base_frequency() <= 0.0 {
+        report.block(
+            "READINESS.FREQUENCY.INVALID",
+            "network",
+            format!(
+                "base frequency must be finite and greater than zero; got {}",
+                net.base_frequency()
+            ),
+        );
+    }
+
+    let mut buses = BTreeSet::new();
+    for bus in net.buses() {
+        if !buses.insert(bus.id.to_ascii_lowercase()) {
+            report.block(
+                "READINESS.BUS.DUPLICATE",
+                &bus.id,
+                "bus identifier is duplicated case-insensitively",
+            );
+        }
+        if bus.terminals.is_empty() {
+            report.block(
+                "READINESS.BUS.TERMINALS_EMPTY",
+                &bus.id,
+                "bus has no terminals",
+            );
+        }
+    }
+
+    let mut linecodes = BTreeMap::new();
+    for code in net.line_codes() {
+        let key = code.name.to_ascii_lowercase();
+        if linecodes.insert(key, code).is_some() {
+            report.block(
+                "READINESS.LINECODE.DUPLICATE",
+                &code.name,
+                "linecode name is duplicated case-insensitively",
+            );
+        }
+        audit_linecode(code, &mut report);
+    }
+
+    for line in net.lines() {
+        if !line.length.is_finite() || line.length <= 0.0 {
+            report.block(
+                "READINESS.LINE.LENGTH_INVALID",
+                &line.name,
+                format!("line length must be finite and greater than zero; got {}", line.length),
+            );
+        }
+
+        if !buses.contains(&line.bus_from.to_ascii_lowercase()) {
+            report.block(
+                "READINESS.LINE.BUS_FROM_UNRESOLVED",
+                &line.name,
+                format!("from-bus {:?} does not exist", line.bus_from),
+            );
+        }
+        if !buses.contains(&line.bus_to.to_ascii_lowercase()) {
+            report.block(
+                "READINESS.LINE.BUS_TO_UNRESOLVED",
+                &line.name,
+                format!("to-bus {:?} does not exist", line.bus_to),
+            );
+        }
+
+        audit_deferred_geometry(line, &mut report);
+
+        let Some(code) = linecodes.get(&line.linecode.to_ascii_lowercase()) else {
+            report.block(
+                "READINESS.LINE.LINECODE_UNRESOLVED",
+                &line.name,
+                format!("linecode {:?} does not exist", line.linecode),
+            );
+            continue;
+        };
+
+        if line.terminal_map_from.len() != code.n_conductors
+            || line.terminal_map_to.len() != code.n_conductors
+        {
+            report.block(
+                "READINESS.LINE.TERMINAL_COUNT_MISMATCH",
+                &line.name,
+                format!(
+                    "terminal maps have lengths {}/{} but linecode requires {} conductors",
+                    line.terminal_map_from.len(),
+                    line.terminal_map_to.len(),
+                    code.n_conductors
+                ),
+            );
+        }
+    }
+
+    report
+}
+
+fn audit_deferred_geometry(line: &crate::model::DistLine, report: &mut ElectricalReadiness) {
+    const GEOMETRY_KEYS: [&str; 5] = ["geometry", "spacing", "wires", "cncables", "tscables"];
+    let keys: Vec<&str> = GEOMETRY_KEYS
+        .into_iter()
+        .filter(|key| line.extras.contains_key(*key))
+        .collect();
+
+    if !keys.is_empty() {
+        report.block(
+            "READINESS.DSS.GEOMETRY_DEFERRED",
+            &line.name,
+            format!(
+                "OpenDSS geometry-family property/properties {:?} are deferred; no geometry-derived impedance may be assumed",
+                keys
+            ),
+        );
+    }
+}
+
+fn audit_linecode(code: &DistLineCode, report: &mut ElectricalReadiness) {
+    if code.n_conductors == 0 {
+        report.block(
+            "READINESS.LINECODE.CONDUCTOR_COUNT_ZERO",
+            &code.name,
+            "linecode has zero conductors",
+        );
+        return;
+    }
+
+    audit_square_matrix(&code.name, "r_series", &code.r_series, code.n_conductors, report);
+    audit_square_matrix(&code.name, "x_series", &code.x_series, code.n_conductors, report);
+    audit_square_matrix(&code.name, "g_from", &code.g_from, code.n_conductors, report);
+    audit_square_matrix(&code.name, "b_from", &code.b_from, code.n_conductors, report);
+    audit_square_matrix(&code.name, "g_to", &code.g_to, code.n_conductors, report);
+    audit_square_matrix(&code.name, "b_to", &code.b_to, code.n_conductors, report);
+}
+
+fn audit_square_matrix(
+    element: &str,
+    field: &str,
+    matrix: &[Vec<f64>],
+    n: usize,
+    report: &mut ElectricalReadiness,
+) {
+    if matrix.len() != n || matrix.iter().any(|row| row.len() != n) {
+        report.block(
+            "READINESS.MATRIX.SHAPE_MISMATCH",
+            element,
+            format!("{field} must be a {n}x{n} matrix"),
+        );
+        return;
+    }
+    if matrix.iter().flatten().any(|value| !value.is_finite()) {
+        report.block(
+            "READINESS.MATRIX.NONFINITE",
+            element,
+            format!("{field} contains a non-finite value"),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DistBus, DistLine, DistLineCode, MulticonductorNetwork};
+
+    fn network_with_line(extras: Extras) -> MulticonductorNetwork {
+        let mut net = MulticonductorNetwork::new();
+        net.buses_mut()
+            .push(DistBus::new("source", vec!["1".into()]));
+        net.buses_mut()
+            .push(DistBus::new("load", vec!["1".into()]));
+        net.line_codes_mut().push(DistLineCode::new(
+            "explicit",
+            vec![vec![0.1]],
+            vec![vec![0.2]],
+        ));
+        let mut line = DistLine::new(
+            "l1",
+            "source",
+            "load",
+            vec!["1".into()],
+            vec!["1".into()],
+            "explicit",
+            100.0,
+        );
+        line.extras = extras;
+        net.lines_mut().push(line);
+        net
+    }
+
+    #[test]
+    fn explicit_line_is_ready() {
+        let report = audit_electrical_readiness(&network_with_line(Extras::new()));
+        assert!(report.is_ready());
+        assert_eq!(report.blockers().count(), 0);
+    }
+
+    #[test]
+    fn geometry_metadata_is_a_hard_blocker() {
+        let mut extras = Extras::new();
+        extras.insert("geometry".into(), serde_json::json!("g601"));
+        let report = audit_electrical_readiness(&network_with_line(extras));
+        assert!(!report.is_ready());
+        assert!(report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    }
+
+    #[test]
+    fn swer_geometry_cannot_be_hidden_by_a_one_phase_linecode() {
+        let mut extras = Extras::new();
+        extras.insert("geometry".into(), serde_json::json!("gswer"));
+        let mut net = network_with_line(extras);
+        net.lines_mut()[0].terminal_map_from = vec!["1".into()];
+        net.lines_mut()[0].terminal_map_to = vec!["1".into()];
+        let report = audit_electrical_readiness(&net);
+        assert!(!report.is_ready());
+        assert!(report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    }
+
+    #[test]
+    fn malformed_impedance_matrix_blocks() {
+        let mut net = network_with_line(Extras::new());
+        net.line_codes_mut()[0].n_conductors = 2;
+        let report = audit_electrical_readiness(&net);
+        assert!(!report.is_ready());
+        assert!(report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.MATRIX.SHAPE_MISMATCH"));
+    }
+}

--- a/powerio-dist/tests/electrical_readiness.rs
+++ b/powerio-dist/tests/electrical_readiness.rs
@@ -1,0 +1,59 @@
+use std::fs;
+
+use powerio_core::Source;
+use powerio_dist::{audit_electrical_readiness, parse};
+
+fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
+    let dir = std::env::temp_dir().join(format!(
+        "powerio-dss-readiness-{name}-{}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("master.dss");
+    fs::write(&path, text).unwrap();
+    parse(Source::open(&path).unwrap()).unwrap()
+}
+
+#[test]
+fn parsed_geometry_is_blocked_before_analysis() {
+    let module = parse_text(
+        "geometry",
+        r#"clear
+new circuit.t basekv=4.16 phases=3 bus1=sourcebus
+new wiredata.w rac=0.1859 gmr=0.0313 radius=0.4635 runits=mi gmrunits=ft radunits=in
+new linegeometry.g nconds=4 nphases=3 reduce=no
+~ cond=1 wire=w x=2.5 h=29 units=ft
+~ cond=2 wire=w x=0 h=29 units=ft
+~ cond=3 wire=w x=7 h=29 units=ft
+~ cond=4 wire=w x=4 h=25 units=ft
+new line.l bus1=sourcebus bus2=b geometry=g length=1 units=m
+"#,
+    );
+
+    let report = audit_electrical_readiness(module.value());
+    assert!(!report.is_ready());
+    assert!(report
+        .blockers()
+        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+}
+
+#[test]
+fn parsed_swer_geometry_is_also_blocked() {
+    let module = parse_text(
+        "swer",
+        r#"clear
+new circuit.swer basekv=19.1 phases=1 bus1=sourcebus
+new wiredata.w rac=1.093 gmr=0.00296 radius=0.00318 runits=km gmrunits=m radunits=m
+new linegeometry.g nconds=1 nphases=1 reduce=no
+~ cond=1 wire=w x=0 h=8.5 units=m
+new line.l bus1=sourcebus.1 bus2=b.1 geometry=g length=1 units=m
+"#,
+    );
+
+    let report = audit_electrical_readiness(module.value());
+    assert!(!report.is_ready());
+    assert!(report
+        .blockers()
+        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+}

--- a/powerio-dist/tests/electrical_readiness.rs
+++ b/powerio-dist/tests/electrical_readiness.rs
@@ -3,7 +3,10 @@ use std::fs;
 use powerio_core::Source;
 use powerio_dist::{audit_electrical_readiness, parse};
 
-fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
+fn parse_text(
+    name: &str,
+    text: &str,
+) -> powerio_core::PioModule<powerio_dist::MulticonductorNetwork> {
     let dir = std::env::temp_dir().join(format!(
         "powerio-dss-readiness-{name}-{}",
         std::process::id()
@@ -19,7 +22,7 @@ fn parse_text(name: &str, text: &str) -> powerio_core::PioModule<powerio_dist::M
 fn parsed_geometry_is_blocked_before_analysis() {
     let module = parse_text(
         "geometry",
-        r#"clear
+        r"clear
 new circuit.t basekv=4.16 phases=3 bus1=sourcebus
 new wiredata.w rac=0.1859 gmr=0.0313 radius=0.4635 runits=mi gmrunits=ft radunits=in
 new linegeometry.g nconds=4 nphases=3 reduce=no
@@ -28,32 +31,36 @@ new linegeometry.g nconds=4 nphases=3 reduce=no
 ~ cond=3 wire=w x=7 h=29 units=ft
 ~ cond=4 wire=w x=4 h=25 units=ft
 new line.l bus1=sourcebus bus2=b geometry=g length=1 units=m
-"#,
+",
     );
 
     let report = audit_electrical_readiness(module.value());
     assert!(!report.is_ready());
-    assert!(report
-        .blockers()
-        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    assert!(
+        report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+    );
 }
 
 #[test]
 fn parsed_swer_geometry_is_also_blocked() {
     let module = parse_text(
         "swer",
-        r#"clear
+        r"clear
 new circuit.swer basekv=19.1 phases=1 bus1=sourcebus
 new wiredata.w rac=1.093 gmr=0.00296 radius=0.00318 runits=km gmrunits=m radunits=m
 new linegeometry.g nconds=1 nphases=1 reduce=no
 ~ cond=1 wire=w x=0 h=8.5 units=m
 new line.l bus1=sourcebus.1 bus2=b.1 geometry=g length=1 units=m
-"#,
+",
     );
 
     let report = audit_electrical_readiness(module.value());
     assert!(!report.is_ready());
-    assert!(report
-        .blockers()
-        .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED"));
+    assert!(
+        report
+            .blockers()
+            .any(|finding| finding.code == "READINESS.DSS.GEOMETRY_DEFERRED")
+    );
 }


### PR DESCRIPTION
## Summary

- add a read-only `audit_electrical_readiness` gate for `MulticonductorNetwork`
- treat deferred OpenDSS `geometry=`, `spacing=`, `wires=`, `cncables=`, and `tscables=` as hard readiness blockers
- catch unresolved endpoints/linecodes, invalid lengths, duplicate IDs, malformed impedance matrices, and non-finite matrix values
- add active parser-to-audit regression coverage for both multi-conductor geometry and one-conductor SWER geometry
- document the intended pre-solver safety boundary

## Rationale

This addresses the safety half of #479 without attempting to implement Carson/geometry lowering. A parsed geometry-backed line may still exist in the typed model for source retention, but callers now have an explicit, non-breaking fail-closed check before numerical lowering or solving. The audit does not infer conductor count or accept OpenDSS factory impedance as evidence of electrical completeness.

## Validation

The branch contains unit tests and parser-to-audit integration tests. GitHub Actions is the authoritative CI check; no local test result is being claimed here before CI runs.